### PR TITLE
DAG for collisions heatmap tile generation

### DIFF
--- a/scripts/airflow/dags/collisions_vector_tiles.py
+++ b/scripts/airflow/dags/collisions_vector_tiles.py
@@ -1,0 +1,20 @@
+"""
+collisions_vector_tiles
+
+Generate vector tiles from collisions data.  These are then
+served from `/tiles` on our web tier, where they are used by `PaneMap`
+in the web frontend to render collisions heatmaps at lower zoom levels.
+"""
+# pylint: disable=pointless-statement
+from datetime import datetime
+
+from airflow_utils import create_dag, create_bash_task
+
+START_DATE = datetime(2019, 12, 8)
+SCHEDULE_INTERVAL = '0 3 * * 6'
+DAG = create_dag(__file__, __doc__, START_DATE, SCHEDULE_INTERVAL)
+
+BUILD_COLLISIONS_TILES = create_bash_task(DAG, 'build_collisions_tiles')
+EXTRACT_COLLISIONS_TILES = create_bash_task(DAG, 'extract_collisions_tiles')
+
+BUILD_COLLISIONS_TILES >> EXTRACT_COLLISIONS_TILES

--- a/scripts/airflow/tasks/build_collisions_tiles.sh
+++ b/scripts/airflow/tasks/build_collisions_tiles.sh
@@ -7,4 +7,4 @@ TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
 mkdir -p /data/tiles
 env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -f "${TASKS_ROOT}/build_collisions_tiles/download_collisions.sql" > /data/tiles/collisions.json
 
-tippecanoe --force -o /data/tiles/collisions.mbtiles --accumulate-attribute=heatmap_weight:sum --cluster-densest-as-needed -r1 -Z10 -z15 collisions.json
+tippecanoe --force -o /data/tiles/collisions.mbtiles --accumulate-attribute=heatmap_weight:sum --cluster-densest-as-needed -r1 -Z10 -z15 /data/tiles/collisions.json

--- a/scripts/airflow/tasks/build_collisions_tiles.sh
+++ b/scripts/airflow/tasks/build_collisions_tiles.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+GIT_ROOT=/home/ec2-user/flashcrow
+TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
+
+mkdir -p /data/tiles
+env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -f "${TASKS_ROOT}/build_collisions_tiles/download_collisions.sql" > /data/tiles/collisions.json
+
+tippecanoe --force -o /data/tiles/collisions.mbtiles --accumulate-attribute=heatmap_weight:sum --cluster-densest-as-needed -r1 -Z10 -z15 collisions.json

--- a/scripts/airflow/tasks/build_collisions_tiles/download_collisions.sql
+++ b/scripts/airflow/tasks/build_collisions_tiles/download_collisions.sql
@@ -1,0 +1,36 @@
+COPY (
+WITH event_injury AS (
+  SELECT i.collision_id, MAX(CONCAT('0', i.injury)::int) AS injury
+  FROM collisions.events e
+  JOIN collisions.involved i ON e.collision_id = i.collision_id
+  WHERE e.accdate >= now() - interval '1 year'
+  GROUP BY i.collision_id
+),
+collisions AS (
+  SELECT
+    ei.collision_id, ei.injury, e.geom,
+    CASE
+      WHEN ei.injury = 4 THEN 10
+      WHEN ei.injury = 3 THEN 3
+      WHEN ei.injury = 2 THEN 0.3
+      ELSE 0.03
+    END AS heatmap_weight
+  FROM event_injury ei
+  JOIN collisions.events e ON ei.collision_id = e.collision_id
+  JOIN collisions.events_centreline ec ON ei.collision_id = ec.collision_id
+),
+geojson_features AS (
+  SELECT jsonb_build_object(
+    'type', 'Feature',
+    'id', collision_id,
+    'geometry', ST_AsGeoJSON(geom)::jsonb,
+    'properties', to_jsonb(collisions.*) - 'collision_id' - 'geom'
+  ) AS feature
+  FROM collisions
+)
+SELECT jsonb_build_object(
+  'type', 'FeatureCollection',
+  'features', jsonb_agg(feature)
+) AS feature_collection
+FROM geojson_features
+) TO STDOUT WITH (HEADER FALSE);

--- a/scripts/airflow/tasks/extract_collisions_tiles.sh
+++ b/scripts/airflow/tasks/extract_collisions_tiles.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euo pipefail
+
+rm -rf /data/tiles/collisions
+mb-util --image_format=pbf --silent /data/tiles/collisions.mbtiles /data/tiles/collisions


### PR DESCRIPTION
This PR makes progress on #269 by introducing the `collisions_vector_tiles` DAG in Airflow, which builds vector tiles covering the last year of collisions Toronto-wide for zoom levels 10-15.

These tiles contain a property `heatmap_weight` that is summed during `tippecanoe`'s clustering.