### PR TITLE
Reduce email noise from replicator

### DIFF
--- a/scripts/replication/replicator-local.ps1
+++ b/scripts/replication/replicator-local.ps1
@@ -191,7 +191,7 @@ if (-Not $transferIp) {
   $transferIp = $transferData.instances[0].PrivateIpAddress
 }
 $transferSsh = "$transferUser@$transferIp"
-Send-Status "Identified transfer machine: $transferSsh..."
+Send-Status -message "Identified transfer machine: $transferSsh..." -emailDisable
 
 # fetch Oracle row counts
 jq -r ".tables[].name" "$configFile" | ForEach-Object {
@@ -219,7 +219,7 @@ EXIT;
     Exit-Error -message "Failed to fetch $sourceSchema.$table row count from Oracle!"
   }
 }
-Send-Status "Fetched Oracle row counts..."
+Send-Status -message "Fetched Oracle row counts..." -emailDisable
 
 # fetch Oracle table schemas
 jq -r ".tables[].name" "$configFile" | ForEach-Object {
@@ -249,7 +249,7 @@ EXIT;
     Exit-Error -message "Failed to fetch $sourceSchema.$table schema from Oracle!"
   }
 }
-Send-Status "Fetched Oracle schemas..."
+Send-Status -message "Fetched Oracle schemas..." -emailDisable
 
 # convert Oracle table schemas to PostgreSQL
 jq -r ".tables[].name" "$configFile" | ForEach-Object {
@@ -272,7 +272,7 @@ jq -r ".tables[].name" "$configFile" | ForEach-Object {
     Exit-Error "Failed to generate local PostgreSQL schema (with foreign tables) for $targetValidationSchema.$table!"
   }
 }
-Send-Status "Generated PostgreSQL schemas..."
+Send-Status -message "Generated PostgreSQL schemas..." -emailDisable
 
 # drop any existing foreign tables in reverse order
 jq -r ".tables | reverse | .[].name" "$configFile" | ForEach-Object {
@@ -294,7 +294,7 @@ jq -r ".tables[].name" "$configFile" | ForEach-Object {
     Exit-Error -message "Failed to create $targetValidationSchema.$table in local PostgreSQL!"
   }
 }
-Send-Status "Created local PostgreSQL tables..."
+Send-Status -message "Created local PostgreSQL tables..." -emailDisable
 
 # copy data from foreign tables to local text files
 jq -c ".tables[]" "$configFile" | ForEach-Object {
@@ -362,7 +362,7 @@ jq -c ".tables[]" "$configFile" | ForEach-Object {
     Exit-Error -message "Failed to copy Oracle data from $targetValidationSchema.$table in local PostgreSQL to $datFile!"
   }
 }
-Send-Status "Copied data from local PostgreSQL..."
+Send-Status -message "Copied data from local PostgreSQL..." -emailDisable
 
 # copy data files to transfer machine
 Get-ChildItem -Recurse -File -Path $dirRoot | ForEach-Object {
@@ -372,7 +372,7 @@ Get-ChildItem -Recurse -File -Path $dirRoot | ForEach-Object {
 }
 Copy-RemoteItem -src $configFile
 Copy-RemoteItem -src $transferScript -exec
-Send-Status "Sent data, config, and scripts to transfer machine..."
+Send-Status -message "Sent data, config, and scripts to transfer machine..."
 
 # run transfer script on transfer machine
 $emailsToOptions = ""
@@ -384,4 +384,4 @@ if (-Not $?) {
   Exit-Error -message "Failed to run transfer script on transfer machine!"
 }
 
-Exit-Success "Completed Oracle -> PostgreSQL replication."
+Exit-Success -message "Completed Oracle -> PostgreSQL replication."

--- a/scripts/replication/replicator-transfer.sh
+++ b/scripts/replication/replicator-transfer.sh
@@ -131,6 +131,12 @@ function sendStatus {
   echo "$GUID $NOW $MESSAGE"
 }
 
+function sendStatusEmailDisable {
+  local -r MESSAGE="$1"
+  local -r NOW=$(TZ='America/Toronto' date +"%Y-%m-%dT%H:%M:%S")
+  echo "$GUID $NOW $MESSAGE"
+}
+
 function exitError {
   local -r MESSAGE="$1"
   local -r NOW=$(TZ='America/Toronto' date +"%Y-%m-%dT%H:%M:%S")
@@ -156,7 +162,7 @@ sendStatus "Starting remote PostgreSQL data transfer..."
 # unpack data files
 cd "$HOME"
 gunzip -rf "$DIR_DAT"
-sendStatus "$GUID Unpacked data on transfer machine..."
+sendStatusEmailDisable "$GUID Unpacked data on transfer machine..."
 
 # drop any existing validation schema tables in reverse order
 # shellcheck disable=SC2086
@@ -176,7 +182,7 @@ jq -r ".tables[].name" "$CONFIG_FILE" | while read -r table; do
     exitError "Failed to create $TARGET_VALIDATION_SCHEMA.$table in remote PostgreSQL!"
   fi
 done
-sendStatus "Created remote PostgreSQL validation tables..."
+sendStatusEmailDisable "Created remote PostgreSQL validation tables..."
 
 # copy data from local text files to tables in validation schema
 # shellcheck disable=SC2086
@@ -193,9 +199,9 @@ jq -r ".tables[].name" "$CONFIG_FILE" | while read -r table; do
   if [ "$ROW_COUNT_VALID" = "0" ]; then
     exitError "Row count mismatch on $TARGET_VALIDATION_SCHEMA.$table: Oracle ($ORA_COUNT rows) -> PostgreSQL ($PG_COUNT rows)!"
   fi
-  sendStatus "Validated $TARGET_VALIDATION_SCHEMA.$table..."
+  sendStatusEmailDisable "Validated $TARGET_VALIDATION_SCHEMA.$table..."
 done
-sendStatus "Copied data into remote PostgreSQL validation schema..."
+sendStatusEmailDisable "Copied data into remote PostgreSQL validation schema..."
 
 # drop any existing target schema tables in reverse order
 # shellcheck disable=SC2086
@@ -214,5 +220,5 @@ jq -r ".tables[].name" "$CONFIG_FILE" | while read -r table; do
     exitError "Failed to move $TARGET_VALIDATION_SCHEMA.$table -> $TARGET_SCHEMA.$table in remote PostgreSQL!"
   fi
 done
-sendStatus "Moved tables to remote PostgreSQL target schema..."
+sendStatusEmailDisable "Moved tables to remote PostgreSQL target schema..."
 exitSuccess "Finished remote PostgreSQL data transfer."


### PR DESCRIPTION
This PR closes #23 .

In `replicator-local.ps1`, pass `-emailDisable` flag to `Send-Status`
almost everywhere.

In `replicator-transfer.sh`, introduce `sendStatusEmailDisable()`
function and use that almost everywhere.