### PR TITLE
Add index on accdate in collisions.events

### DIFF
--- a/scripts/airflow/tasks/crash_norm/crash_norm.sql
+++ b/scripts/airflow/tasks/crash_norm/crash_norm.sql
@@ -56,6 +56,7 @@ CREATE TABLE collisions_new.events AS (
     GROUP BY "ACCDATE", "ACCNB"
 );
 CREATE UNIQUE INDEX events_collision_id ON collisions_new.events (collision_id);
+CREATE INDEX events_accdate ON collisions.events (accdate);
 CREATE INDEX events_geom ON collisions_new.events USING GIST (geom);
 CREATE INDEX events_srid3857_geom ON collisions_new.events USING GIST (ST_Transform(geom, 3857));
 


### PR DESCRIPTION
This PR makes further progress on #276 .

Based on profiling and Apache Bench load testing, this single index significantly lowers p95 response time on dynamic tile requests for collisions.