### PR TITLE
Simplify point geometry queries in DynamicTileDAO

### DIFF
--- a/lib/db/DynamicTileDAO.js
+++ b/lib/db/DynamicTileDAO.js
@@ -58,21 +58,14 @@ collisions AS (
   JOIN collisions.events_centreline ec ON ei.collision_id = ec.collision_id
 )
 SELECT ST_AsGeoJSON(
-  ST_Intersection(
-    ST_SnapToGrid(
-      ST_Affine(
-        ST_Simplify(
-          ST_RemoveRepeatedPoints(ST_Transform(geom, 3857), $(res)),
-          $(res),
-          FALSE
-        ),
-        $(fx), 0,
-        0, $(fy),
-        $(xoff), $(yoff)
-      ),
-      0, 0, 1, 1
+  ST_SnapToGrid(
+    ST_Affine(
+      ST_Transform(geom, 3857),
+      $(fx), 0,
+      0, $(fy),
+      $(xoff), $(yoff)
     ),
-    ST_MakeEnvelope($(bmin), $(bmin), $(bmax), $(bmax), 3857)
+    0, 0, 1, 1
   )
 )::json AS geom,
 collision_id AS id,
@@ -110,21 +103,14 @@ WITH counts AS ((
   GROUP BY ac.centreline_id, ac.centreline_type, ac.geom
 ))
 SELECT ST_AsGeoJSON(
-  ST_Intersection(
-    ST_SnapToGrid(
-      ST_Affine(
-        ST_Simplify(
-          ST_RemoveRepeatedPoints(ST_Transform(geom, 3857), $(res)),
-          $(res),
-          FALSE
-        ),
-        $(fx), 0,
-        0, $(fy),
-        $(xoff), $(yoff)
-      ),
-      0, 0, 1, 1
+  ST_SnapToGrid(
+    ST_Affine(
+      ST_Transform(geom, 3857),
+      $(fx), 0,
+      0, $(fy),
+      $(xoff), $(yoff)
     ),
-    ST_MakeEnvelope($(bmin), $(bmin), $(bmax), $(bmax), 3857)
+    0, 0, 1, 1
   )
 )::json AS geom,
 centreline_type * 1000000000 + centreline_id AS id,
@@ -146,21 +132,14 @@ WITH schools AS (
   )
 )
 SELECT ST_AsGeoJSON(
-  ST_Intersection(
-    ST_SnapToGrid(
-      ST_Affine(
-        ST_Simplify(
-          ST_RemoveRepeatedPoints(ST_Transform(geom, 3857), $(res)),
-          $(res),
-          FALSE
-        ),
-        $(fx), 0,
-        0, $(fy),
-        $(xoff), $(yoff)
-      ),
-      0, 0, 1, 1
+  ST_SnapToGrid(
+    ST_Affine(
+      ST_Transform(geom, 3857),
+      $(fx), 0,
+      0, $(fy),
+      $(xoff), $(yoff)
     ),
-    ST_MakeEnvelope($(bmin), $(bmin), $(bmax), $(bmax), 3857)
+    0, 0, 1, 1
   )
 )::json AS geom,
 objectid AS id,


### PR DESCRIPTION
This PR closes #276 by improving the performance of dynamic tile generation database queries.

Several of the tile generation steps are unnecessary for point geometries, so to speed these queries up (and make them more readable) I've removed them.  In combination with #281 , this noticeably improves performance of dynamic tile generation.