### PR TITLE
Supervisor view for Track Requests

### DIFF
--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -147,8 +147,8 @@ StudyRequestController.push({
       params: {
         id: Joi.number().integer().positive().required(),
       },
-      payload: StudyRequest.update,
-      query: {
+      payload: {
+        ...StudyRequest.update,
         // TODO: remove when we have RBAC
         isSupervisor: Joi.boolean().default(false),
       },
@@ -157,7 +157,8 @@ StudyRequestController.push({
   handler: async (request) => {
     const user = request.auth.credentials;
     const { id } = request.params;
-    const { isSupervisor } = request.query;
+    const { isSupervisor, ...studyRequestNew } = request.payload;
+
     const studyRequestOld = await StudyRequestDAO.byId(id);
     if (studyRequestOld === null) {
       return Boom.notFound(`no study request found with ID ${id}`);
@@ -165,7 +166,7 @@ StudyRequestController.push({
     if (studyRequestOld.userSubject !== user.subject && !isSupervisor) {
       return Boom.forbidden('cannot update study request owned by another user');
     }
-    const studyRequestNew = request.payload;
+
     if (studyRequestNew.id !== studyRequestOld.id) {
       return Boom.badRequest('cannot change ID for study request');
     }
@@ -175,6 +176,7 @@ StudyRequestController.push({
     if (studyRequestNew.userSubject !== studyRequestOld.userSubject) {
       return Boom.badRequest('cannot change owner for study request');
     }
+
     return StudyRequestDAO.update(studyRequestNew);
   },
 });

--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -71,20 +71,55 @@ StudyRequestController.push({
       params: {
         id: Joi.number().integer().positive().required(),
       },
+      query: {
+        // TODO: remove when we have RBAC
+        isSupervisor: Joi.boolean().default(false),
+      },
     },
   },
   handler: async (request) => {
     const user = request.auth.credentials;
     const { id } = request.params;
+    const { isSupervisor } = request.query;
     const studyRequest = await StudyRequestDAO.byId(id);
     if (studyRequest === null) {
       return Boom.notFound(`no study request found with ID ${id}`);
     }
-    // TODO: remove this for supervisor view
-    if (studyRequest.userSubject !== user.subject) {
+    if (studyRequest.userSubject !== user.subject && !isSupervisor) {
       return Boom.forbidden('cannot view study request owned by another user');
     }
     return studyRequest;
+  },
+});
+
+/**
+ * Returns all requests submitted (i.e. created) by the current user.
+ *
+ * @memberof StudyRequestController
+ * @name getUserStudyRequests
+ * @type {Hapi.ServerRoute}
+ */
+StudyRequestController.push({
+  method: 'GET',
+  path: '/requests/study',
+  options: {
+    response: {
+      schema: Joi.array().items(StudyRequest.read),
+    },
+    validate: {
+      query: {
+        // TODO: remove when we have RBAC
+        isSupervisor: Joi.boolean().default(false),
+      },
+    },
+  },
+  handler: async (request) => {
+    const { isSupervisor } = request.query;
+    if (isSupervisor) {
+      return StudyRequestDAO.all();
+    }
+    const user = request.auth.credentials;
+    return StudyRequestDAO.byUser(user);
   },
 });
 
@@ -113,17 +148,21 @@ StudyRequestController.push({
         id: Joi.number().integer().positive().required(),
       },
       payload: StudyRequest.update,
+      query: {
+        // TODO: remove when we have RBAC
+        isSupervisor: Joi.boolean().default(false),
+      },
     },
   },
   handler: async (request) => {
     const user = request.auth.credentials;
     const { id } = request.params;
+    const { isSupervisor } = request.query;
     const studyRequestOld = await StudyRequestDAO.byId(id);
     if (studyRequestOld === null) {
       return Boom.notFound(`no study request found with ID ${id}`);
     }
-    // TODO: supervisor view?
-    if (studyRequestOld.userSubject !== user.subject) {
+    if (studyRequestOld.userSubject !== user.subject && !isSupervisor) {
       return Boom.forbidden('cannot update study request owned by another user');
     }
     const studyRequestNew = request.payload;
@@ -134,7 +173,6 @@ StudyRequestController.push({
       return Boom.badRequest('cannot change creation timestamp for study request');
     }
     if (studyRequestNew.userSubject !== studyRequestOld.userSubject) {
-      // TODO: can supervisors change the owner of a request?
       return Boom.badRequest('cannot change owner for study request');
     }
     return StudyRequestDAO.update(studyRequestNew);
@@ -159,47 +197,28 @@ StudyRequestController.push({
       params: {
         id: Joi.number().integer().positive().required(),
       },
+      query: {
+        // TODO: remove when we have RBAC
+        isSupervisor: Joi.boolean().default(false),
+      },
     },
   },
   handler: async (request) => {
     const user = request.auth.credentials;
     const { id } = request.params;
+    const { isSupervisor } = request.query;
     const studyRequest = await StudyRequestDAO.byId(id);
     if (studyRequest === null) {
       return Boom.notFound(`no study request found with ID ${id}`);
     }
-    // TODO: supervisor view?
-    if (studyRequest.userSubject !== user.subject) {
-      return Boom.forbidden('cannot view study request owned by another user');
+    if (studyRequest.userSubject !== user.subject && !isSupervisor) {
+      return Boom.forbidden('cannot delete study request owned by another user');
     }
     const success = await StudyRequestDAO.delete(studyRequest);
     if (!success) {
       return Boom.notFound(`could not delete study request with ID ${id}`);
     }
     return { success };
-  },
-});
-
-/**
- * Returns all requests submitted (i.e. created) by the current user.
- *
- * @memberof StudyRequestController
- * @name getUserStudyRequests
- * @type {Hapi.ServerRoute}
- */
-StudyRequestController.push({
-  method: 'GET',
-  path: '/requests/study',
-  options: {
-    response: {
-      schema: Joi.array().items(StudyRequest.read),
-    },
-  },
-  handler: async (request) => {
-    // TODO: pagination
-    // TODO: admin fetching for TSU
-    const user = request.auth.credentials;
-    return StudyRequestDAO.byUser(user);
   },
 });
 

--- a/lib/db/StudyRequestDAO.js
+++ b/lib/db/StudyRequestDAO.js
@@ -79,6 +79,43 @@ SELECT
   }
 
   /**
+   * Fetch all study requests.
+   *
+   * @returns {Array<Object>} array of all study request objects
+   */
+  static async all() {
+    const sql = `
+SELECT
+  "id",
+  "createdAt",
+  "userSubject",
+  "status",
+  "serviceRequestId",
+  "priority",
+  "dueDate",
+  "estimatedDeliveryDate",
+  "reasons",
+  "ccEmails",
+  "centrelineId",
+  "centrelineType",
+  ST_AsGeoJSON("geom")::json AS "geom"
+  FROM "study_requests"`;
+    const studyRequests = await db.manyOrNone(sql);
+    if (studyRequests.length === 0) {
+      return studyRequests;
+    }
+    const studies = await StudyDAO.byStudyRequests(studyRequests);
+    return studyRequests.map((studyRequest) => {
+      const { id } = studyRequest;
+      const studiesForRequest = studies.filter(({ studyRequestId }) => studyRequestId === id);
+      return {
+        ...studyRequest,
+        studies: studiesForRequest,
+      };
+    });
+  }
+
+  /**
    * Fetch study requests at the given centreline feature (segment or intersection).
    * TODO: link to CentrelineType
    *

--- a/web/components/FcActionBottomConfirm.vue
+++ b/web/components/FcActionBottomConfirm.vue
@@ -15,6 +15,9 @@ import ValidationsStudyRequest from '@/lib/validation/ValidationsStudyRequest';
 export default {
   name: 'FcActionBottomConfirm',
   computed: {
+    isSupervisor() {
+      return Object.prototype.hasOwnProperty.call(this.$route.query, 'isSupervisor');
+    },
     linkFinish() {
       if (this.studyRequest.id !== undefined) {
         // coming from edit flow
@@ -23,6 +26,9 @@ export default {
           name: 'requestStudyView',
           params: { id },
         };
+        if (this.isSupervisor) {
+          route.query = { isSupervisor: true };
+        }
         const label = 'Save';
         return { route, label };
       }
@@ -40,7 +46,7 @@ export default {
   validations: ValidationsStudyRequest.validations,
   methods: {
     onClickConfirm() {
-      this.saveActiveStudyRequest();
+      this.saveActiveStudyRequest(this.isSupervisor);
       this.$router.push(this.linkFinish.route);
     },
     ...mapActions(['saveActiveStudyRequest']),

--- a/web/components/FcActionBottomContinueToConfirm.vue
+++ b/web/components/FcActionBottomContinueToConfirm.vue
@@ -15,6 +15,9 @@ import ValidationsStudyRequest from '@/lib/validation/ValidationsStudyRequest';
 export default {
   name: 'FcActionBottomContinueToConfirm',
   computed: {
+    isSupervisor() {
+      return Object.prototype.hasOwnProperty.call(this.$route.query, 'isSupervisor');
+    },
     ...mapState(['studyRequest']),
   },
   validations: ValidationsStudyRequest.validations,
@@ -22,7 +25,11 @@ export default {
     onClickContinue() {
       let { name } = this.$route;
       name = name.replace('Specify', 'Confirm');
-      this.$router.push({ name });
+      const route = { name };
+      if (this.isSupervisor) {
+        route.query = { isSupervisor: true };
+      }
+      this.$router.push(route);
     },
   },
 };

--- a/web/components/FcActionBottomContinueToSpecify.vue
+++ b/web/components/FcActionBottomContinueToSpecify.vue
@@ -15,6 +15,9 @@ import ValidationsStudyRequest from '@/lib/validation/ValidationsStudyRequest';
 export default {
   name: 'FcActionBottomContinue',
   computed: {
+    isSupervisor() {
+      return Object.prototype.hasOwnProperty.call(this.$route.query, 'isSupervisor');
+    },
     ...mapState(['studyRequest']),
   },
   validations: ValidationsStudyRequest.validationsMeta,
@@ -22,7 +25,11 @@ export default {
     onClickContinue() {
       let { name } = this.$route;
       name = name.replace('Schedule', 'Specify');
-      this.$router.push({ name });
+      const route = { name };
+      if (this.isSupervisor) {
+        route.query = { isSupervisor: true };
+      }
+      this.$router.push(route);
     },
   },
 };

--- a/web/components/FcActionBottomRequestData.vue
+++ b/web/components/FcActionBottomRequestData.vue
@@ -14,6 +14,9 @@ import { mapState } from 'vuex';
 export default {
   name: 'FcActionBottomRequestData',
   computed: {
+    isSupervisor() {
+      return Object.prototype.hasOwnProperty.call(this.$route.query, 'isSupervisor');
+    },
     ...mapState(['studyRequest']),
   },
   validations: {
@@ -25,7 +28,11 @@ export default {
     onClickRequestData() {
       let { name } = this.$route;
       name = `${name}Schedule`;
-      this.$router.push({ name });
+      const route = { name };
+      if (this.isSupervisor) {
+        route.query = { isSupervisor: true };
+      }
+      this.$router.push(route);
     },
   },
 };

--- a/web/components/FcCardTable.vue
+++ b/web/components/FcCardTable.vue
@@ -254,10 +254,10 @@ export default {
       &.sortable {
         cursor: pointer;
         &.sorted {
-          background-color: var(--base-light);
+          background-color: var(--base-lighter);
         }
         &:hover {
-          background-color: var(--primary-light);
+          background-color: var(--primary-lighter);
           color: var(--primary-darker);
         }
       }

--- a/web/components/FcCardTableRequests.vue
+++ b/web/components/FcCardTableRequests.vue
@@ -141,14 +141,21 @@ export default {
         this.$emit('input', value);
       },
     },
+    isSupervisor() {
+      return Object.prototype.hasOwnProperty.call(this.$route.query, 'isSupervisor');
+    },
     ...mapGetters(['itemsStudyRequests']),
   },
   methods: {
     onActionShowRequest(item) {
-      this.$router.push({
+      const route = {
         name: 'requestStudyView',
         params: { id: item.id },
-      });
+      };
+      if (this.isSupervisor) {
+        route.query = { isSupervisor: true };
+      }
+      this.$router.push(route);
     },
   },
 };

--- a/web/store.js
+++ b/web/store.js
@@ -616,8 +616,13 @@ export default new Vuex.Store({
         studyRequestUser,
       };
     },
-    async fetchAllStudyRequests({ commit, dispatch }) {
-      const studyRequests = await apiFetch('/requests/study');
+    async fetchAllStudyRequests({ commit, dispatch }, isSupervisor) {
+      const data = {};
+      if (isSupervisor) {
+        data.isSupervisor = true;
+      }
+      const options = { data };
+      const studyRequests = await apiFetch('/requests/study', options);
       commit('setStudyRequests', studyRequests);
 
       const centrelineKeys = new Set();

--- a/web/store.js
+++ b/web/store.js
@@ -581,9 +581,13 @@ export default new Vuex.Store({
       return result;
     },
     // STUDY REQUESTS
-    async fetchStudyRequest({ commit, dispatch }, id) {
+    async fetchStudyRequest({ commit, dispatch }, { id, isSupervisor }) {
       const url = `/requests/study/${id}`;
-      const studyRequest = await apiFetch(url);
+      const options = {};
+      if (isSupervisor) {
+        options.data = { isSupervisor };
+      }
+      const studyRequest = await apiFetch(url, options);
       commit('setStudyRequest', studyRequest);
 
       const {
@@ -617,11 +621,10 @@ export default new Vuex.Store({
       };
     },
     async fetchAllStudyRequests({ commit, dispatch }, isSupervisor) {
-      const data = {};
+      const options = {};
       if (isSupervisor) {
-        data.isSupervisor = true;
+        options.data = { isSupervisor };
       }
-      const options = { data };
       const studyRequests = await apiFetch('/requests/study', options);
       commit('setStudyRequests', studyRequests);
 
@@ -652,9 +655,12 @@ export default new Vuex.Store({
         studyRequestLocations,
       };
     },
-    async saveActiveStudyRequest({ commit, getters, state }) {
+    async saveActiveStudyRequest({ commit, getters, state }, isSupervisor) {
       const data = getters.studyRequestModel;
       const update = data.id !== undefined;
+      if (update && isSupervisor) {
+        data.isSupervisor = true;
+      }
       const method = update ? 'PUT' : 'POST';
       const url = update ? `/requests/study/${data.id}` : '/requests/study';
       const options = {
@@ -669,11 +675,14 @@ export default new Vuex.Store({
       });
       return studyRequest;
     },
-    async deleteStudyRequests({ dispatch, state }, studyRequests) {
+    async deleteStudyRequests({ dispatch, state }, { isSupervisor, studyRequests }) {
       const options = {
         method: 'DELETE',
         csrf: state.auth.csrf,
       };
+      if (isSupervisor) {
+        options.data = { isSupervisor };
+      }
       const promisesStudyRequests = studyRequests.map(
         ({ id }) => apiFetch(`/requests/study/${id}`, options),
       );

--- a/web/views/FcRequestStudyView.vue
+++ b/web/views/FcRequestStudyView.vue
@@ -24,14 +24,7 @@
             <span
               v-if="studyRequestLocation !== null">
               at
-              <router-link
-                :to="{
-                  name: 'viewDataAtLocation',
-                  params: {
-                    centrelineId: studyRequest.centrelineId,
-                    centrelineType: studyRequest.centrelineType,
-                  }
-                }">
+              <router-link :to="linkLocation">
                 <span> {{studyRequestLocation.description}}</span>
               </router-link>
             </span>
@@ -108,6 +101,13 @@ export default {
       }
       return route;
     },
+    linkLocation() {
+      const { centrelineId, centrelineType } = this.studyRequest;
+      return {
+        name: 'viewDataAtLocation',
+        params: { centrelineId, centrelineType },
+      };
+    },
     ...mapState(['studyRequest', 'studyRequestLocation']),
   },
   beforeRouteEnter(to, from, next) {
@@ -129,10 +129,14 @@ export default {
         return;
       }
       const { id } = this.studyRequest;
-      this.$router.push({
+      const route = {
         name: 'requestStudyEdit',
         params: { id },
-      });
+      };
+      if (this.isSupervisor) {
+        route.query = { isSupervisor: true };
+      }
+      this.$router.push(route);
     },
     syncFromRoute(to) {
       const { id } = to.params;

--- a/web/views/FcRequestStudyView.vue
+++ b/web/views/FcRequestStudyView.vue
@@ -2,8 +2,7 @@
   <main class="fc-request-study-view flex-fill flex-container-column">
     <TdsTopBar class="nav-links text-size-l">
       <template v-slot:left>
-        <router-link
-          :to="{ name: 'requestsTrack' }">
+        <router-link :to="linkBack">
           <i class="fa fa-chevron-left"></i>
           <span> Back to All</span>
         </router-link>
@@ -99,6 +98,16 @@ export default {
     };
   },
   computed: {
+    isSupervisor() {
+      return Object.prototype.hasOwnProperty.call(this.$route.query, 'isSupervisor');
+    },
+    linkBack() {
+      const route = { name: 'requestsTrack' };
+      if (this.isSupervisor) {
+        route.query = { isSupervisor: true };
+      }
+      return route;
+    },
     ...mapState(['studyRequest', 'studyRequestLocation']),
   },
   beforeRouteEnter(to, from, next) {
@@ -127,7 +136,10 @@ export default {
     },
     syncFromRoute(to) {
       const { id } = to.params;
-      return this.fetchStudyRequest(id)
+      return this.fetchStudyRequest({
+        id,
+        isSupervisor: this.isSupervisor,
+      })
         .catch((err) => {
           const toast = getToast(err);
           this.setToast(toast);

--- a/web/views/FcRequestsTrack.vue
+++ b/web/views/FcRequestsTrack.vue
@@ -100,7 +100,10 @@ export default {
           title,
           prompt,
           action: () => {
-            this.deleteStudyRequests(studyRequests);
+            this.deleteStudyRequests({
+              isSupervisor: this.isSupervisor,
+              studyRequests,
+            });
           },
         },
       });

--- a/web/views/FcRequestsTrack.vue
+++ b/web/views/FcRequestsTrack.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fc-requests-track-by-type flex-container-column flex-fill">
+  <div class="fc-requests-track flex-container-column flex-fill">
     <section>
       <header class="flex-container-row">
         <label class="tds-checkbox">
@@ -36,7 +36,7 @@ import {
 import FcCardTableRequests from '@/web/components/FcCardTableRequests.vue';
 
 export default {
-  name: 'FcRequestsTrackByStatus',
+  name: 'FcRequestsTrack',
   components: {
     FcCardTableRequests,
   },
@@ -46,6 +46,9 @@ export default {
     };
   },
   computed: {
+    isSupervisor() {
+      return Object.prototype.hasOwnProperty.call(this.$route.query, 'isSupervisor');
+    },
     selectableIds() {
       return this.itemsStudyRequests.map(({ id }) => id);
     },
@@ -127,7 +130,7 @@ export default {
       }
     },
     syncFromRoute() {
-      return this.fetchAllStudyRequests();
+      return this.fetchAllStudyRequests(this.isSupervisor);
     },
     ...mapActions([
       'deleteStudyRequests',
@@ -141,7 +144,7 @@ export default {
 </script>
 
 <style lang="postcss">
-.fc-requests-track-by-type {
+.fc-requests-track {
   max-height: 100%;
   overflow: auto;
   padding: var(--space-m) var(--space-xl);

--- a/web/views/LayoutRequestStudy.vue
+++ b/web/views/LayoutRequestStudy.vue
@@ -41,6 +41,9 @@ export default {
     TdsTopBar,
   },
   computed: {
+    isSupervisor() {
+      return Object.prototype.hasOwnProperty.call(this.$route.query, 'isSupervisor');
+    },
     linkBack() {
       if (this.studyRequest.id !== undefined) {
         // coming from edit flow
@@ -49,6 +52,9 @@ export default {
           name: 'requestStudyView',
           params: { id },
         };
+        if (this.isSupervisor) {
+          route.query = { isSupervisor: true };
+        }
         const label = `Back to Request #${id}`;
         return { route, label };
       }


### PR DESCRIPTION
This PR closes #251 by adding a query parameter `?isSupervisor=true` throughout the study request track, view, and edit pages.

If present with _any_ value, this query param:

- sends `?isSupervisor=true` to relevant REST API CRUD endpoints;
- ensures that all links that keep the user within those pages preserve the `isSupervisor` flag.