### PR TITLE
Edit request priority in table

### DIFF
--- a/scripts/db/schema-4.down.sql
+++ b/scripts/db/schema-4.down.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+DELETE FROM "study_request_status"
+  WHERE "value" IN ('ACCEPTED', 'REJECTED', 'IN_PROGRESS');
+
+INSERT INTO "study_request_status"
+  ("value", "label")
+VALUES
+  ('FLAGGED', 'Flagged'),
+  ('REVIEWED', 'Reviewed'),
+  ('SUBMITTED', 'Submitted'),
+  ('SCHEDULED', 'Scheduled'),
+  ('DATA_READY', 'Data Ready');
+
+UPDATE "APP_META"."DB_UPDATE" SET "currentVersion" = 3;
+COMMIT;

--- a/scripts/db/schema-4.up.sql
+++ b/scripts/db/schema-4.up.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+DELETE FROM "study_request_status"
+  WHERE "value" IN ('FLAGGED', 'REVIEWED', 'SUBMITTED', 'SCHEDULED', 'DATA_READY');
+
+INSERT INTO "study_request_status"
+  ("value", "label")
+VALUES
+  ('ACCEPTED', 'Accepted'),
+  ('REJECTED', 'Rejected'),
+  ('IN_PROGRESS', 'In Progress');
+
+UPDATE "APP_META"."DB_UPDATE" SET "currentVersion" = 4;
+COMMIT;

--- a/web/components/FcActionBottomConfirm.vue
+++ b/web/components/FcActionBottomConfirm.vue
@@ -46,10 +46,11 @@ export default {
   validations: ValidationsStudyRequest.validations,
   methods: {
     onClickConfirm() {
-      this.saveActiveStudyRequest(this.isSupervisor);
+      const { isSupervisor, studyRequest } = this;
+      this.saveStudyRequest({ isSupervisor, studyRequest });
       this.$router.push(this.linkFinish.route);
     },
-    ...mapActions(['saveActiveStudyRequest']),
+    ...mapActions(['saveStudyRequest']),
   },
 };
 </script>

--- a/web/components/tds/TdsActionDropdown.vue
+++ b/web/components/tds/TdsActionDropdown.vue
@@ -6,8 +6,8 @@
     <template v-slot:dropdown>
       <ul>
         <li
-          v-for="{ label, value, disabled } in options"
-          :key="value"
+          v-for="({ label, value, disabled }, i) in options"
+          :key="i"
           :class="{ disabled }">
           <span v-if="disabled">
             {{label}}

--- a/web/views/FcRequestsTrack.vue
+++ b/web/views/FcRequestsTrack.vue
@@ -69,7 +69,26 @@
           <span>{{item.dueDate | date}}</span>
         </template>
         <template v-slot:PRIORITY="{ item }">
+          <TdsActionDropdown
+            v-if="isSupervisor"
+            class="font-size-m full-width"
+            :options="[
+              { label: 'STANDARD', value: { item, priority: 'STANDARD' } },
+              { label: 'URGENT', value: { item, priority: 'URGENT' } },
+            ]"
+            @action-selected="actionSetPriority">
+            <span
+              :class="{
+                'priority-urgent': item.priority === 'URGENT',
+              }">
+              <i
+                v-if="item.priority === 'URGENT'"
+                class="fa fa-exclamation"></i>
+              <span> {{item.priority}}</span>
+            </span>
+          </TdsActionDropdown>
           <span
+            v-else
             :class="{
               'priority-urgent': item.priority === 'URGENT',
             }">
@@ -130,6 +149,7 @@ import {
 import TimeFormatters from '@/lib/time/TimeFormatters';
 import FcCardTable from '@/web/components/FcCardTable.vue';
 import FcSummaryStudy from '@/web/components/FcSummaryStudy.vue';
+import TdsActionDropdown from '@/web/components/tds/TdsActionDropdown.vue';
 import TdsLabel from '@/web/components/tds/TdsLabel.vue';
 
 export default {
@@ -137,6 +157,7 @@ export default {
   components: {
     FcCardTable,
     FcSummaryStudy,
+    TdsActionDropdown,
     TdsLabel,
   },
   data() {
@@ -269,6 +290,12 @@ export default {
       const csvData = new Blob([csvStr], { type: 'text/csv' });
       saveAs(csvData, 'requests.csv');
     },
+    actionSetPriority({ item, priority }) {
+      const { isSupervisor } = this;
+      const studyRequest = this.studyRequests.find(({ id }) => id === item.id);
+      studyRequest.priority = priority;
+      this.saveStudyRequest({ isSupervisor, studyRequest });
+    },
     actionShowRequest(item) {
       const route = {
         name: 'requestStudyView',
@@ -295,6 +322,7 @@ export default {
     ...mapActions([
       'deleteStudyRequests',
       'fetchAllStudyRequests',
+      'saveStudyRequest',
       'setToast',
     ]),
     ...mapMutations([


### PR DESCRIPTION
This PR closes #261 by allowing supervisors to edit the priority of a request within the Track Requests table.

In addition, it updates the set of status codes for requests to reflect recent user stories.  (Most importantly, it simplifies them from 7 codes to 4.)