### PR TITLE
Fix REST API tests

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -10,7 +10,7 @@
         <span> | </span>
         <router-link :to="{ name: 'about' }" id="link_about">About</router-link>
         <span> | </span>
-        <form id="form_logout" method="POST" action="/flashcrow/api/logout">
+        <form id="form_logout" method="POST" action="/flashcrow/api/auth/logout">
           <input type="submit" id="btn_logout" value="Sign Out" />
         </form>
       </template>

--- a/tests/unit/RestApi.spec.js
+++ b/tests/unit/RestApi.spec.js
@@ -1,4 +1,3 @@
-import config from '@/../lib/config';
 import fs from 'fs';
 import path from 'path';
 import request from 'request-promise-native';
@@ -34,13 +33,12 @@ function fcTransformGetCookie(body, response) {
 
 function fcLogin() {
   const options = {
-    formData: config.credentials,
     json: false,
     method: 'POST',
     simple: false,
     transform: fcTransformGetCookie,
   };
-  return fcApi('/login', options)
+  return fcApi('/auth/test-login', options)
     .then((cookie) => {
       if (cookie !== null) {
         COOKIE_JAR.setCookie(cookie, HOST);
@@ -54,7 +52,7 @@ function fcLogout() {
     simple: false,
     transform: fcTransformGetCookie,
   };
-  return fcApi('/logout', options)
+  return fcApi('/auth/logout', options)
     .then(() => {
       COOKIE_JAR = request.jar(null, {
         rejectPublicSuffixes: false,


### PR DESCRIPTION
so that these can run under our current OpenID Connect authentication
setup.

The "fix" is actually more of a workaround: instead of going through the
OpenID Connect flow before creating an application session, we add a new
endpoint that can be used in testing / development environments to
authenticate a test user.

I investigated crafting a valid JWT and moving this to a Cypress-based
end-to-end test, but eventually settled on this workaround approach -
after all, we're not trying to test OpenID Connect here!