### PR TITLE
CRUD methods and API endpoints for comments

### DIFF
--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -2,18 +2,22 @@ import Boom from '@hapi/boom';
 import Joi from '@hapi/joi';
 
 import StudyRequestDAO from '@/lib/db/StudyRequestDAO';
+import StudyRequestCommentDAO from '@/lib/db/StudyRequestCommentDAO';
 import EmailStudyRequestConfirmation from '@/lib/email/EmailStudyRequestConfirmation';
 import Mailer from '@/lib/email/Mailer';
 import LogTag from '@/lib/log/LogTag';
 import StudyRequest from '@/lib/model/StudyRequest';
+import StudyRequestComment from '@/lib/model/StudyRequestComment';
 import SuccessResponse from '@/lib/model/SuccessResponse';
 
 /**
- * CRUD handling for study requests.
+ * CRUD handling for study requests and related comments.
  *
  * @type {Array<Hapi.ServerRoute>}
  */
 const StudyRequestController = [];
+
+// STUDY REQUESTS
 
 /**
  * Create a new study request.  This endpoint also sends an email to the requester
@@ -34,7 +38,7 @@ StudyRequestController.push({
       schema: StudyRequest.read,
     },
     validate: {
-      payload: StudyRequest.transient,
+      payload: StudyRequest.create,
     },
   },
   handler: async (request) => {
@@ -227,6 +231,216 @@ StudyRequestController.push({
     const success = await StudyRequestDAO.delete(studyRequest);
     if (!success) {
       return Boom.notFound(`could not delete study request with ID ${id}`);
+    }
+    return { success };
+  },
+});
+
+// STUDY REQUEST COMMENTS
+
+/**
+ * Create a new comment on the given study request.
+ *
+ * The request body should contain the comment in JSON format, e.g.
+ * `{ "comment": "best comment ever~~1" }`.
+ *
+ * @memberof StudyRequestController
+ * @name postStudyRequestComment
+ * @type {Hapi.ServerRoute}
+ */
+StudyRequestController.push({
+  method: 'POST',
+  path: '/requests/study/{studyRequestId}/comments',
+  options: {
+    response: {
+      schema: StudyRequestComment.read,
+    },
+    validate: {
+      params: {
+        studyRequestId: Joi.number().integer().positive().required(),
+      },
+      payload: StudyRequestComment.create,
+      query: {
+        // TODO: remove when we have RBAC
+        isSupervisor: Joi.boolean().default(false),
+      },
+    },
+  },
+  handler: async (request) => {
+    const { subject } = request.auth.credentials;
+    const { studyRequestId } = request.params;
+    const { isSupervisor } = request.query;
+    const studyRequest = await StudyRequestDAO.byId(studyRequestId);
+    if (studyRequest === null) {
+      return Boom.notFound(`no study request found with ID ${studyRequestId}`);
+    }
+    if (studyRequest.userSubject !== subject && !isSupervisor) {
+      return Boom.forbidden('cannot comment on study request owned by another user');
+    }
+    const studyRequestComment = await StudyRequestCommentDAO.create(studyRequest, {
+      userSubject: subject,
+      ...request.payload,
+    });
+    return studyRequestComment;
+  },
+});
+
+/**
+ * Get comments for the given study request.
+ *
+ * @memberof StudyRequestController
+ * @name getStudyRequestComments
+ * @type {Hapi.ServerRoute}
+ */
+StudyRequestController.push({
+  method: 'GET',
+  path: '/requests/study/{studyRequestId}/comments',
+  options: {
+    response: {
+      schema: Joi.array.items(StudyRequestComment.read),
+    },
+    validate: {
+      params: {
+        studyRequestId: Joi.number().integer().positive().required(),
+      },
+      payload: {
+        ...StudyRequestComment.create,
+        // TODO: remove when we have RBAC
+        isSupervisor: Joi.boolean().default(false),
+      },
+    },
+  },
+  handler: async (request) => {
+    const { subject } = request.auth.credentials;
+    const { studyRequestId } = request.params;
+    const { isSupervisor } = request.query;
+    const studyRequest = await StudyRequestDAO.byId(studyRequestId);
+    if (studyRequest === null) {
+      return Boom.notFound(`no study request found with ID ${studyRequestId}`);
+    }
+    if (studyRequest.userSubject !== subject && !isSupervisor) {
+      return Boom.forbidden('cannot view comments for study request owned by another user');
+    }
+    return StudyRequestCommentDAO.byStudyRequest(studyRequest);
+  },
+});
+
+/**
+ * Update the given comment on the given study request.
+ *
+ * The request body should contain the comment.
+ *
+ * The ID of the request URI should match the ID of the comment in the body.
+ *
+ * @memberof StudyRequestController
+ * @name putStudyRequestComment
+ * @type {Hapi.ServerRoute}
+ */
+StudyRequestController.push({
+  method: 'PUT',
+  path: '/requests/study/{studyRequestId}/comments/{commentId}',
+  options: {
+    response: {
+      schema: StudyRequest.read,
+    },
+    validate: {
+      params: {
+        commentId: Joi.number().integer().positive().required(),
+        studyRequestId: Joi.number().integer().positive().required(),
+      },
+      payload: {
+        ...StudyRequest.update,
+        // TODO: remove when we have RBAC
+        isSupervisor: Joi.boolean().default(false),
+      },
+    },
+  },
+  handler: async (request) => {
+    const user = request.auth.credentials;
+    const { commentId, studyRequestId } = request.params;
+    const { isSupervisor, ...commentNew } = request.payload;
+
+    const studyRequest = await StudyRequestDAO.byId(studyRequestId);
+    if (studyRequest === null) {
+      return Boom.notFound(`no study request found with ID ${studyRequestId}`);
+    }
+    const commentOld = await StudyRequestCommentDAO.byId(commentId);
+    if (commentOld.studyRequestId !== studyRequest.id) {
+      return Boom.badRequest(
+        `no comment with ID ${commentId} for study request ${studyRequestId}`,
+      );
+    }
+
+    if (commentOld.id !== commentNew.id) {
+      return Boom.badRequest('cannot change ID for study request');
+    }
+    if (!commentOld.createdAt.equals(commentNew.createdAt)) {
+      return Boom.badRequest('cannot change creation timestamp for study request');
+    }
+    if (commentOld.userSubject !== commentNew.userSubject) {
+      return Boom.badRequest('cannot change owner for study request');
+    }
+    if (commentOld.studyRequestId !== commentNew.studyRequestId) {
+      return Boom.badRequest('cannot change owner for study request');
+    }
+
+    if (commentOld.userSubject !== user.subject && !isSupervisor) {
+      return Boom.forbidden(
+        'not authorized to change comment for study request owned by another user',
+      );
+    }
+
+    return StudyRequestCommentDAO.update(commentNew);
+  },
+});
+
+/**
+ * Delete the given comment on the given study request.
+ *
+ * @memberof StudyRequestController
+ * @name deleteStudyRequestComment
+ * @type {Hapi.ServerRoute}
+ */
+StudyRequestController.push({
+  method: 'DELETE',
+  path: '/requests/study/{studyRequestId}/comments/{commentId}',
+  options: {
+    response: {
+      schema: SuccessResponse,
+    },
+    validate: {
+      params: {
+        commentId: Joi.number().integer().positive().required(),
+        studyRequestId: Joi.number().integer().positive().required(),
+      },
+      query: {
+        // TODO: remove when we have RBAC
+        isSupervisor: Joi.boolean().default(false),
+      },
+    },
+  },
+  handler: async (request) => {
+    const user = request.auth.credentials;
+    const { commentId, studyRequestId } = request.params;
+    const { isSupervisor } = request.query;
+
+    const studyRequest = await StudyRequestDAO.byId(studyRequestId);
+    if (studyRequest === null) {
+      return Boom.notFound(`no study request found with ID ${studyRequestId}`);
+    }
+    const comment = await StudyRequestCommentDAO.byId(commentId);
+    if (comment.studyRequestId !== studyRequest.id) {
+      return Boom.badRequest(
+        `no comment with ID ${commentId} for study request ${studyRequestId}`,
+      );
+    }
+
+    if (comment.userSubject !== user.subject && !isSupervisor) {
+      return Boom.forbidden('cannot delete comment owned by another user');
+    }
+    const success = await StudyRequestCommentDAO.delete(comment);
+    if (!success) {
+      return Boom.notFound(`could not delete comment with ID ${commentId}`);
     }
     return { success };
   },

--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -43,6 +43,7 @@ StudyRequestController.push({
     const studyRequest = await StudyRequestDAO.create({
       userSubject: subject,
       status: 'REQUESTED',
+      closed: false,
       ...request.payload,
     });
     const email = new EmailStudyRequestConfirmation(user, studyRequest);

--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -76,22 +76,13 @@ StudyRequestController.push({
       params: {
         id: Joi.number().integer().positive().required(),
       },
-      query: {
-        // TODO: remove when we have RBAC
-        isSupervisor: Joi.boolean().default(false),
-      },
     },
   },
   handler: async (request) => {
-    const user = request.auth.credentials;
     const { id } = request.params;
-    const { isSupervisor } = request.query;
     const studyRequest = await StudyRequestDAO.byId(id);
     if (studyRequest === null) {
       return Boom.notFound(`no study request found with ID ${id}`);
-    }
-    if (studyRequest.userSubject !== user.subject && !isSupervisor) {
-      return Boom.forbidden('cannot view study request owned by another user');
     }
     return studyRequest;
   },
@@ -218,15 +209,14 @@ StudyRequestController.push({
     },
   },
   handler: async (request) => {
-    const user = request.auth.credentials;
     const { id } = request.params;
     const { isSupervisor } = request.query;
     const studyRequest = await StudyRequestDAO.byId(id);
     if (studyRequest === null) {
       return Boom.notFound(`no study request found with ID ${id}`);
     }
-    if (studyRequest.userSubject !== user.subject && !isSupervisor) {
-      return Boom.forbidden('cannot delete study request owned by another user');
+    if (!isSupervisor) {
+      return Boom.forbidden('cannot delete study request as non-supervisor');
     }
     const success = await StudyRequestDAO.delete(studyRequest);
     if (!success) {
@@ -260,28 +250,19 @@ StudyRequestController.push({
         studyRequestId: Joi.number().integer().positive().required(),
       },
       payload: StudyRequestComment.create,
-      query: {
-        // TODO: remove when we have RBAC
-        isSupervisor: Joi.boolean().default(false),
-      },
     },
   },
   handler: async (request) => {
     const { subject } = request.auth.credentials;
     const { studyRequestId } = request.params;
-    const { isSupervisor } = request.query;
     const studyRequest = await StudyRequestDAO.byId(studyRequestId);
     if (studyRequest === null) {
       return Boom.notFound(`no study request found with ID ${studyRequestId}`);
     }
-    if (studyRequest.userSubject !== subject && !isSupervisor) {
-      return Boom.forbidden('cannot comment on study request owned by another user');
-    }
-    const studyRequestComment = await StudyRequestCommentDAO.create(studyRequest, {
+    return StudyRequestCommentDAO.create(studyRequest, {
       userSubject: subject,
       ...request.payload,
     });
-    return studyRequestComment;
   },
 });
 
@@ -303,23 +284,13 @@ StudyRequestController.push({
       params: {
         studyRequestId: Joi.number().integer().positive().required(),
       },
-      payload: {
-        ...StudyRequestComment.create,
-        // TODO: remove when we have RBAC
-        isSupervisor: Joi.boolean().default(false),
-      },
     },
   },
   handler: async (request) => {
-    const { subject } = request.auth.credentials;
     const { studyRequestId } = request.params;
-    const { isSupervisor } = request.query;
     const studyRequest = await StudyRequestDAO.byId(studyRequestId);
     if (studyRequest === null) {
       return Boom.notFound(`no study request found with ID ${studyRequestId}`);
-    }
-    if (studyRequest.userSubject !== subject && !isSupervisor) {
-      return Boom.forbidden('cannot view comments for study request owned by another user');
     }
     return StudyRequestCommentDAO.byStudyRequest(studyRequest);
   },
@@ -341,24 +312,20 @@ StudyRequestController.push({
   path: '/requests/study/{studyRequestId}/comments/{commentId}',
   options: {
     response: {
-      schema: StudyRequest.read,
+      schema: StudyRequestComment.read,
     },
     validate: {
       params: {
         commentId: Joi.number().integer().positive().required(),
         studyRequestId: Joi.number().integer().positive().required(),
       },
-      payload: {
-        ...StudyRequest.update,
-        // TODO: remove when we have RBAC
-        isSupervisor: Joi.boolean().default(false),
-      },
+      payload: StudyRequestComment.update,
     },
   },
   handler: async (request) => {
     const user = request.auth.credentials;
     const { commentId, studyRequestId } = request.params;
-    const { isSupervisor, ...commentNew } = request.payload;
+    const commentNew = request.payload;
 
     const studyRequest = await StudyRequestDAO.byId(studyRequestId);
     if (studyRequest === null) {
@@ -384,10 +351,8 @@ StudyRequestController.push({
       return Boom.badRequest('cannot change owner for study request');
     }
 
-    if (commentOld.userSubject !== user.subject && !isSupervisor) {
-      return Boom.forbidden(
-        'not authorized to change comment for study request owned by another user',
-      );
+    if (commentOld.userSubject !== user.subject) {
+      return Boom.forbidden('cannot update comment owned by another user');
     }
 
     return StudyRequestCommentDAO.update(commentNew);
@@ -413,16 +378,11 @@ StudyRequestController.push({
         commentId: Joi.number().integer().positive().required(),
         studyRequestId: Joi.number().integer().positive().required(),
       },
-      query: {
-        // TODO: remove when we have RBAC
-        isSupervisor: Joi.boolean().default(false),
-      },
     },
   },
   handler: async (request) => {
     const user = request.auth.credentials;
     const { commentId, studyRequestId } = request.params;
-    const { isSupervisor } = request.query;
 
     const studyRequest = await StudyRequestDAO.byId(studyRequestId);
     if (studyRequest === null) {
@@ -435,7 +395,7 @@ StudyRequestController.push({
       );
     }
 
-    if (comment.userSubject !== user.subject && !isSupervisor) {
+    if (comment.userSubject !== user.subject) {
       return Boom.forbidden('cannot delete comment owned by another user');
     }
     const success = await StudyRequestCommentDAO.delete(comment);

--- a/lib/db/StudyDAO.js
+++ b/lib/db/StudyDAO.js
@@ -91,7 +91,7 @@ INSERT INTO "studies" (
    * Updates the given study.
    *
    * @param {Object} study - desired study state
-   * @returns {boolean} whether any rows were updated
+   * @returns {Object} updated study state
    */
   static async update(study) {
     const sql = `

--- a/lib/db/StudyRequestCommentDAO.js
+++ b/lib/db/StudyRequestCommentDAO.js
@@ -1,0 +1,116 @@
+import db from '@/lib/db/db';
+import DateTime from '@/lib/time/DateTime';
+
+/**
+ * Data Access Object for comments made on study requests submitted via MOVE.
+ */
+class StudyRequestCommentDAO {
+  /**
+   * Create a row for the given comment in database.
+   *
+   * @param {Object} studyRequest - study request to attach this comment to
+   * @param {Object} comment - comment information, as submitted by frontend
+   * @returns {Object} comment object, as persisted to database
+   */
+  static async create(studyRequest, comment) {
+    const sql = `
+INSERT INTO "study_request_comments" (
+  "createdAt",
+  "userSubject",
+  "studyRequestId",
+  "comment"
+) VALUES (
+  $(createdAt),
+  $(userSubject),
+  $(studyRequestId),
+  $(comment)
+) RETURNING "id"`;
+    const createdAt = DateTime.local();
+    const { id: studyRequestId } = studyRequest;
+    const { id } = await db.one(sql, {
+      createdAt,
+      studyRequestId,
+      ...comment,
+    });
+    return {
+      id,
+      createdAt,
+      studyRequestId,
+      ...comment,
+    };
+  }
+
+  /**
+   * Fetch the comment with the given ID.
+   *
+   * @param {number} id - ID to fetch comment for
+   * @returns {Object} comment object, or null if no such comment exists
+   */
+  static async byId(id) {
+    const sql = 'SELECT * FROM "study_request_comments" WHERE "id" = $(id)';
+    return db.oneOrNone(sql, { id });
+  }
+
+  /**
+   * Fetch all comments for the given study request.
+   *
+   * @param {Object} studyRequest - study request to fetch comments for
+   * @returns {Object} comments that were made on the given study request
+   */
+  static async byStudyRequest(studyRequest) {
+    const sql = `
+SELECT * FROM "study_request_comments"
+WHERE "studyRequestId" = $(studyRequestId)
+ORDER BY "createdAt" DESC`;
+    const { id: studyRequestId } = studyRequest;
+    return db.manyOrNone(sql, { studyRequestId });
+  }
+
+  /**
+   * Updates the given comment.
+   *
+   * @param {Object} comment - desired comment state
+   * @returns {Object} updated comment state
+   */
+  static async update(comment) {
+    const sql = `
+UPDATE "study_request_comments" SET
+  "comment" = $(comment)
+WHERE "id" = $(id)`;
+    await db.query(sql, comment);
+    return comment;
+  }
+
+  /**
+   * Delete given comment.
+   *
+   * @param {Object} comment - comment to delete
+   * @param {number} comment.id - ID of comment to delete, used to identify it
+   * @returns {boolean} whether any rows were deleted
+   */
+  static async delete({ id }) {
+    const sql = 'DELETE FROM "study_request_comments" WHERE "id" = $(id)';
+    const rowsDeleted = await db.result(sql, { id }, r => r.rowCount);
+    return rowsDeleted === 1;
+  }
+
+  /**
+   * Delete all comments for the given study request.  This is intended for use
+   * by `StudyRequestDAO.delete`.
+   *
+   * @see {StudyRequestDAO}
+   * @param {Object} studyRequest - comment to delete
+   * @param {number} studyRequest.id - ID of study request to delete comments for, used to
+   * identify it
+   * @returns {boolean} whether any rows were deleted
+   */
+  static async deleteByStudyRequest({ id: studyRequestId }) {
+    const sql = `
+DELETE FROM "study_request_comments"
+WHERE "studyRequestId" = $(studyRequestId)`;
+    const rowsDeleted = await db.result(sql, { studyRequestId }, r => r.rowCount);
+    return rowsDeleted > 0;
+  }
+}
+
+export default StudyRequestCommentDAO;

--- a/lib/db/StudyRequestDAO.js
+++ b/lib/db/StudyRequestDAO.js
@@ -1,5 +1,6 @@
 import db from '@/lib/db/db';
 import StudyDAO from '@/lib/db/StudyDAO';
+import StudyRequestCommentDAO from '@/lib/db/StudyRequestCommentDAO';
 import DateTime from '@/lib/time/DateTime';
 
 /**
@@ -261,7 +262,10 @@ UPDATE "study_requests" SET
    * @returns {boolean} whether any rows were deleted
    */
   static async delete(studyRequest) {
-    const studiesDeleted = await StudyDAO.deleteByStudyRequest(studyRequest);
+    const [studiesDeleted] = await Promise.all([
+      StudyDAO.deleteByStudyRequest(studyRequest),
+      StudyRequestCommentDAO.deleteByStudyRequest(studyRequest),
+    ]);
     const sql = 'DELETE FROM "study_requests" WHERE "id" = $(id)';
     const studyRequestsDeleted = await db.result(sql, studyRequest, r => r.rowCount);
     return studiesDeleted && studyRequestsDeleted === 1;

--- a/lib/db/StudyRequestDAO.js
+++ b/lib/db/StudyRequestDAO.js
@@ -20,6 +20,7 @@ SELECT
   "createdAt",
   "userSubject",
   "status",
+  "closed",
   "serviceRequestId",
   "priority",
   "assignedTo",
@@ -54,6 +55,7 @@ SELECT
   "createdAt",
   "userSubject",
   "status",
+  "closed",
   "serviceRequestId",
   "priority",
   "assignedTo",
@@ -92,6 +94,7 @@ SELECT
   "createdAt",
   "userSubject",
   "status",
+  "closed",
   "serviceRequestId",
   "priority",
   "assignedTo",
@@ -133,6 +136,7 @@ SELECT
   "createdAt",
   "userSubject",
   "status",
+  "closed",
   "serviceRequestId",
   "priority",
   "assignedTo",
@@ -146,7 +150,19 @@ SELECT
   FROM "study_requests"
   WHERE "centrelineId" = $(centrelineId)
   AND "centrelineType" = $(centrelineType)`;
-    return db.manyOrNone(sql, { centrelineId, centrelineType });
+    const studyRequests = await db.manyOrNone(sql, { centrelineId, centrelineType });
+    if (studyRequests.length === 0) {
+      return studyRequests;
+    }
+    const studies = await StudyDAO.byStudyRequests(studyRequests);
+    return studyRequests.map((studyRequest) => {
+      const { id } = studyRequest;
+      const studiesForRequest = studies.filter(({ studyRequestId }) => studyRequestId === id);
+      return {
+        ...studyRequest,
+        studies: studiesForRequest,
+      };
+    });
   }
 
   /**
@@ -162,6 +178,7 @@ INSERT INTO "study_requests" (
   "createdAt",
   "userSubject",
   "status",
+  "closed",
   "serviceRequestId",
   "priority",
   "assignedTo",
@@ -176,6 +193,7 @@ INSERT INTO "study_requests" (
   $(createdAt),
   $(userSubject),
   $(status),
+  $(closed),
   $(serviceRequestId),
   $(priority),
   $(assignedTo),
@@ -216,6 +234,7 @@ INSERT INTO "study_requests" (
 UPDATE "study_requests" SET
   "userSubject" = $(userSubject),
   "status" = $(status),
+  "closed" = $(closed),
   "serviceRequestId" = $(serviceRequestId),
   "priority" = $(priority),
   "assignedTo" = $(assignedTo),

--- a/lib/model/StudyRequest.js
+++ b/lib/model/StudyRequest.js
@@ -8,6 +8,7 @@ const PERSISTED_COLUMNS = {
   createdAt: Joi.dateTime().required(),
   userSubject: Joi.string().required(),
   status: Joi.string().required(),
+  closed: Joi.boolean().required(),
 };
 
 const COLUMNS = {

--- a/lib/model/StudyRequestComment.js
+++ b/lib/model/StudyRequestComment.js
@@ -1,0 +1,24 @@
+import Joi from '@/lib/model/Joi';
+
+const PERSISTED_COLUMNS = {
+  id: Joi.number().integer().positive().required(),
+  createdAt: Joi.dateTime().required(),
+  userSubject: Joi.string().required(),
+  studyRequestId: Joi.number().integer().positive().required(),
+};
+
+const COLUMNS = {
+  comment: Joi.string().required(),
+};
+
+export default {
+  read: {
+    ...PERSISTED_COLUMNS,
+    ...COLUMNS,
+  },
+  update: {
+    ...PERSISTED_COLUMNS,
+    ...COLUMNS,
+  },
+  create: COLUMNS,
+};

--- a/scripts/db/schema-6.down.sql
+++ b/scripts/db/schema-6.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE "study_requests" DROP COLUMN "closed";
+
+DROP TABLE "study_request_comments";
+
+UPDATE "APP_META"."DB_UPDATE" SET "currentVersion" = 5;
+COMMIT;

--- a/scripts/db/schema-6.up.sql
+++ b/scripts/db/schema-6.up.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+CREATE TABLE "study_request_comments" (
+  "id" BIGSERIAL PRIMARY KEY NOT NULL,
+  "createdAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  "userSubject" VARCHAR NOT NULL REFERENCES "users" ("subject"),
+  "studyRequestId" BIGINT NOT NULL REFERENCES "study_requests" ("id"),
+  "comment" VARCHAR NOT NULL
+);
+CREATE INDEX "study_request_comments_studyRequestId_createdAt" ON "study_request_comments" ("studyRequestId", "createdAt");
+
+ALTER TABLE "study_requests" ADD COLUMN "closed" BOOLEAN DEFAULT FALSE;
+
+UPDATE "APP_META"."DB_UPDATE" SET "currentVersion" = 6;
+COMMIT;

--- a/tests/jest/db/DAO.spec.js
+++ b/tests/jest/db/DAO.spec.js
@@ -388,6 +388,7 @@ test('StudyRequestDAO', async () => {
   const transientStudyRequest = {
     userSubject: userCreated.subject,
     status: 'REQUESTED',
+    closed: false,
     serviceRequestId: null,
     priority: 'STANDARD',
     assignedTo: null,
@@ -434,6 +435,18 @@ test('StudyRequestDAO', async () => {
   persistedStudyRequest.studies[0].daysOfWeek = [3, 4];
   persistedStudyRequest.studies[0].hours = 'SCHOOL';
   persistedStudyRequest.studies[0].notes = 'oops, this is actually a school count';
+  persistedStudyRequest = await StudyRequestDAO.update(persistedStudyRequest);
+  fetchedStudyRequest = await StudyRequestDAO.byId(persistedStudyRequest.id);
+  expect(fetchedStudyRequest).toEqual(persistedStudyRequest);
+
+  // close
+  persistedStudyRequest.closed = true;
+  persistedStudyRequest = await StudyRequestDAO.update(persistedStudyRequest);
+  fetchedStudyRequest = await StudyRequestDAO.byId(persistedStudyRequest.id);
+  expect(fetchedStudyRequest).toEqual(persistedStudyRequest);
+
+  // reopen
+  persistedStudyRequest.closed = false;
   persistedStudyRequest = await StudyRequestDAO.update(persistedStudyRequest);
   fetchedStudyRequest = await StudyRequestDAO.byId(persistedStudyRequest.id);
   expect(fetchedStudyRequest).toEqual(persistedStudyRequest);

--- a/web/components/FcDisplayRequestStudyView.vue
+++ b/web/components/FcDisplayRequestStudyView.vue
@@ -138,10 +138,7 @@ export default {
     },
     syncFromRoute(to) {
       const { id } = to.params;
-      return this.fetchStudyRequest({
-        id,
-        isSupervisor: this.isSupervisor,
-      })
+      return this.fetchStudyRequest({ id })
         .then(() => {
           this.setLocation(this.studyRequestLocation);
         })

--- a/web/store.js
+++ b/web/store.js
@@ -549,13 +549,9 @@ export default new Vuex.Store({
       return result;
     },
     // STUDY REQUESTS
-    async fetchStudyRequest({ commit, dispatch }, { id, isSupervisor }) {
+    async fetchStudyRequest({ commit, dispatch }, { id }) {
       const url = `/requests/study/${id}`;
-      const options = {};
-      if (isSupervisor) {
-        options.data = { isSupervisor };
-      }
-      const studyRequest = await apiFetch(url, options);
+      const studyRequest = await apiFetch(url);
       commit('setStudyRequest', studyRequest);
 
       const {


### PR DESCRIPTION
This PR makes progress on #283 and #284 by making the database, DAO layer, and REST API changes necessary to:

- handle opening / closing requests;
- manage comments on requests.

It also updates `DAO.spec.js` to cover these use cases.