### PR TITLE
Expand and standardize use of pregenerated tiles in PaneMap

### DIFF
--- a/lib/controller/DynamicTileController.js
+++ b/lib/controller/DynamicTileController.js
@@ -26,9 +26,9 @@ DynamicTileController.push({
     validate: {
       params: {
         layerName: Joi.string().valid(
-          'collisions',
+          'collisionsLevel1',
           'counts',
-          'schools',
+          'schoolsLevel1',
         ).required(),
         z: Joi.number().integer().min(0).required(),
         x: Joi.number().integer().min(0).required(),

--- a/lib/db/DynamicTileDAO.js
+++ b/lib/db/DynamicTileDAO.js
@@ -172,13 +172,13 @@ FROM schools`;
 
   static async getTileFeatures(layerName, z, x, y) {
     const tileInfo = DynamicTileDAO.getTileInfo(z, x, y);
-    if (layerName === 'collisions') {
+    if (layerName === 'collisionsLevel1') {
       return DynamicTileDAO.getCollisionsFeatures(tileInfo);
     }
     if (layerName === 'counts') {
       return DynamicTileDAO.getCountsFeatures(tileInfo);
     }
-    if (layerName === 'schools') {
+    if (layerName === 'schoolsLevel1') {
       return DynamicTileDAO.getSchoolsFeatures(tileInfo);
     }
     throw new InvalidDynamicTileLayerError(layerName);

--- a/web/components/PaneMap.vue
+++ b/web/components/PaneMap.vue
@@ -92,15 +92,9 @@ MapZoom.MAX = MapZoom.LEVEL_1.maxzoomSource;
 function interactionAttr(base, hovered, selected) {
   return [
     'case',
-    ['boolean', ['feature-state', 'selected'], false],
-    selected,
-    [
-      'case',
-      ['boolean', ['feature-state', 'hover'], false],
-      hovered,
-      // normal
-      base,
-    ],
+    ['boolean', ['feature-state', 'selected'], false], selected,
+    ['boolean', ['feature-state', 'hover'], false], hovered,
+    base,
   ];
 }
 
@@ -160,7 +154,7 @@ function injectSourcesAndLayers(rawStyle) {
 
   addTippecanoeSource(STYLE, 'midblocks', MapZoom.LEVEL_3, MapZoom.LEVEL_1);
   addTippecanoeSource(STYLE, 'intersections', MapZoom.LEVEL_2, MapZoom.LEVEL_1);
-  addTippecanoeSource(STYLE, 'collisionsLevel3', MapZoom.LEVEL_3, MapZoom.LEVEL_3, 1);
+  addTippecanoeSource(STYLE, 'collisionsLevel3', MapZoom.LEVEL_3, MapZoom.LEVEL_3, 2);
   addTippecanoeSource(STYLE, 'collisionsLevel2', MapZoom.LEVEL_2, MapZoom.LEVEL_2);
   addDynamicTileSource(STYLE, 'collisionsLevel1', MapZoom.LEVEL_1, MapZoom.LEVEL_1);
   addTippecanoeSource(STYLE, 'schoolsLevel2', MapZoom.LEVEL_2, MapZoom.LEVEL_2);
@@ -223,6 +217,9 @@ function injectSourcesAndLayers(rawStyle) {
     },
   });
   addLayer(STYLE, 'collisionsLevel2', 'circle', {
+    layout: {
+      'circle-sort-key': ['get', 'injury'],
+    },
     paint: {
       'circle-color': [
         'case',
@@ -241,10 +238,12 @@ function injectSourcesAndLayers(rawStyle) {
         ['>=', ['get', 'injury'], 3], 10,
         5,
       ],
-      'circle-sort-key': ['get', 'injury'],
     },
   });
   addLayer(STYLE, 'collisionsLevel1', 'circle', {
+    layout: {
+      'circle-sort-key': ['get', 'injury'],
+    },
     paint: {
       'circle-color': [
         'case',
@@ -257,7 +256,6 @@ function injectSourcesAndLayers(rawStyle) {
         ['>=', ['get', 'injury'], 3], 10,
         5,
       ],
-      'circle-sort-key': ['get', 'injury'],
     },
   });
   addLayer(STYLE, 'schoolsLevel2', 'symbol', {
@@ -292,7 +290,6 @@ function injectSourcesAndLayers(rawStyle) {
       'text-color': '#00a91c',
     },
   });
-
   return STYLE;
 }
 

--- a/web/components/PaneMapPopup.vue
+++ b/web/components/PaneMapPopup.vue
@@ -29,9 +29,9 @@ import TimeFormatters from '@/lib/time/TimeFormatters';
 import TdsPanel from '@/web/components/tds/TdsPanel.vue';
 
 const SELECTABLE_LAYERS = [
-  'centreline',
   'counts',
   'intersections',
+  'midblocks',
 ];
 
 export default {
@@ -45,64 +45,45 @@ export default {
   },
   computed: {
     centrelineId() {
-      if (this.layerId === 'centreline') {
-        return this.feature.properties.geo_id;
-      }
       if (this.layerId === 'intersections') {
         return this.feature.properties.int_id;
       }
       if (this.layerId === 'counts') {
         return this.feature.properties.centrelineId;
       }
+      if (this.layerId === 'midblocks') {
+        return this.feature.properties.geo_id;
+      }
       return null;
     },
     centrelineType() {
-      if (this.layerId === 'centreline') {
-        return CentrelineType.SEGMENT;
-      }
       if (this.layerId === 'intersections') {
         return CentrelineType.INTERSECTION;
       }
       if (this.layerId === 'counts') {
         return this.feature.properties.centrelineType;
       }
+      if (this.layerId === 'midblocks') {
+        return CentrelineType.SEGMENT;
+      }
       return null;
     },
     coordinates() {
       const { coordinates } = this.feature.geometry;
-      if (this.layerId === 'centreline') {
+      if (this.layerId === 'midblocks') {
         return getLineStringMidpoint(coordinates);
       }
       return coordinates;
     },
     description() {
-      if (this.layerId === 'centreline') {
-        const description = this.feature.properties.lf_name;
-        if (!description) {
-          return description;
-        }
-        return formatCountLocationDescription(description);
-      }
-      if (this.layerId === 'counts') {
-        const { numArteryCodes } = this.feature.properties;
-        if (numArteryCodes === 1) {
-          return '1 count station';
-        }
-        return `${numArteryCodes} count stations`;
-      }
-      if (this.layerId === 'intersections') {
-        const description = this.feature.properties.intersec5;
-        if (!description) {
-          return description;
-        }
-        return formatCountLocationDescription(description);
-      }
-      if (this.layerId === 'schools') {
-        return this.feature.properties.name;
-      }
-      if (this.layerId === 'collisions-non-ksi' || this.layerId === 'collisions-ksi') {
+      if (this.layerId === 'collisionsLevel2' || this.layerId === 'collisionsLevel1') {
         const { accdate, acctime, injury } = this.feature.properties;
-        let dt = DateTime.fromJSON(accdate);
+        let dt;
+        if (this.layerId === 'collisionsLevel2') {
+          dt = DateTime.fromISO(accdate);
+        } else {
+          dt = DateTime.fromJSON(accdate);
+        }
 
         const hhmm = parseInt(acctime, 10);
         const hour = Math.floor(hhmm / 100);
@@ -118,6 +99,30 @@ export default {
         }
         return dtStr;
       }
+      if (this.layerId === 'counts') {
+        const { numArteryCodes } = this.feature.properties;
+        if (numArteryCodes === 1) {
+          return '1 count station';
+        }
+        return `${numArteryCodes} count stations`;
+      }
+      if (this.layerId === 'intersections') {
+        const description = this.feature.properties.intersec5;
+        if (!description) {
+          return description;
+        }
+        return formatCountLocationDescription(description);
+      }
+      if (this.layerId === 'midblocks') {
+        const description = this.feature.properties.lf_name;
+        if (!description) {
+          return description;
+        }
+        return formatCountLocationDescription(description);
+      }
+      if (this.layerId === 'schoolsLevel2' || this.layerId === 'schoolsLevel1') {
+        return this.feature.properties.name;
+      }
       return null;
     },
     descriptionFormatted() {
@@ -127,11 +132,11 @@ export default {
       return null;
     },
     featureCode() {
-      if (this.layerId === 'centreline') {
-        return this.feature.properties.fcode;
-      }
       if (this.layerId === 'intersections') {
         return this.feature.properties.elevatio9;
+      }
+      if (this.layerId === 'midblocks') {
+        return this.feature.properties.fcode;
       }
       /*
        * In this case, we don't have a reliable feature code we can use.  Eventually, we should
@@ -143,15 +148,18 @@ export default {
       return SELECTABLE_LAYERS.includes(this.layerId);
     },
     icon() {
-      if (this.layerId === 'schools') {
+      if (this.layerId === 'collisionsLevel2' || this.layerId === 'collisionsLevel1') {
+        return 'car-crash';
+      }
+      if (this.layerId === 'counts') {
+        return this.hover ? 'list-ol' : 'map-marker-alt';
+      }
+      if (this.layerId === 'schoolsLevel2' || this.layerId === 'schoolsLevel1') {
         const { schoolType } = this.feature.properties;
         if (schoolType === 'U' || schoolType === 'C') {
           return 'graduation-cap';
         }
         return 'school';
-      }
-      if (this.layerId === 'collisions-ksi' || this.layerId === 'collisions-non-ksi') {
-        return 'car-crash';
       }
       return this.hover ? 'road' : 'map-marker-alt';
     },


### PR DESCRIPTION
This PR makes further progress on #276 as the counterpart to the ETL work in #279 .

By standardizing sources and layers, we're able to drastically reduce the amount of Mapbox GL style boilerplate in `PaneMap`.  This also allows us to simplify the zoom level naming down to zoom level ranges for our three semantic levels.