### PR TITLE
Layer tweaks for collisions, counts, and schools

### DIFF
--- a/bdit-flashcrow.code-workspace
+++ b/bdit-flashcrow.code-workspace
@@ -6,7 +6,7 @@
 			"jcbuisson.vue",
 			"ms-python.python",
 			"ms-vscode-remote.vscode-remote-extensionpack",
-			"shinnn.stylelint"
+			"thibaudcolas.stylelint"
 		]
 	},
 	"folders": [

--- a/lib/db/DynamicTileDAO.js
+++ b/lib/db/DynamicTileDAO.js
@@ -38,17 +38,24 @@ class DynamicTileDAO {
 
   static async getCollisionsFeatures(tileInfo) {
     const sql = `
-WITH collisions AS (
-  SELECT
-    e.collision_id, e.geom,
-    e.accnb, e.accdate, e.acctime,
-    ec.centreline_id, ec.centreline_type
+WITH event_injury AS (
+  SELECT i.collision_id, MAX(CONCAT('0', i.injury)::int) AS injury
   FROM collisions.events e
-  JOIN collisions.events_centreline ec ON e.collision_id = ec.collision_id
+  JOIN collisions.involved i ON e.collision_id = i.collision_id
   WHERE ST_Intersects(
     ST_Transform(e.geom, 3857),
     ST_MakeEnvelope($(xmin), $(ymin), $(xmax), $(ymax), 3857)
   ) AND e.accdate >= now() - interval '1 year'
+  GROUP BY i.collision_id
+),
+collisions AS (
+  SELECT
+    ei.collision_id, ei.injury,
+    e.geom, e.accnb, e.accdate, e.acctime,
+    ec.centreline_id, ec.centreline_type
+  FROM event_injury ei
+  JOIN collisions.events e ON ei.collision_id = e.collision_id
+  JOIN collisions.events_centreline ec ON ei.collision_id = ec.collision_id
 )
 SELECT ST_AsGeoJSON(
   ST_Intersection(
@@ -73,7 +80,8 @@ accnb,
 accdate,
 acctime,
 centreline_id AS "centrelineId",
-centreline_type AS "centrelineType"
+centreline_type AS "centrelineType",
+injury
 FROM collisions`;
     return db.manyOrNone(sql, tileInfo);
   }

--- a/lib/db/DynamicTileDAO.js
+++ b/lib/db/DynamicTileDAO.js
@@ -89,25 +89,25 @@ FROM collisions`;
   static async getCountsFeatures(tileInfo) {
     const sql = `
 WITH counts AS ((
-  SELECT ac.centreline_id, ac.centreline_type, ad."LOCATION",
-  ci."COUNT_INFO_ID", ci."ARTERYCODE", ac.geom
+  SELECT ac.centreline_id, ac.centreline_type, ac.geom,
+  COUNT(DISTINCT(ci."ARTERYCODE")) AS "numArteryCodes"
   FROM "TRAFFIC"."COUNTINFO" ci
-  JOIN "TRAFFIC"."ARTERYDATA" ad ON ci."ARTERYCODE" = ad."ARTERYCODE"
   JOIN prj_volume.artery_centreline ac ON ci."ARTERYCODE" = ac.arterycode
   WHERE ST_Intersects(
     ST_Transform(ac.geom, 3857),
     ST_MakeEnvelope($(xmin), $(ymin), $(xmax), $(ymax), 3857)
   )
+  GROUP BY ac.centreline_id, ac.centreline_type, ac.geom
 ) UNION ALL (
-  SELECT ac.centreline_id, ac.centreline_type, ad."LOCATION",
-  cim."COUNT_INFO_ID", cim."ARTERYCODE", ac.geom
+  SELECT ac.centreline_id, ac.centreline_type, ac.geom,
+  COUNT(DISTINCT(cim."ARTERYCODE")) AS "numArteryCodes"
   FROM "TRAFFIC"."COUNTINFOMICS" cim
-  JOIN "TRAFFIC"."ARTERYDATA" ad ON cim."ARTERYCODE" = ad."ARTERYCODE"
   JOIN prj_volume.artery_centreline ac ON cim."ARTERYCODE" = ac.arterycode
   WHERE ST_Intersects(
     ST_Transform(ac.geom, 3857),
     ST_MakeEnvelope($(xmin), $(ymin), $(xmax), $(ymax), 3857)
   )
+  GROUP BY ac.centreline_id, ac.centreline_type, ac.geom
 ))
 SELECT ST_AsGeoJSON(
   ST_Intersection(
@@ -127,11 +127,10 @@ SELECT ST_AsGeoJSON(
     ST_MakeEnvelope($(bmin), $(bmin), $(bmax), $(bmax), 3857)
   )
 )::json AS geom,
-"COUNT_INFO_ID" AS id,
-"ARTERYCODE" AS "arteryCode",
+centreline_type * 1000000000 + centreline_id AS id,
 centreline_id AS "centrelineId",
 centreline_type AS "centrelineType",
-"LOCATION" AS "locationDesc"
+"numArteryCodes"
 FROM counts`;
     return db.manyOrNone(sql, tileInfo);
   }

--- a/scripts/deployment/etl/nginx/default.d/glyphs.conf
+++ b/scripts/deployment/etl/nginx/default.d/glyphs.conf
@@ -1,0 +1,5 @@
+location /glyphs {
+    alias /data/glyphs;
+    autoindex on;
+    add_header Access-Control-Allow-Origin * always;
+}

--- a/scripts/deployment/web/nginx/default.d/glyphs.conf
+++ b/scripts/deployment/web/nginx/default.d/glyphs.conf
@@ -1,0 +1,5 @@
+location /glyphs {
+    alias /data/glyphs;
+    autoindex on;
+    add_header Access-Control-Allow-Origin * always;
+}

--- a/web/components/FcDisplayViewDataAtLocation.vue
+++ b/web/components/FcDisplayViewDataAtLocation.vue
@@ -215,7 +215,8 @@ export default {
       const location = result[1];
       if (this.location === null
           || location.centrelineId !== this.location.centrelineId
-          || location.centrelineType !== this.location.centrelineType) {
+          || location.centrelineType !== this.location.centrelineType
+          || location.description !== this.location.description) {
         this.setLocation(location);
       }
     },

--- a/web/components/PaneMap.vue
+++ b/web/components/PaneMap.vue
@@ -144,6 +144,11 @@ function injectSourcesAndLayers(rawStyle) {
     tiles: ['https://move.intra.dev-toronto.ca/tiles/intersections/{z}/{x}/{y}.pbf'],
   };
 
+  STYLE.sources['collisions-heatmap'] = {
+    type: 'vector',
+    tiles: ['https://move.intra.dev-toronto.ca/tiles/collisions/{z}/{x}/{y}.pbf'],
+  };
+
   const { origin } = window.location;
 
   STYLE.sources.collisions = {
@@ -205,7 +210,7 @@ function injectSourcesAndLayers(rawStyle) {
 
   STYLE.layers.push({
     id: 'collisions-heatmap',
-    source: 'collisions',
+    source: 'collisions-heatmap',
     'source-layer': 'collisions',
     type: 'heatmap',
     minzoom: ZOOM_TORONTO,
@@ -240,14 +245,7 @@ function injectSourcesAndLayers(rawStyle) {
         ZOOM_TORONTO, 5,
         ZOOM_MIN_COUNTS, 10,
       ],
-      'heatmap-weight': [
-        'step',
-        ['get', 'injury'],
-        0.2,
-        2, 0.5,
-        3, 5,
-        4, 10,
-      ],
+      'heatmap-weight': ['get', 'heatmap_weight'],
     },
   });
 

--- a/web/components/PaneMap.vue
+++ b/web/components/PaneMap.vue
@@ -130,7 +130,7 @@ function injectSourcesAndLayers(rawStyle) {
   const STYLE = {};
   Object.assign(STYLE, rawStyle);
 
-  STYLE.glyphs = 'https://basemaps.arcgis.com/arcgis/rest/services/World_Basemap_v2/VectorTileServer/resources/fonts/{fontstack}/{range}.pbf';
+  STYLE.glyphs = 'https://move.intra.dev-toronto.ca/glyphs/{fontstack}/{range}.pbf';
 
   STYLE.sources.centreline = {
     type: 'vector',
@@ -184,20 +184,6 @@ function injectSourcesAndLayers(rawStyle) {
       'circle-color': PAINT_COLOR_CENTRELINE,
       'circle-radius': PAINT_SIZE_INTERSECTIONS,
       'circle-opacity': PAINT_OPACITY,
-    },
-  });
-
-  STYLE.layers.push({
-    id: 'schools',
-    source: 'schools',
-    'source-layer': 'schools',
-    type: 'circle',
-    minzoom: ZOOM_MIN_COUNTS,
-    maxzoom: ZOOM_MAX + 1,
-    paint: {
-      'circle-color': '#70e17b',
-      'circle-opacity': 0.5,
-      'circle-radius': 5,
     },
   });
 
@@ -302,6 +288,28 @@ function injectSourcesAndLayers(rawStyle) {
         ZOOM_MIN_COUNTS + 1, 0.8,
       ],
       'circle-radius': 10,
+    },
+  });
+
+  STYLE.layers.push({
+    id: 'schools',
+    source: 'schools',
+    'source-layer': 'schools',
+    type: 'symbol',
+    minzoom: ZOOM_MIN_COUNTS,
+    maxzoom: ZOOM_MAX + 1,
+    layout: {
+      'text-field': '\uf549',
+      'text-font': ['literal', ['Font Awesome 5 Free']],
+      'text-size': [
+        'step',
+        ['zoom'],
+        16,
+        ZOOM_LOCATION, 20,
+      ],
+    },
+    paint: {
+      'text-color': '#00a91c',
     },
   });
 

--- a/web/components/PaneMap.vue
+++ b/web/components/PaneMap.vue
@@ -252,14 +252,22 @@ function injectSourcesAndLayers(rawStyle) {
         ZOOM_TORONTO, 3,
         ZOOM_MIN_COUNTS, 8,
       ],
-      'heatmap-weight': 1,
+      'heatmap-weight': [
+        'step',
+        ['get', 'injury'],
+        1,
+        2, 2,
+        3, 5,
+        4, 10,
+      ],
     },
   });
 
   STYLE.layers.push({
-    id: 'collisions',
+    id: 'collisions-non-ksi',
     source: 'collisions',
     'source-layer': 'collisions',
+    filter: ['<', ['get', 'injury'], 3],
     type: 'circle',
     minzoom: ZOOM_MIN_COUNTS,
     maxzoom: ZOOM_MAX + 1,
@@ -270,9 +278,30 @@ function injectSourcesAndLayers(rawStyle) {
         ['linear'],
         ['zoom'],
         ZOOM_MIN_COUNTS, 0.2,
-        ZOOM_MIN_COUNTS + 1, 0.8,
+        ZOOM_MIN_COUNTS + 1, 0.6,
       ],
       'circle-radius': 5,
+    },
+  });
+
+  STYLE.layers.push({
+    id: 'collisions-ksi',
+    source: 'collisions',
+    'source-layer': 'collisions',
+    filter: ['>=', ['get', 'injury'], 3],
+    type: 'circle',
+    minzoom: ZOOM_MIN_COUNTS,
+    maxzoom: ZOOM_MAX + 1,
+    paint: {
+      'circle-color': '#b51d09',
+      'circle-opacity': [
+        'interpolate',
+        ['linear'],
+        ['zoom'],
+        ZOOM_MIN_COUNTS, 0.2,
+        ZOOM_MIN_COUNTS + 1, 0.8,
+      ],
+      'circle-radius': 10,
     },
   });
 
@@ -285,11 +314,6 @@ export default {
     TdsLoadingSpinner,
     PaneMapPopup,
   },
-  props: {
-    cols: Number,
-
-  },
-
   provide() {
     const self = this;
     return {
@@ -298,7 +322,6 @@ export default {
       },
     };
   },
-
   data() {
     return {
       coordinates: null,

--- a/web/components/PaneMap.vue
+++ b/web/components/PaneMap.vue
@@ -192,12 +192,12 @@ function injectSourcesAndLayers(rawStyle) {
     source: 'schools',
     'source-layer': 'schools',
     type: 'circle',
-    minzoom: ZOOM_TORONTO,
+    minzoom: ZOOM_MIN_COUNTS,
     maxzoom: ZOOM_MAX + 1,
     paint: {
-      'circle-color': '#77ff77',
+      'circle-color': '#70e17b',
       'circle-opacity': 0.5,
-      'circle-radius': 10,
+      'circle-radius': 5,
     },
   });
 
@@ -216,6 +216,47 @@ function injectSourcesAndLayers(rawStyle) {
   });
 
   STYLE.layers.push({
+    id: 'collisions-heatmap',
+    source: 'collisions',
+    'source-layer': 'collisions',
+    type: 'heatmap',
+    minzoom: ZOOM_TORONTO,
+    maxzoom: ZOOM_MIN_COUNTS + 1,
+    paint: {
+      'heatmap-color': [
+        'interpolate',
+        ['linear'],
+        ['heatmap-density'],
+        0, 'rgba(244, 227, 219, 0)',
+        0.5, '#f39268',
+        1, '#d63e04',
+      ],
+      'heatmap-intensity': [
+        'interpolate',
+        ['linear'],
+        ['zoom'],
+        ZOOM_TORONTO, 1,
+        ZOOM_MIN_COUNTS, 3,
+      ],
+      'heatmap-opacity': [
+        'interpolate',
+        ['linear'],
+        ['zoom'],
+        ZOOM_MIN_COUNTS, 0.8,
+        ZOOM_MIN_COUNTS + 1, 0,
+      ],
+      'heatmap-radius': [
+        'interpolate',
+        ['linear'],
+        ['zoom'],
+        ZOOM_TORONTO, 3,
+        ZOOM_MIN_COUNTS, 8,
+      ],
+      'heatmap-weight': 1,
+    },
+  });
+
+  STYLE.layers.push({
     id: 'collisions',
     source: 'collisions',
     'source-layer': 'collisions',
@@ -223,8 +264,14 @@ function injectSourcesAndLayers(rawStyle) {
     minzoom: ZOOM_MIN_COUNTS,
     maxzoom: ZOOM_MAX + 1,
     paint: {
-      'circle-color': '#ff0000',
-      'circle-opacity': 0.4,
+      'circle-color': '#d63e04',
+      'circle-opacity': [
+        'interpolate',
+        ['linear'],
+        ['zoom'],
+        ZOOM_MIN_COUNTS, 0.2,
+        ZOOM_MIN_COUNTS + 1, 0.8,
+      ],
       'circle-radius': 5,
     },
   });

--- a/web/components/PaneMapPopup.vue
+++ b/web/components/PaneMapPopup.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="pane-map-popup">
     <TdsPanel
-      icon="map-marker-alt"
+      :icon="icon"
       :variant="variant">
       <div class="ml-l">
         <strong v-if="descriptionFormatted"> {{descriptionFormatted}}</strong>
@@ -93,6 +93,9 @@ export default {
        * change `CountDAO` to provide this when returning counts.
        */
       return null;
+    },
+    icon() {
+      return this.hover ? 'hand-pointer' : 'map-marker-alt';
     },
     layerId() {
       return this.feature.layer.id;

--- a/web/components/PaneMapPopup.vue
+++ b/web/components/PaneMapPopup.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="pane-map-popup">
-    <div class="mb-m pr-xl">
+  <div class="pane-map-popup text-center p-m">
+    <div>
       <i class="fa fa-map-marker-alt"></i>
       <strong v-if="descriptionFormatted"> {{descriptionFormatted}}</strong>
       <span v-else class="text-muted"> name unknown</span>
     </div>
     <button
-      class="font-size-l"
+      class="font-size-l mt-m"
       @click="onViewData">
       View Data
     </button>
@@ -14,8 +14,6 @@
 </template>
 
 <script>
-import mapboxgl from 'mapbox-gl/dist/mapbox-gl';
-import Vue from 'vue';
 import { mapMutations } from 'vuex';
 
 import { CentrelineType } from '@/lib/Constants';
@@ -26,11 +24,6 @@ export default {
   name: 'PaneMapPopup',
   props: {
     feature: Object,
-  },
-  inject: {
-    map: {
-      default: null,
-    },
   },
   computed: {
     centrelineId() {
@@ -97,23 +90,6 @@ export default {
       return this.feature.layer.id;
     },
   },
-  created() {
-    this.popup = new mapboxgl.Popup({
-      closeOnClick: false,
-      maxWidth: 'none',
-    });
-  },
-  mounted() {
-    Vue.nextTick(this.refreshPopup.bind(this));
-  },
-  updated() {
-    Vue.nextTick(this.refreshPopup.bind(this));
-  },
-  beforeDestroy() {
-    if (this.map) {
-      this.popup.remove();
-    }
-  },
   methods: {
     onViewData() {
       // update location
@@ -138,12 +114,6 @@ export default {
         params: routerParameters,
       });
     },
-    refreshPopup() {
-      this.popup
-        .setLngLat(this.coordinates)
-        .setDOMContent(this.$el)
-        .addTo(this.map);
-    },
     ...mapMutations(['setLocation']),
   },
 };
@@ -152,5 +122,13 @@ export default {
 <style lang="postcss">
 .pane-map-popup {
   background-color: white;
+  border: var(--border-default);
+  border-radius: var(--space-s);
+  box-shadow: var(--shadow-2);
+  left: 8px;
+  position: absolute;
+  top: 8px;
+  width: var(--space-4xl);
+  z-index: var(--z-index-controls);
 }
 </style>

--- a/web/components/PaneMapPopup.vue
+++ b/web/components/PaneMapPopup.vue
@@ -1,15 +1,18 @@
 <template>
-  <div class="pane-map-popup text-center p-m">
-    <div>
-      <i class="fa fa-map-marker-alt"></i>
-      <strong v-if="descriptionFormatted"> {{descriptionFormatted}}</strong>
-      <span v-else class="text-muted"> name unknown</span>
-    </div>
-    <button
-      class="font-size-l mt-m"
-      @click="onViewData">
-      View Data
-    </button>
+  <div class="pane-map-popup">
+    <TdsPanel
+      icon="map-marker-alt"
+      :variant="variant">
+      <div class="ml-l">
+        <strong v-if="descriptionFormatted"> {{descriptionFormatted}}</strong>
+        <span v-else class="text-muted"> name unknown</span>
+      </div>
+      <button
+        class="font-size-l mt-s"
+        @click="onViewData">
+        View Data
+      </button>
+    </TdsPanel>
   </div>
 </template>
 
@@ -19,11 +22,16 @@ import { mapMutations } from 'vuex';
 import { CentrelineType } from '@/lib/Constants';
 import { formatCountLocationDescription } from '@/lib/StringFormatters';
 import { getLineStringMidpoint } from '@/lib/geo/GeometryUtils';
+import TdsPanel from '@/web/components/tds/TdsPanel.vue';
 
 export default {
   name: 'PaneMapPopup',
+  components: {
+    TdsPanel,
+  },
   props: {
     feature: Object,
+    hover: Boolean,
   },
   computed: {
     centrelineId() {
@@ -58,9 +66,9 @@ export default {
       if (this.layerId === 'counts') {
         const { numArteryCodes } = this.feature.properties;
         if (numArteryCodes === 1) {
-          return '1 location';
+          return '1 count station';
         }
-        return `${numArteryCodes} locations`;
+        return `${numArteryCodes} count stations`;
       }
       if (this.layerId === 'intersections') {
         return this.feature.properties.intersec5;
@@ -88,6 +96,9 @@ export default {
     },
     layerId() {
       return this.feature.layer.id;
+    },
+    variant() {
+      return this.hover ? 'warning' : 'success';
     },
   },
   methods: {
@@ -121,13 +132,14 @@ export default {
 
 <style lang="postcss">
 .pane-map-popup {
-  background-color: white;
-  border: var(--border-default);
-  border-radius: var(--space-s);
-  box-shadow: var(--shadow-2);
-  left: 8px;
+  & > .tds-panel {
+    border-radius: var(--space-s);
+    box-shadow: var(--shadow-2);
+  }
+
+  left: var(--space-l);
   position: absolute;
-  top: 8px;
+  top: var(--space-m);
   width: var(--space-4xl);
   z-index: var(--z-index-controls);
 }

--- a/web/components/PaneMapPopup.vue
+++ b/web/components/PaneMapPopup.vue
@@ -62,6 +62,13 @@ export default {
       if (this.layerId === 'centreline') {
         return this.feature.properties.lf_name;
       }
+      if (this.layerId === 'counts') {
+        const { numArteryCodes } = this.feature.properties;
+        if (numArteryCodes === 1) {
+          return '1 location';
+        }
+        return `${numArteryCodes} locations`;
+      }
       if (this.layerId === 'intersections') {
         return this.feature.properties.intersec5;
       }

--- a/web/components/tds/TdsTopBar.vue
+++ b/web/components/tds/TdsTopBar.vue
@@ -15,7 +15,7 @@ export default {
 <style lang="postcss">
 .tds-top-bar {
   align-items: center;
-  padding: var(--space-m) var(--space-xl);
+  padding: var(--space-m) var(--space-l);
   & > * {
     margin-right: var(--space-m);
     &:last-child {

--- a/web/components/tds/tds.postcss
+++ b/web/components/tds/tds.postcss
@@ -967,6 +967,11 @@ button {
       margin-bottom: 0;
     }
   }
+  &.tds-panel-success {
+    background-color: var(--success-lighter);
+    border-color: var(--success-darker);
+    color: var(--success-darker);
+  }
   &.tds-panel-info {
     background-color: var(--info-lighter);
     border-color: var(--info-darker);


### PR DESCRIPTION
This PR closes #269 by making several small performance and visualization changes to the collisions, counts, and schools layers.

It adds a collisions heatmap visible at lower zoom levels (10-15), with heavy weighting on KSI collisions.  At higher zoom levels, this heatmap fades into individual points, with KSI collisions shown larger in a deeper red.

The school layer is now rendered using Font Awesome icons - this gives us a wide range of icons to play with in prototyping layers.  (We may eventually want to switch these out for nicer icons.)

Counts are rolled up by location to reduce the response size from `/api/dynamicTiles/counts`.

In addition, this PR tests out the proposed switch from at-marker popups to an info box at top-left.  The idea is that this will reduce clutter and make mouse gestures easier, and that it prepares us for future updates to the interface.