### PR TITLE
Add Requested By to request table

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -363,6 +363,15 @@ const RequestStatus = {
   },
 };
 
+const SearchKeys = {
+  Requests: {
+    ID: (q, r) => r.id.toString() === q,
+    LOCATION: (q, r) => r.location.description.indexOf(q) !== -1,
+    REQUESTER: (q, r) => r.requestedBy.name.indexOf(q) !== 1,
+    STATUS: (q, r) => r.status.indexOf(q) !== 1,
+  },
+};
+
 const SignalType = {
   NORMAL: 1,
   PEDCROSS: 2,
@@ -477,6 +486,7 @@ const Constants = {
   ReportParameter,
   ReportType,
   RequestStatus,
+  SearchKeys,
   SignalType,
   SortDirection,
   SortKeys,
@@ -504,6 +514,7 @@ export {
   ReportParameter,
   ReportType,
   RequestStatus,
+  SearchKeys,
   SignalType,
   SortDirection,
   SortKeys,

--- a/lib/controller/UserController.js
+++ b/lib/controller/UserController.js
@@ -1,0 +1,50 @@
+import UserDAO from '@/lib/db/UserDAO';
+import Joi from '@/lib/model/Joi';
+import User from '@/lib/model/User';
+
+/**
+ * Utilities for user lookups.
+ *
+ * @type {Array<Hapi.ServerRoute>}
+ */
+const UserController = [];
+
+/**
+ * Get user names and emails for the given auth provider subjects.
+ *
+ * @memberof UserController
+ * @name getUsersBySubjects
+ * @type {Hapi.ServerRoute}
+ */
+UserController.push({
+  method: 'GET',
+  path: '/users/bySubject',
+  options: {
+    response: {
+      schema: Joi.array().items(
+        Joi.array().ordered(
+          Joi.string().uuid().required(),
+          User.read,
+        ),
+      ),
+    },
+    validate: {
+      query: {
+        subject: Joi.array().single().items(
+          Joi.string().uuid().required(),
+        ).required(),
+      },
+    },
+  },
+  handler: async (request) => {
+    const { subject } = request.query;
+    const users = await UserDAO.bySubjects(subject);
+    const filteredUsers = new Map();
+    users.forEach(({ email, name }, userSubject) => {
+      filteredUsers.set(userSubject, { email, name });
+    });
+    return Array.from(filteredUsers);
+  },
+});
+
+export default UserController;

--- a/lib/db/UserDAO.js
+++ b/lib/db/UserDAO.js
@@ -19,12 +19,7 @@ class UserDAO {
     const uniqueSubjects = Array.from(new Set(subjects));
     const sql = 'SELECT * FROM "users" WHERE "subject" IN ($(uniqueSubjects:csv))';
     const rows = await db.manyOrNone(sql, { uniqueSubjects });
-    const users = new Map();
-    rows.forEach((user) => {
-      const { subject } = user;
-      users.set(subject, user);
-    });
-    return users;
+    return new Map(rows.map(user => [user.subject, user]));
   }
 
   static async byEmail(email) {

--- a/lib/db/UserDAO.js
+++ b/lib/db/UserDAO.js
@@ -1,9 +1,30 @@
 import db from '@/lib/db/db';
 
+/**
+ * Data access layer for users.
+ */
 class UserDAO {
   static async bySubject(subject) {
     const sql = 'SELECT * FROM "users" WHERE "subject" = $(subject)';
     return db.oneOrNone(sql, { subject });
+  }
+
+  /**
+   * Map user subjects to users.
+   *
+   * @param {Array<string>} subjects - array of user subjects
+   * @returns {Promise<Map<string, Object>>} map from user subjects to users
+   */
+  static async bySubjects(subjects) {
+    const uniqueSubjects = Array.from(new Set(subjects));
+    const sql = 'SELECT * FROM "users" WHERE "subject" IN ($(uniqueSubjects:csv))';
+    const rows = await db.manyOrNone(sql, { uniqueSubjects });
+    const users = new Map();
+    rows.forEach((user) => {
+      const { subject } = user;
+      users.set(subject, user);
+    });
+    return users;
   }
 
   static async byEmail(email) {

--- a/lib/model/User.js
+++ b/lib/model/User.js
@@ -1,0 +1,8 @@
+import Joi from '@/lib/model/Joi';
+
+export default {
+  read: {
+    email: Joi.string().email().required(),
+    name: Joi.string().required(),
+  },
+};

--- a/web/components/FcCardTableRequests.vue
+++ b/web/components/FcCardTableRequests.vue
@@ -32,8 +32,15 @@
         {{item.location.description}}
       </span>
     </template>
-    <template v-slot:STUDY_TYPES="{ item, children }">
-      <span>TODO: item type</span>
+    <template v-slot:REQUESTER="{ item }">
+      <span
+        v-if="item.requestedBy === null"
+        class="text-muted">
+        N/A
+      </span>
+      <span v-else>
+        {{item.requestedBy.name}}
+      </span>
     </template>
     <template v-slot:DATE="{ item }">
       <span>{{item.dueDate | date}}</span>
@@ -95,23 +102,21 @@ export default {
       name: 'SELECTION',
     }, {
       name: 'ID',
-      sortable: true,
       title: 'ID#',
     }, {
       name: 'LOCATION',
-      sortable: true,
       title: 'Location',
     }, {
+      name: 'REQUESTER',
+      title: 'Requested By',
+    }, {
       name: 'DATE',
-      sortable: true,
       title: 'Due Date',
     }, {
       name: 'PRIORITY',
-      sortable: true,
       title: 'Priority',
     }, {
       name: 'STATUS',
-      sortable: true,
       title: 'Status',
     }, {
       name: 'ACTIONS',

--- a/web/server.js
+++ b/web/server.js
@@ -12,6 +12,7 @@ import CountController from '@/lib/controller/CountController';
 import LocationController from '@/lib/controller/LocationController';
 import StudyController from '@/lib/controller/StudyController';
 import StudyRequestController from '@/lib/controller/StudyRequestController';
+import UserController from '@/lib/controller/UserController';
 import WebInitController from '@/lib/controller/WebInitController';
 import SignalSuggestionController from '@/lib/controller/SignalSuggestionController';
 import db from '@/lib/db/db';
@@ -186,6 +187,7 @@ async function initServer() {
   server.route(LocationController);
   server.route(StudyController);
   server.route(StudyRequestController);
+  server.route(UserController);
   server.route(WebInitController);
   server.route(SignalSuggestionController);
 


### PR DESCRIPTION
This PR starts work on #250 and #251 by introducing a "Requested By" column to the list of requests in Track Requests.

To make this work, I've added `UserController` and `UserDAO.bySubjects`, which perform multi-lookups of users by their `subject` field.  This is then used by the `itemsStudyRequests` getter to populate `requestedBy`, which is in turn used by `FcCardTableRequests`.