### PR TITLE
Dynamically generated vector tiles: counts, collisions, and schools

### DIFF
--- a/lib/controller/CountController.js
+++ b/lib/controller/CountController.js
@@ -9,49 +9,6 @@ const CountController = [];
 
 CountController.push({
   method: 'GET',
-  path: '/counts/byBoundingBox',
-  options: {
-    auth: { mode: 'try' },
-    validate: {
-      query: {
-        xmin: Joi.number().min(-180).max(180).required(),
-        ymin: Joi.number().min(-90).max(90).required(),
-        xmax: Joi.number().min(-180).max(180).greater(Joi.ref('xmin'))
-          .required(),
-        ymax: Joi.number().min(-90).max(90).greater(Joi.ref('ymin'))
-          .required(),
-      },
-    },
-  },
-  handler: async (request) => {
-    const {
-      xmin,
-      ymin,
-      xmax,
-      ymax,
-    } = request.query;
-    const counts = await CountDAO.byBoundingBox(xmin, ymin, xmax, ymax);
-    // convert to GeoJSON FeatureCollection
-    const features = counts.map((count) => {
-      const { id } = count;
-      const properties = Object.assign({}, count);
-      delete properties.geom;
-      return {
-        type: 'Feature',
-        geometry: count.geom,
-        properties,
-        id,
-      };
-    });
-    return {
-      type: 'FeatureCollection',
-      features,
-    };
-  },
-});
-
-CountController.push({
-  method: 'GET',
   path: '/counts/byCentreline',
   options: {
     auth: { mode: 'try' },

--- a/lib/controller/DynamicTileController.js
+++ b/lib/controller/DynamicTileController.js
@@ -1,0 +1,55 @@
+import Joi from '@hapi/joi';
+import vtpbf from 'vt-pbf';
+
+import DynamicTileDAO from '@/lib/db/DynamicTileDAO';
+import VectorTile from '@/lib/geo/VectorTile';
+
+/**
+ * Endpoints for dynamic tile generation.
+ *
+ * @type {Array<Hapi.ServerRoute>}
+ */
+const DynamicTileController = [];
+
+/**
+ * Get the given tile.
+ *
+ * @memberof DynamicTileController
+ * @name getTestDynamicTile
+ * @type {Hapi.ServerRoute}
+ */
+DynamicTileController.push({
+  method: 'GET',
+  path: '/dynamicTiles/{layerName}/{z}/{x}/{y}.pbf',
+  options: {
+    validate: {
+      params: {
+        layerName: Joi.string().required(),
+        z: Joi.number().integer().min(0).required(),
+        x: Joi.number().integer().min(0).required(),
+        y: Joi.number().integer().min(0).required(),
+      },
+    },
+  },
+  handler: async (request, h) => {
+    const {
+      layerName,
+      z,
+      x,
+      y,
+    } = request.params;
+    const features = await DynamicTileDAO.getTileFeatures(layerName, z, x, y);
+    const tile = new VectorTile(layerName, features);
+    const tileData = vtpbf(tile);
+    const tileBuffer = Buffer.from(tileData);
+    /*
+     * See https://github.com/mapbox/vector-tile-spec/tree/master/2.1#22-multipurpose-internet-mail-extensions-mime
+     * for preferred MIME type here.
+     */
+    return h.response(tileBuffer)
+      .encoding('binary')
+      .type('application/vnd.mapbox-vector-tile');
+  },
+});
+
+export default DynamicTileController;

--- a/lib/controller/DynamicTileController.js
+++ b/lib/controller/DynamicTileController.js
@@ -25,7 +25,11 @@ DynamicTileController.push({
     auth: { mode: 'try' },
     validate: {
       params: {
-        layerName: Joi.string().required(),
+        layerName: Joi.string().valid(
+          'collisions',
+          'counts',
+          'schools',
+        ).required(),
         z: Joi.number().integer().min(0).required(),
         x: Joi.number().integer().min(0).required(),
         y: Joi.number().integer().min(0).required(),

--- a/lib/controller/DynamicTileController.js
+++ b/lib/controller/DynamicTileController.js
@@ -22,6 +22,7 @@ DynamicTileController.push({
   method: 'GET',
   path: '/dynamicTiles/{layerName}/{z}/{x}/{y}.pbf',
   options: {
+    auth: { mode: 'try' },
     validate: {
       params: {
         layerName: Joi.string().required(),

--- a/lib/db/CountDAO.js
+++ b/lib/db/CountDAO.js
@@ -3,18 +3,6 @@ import CategoryDAO from '@/lib/db/CategoryDAO';
 import { Status } from '@/lib/Constants';
 import DateTime from '@/lib/time/DateTime';
 
-const COUNTINFO_FIELDS_BYBOUNDINGBOX = `
-  SELECT ac.centreline_id, ac.centreline_type, ad."LOCATION",
-  ci."ARTERYCODE", ac.geom
-  FROM "TRAFFIC"."COUNTINFO" ci
-  JOIN "TRAFFIC"."ARTERYDATA" ad ON ci."ARTERYCODE" = ad."ARTERYCODE"
-  JOIN prj_volume.artery_centreline ac ON ci."ARTERYCODE" = ac.arterycode`;
-const COUNTINFOMICS_FIELDS_BYBOUNDINGBOX = `
-  SELECT ac.centreline_id, ac.centreline_type, ad."LOCATION",
-  cim."ARTERYCODE", ac.geom
-  FROM "TRAFFIC"."COUNTINFOMICS" cim
-  JOIN "TRAFFIC"."ARTERYDATA" ad ON cim."ARTERYCODE" = ad."ARTERYCODE"
-  JOIN prj_volume.artery_centreline ac ON cim."ARTERYCODE" = ac.arterycode`;
 const COUNTINFO_FIELDS = `
   ci."COUNT_INFO_ID", ci."ARTERYCODE", ci."COUNT_DATE",
   ci."CATEGORY_ID", ci."COMMENT_",
@@ -252,30 +240,6 @@ class CountDAO {
   }
 
   // COMBINED
-  static async byBoundingBox(xmin, ymin, xmax, ymax) {
-    if (xmin >= xmax || ymin >= ymax) {
-      return [];
-    }
-    const sql = `SELECT centreline_id "centrelineId", centreline_type "centrelineType",
-    "LOCATION" locationDesc, COUNT(*) cnt,
-    "ARTERYCODE", ST_AsGeoJSON(geom)::json AS geom,
-    CONCAT(centreline_type, centreline_id) as id
-    FROM
-    ( ${COUNTINFO_FIELDS_BYBOUNDINGBOX}
-    WHERE ac.geom @ ST_MakeEnvelope($(xmin), $(ymin), $(xmax), $(ymax), 4326)
-    UNION ALL
-    ${COUNTINFOMICS_FIELDS_BYBOUNDINGBOX}
-    WHERE ac.geom @ ST_MakeEnvelope($(xmin), $(ymin), $(xmax), $(ymax), 4326)
-    ) AS x
-    GROUP BY "ARTERYCODE", "LOCATION", centreline_id, centreline_type, geom`;
-    const rows = await db.manyOrNone(sql, {
-      xmin,
-      ymin,
-      xmax,
-      ymax,
-    });
-    return rows;
-  }
 
   static async byCentrelineNumPerCategory(centrelineId, centrelineType, dateRange) {
     const [countInfoNumPerCategory, countInfomicsNumPerCategory] = await Promise.all([

--- a/lib/db/DynamicTileDAO.js
+++ b/lib/db/DynamicTileDAO.js
@@ -1,4 +1,5 @@
 import db from '@/lib/db/db';
+import { InvalidDynamicTileLayerError } from '@/lib/error/MoveErrors';
 import VectorTile from '@/lib/geo/VectorTile';
 
 const EPSG_3857_MAX = 20037508.3427892;
@@ -172,8 +173,7 @@ FROM schools`;
     if (layerName === 'schools') {
       return DynamicTileDAO.getSchoolsFeatures(tileInfo);
     }
-    // TODO: throw an error here
-    return [];
+    throw new InvalidDynamicTileLayerError(layerName);
   }
 }
 

--- a/lib/db/DynamicTileDAO.js
+++ b/lib/db/DynamicTileDAO.js
@@ -76,11 +76,11 @@ SELECT ST_AsGeoJSON(
     ST_MakeEnvelope($(bmin), $(bmin), $(bmax), $(bmax), 3857)
   )
 )::json AS geom,
-"COUNT_INFO_ID" as id,
-"ARTERYCODE",
-centreline_id,
-centreline_type,
-"LOCATION"
+"COUNT_INFO_ID" AS id,
+"ARTERYCODE" AS "arteryCode",
+centreline_id AS "centrelineId",
+centreline_type AS "centrelineType",
+"LOCATION" AS "locationDesc"
 FROM counts`;
     return db.manyOrNone(sql, tileInfo);
   }

--- a/lib/db/DynamicTileDAO.js
+++ b/lib/db/DynamicTileDAO.js
@@ -1,41 +1,94 @@
-// import db from '@/lib/db/db';
+import db from '@/lib/db/db';
+import VectorTile from '@/lib/geo/VectorTile';
+
+const EPSG_3857_MAX = 20037508.3427892;
+const EPSG_3857_MIN = -EPSG_3857_MAX;
+const EPSG_3857_SIZE = EPSG_3857_MAX - EPSG_3857_MIN;
 
 class DynamicTileDAO {
-  static getTileEnvelope(z, x, y) {
-    // TODO: implement this
-    return { z, x, y };
-  }
+  static getTileInfo(z, x, y) {
+    const bmin = -VectorTile.BUFFER;
+    const bmax = VectorTile.EXTENT + VectorTile.BUFFER;
+    const tileSize = EPSG_3857_SIZE / Math.pow(2, z);
+    const xmin = EPSG_3857_MIN + tileSize * x;
+    const xmax = EPSG_3857_MIN + tileSize * (x + 1);
+    const ymin = EPSG_3857_MAX - tileSize * (y + 1);
+    const ymax = EPSG_3857_MAX - tileSize * y;
+    const res = tileSize / VectorTile.EXTENT;
+    const fx = 1 / res;
+    const fy = -fx;
+    const xoff = -xmin * fx;
+    const yoff = -ymax * fy;
 
-  static getTestFeatureId(z, x, y) {
-    if (z === 0) {
-      return 0;
-    }
-    const fz = Math.pow(4, z);
-    const fx = x * Math.pow(2, z);
-    return fz + fx + y;
-  }
-
-  static async getTestFeatures(tileEnvelope) {
-    // TODO: implement this
-    const { z, x, y } = tileEnvelope;
-    const id = DynamicTileDAO.getTestFeatureId(z, x, y);
-    const geom = {
-      type: 'Point',
-      coordinates: [2048, 2048],
+    return {
+      bmin,
+      bmax,
+      xmin,
+      ymin,
+      xmax,
+      ymax,
+      res,
+      fx,
+      fy,
+      xoff,
+      yoff,
     };
-    return [{
-      id,
-      geom,
-      z,
-      x,
-      y,
-    }];
+  }
+
+  static async getCountsFeatures(tileInfo) {
+    const sql = `
+WITH counts AS ((
+  SELECT ac.centreline_id, ac.centreline_type, ad."LOCATION",
+  ci."COUNT_INFO_ID", ci."ARTERYCODE", ac.geom
+  FROM "TRAFFIC"."COUNTINFO" ci
+  JOIN "TRAFFIC"."ARTERYDATA" ad ON ci."ARTERYCODE" = ad."ARTERYCODE"
+  JOIN prj_volume.artery_centreline ac ON ci."ARTERYCODE" = ac.arterycode
+  WHERE ST_Intersects(
+    ST_Transform(ac.geom, 3857),
+    ST_MakeEnvelope($(xmin), $(ymin), $(xmax), $(ymax), 3857)
+  )
+) UNION ALL (
+  SELECT ac.centreline_id, ac.centreline_type, ad."LOCATION",
+  cim."COUNT_INFO_ID", cim."ARTERYCODE", ac.geom
+  FROM "TRAFFIC"."COUNTINFOMICS" cim
+  JOIN "TRAFFIC"."ARTERYDATA" ad ON cim."ARTERYCODE" = ad."ARTERYCODE"
+  JOIN prj_volume.artery_centreline ac ON cim."ARTERYCODE" = ac.arterycode
+  WHERE ST_Intersects(
+    ST_Transform(ac.geom, 3857),
+    ST_MakeEnvelope($(xmin), $(ymin), $(xmax), $(ymax), 3857)
+  )
+))
+SELECT ST_AsGeoJSON(
+  ST_Intersection(
+    ST_SnapToGrid(
+      ST_Affine(
+        ST_Simplify(
+          ST_RemoveRepeatedPoints(ST_Transform(geom, 3857), $(res)),
+          $(res),
+          FALSE
+        ),
+        $(fx), 0,
+        0, $(fy),
+        $(xoff), $(yoff)
+      ),
+      0, 0, 1, 1
+    ),
+    ST_MakeEnvelope($(bmin), $(bmin), $(bmax), $(bmax), 3857)
+  )
+)::json AS geom,
+"COUNT_INFO_ID" as id,
+"ARTERYCODE",
+centreline_id,
+centreline_type,
+"LOCATION"
+FROM counts`;
+    return db.manyOrNone(sql, tileInfo);
   }
 
   static async getTileFeatures(layerName, z, x, y) {
-    const tileEnvelope = DynamicTileDAO.getTileEnvelope(z, x, y);
-    if (layerName === 'test') {
-      return DynamicTileDAO.getTestFeatures(tileEnvelope);
+    const tileInfo = DynamicTileDAO.getTileInfo(z, x, y);
+    if (layerName === 'counts') {
+      return DynamicTileDAO.getCountsFeatures(tileInfo);
     }
     // TODO: throw an error here
     return [];

--- a/lib/db/DynamicTileDAO.js
+++ b/lib/db/DynamicTileDAO.js
@@ -35,6 +35,48 @@ class DynamicTileDAO {
     };
   }
 
+  static async getCollisionsFeatures(tileInfo) {
+    const sql = `
+WITH collisions AS (
+  SELECT
+    e.collision_id, e.geom,
+    e.accnb, e.accdate, e.acctime,
+    ec.centreline_id, ec.centreline_type
+  FROM collisions.events e
+  JOIN collisions.events_centreline ec ON e.collision_id = ec.collision_id
+  WHERE ST_Intersects(
+    ST_Transform(e.geom, 3857),
+    ST_MakeEnvelope($(xmin), $(ymin), $(xmax), $(ymax), 3857)
+  ) AND e.accdate >= now() - interval '1 year'
+)
+SELECT ST_AsGeoJSON(
+  ST_Intersection(
+    ST_SnapToGrid(
+      ST_Affine(
+        ST_Simplify(
+          ST_RemoveRepeatedPoints(ST_Transform(geom, 3857), $(res)),
+          $(res),
+          FALSE
+        ),
+        $(fx), 0,
+        0, $(fy),
+        $(xoff), $(yoff)
+      ),
+      0, 0, 1, 1
+    ),
+    ST_MakeEnvelope($(bmin), $(bmin), $(bmax), $(bmax), 3857)
+  )
+)::json AS geom,
+collision_id AS id,
+accnb,
+accdate,
+acctime,
+centreline_id AS "centrelineId",
+centreline_type AS "centrelineType"
+FROM collisions`;
+    return db.manyOrNone(sql, tileInfo);
+  }
+
   static async getCountsFeatures(tileInfo) {
     const sql = `
 WITH counts AS ((
@@ -87,6 +129,9 @@ FROM counts`;
 
   static async getTileFeatures(layerName, z, x, y) {
     const tileInfo = DynamicTileDAO.getTileInfo(z, x, y);
+    if (layerName === 'collisions') {
+      return DynamicTileDAO.getCollisionsFeatures(tileInfo);
+    }
     if (layerName === 'counts') {
       return DynamicTileDAO.getCountsFeatures(tileInfo);
     }

--- a/lib/db/DynamicTileDAO.js
+++ b/lib/db/DynamicTileDAO.js
@@ -1,0 +1,45 @@
+// import db from '@/lib/db/db';
+
+class DynamicTileDAO {
+  static getTileEnvelope(z, x, y) {
+    // TODO: implement this
+    return { z, x, y };
+  }
+
+  static getTestFeatureId(z, x, y) {
+    if (z === 0) {
+      return 0;
+    }
+    const fz = Math.pow(4, z);
+    const fx = x * Math.pow(2, z);
+    return fz + fx + y;
+  }
+
+  static async getTestFeatures(tileEnvelope) {
+    // TODO: implement this
+    const { z, x, y } = tileEnvelope;
+    const id = DynamicTileDAO.getTestFeatureId(z, x, y);
+    const geom = {
+      type: 'Point',
+      coordinates: [2048, 2048],
+    };
+    return [{
+      id,
+      geom,
+      z,
+      x,
+      y,
+    }];
+  }
+
+  static async getTileFeatures(layerName, z, x, y) {
+    const tileEnvelope = DynamicTileDAO.getTileEnvelope(z, x, y);
+    if (layerName === 'test') {
+      return DynamicTileDAO.getTestFeatures(tileEnvelope);
+    }
+    // TODO: throw an error here
+    return [];
+  }
+}
+
+export default DynamicTileDAO;

--- a/lib/db/DynamicTileDAO.js
+++ b/lib/db/DynamicTileDAO.js
@@ -127,6 +127,40 @@ FROM counts`;
     return db.manyOrNone(sql, tileInfo);
   }
 
+  static getSchoolsFeatures(tileInfo) {
+    const sql = `
+WITH schools AS (
+  SELECT objectid, geom, name
+  FROM gis.school
+  WHERE ST_Intersects(
+    ST_Transform(geom, 3857),
+    ST_MakeEnvelope($(xmin), $(ymin), $(xmax), $(ymax), 3857)
+  )
+)
+SELECT ST_AsGeoJSON(
+  ST_Intersection(
+    ST_SnapToGrid(
+      ST_Affine(
+        ST_Simplify(
+          ST_RemoveRepeatedPoints(ST_Transform(geom, 3857), $(res)),
+          $(res),
+          FALSE
+        ),
+        $(fx), 0,
+        0, $(fy),
+        $(xoff), $(yoff)
+      ),
+      0, 0, 1, 1
+    ),
+    ST_MakeEnvelope($(bmin), $(bmin), $(bmax), $(bmax), 3857)
+  )
+)::json AS geom,
+objectid AS id,
+name
+FROM schools`;
+    return db.manyOrNone(sql, tileInfo);
+  }
+
   static async getTileFeatures(layerName, z, x, y) {
     const tileInfo = DynamicTileDAO.getTileInfo(z, x, y);
     if (layerName === 'collisions') {
@@ -134,6 +168,9 @@ FROM counts`;
     }
     if (layerName === 'counts') {
       return DynamicTileDAO.getCountsFeatures(tileInfo);
+    }
+    if (layerName === 'schools') {
+      return DynamicTileDAO.getSchoolsFeatures(tileInfo);
     }
     // TODO: throw an error here
     return [];

--- a/lib/error/MoveErrors.js
+++ b/lib/error/MoveErrors.js
@@ -42,6 +42,14 @@ class InvalidCentrelineTypeError extends Error {}
 class InvalidCssVariableError extends Error {}
 
 /**
+ * Thrown by {@link DynamicTileDAO.getTileFeatures} for invalid layer names.
+ *
+ * @memberof MoveErrors
+ * @see DynamicTileDAO.getTileFeatures
+ */
+class InvalidDynamicTileLayerError extends Error {}
+
+/**
  * Thrown by {@link ReportBase#generate} for invalid report formats.
  *
  * @memberof MoveErrors
@@ -82,6 +90,7 @@ const MoveErrors = {
   EnumValueError,
   InvalidCentrelineTypeError,
   InvalidCssVariableError,
+  InvalidDynamicTileLayerError,
   InvalidReportFormatError,
   InvalidReportIdError,
   InvalidReportTypeError,
@@ -94,6 +103,7 @@ export {
   EnumValueError,
   InvalidCentrelineTypeError,
   InvalidCssVariableError,
+  InvalidDynamicTileLayerError,
   InvalidReportFormatError,
   InvalidReportIdError,
   InvalidReportTypeError,

--- a/lib/geo/VectorTile.js
+++ b/lib/geo/VectorTile.js
@@ -1,0 +1,63 @@
+function positionToGeometry([x, y]) {
+  return { x, y };
+}
+
+function coordinatesToGeometry(type, coordinates) {
+  if (type === 1) {
+    return [[positionToGeometry(coordinates)]];
+  }
+  if (type === 2) {
+    return [coordinates.map(positionToGeometry)];
+  }
+  // TODO: throw error
+  return null;
+}
+
+class VectorTileFeature {
+  constructor({ id, geom, ...properties }) {
+    this.id = id;
+    this.properties = properties;
+    this.initGeometry(geom);
+  }
+
+  initGeometry(geom) {
+    const { type, coordinates } = geom;
+    // TODO: handle case where GeomType doesn't have property
+    this.type = VectorTileFeature.GeomType[type];
+    this.geometry = coordinatesToGeometry(this.type, coordinates);
+  }
+
+  loadGeometry() {
+    return this.geometry;
+  }
+}
+// TODO: handle polygons, multi-types
+VectorTileFeature.GeomType = {
+  Point: 1,
+  LineString: 2,
+};
+
+class VectorTileLayer {
+  constructor(layerName, features) {
+    this.version = VectorTileLayer.VERSION;
+    this.name = layerName;
+    this.extent = VectorTileLayer.EXTENT;
+    this.length = features.length;
+    this.features = features.map(feature => new VectorTileFeature(feature));
+  }
+
+  feature(i) {
+    return this.features[i];
+  }
+}
+VectorTileLayer.VERSION = 2;
+VectorTileLayer.EXTENT = 4096;
+
+class VectorTile {
+  constructor(layerName, features) {
+    this.layers = {};
+    this.layers[layerName] = new VectorTileLayer(layerName, features);
+  }
+}
+
+export default VectorTile;

--- a/lib/geo/VectorTile.js
+++ b/lib/geo/VectorTile.js
@@ -1,3 +1,7 @@
+const BUFFER = 256;
+const EXTENT = 4096;
+const VERSION = 2;
+
 function positionToGeometry([x, y]) {
   return { x, y };
 }
@@ -39,9 +43,9 @@ VectorTileFeature.GeomType = {
 
 class VectorTileLayer {
   constructor(layerName, features) {
-    this.version = VectorTileLayer.VERSION;
+    this.version = VERSION;
     this.name = layerName;
-    this.extent = VectorTileLayer.EXTENT;
+    this.extent = EXTENT;
     this.length = features.length;
     this.features = features.map(feature => new VectorTileFeature(feature));
   }
@@ -50,8 +54,6 @@ class VectorTileLayer {
     return this.features[i];
   }
 }
-VectorTileLayer.VERSION = 2;
-VectorTileLayer.EXTENT = 4096;
 
 class VectorTile {
   constructor(layerName, features) {
@@ -59,5 +61,8 @@ class VectorTile {
     this.layers[layerName] = new VectorTileLayer(layerName, features);
   }
 }
+VectorTile.BUFFER = BUFFER;
+VectorTile.EXTENT = EXTENT;
+VectorTile.VERSION = VERSION;
 
 export default VectorTile;

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "request-promise-native": "^1.0.8",
     "uuid": "^3.3.3",
     "v-calendar": "^0.9.7",
+    "vt-pbf": "^3.1.1",
     "vue": "^2.6.3",
     "vue-router": "^3.1.3",
     "vuelidate": "^0.7.4",

--- a/tests/jest/db/DAO.spec.js
+++ b/tests/jest/db/DAO.spec.js
@@ -225,7 +225,7 @@ test('CountDAO.byCentreline()', async () => {
     null,
     10,
   );
-  expect(counts).toHaveLength(2);
+  expect(counts).toHaveLength(16);
 
   // valid feature with less than maxPerCategory counts, date range
   // filters to empty
@@ -255,7 +255,7 @@ test('CountDAO.byCentreline()', async () => {
     { start, end },
     10,
   );
-  expect(counts).toHaveLength(3);
+  expect(counts).toHaveLength(10);
 });
 
 function expectNumPerCategory(actual, expected) {
@@ -295,7 +295,7 @@ test('CountDAO.byCentrelineNumPerCategory()', async () => {
     null,
     10,
   );
-  expectNumPerCategory(numPerCategory, [[2, 'ATR_SPEED_VOLUME']]);
+  expectNumPerCategory(numPerCategory, [[10, 'ATR_VOLUME'], [6, 'ATR_SPEED_VOLUME']]);
 
   // valid feature with some counts, date range filters to empty
   start = DateTime.fromObject({ year: 2018, month: 1, day: 1 });
@@ -313,7 +313,7 @@ test('CountDAO.byCentrelineNumPerCategory()', async () => {
     null,
     10,
   );
-  expectNumPerCategory(numPerCategory, [[14, 'RESCU']]);
+  expectNumPerCategory(numPerCategory, [[3633, 'RESCU']]);
 
   // centreline feature with lots of counts, date range filters to empty
   start = DateTime.fromObject({ year: 1980, month: 1, day: 1 });
@@ -333,7 +333,7 @@ test('CountDAO.byCentrelineNumPerCategory()', async () => {
     { start, end },
     10,
   );
-  expectNumPerCategory(numPerCategory, [[3, 'RESCU']]);
+  expectNumPerCategory(numPerCategory, [[187, 'RESCU']]);
 
   // centreline feature with more than one kind of count
   numPerCategory = await CountDAO.byCentrelineNumPerCategory(
@@ -341,7 +341,7 @@ test('CountDAO.byCentrelineNumPerCategory()', async () => {
     null,
     10,
   );
-  expectNumPerCategory(numPerCategory, [[1, 'ATR_VOLUME'], [1, 'ATR_SPEED_VOLUME']]);
+  expectNumPerCategory(numPerCategory, [[6, 'ATR_VOLUME'], [2, 'ATR_SPEED_VOLUME']]);
 });
 
 test('CountDAO.byIdAndCategory()', async () => {

--- a/tests/jest/db/DAO.spec.js
+++ b/tests/jest/db/DAO.spec.js
@@ -204,40 +204,6 @@ test('CentrelineDAO.byIdsAndTypes()', async () => {
   expectIdsAndTypesResults(results, query);
 });
 
-test('CountDAO.byBoundingBox()', async () => {
-  // bounding box outside of Toronto
-  let results = await CountDAO.byBoundingBox(0, 0, 1, 1);
-  expect(results).toHaveLength(0);
-
-  // empty bounding box
-  results = await CountDAO.byBoundingBox(
-    -79.347015, 43.651070,
-    -79.347015, 43.651070,
-  );
-  expect(results).toHaveLength(0);
-
-  // invalid bounding box (xmin > xmax, ymin > ymax)
-  results = await CountDAO.byBoundingBox(
-    -79.115243191, 43.855457183,
-    -79.639264937, 43.580995995,
-  );
-  expect(results).toHaveLength(0);
-
-  // bounding box containing one item
-  results = await CountDAO.byBoundingBox(
-    -79.39105486856735, 43.66697119145863,
-    -79.3797296679832, 43.67108387524755,
-  );
-  expect(results).toHaveLength(1);
-
-  // bounding box containing a bunch of items
-  results = await CountDAO.byBoundingBox(
-    -79.40506206200341, 43.663771812301974,
-    -79.37883903724058, 43.673294636735676,
-  );
-  expect(results.length).toBeGreaterThan(1);
-});
-
 test('CountDAO.byCentreline()', async () => {
   // invalid feature
   let counts = await CountDAO.byCentreline(-1, -1, null, 10);

--- a/web/components/PaneMap.vue
+++ b/web/components/PaneMap.vue
@@ -177,7 +177,7 @@ function injectSourcesAndLayers(rawStyle, dataCountsVisible) {
 
   STYLE.sources.test = {
     type: 'vector',
-    tiles: ['https://localhost:8080/api/dynamicTiles/test/{z}/{x}/{y}.pbf'],
+    tiles: ['https://localhost:8080/api/dynamicTiles/counts/{z}/{x}/{y}.pbf'],
   };
 
   STYLE.layers.push({
@@ -249,11 +249,14 @@ function injectSourcesAndLayers(rawStyle, dataCountsVisible) {
 
   STYLE.layers.push({
     id: 'test',
-    type: 'circle',
     source: 'test',
-    'source-layer': 'test',
+    'source-layer': 'counts',
+    type: 'circle',
+    minzoom: ZOOM_MIN_COUNTS,
+    maxzoom: ZOOM_MAX + 1,
     paint: {
       'circle-color': '#ff0000',
+      'circle-opacity': 0.3,
       'circle-radius': 10,
     },
   });

--- a/web/components/PaneMap.vue
+++ b/web/components/PaneMap.vue
@@ -154,6 +154,11 @@ function injectSourcesAndLayers(rawStyle) {
     tiles: [`${origin}/api/dynamicTiles/counts/{z}/{x}/{y}.pbf`],
   };
 
+  STYLE.sources.schools = {
+    type: 'vector',
+    tiles: [`${origin}/api/dynamicTiles/schools/{z}/{x}/{y}.pbf`],
+  };
+
   STYLE.layers.push({
     id: 'centreline',
     source: 'centreline',
@@ -207,6 +212,20 @@ function injectSourcesAndLayers(rawStyle) {
       'circle-color': '#ff0000',
       'circle-opacity': 0.4,
       'circle-radius': 5,
+    },
+  });
+
+  STYLE.layers.push({
+    id: 'schools',
+    source: 'schools',
+    'source-layer': 'schools',
+    type: 'circle',
+    minzoom: ZOOM_TORONTO,
+    maxzoom: ZOOM_MAX + 1,
+    paint: {
+      'circle-color': '#777777',
+      'circle-opacity': 0.8,
+      'circle-radius': 10,
     },
   });
 

--- a/web/components/PaneMap.vue
+++ b/web/components/PaneMap.vue
@@ -188,6 +188,20 @@ function injectSourcesAndLayers(rawStyle) {
   });
 
   STYLE.layers.push({
+    id: 'schools',
+    source: 'schools',
+    'source-layer': 'schools',
+    type: 'circle',
+    minzoom: ZOOM_TORONTO,
+    maxzoom: ZOOM_MAX + 1,
+    paint: {
+      'circle-color': '#77ff77',
+      'circle-opacity': 0.5,
+      'circle-radius': 10,
+    },
+  });
+
+  STYLE.layers.push({
     id: 'counts',
     source: 'counts',
     'source-layer': 'counts',
@@ -212,20 +226,6 @@ function injectSourcesAndLayers(rawStyle) {
       'circle-color': '#ff0000',
       'circle-opacity': 0.4,
       'circle-radius': 5,
-    },
-  });
-
-  STYLE.layers.push({
-    id: 'schools',
-    source: 'schools',
-    'source-layer': 'schools',
-    type: 'circle',
-    minzoom: ZOOM_TORONTO,
-    maxzoom: ZOOM_MAX + 1,
-    paint: {
-      'circle-color': '#777777',
-      'circle-opacity': 0.8,
-      'circle-radius': 10,
     },
   });
 

--- a/web/components/PaneMap.vue
+++ b/web/components/PaneMap.vue
@@ -111,6 +111,20 @@ const PAINT_SIZE_INTERSECTIONS = [
     8,
   ],
 ];
+const PAINT_COLOR_COUNTS = [
+  'case',
+  ['boolean', ['feature-state', 'selected'], false],
+  // selected
+  '#00a91c',
+  [
+    'case',
+    ['boolean', ['feature-state', 'hover'], false],
+    // hovered
+    '#e5a000',
+    // unhovered
+    '#00bde3',
+  ],
+];
 
 function injectSourcesAndLayers(rawStyle) {
   const STYLE = {};
@@ -128,9 +142,16 @@ function injectSourcesAndLayers(rawStyle) {
     tiles: ['https://move.intra.dev-toronto.ca/tiles/intersections/{z}/{x}/{y}.pbf'],
   };
 
+  const { origin } = window.location;
+
+  STYLE.sources.collisions = {
+    type: 'vector',
+    tiles: [`${origin}/api/dynamicTiles/collisions/{z}/{x}/{y}.pbf`],
+  };
+
   STYLE.sources.counts = {
     type: 'vector',
-    tiles: ['https://localhost:8080/api/dynamicTiles/counts/{z}/{x}/{y}.pbf'],
+    tiles: [`${origin}/api/dynamicTiles/counts/{z}/{x}/{y}.pbf`],
   };
 
   STYLE.layers.push({
@@ -169,9 +190,23 @@ function injectSourcesAndLayers(rawStyle) {
     minzoom: ZOOM_MIN_COUNTS,
     maxzoom: ZOOM_MAX + 1,
     paint: {
-      'circle-color': '#ff0000',
-      'circle-opacity': 0.3,
+      'circle-color': PAINT_COLOR_COUNTS,
       'circle-radius': 10,
+      'circle-opacity': PAINT_OPACITY,
+    },
+  });
+
+  STYLE.layers.push({
+    id: 'collisions',
+    source: 'collisions',
+    'source-layer': 'collisions',
+    type: 'circle',
+    minzoom: ZOOM_MIN_COUNTS,
+    maxzoom: ZOOM_MAX + 1,
+    paint: {
+      'circle-color': '#ff0000',
+      'circle-opacity': 0.4,
+      'circle-radius': 5,
     },
   });
 

--- a/web/components/PaneMap.vue
+++ b/web/components/PaneMap.vue
@@ -18,12 +18,10 @@
       </button>
       <PaneMapPopup
         v-if="hoveredFeature"
-        :feature="hoveredFeature"
-        @zoom-in="onCountsVisibleClustersClick" />
+        :feature="hoveredFeature" />
       <PaneMapPopup
         v-else-if="selectedFeature"
-        :feature="selectedFeature"
-        @zoom-in="onCountsVisibleClustersClick" />
+        :feature="selectedFeature" />
     </div>
   </div>
 </template>
@@ -34,7 +32,6 @@ import Vue from 'vue';
 import { mapMutations, mapState } from 'vuex';
 
 import TdsLoadingSpinner from '@/web/components/tds/TdsLoadingSpinner.vue';
-import { apiFetch } from '@/lib/BackendClient';
 import { CentrelineType } from '@/lib/Constants';
 import { debounce } from '@/lib/FunctionUtils';
 import { formatCountLocationDescription } from '@/lib/StringFormatters';
@@ -54,9 +51,23 @@ const ZOOM_TORONTO = 10;
 const ZOOM_MIN_INTERSECTIONS = 12;
 const ZOOM_MIN_COUNTS = 14;
 const ZOOM_LOCATION = 17;
-const ZOOM_MAX_COUNTS_CLUSTERED = 17;
 const ZOOM_MAX = 19;
 const ZOOM_MAX_BASEMAP = 23;
+
+const PAINT_OPACITY = [
+  'case',
+  ['boolean', ['feature-state', 'selected'], false],
+  // selected
+  0.6,
+  [
+    'case',
+    ['boolean', ['feature-state', 'hover'], false],
+    // hovered
+    0.6,
+    // normal
+    0.45,
+  ],
+];
 
 const PAINT_COLOR_CENTRELINE = [
   'case',
@@ -70,20 +81,6 @@ const PAINT_COLOR_CENTRELINE = [
     '#e5a000',
     // unhovered
     '#dcdee0',
-  ],
-];
-const PAINT_COLOR_COUNTS = [
-  'case',
-  ['boolean', ['feature-state', 'selected'], false],
-  // selected
-  '#00a91c',
-  [
-    'case',
-    ['boolean', ['feature-state', 'hover'], false],
-    // hovered
-    '#e5a000',
-    // normal
-    '#00bde3',
   ],
 ];
 const PAINT_SIZE_CENTRELINE = [
@@ -114,44 +111,8 @@ const PAINT_SIZE_INTERSECTIONS = [
     8,
   ],
 ];
-const PAINT_SIZE_COUNT_POINTS = [
-  'case',
-  ['boolean', ['feature-state', 'selected'], false],
-  // selected
-  12,
-  [
-    'case',
-    ['boolean', ['feature-state', 'hover'], false],
-    // hovered
-    12,
-    // normal
-    10,
-  ],
-];
-const PAINT_SIZE_COUNT_CLUSTERS = [
-  'case',
-  ['boolean', ['feature-state', 'hover'], false],
-  // hovered
-  22,
-  // normal
-  20,
-];
-const PAINT_OPACITY = [
-  'case',
-  ['boolean', ['feature-state', 'selected'], false],
-  // selected
-  0.6,
-  [
-    'case',
-    ['boolean', ['feature-state', 'hover'], false],
-    // hovered
-    0.6,
-    // normal
-    0.45,
-  ],
-];
 
-function injectSourcesAndLayers(rawStyle, dataCountsVisible) {
+function injectSourcesAndLayers(rawStyle) {
   const STYLE = {};
   Object.assign(STYLE, rawStyle);
 
@@ -167,15 +128,7 @@ function injectSourcesAndLayers(rawStyle, dataCountsVisible) {
     tiles: ['https://move.intra.dev-toronto.ca/tiles/intersections/{z}/{x}/{y}.pbf'],
   };
 
-  STYLE.sources['counts-visible'] = {
-    type: 'geojson',
-    data: dataCountsVisible,
-    cluster: true,
-    clusterMaxZoom: ZOOM_MAX_COUNTS_CLUSTERED,
-    clusterProperties: { sum: ['+', ['get', 'cnt']] },
-  };
-
-  STYLE.sources.test = {
+  STYLE.sources.counts = {
     type: 'vector',
     tiles: ['https://localhost:8080/api/dynamicTiles/counts/{z}/{x}/{y}.pbf'],
   };
@@ -209,47 +162,8 @@ function injectSourcesAndLayers(rawStyle, dataCountsVisible) {
   });
 
   STYLE.layers.push({
-    id: 'counts-visible-clusters',
-    type: 'circle',
-    source: 'counts-visible',
-    filter: ['has', 'point_count'],
-    paint: {
-      'circle-color': PAINT_COLOR_COUNTS,
-      'circle-opacity': PAINT_OPACITY,
-      'circle-radius': PAINT_SIZE_COUNT_CLUSTERS,
-    },
-  });
-
-  STYLE.layers.push({
-    id: 'counts-visible-cluster-counts',
-    type: 'symbol',
-    source: 'counts-visible',
-    filter: ['has', 'point_count'],
-    layout: {
-      'text-field': '{sum}',
-      'text-font': ['Ubuntu Regular'],
-      'text-size': 18,
-    },
-    paint: {
-      'text-color': '#1b1b1b',
-    },
-  });
-
-  STYLE.layers.push({
-    id: 'counts-visible-points',
-    type: 'circle',
-    source: 'counts-visible',
-    filter: ['!', ['has', 'point_count']],
-    paint: {
-      'circle-color': PAINT_COLOR_COUNTS,
-      'circle-opacity': PAINT_OPACITY,
-      'circle-radius': PAINT_SIZE_COUNT_POINTS,
-    },
-  });
-
-  STYLE.layers.push({
-    id: 'test',
-    source: 'test',
+    id: 'counts',
+    source: 'counts',
     'source-layer': 'counts',
     type: 'circle',
     minzoom: ZOOM_MIN_COUNTS,
@@ -320,7 +234,7 @@ export default {
         return true;
       }
       if (centrelineType === CentrelineType.INTERSECTION) {
-        if (layerId === 'counts-visible-points') {
+        if (layerId === 'counts') {
           return this.selectedFeature.properties.centrelineId !== centrelineId;
         }
         if (layerId === 'intersections') {
@@ -336,13 +250,9 @@ export default {
     this.map = null;
   },
   mounted() {
-    this.dataCountsVisible = {
-      type: 'FeatureCollection',
-      features: [],
-    };
     const bounds = BOUNDS_TORONTO;
     const mapStyle = new GeoStyle(style, metadata).get();
-    this.mapStyle = injectSourcesAndLayers(mapStyle, this.dataCountsVisible);
+    this.mapStyle = injectSourcesAndLayers(mapStyle);
     this.satelliteStyle = injectSourcesAndLayers({
       version: 8,
       sources: {
@@ -363,7 +273,7 @@ export default {
           maxzoom: ZOOM_MAX_BASEMAP,
         },
       ],
-    }, this.dataCountsVisible);
+    });
 
     // marker
     this.selectedMarker = new mapboxgl.Marker()
@@ -455,26 +365,6 @@ export default {
         });
       }
     },
-    fetchVisibleCounts(bounds) {
-      const xmin = bounds.getWest();
-      const ymin = bounds.getSouth();
-      const xmax = bounds.getEast();
-      const ymax = bounds.getNorth();
-      const data = {
-        xmin,
-        ymin,
-        xmax,
-        ymax,
-      };
-      const options = { data };
-      return apiFetch('/counts/byBoundingBox', options)
-        .then((dataCountsVisible) => {
-          this.dataCountsVisible = dataCountsVisible;
-          this.map.getSource('counts-visible')
-            .setData(this.dataCountsVisible);
-          return dataCountsVisible;
-        });
-    },
     getFeatureForLayerAndProperty(layer, key, value) {
       const features = this.map.queryRenderedFeatures({
         layers: [layer],
@@ -505,7 +395,7 @@ export default {
       }
       if (centrelineType === CentrelineType.INTERSECTION) {
         let feature = this.getFeatureForLayerAndProperty(
-          'counts-visible-points',
+          'counts',
           'centrelineId',
           centrelineId,
         );
@@ -529,8 +419,7 @@ export default {
      * priority order:
      *
      * - intersections
-     * - counts-visible-points
-     * - counts-visible-clusters
+     * - counts
      * - centreline
      *
      * TODO: within layers, rank by closest to `point`
@@ -542,8 +431,7 @@ export default {
     getFeatureForPoint(point) {
       const layers = [
         'centreline',
-        'counts-visible-clusters',
-        'counts-visible-points',
+        'counts',
         'intersections',
       ];
       let features = this.map.queryRenderedFeatures(point, { layers });
@@ -581,24 +469,13 @@ export default {
       };
       this.setLocation(elementInfo);
     },
-    onCountsVisibleClustersClick(feature) {
-      const clusterId = feature.properties.cluster_id;
-      this.map.getSource('counts-visible')
-        .getClusterExpansionZoom(clusterId, (err, zoom) => {
-          if (err) {
-            return;
-          }
-          const center = feature.geometry.coordinates;
-          this.map.easeTo({ center, zoom });
-        });
-    },
-    onCountsVisiblePointsClick(feature) {
+    onCountsClick(feature) {
       const [lng, lat] = feature.geometry.coordinates;
-      const { centrelineId, centrelineType, locationdesc } = feature.properties;
+      const { centrelineId, centrelineType, locationDesc } = feature.properties;
       const elementInfo = {
         centrelineId,
         centrelineType,
-        description: formatCountLocationDescription(locationdesc),
+        description: formatCountLocationDescription(locationDesc),
         /*
          * The backend doesn't provide these feature codes, so we have to fetch it from
          * the visible layer.
@@ -651,20 +528,16 @@ export default {
         return;
       }
       const layerId = feature.layer.id;
-      if (layerId !== 'counts-visible-clusters') {
-        if (this.selectedFeature !== null) {
-          this.map.setFeatureState(this.selectedFeature, { selected: false });
-        }
-        // select clicked feature
-        this.selectedFeature = feature;
-        this.map.setFeatureState(this.selectedFeature, { selected: true });
+      if (this.selectedFeature !== null) {
+        this.map.setFeatureState(this.selectedFeature, { selected: false });
       }
+      // select clicked feature
+      this.selectedFeature = feature;
+      this.map.setFeatureState(this.selectedFeature, { selected: true });
       if (layerId === 'centreline') {
         this.onCentrelineClick(feature);
-      } else if (layerId === 'counts-visible-clusters') {
-        this.onCountsVisibleClustersClick(feature);
-      } else if (layerId === 'counts-visible-points') {
-        this.onCountsVisiblePointsClick(feature);
+      } else if (layerId === 'counts') {
+        this.onCountsClick(feature);
       } else if (layerId === 'intersections') {
         this.onIntersectionsClick(feature);
       }
@@ -692,15 +565,6 @@ export default {
     },
     onMapMove: debounce(function onMapMove() {
       this.updateCoordinates();
-      const zoom = this.map.getZoom();
-      if (zoom >= ZOOM_MIN_COUNTS) {
-        const bounds = this.map.getBounds();
-        this.fetchVisibleCounts(bounds);
-      } else {
-        this.dataCountsVisible.features = [];
-        this.map.getSource('counts-visible')
-          .setData(this.dataCountsVisible);
-      }
     }, 250),
     toggleSatellite() {
       this.satellite = !this.satellite;

--- a/web/components/PaneMap.vue
+++ b/web/components/PaneMap.vue
@@ -175,6 +175,11 @@ function injectSourcesAndLayers(rawStyle, dataCountsVisible) {
     clusterProperties: { sum: ['+', ['get', 'cnt']] },
   };
 
+  STYLE.sources.test = {
+    type: 'vector',
+    tiles: ['https://localhost:8080/api/dynamicTiles/test/{z}/{x}/{y}.pbf'],
+  };
+
   STYLE.layers.push({
     id: 'centreline',
     source: 'centreline',
@@ -239,6 +244,17 @@ function injectSourcesAndLayers(rawStyle, dataCountsVisible) {
       'circle-color': PAINT_COLOR_COUNTS,
       'circle-opacity': PAINT_OPACITY,
       'circle-radius': PAINT_SIZE_COUNT_POINTS,
+    },
+  });
+
+  STYLE.layers.push({
+    id: 'test',
+    type: 'circle',
+    source: 'test',
+    'source-layer': 'test',
+    paint: {
+      'circle-color': '#ff0000',
+      'circle-radius': 10,
     },
   });
 

--- a/web/components/PaneMapPopup.vue
+++ b/web/components/PaneMapPopup.vue
@@ -6,12 +6,6 @@
       <span v-else class="text-muted"> name unknown</span>
     </div>
     <button
-      v-if="layerId === 'counts-visible-clusters'"
-      @click="onZoomIn">
-      Zoom In
-    </button>
-    <button
-      v-else
       class="font-size-l"
       @click="onViewData">
       View Data
@@ -71,11 +65,7 @@ export default {
       if (this.layerId === 'intersections') {
         return this.feature.properties.intersec5;
       }
-      if (this.layerId === 'counts-visible-clusters') {
-        const n = this.feature.properties.point_count_abbreviated;
-        return `${n} locations`;
-      }
-      return this.feature.properties.locationdesc;
+      return this.feature.properties.locationDesc;
     },
     descriptionFormatted() {
       if (this.description) {
@@ -140,9 +130,6 @@ export default {
         name: 'viewDataAtLocation',
         params: routerParameters,
       });
-    },
-    onZoomIn() {
-      this.$emit('zoom-in', this.feature);
     },
     refreshPopup() {
       this.popup

--- a/web/server.js
+++ b/web/server.js
@@ -9,6 +9,7 @@ import Blankie from 'blankie';
 import config from '@/lib/config/MoveConfig';
 import AuthController from '@/lib/controller/AuthController';
 import CountController from '@/lib/controller/CountController';
+import DynamicTileController from '@/lib/controller/DynamicTileController';
 import LocationController from '@/lib/controller/LocationController';
 import StudyController from '@/lib/controller/StudyController';
 import StudyRequestController from '@/lib/controller/StudyRequestController';
@@ -184,6 +185,7 @@ async function initServer() {
   server.log(LogTag.INIT, 'registering routes...');
   server.route(AuthController);
   server.route(CountController);
+  server.route(DynamicTileController);
   server.route(LocationController);
   server.route(StudyController);
   server.route(StudyRequestController);


### PR DESCRIPTION
This PR closes #265 by successfully implementing dynamic generation of vector tiles.

This implementation is then used to build vector tiles for counts, collisions, and schools, as a proof-of-concept of this process.

The core of the implementation consists of two key pieces.  First, a general format for SQL queries that fetches relevant features for a tile, then transforms feature geometry into tile coordinate space:

```sql
WITH features AS (
  SELECT
    geom,
    -- other columns
  WHERE ST_Intersects(
    ST_Transform(geom, 3857),
    ST_MakeEnvelope($(xmin), $(ymin), $(xmax), $(ymax), 3857)
  )
)
SELECT ST_AsGeoJSON(
  ST_Intersection(
    ST_SnapToGrid(
      ST_Affine(
        ST_Simplify(
          ST_RemoveRepeatedPoints(ST_Transform(geom, 3857), $(res)),
          $(res),
          FALSE
        ),
        $(fx), 0,
        0, $(fy),
        $(xoff), $(yoff)
      ),
      0, 0, 1, 1
    ),
    ST_MakeEnvelope($(bmin), $(bmin), $(bmax), $(bmax), 3857)
  )
)::json AS geom,
-- other columns
FROM features;
```

Second, `lib/geo/VectorTile` provides a way to convert feature geometries and attributes from PostgreSQL to a form compatible with `vt-pbf`, which then writes out the vector tile protobuf.

