### PR TITLE
Commenting interface for study requests

### DIFF
--- a/lib/controller/AuthController.js
+++ b/lib/controller/AuthController.js
@@ -180,8 +180,8 @@ AuthController.push({
       user: null,
     };
     if (out.loggedIn) {
-      const { email, name } = request.auth.credentials;
-      out.user = { email, name };
+      const { email, name, subject } = request.auth.credentials;
+      out.user = { email, name, subject };
     }
     return out;
   },

--- a/web/components/FcCardTableCounts.vue
+++ b/web/components/FcCardTableCounts.vue
@@ -27,9 +27,9 @@
         <div class="flex-fill"></div>
         <button
           v-if="item.counts[item.activeIndex].status !== Status.NO_EXISTING_COUNT"
-          class="font-size-m ml-m">
-          <span>Reports </span>
+          class="font-size-m ml-m uppercase">
           <i class="fa fa-expand"></i>
+          <span> Reports</span>
         </button>
       </div>
     </template>

--- a/web/components/FcCommentsStudyRequest.vue
+++ b/web/components/FcCommentsStudyRequest.vue
@@ -1,0 +1,140 @@
+<template>
+  <div class="fc-comments-study-request mb-l">
+    <h2>Comments</h2>
+    <div class="fc-comment-new">
+      <textarea
+        v-model="commentText"
+        class="font-size-m full-width mb-m"
+        :disabled="loadingCommentNew"
+        placeholder="Compose message"
+        rows="5"></textarea>
+      <div class="fc-comment-new-submit flex-container-row">
+        <div
+          v-if="loadingCommentNew"
+          class="fc-comment-new-spinner mx-s my-xs">
+          <TdsLoadingSpinner />
+        </div>
+        <button
+          v-else
+          class="font-size-m tds-button-primary uppercase"
+          :disabled="commentText.length === 0 || charsRemaining < 0 || loadingCommentNew"
+          @click="onSubmitCommentNew">
+          Submit
+        </button>
+        <div
+          class="fc-comment-chars-remaining ml-m"
+          :class="{
+            invalid: charsRemaining < 0,
+          }">
+          {{charsRemaining}}
+        </div>
+      </div>
+    </div>
+    <div
+      v-if="studyRequestComments.length === 0"
+      class="mt-l">
+      <span class="font-size-l text-muted">No comments.</span>
+    </div>
+    <section
+      v-for="comment in studyRequestComments"
+      :key="comment.id"
+      class="fc-comment font-size-s mt-l">
+      <hr />
+      <header class="flex-container-row font-size-s mx-l">
+        <div>
+          <div class="mt-m">
+            <strong>{{comment.userSubject}}</strong>
+          </div>
+          <div class="mt-s">
+            {{comment.createdAt | dateTime}}
+          </div>
+        </div>
+        <div class="flex-fill"></div>
+        <button
+          v-if="auth.user.subject === comment.userSubject"
+          class="font-size-m uppercase"
+          @click="actionDelete(comment)">
+          <i class="fa fa-trash" />
+          <span> Delete</span>
+        </button>
+      </header>
+      <div class="font-size-m mt-l mx-l">
+        {{ comment.comment }}
+      </div>
+    </section>
+  </div>
+</template>
+
+<script>
+import { mapActions, mapState } from 'vuex';
+
+import TdsLoadingSpinner from '@/web/components/tds/TdsLoadingSpinner.vue';
+
+export default {
+  name: 'FcCommentsStudyRequest',
+  components: {
+    TdsLoadingSpinner,
+  },
+  props: {
+    sizeLimit: Number,
+    studyRequest: Object,
+  },
+  data() {
+    return {
+      commentText: '',
+      loadingCommentNew: false,
+    };
+  },
+  computed: {
+    charsRemaining() {
+      return this.sizeLimit - this.commentText.length;
+    },
+    ...mapState([
+      'auth',
+      'studyRequestComments',
+    ]),
+  },
+  methods: {
+    actionDelete(comment) {
+      const { studyRequest } = this;
+      this.deleteStudyRequestComment({ studyRequest, comment });
+    },
+    async onSubmitCommentNew() {
+      const { studyRequest } = this;
+      const comment = {
+        comment: this.commentText,
+      };
+      this.loadingCommentNew = true;
+      await this.saveStudyRequestComment({ studyRequest, comment });
+      this.loadingCommentNew = false;
+    },
+    ...mapActions([
+      'saveStudyRequestComment',
+      'deleteStudyRequestComment',
+    ]),
+  },
+};
+</script>
+
+<style lang="postcss">
+.fc-comments-study-request {
+  & > .fc-comment-new {
+    & > textarea {
+      resize: none;
+    }
+    & > .fc-comment-new-submit {
+      align-items: center;
+      & > .fc-comment-new-spinner {
+        height: var(--font-size-l);
+        width: var(--font-size-l);
+      }
+      & > .fc-comment-chars-remaining.invalid {
+        color: var(--error-dark);
+      }
+    }
+    & > .fc-comment > header {
+      align-items: center;
+    }
+  }
+}
+</style>

--- a/web/components/FcCommentsStudyRequest.vue
+++ b/web/components/FcCommentsStudyRequest.vue
@@ -4,7 +4,7 @@
     <div class="fc-comment-new">
       <textarea
         v-model="commentText"
-        class="font-size-m full-width mb-m"
+        class="font-size-m full-width my-m px-l py-m"
         :disabled="loadingCommentNew"
         placeholder="Compose message"
         rows="5"></textarea>
@@ -43,7 +43,7 @@
       <header class="flex-container-row font-size-s mx-l">
         <div>
           <div class="mt-m">
-            <strong>{{comment.userSubject}}</strong>
+            <strong>{{studyRequestCommentUsers.get(comment.userSubject).name}}</strong>
           </div>
           <div class="mt-s">
             {{comment.createdAt | dateTime}}
@@ -92,6 +92,7 @@ export default {
     ...mapState([
       'auth',
       'studyRequestComments',
+      'studyRequestCommentUsers',
     ]),
   },
   methods: {

--- a/web/components/FcCommentsStudyRequest.vue
+++ b/web/components/FcCommentsStudyRequest.vue
@@ -43,7 +43,9 @@
       <header class="flex-container-row font-size-s mx-l">
         <div>
           <div class="mt-m">
-            <strong>{{studyRequestCommentUsers.get(comment.userSubject).name}}</strong>
+            <strong>
+              {{studyRequestCommentUsers.get(comment.userSubject).name}}
+            </strong>
           </div>
           <div class="mt-s">
             {{comment.createdAt | dateTime}}

--- a/web/components/FcDisplayRequestStudyView.vue
+++ b/web/components/FcDisplayRequestStudyView.vue
@@ -1,22 +1,24 @@
 <template>
   <div class="fc-display-request-study-view flex-container-column">
-    <div class="nav-links flex-container-row px-xl py-l text-size-l">
+    <div class="nav-links flex-container-row px-l pt-l pb-s text-size-l">
       <router-link :to="linkBack">
         <i class="fa fa-chevron-left"></i>
         <span> Back to All</span>
       </router-link>
     </div>
-    <div class="px-xl flex-fill flex-container-column">
-      <hr />
+    <div class="flex-fill flex-container-column">
+      <div class="px-l">
+        <hr />
+      </div>
       <div
         v-if="studyRequest === null"
-        class="request-loading-spinner">
+        class="request-loading-spinner ml-l mt-l">
         <TdsLoadingSpinner />
       </div>
       <div
         v-else
         class="flex-fill flex-container-column">
-        <header class="flex-container-row">
+        <header class="flex-container-row px-l">
           <h2>
             Request #{{studyRequest.id}}
             <span
@@ -29,20 +31,24 @@
           </h2>
           <div class="flex-fill"></div>
           <button
-            class="font-size-l"
+            v-if="auth.user.subject === studyRequest.userSubject || isSupervisor"
+            class="font-size-l uppercase"
             @click="onActionEdit">
             <i class="fa fa-edit" />
             <span> Edit</span>
           </button>
         </header>
         <section class="flex-fill flex-container-row">
-          <div class="flex-cross-scroll">
+          <div class="flex-cross-scroll px-l">
             <FcSummaryStudyRequest
               :study-request="studyRequest" />
             <FcSummaryStudy
               v-for="(_, i) in studyRequest.studies"
               :key="i"
               :index="i"
+              :study-request="studyRequest" />
+            <FcCommentsStudyRequest
+              :size-limit="240"
               :study-request="studyRequest" />
           </div>
         </section>
@@ -54,6 +60,7 @@
 <script>
 import { mapActions, mapMutations, mapState } from 'vuex';
 
+import FcCommentsStudyRequest from '@/web/components/FcCommentsStudyRequest.vue';
 import FcSummaryStudy from '@/web/components/FcSummaryStudy.vue';
 import FcSummaryStudyRequest from '@/web/components/FcSummaryStudyRequest.vue';
 import TdsLoadingSpinner from '@/web/components/tds/TdsLoadingSpinner.vue';
@@ -79,6 +86,7 @@ function getToast(err) {
 export default {
   name: 'FcDisplayRequestStudyView',
   components: {
+    FcCommentsStudyRequest,
     FcSummaryStudy,
     FcSummaryStudyRequest,
     TdsLoadingSpinner,
@@ -106,7 +114,12 @@ export default {
         params: { centrelineId, centrelineType },
       };
     },
-    ...mapState(['studyRequest', 'studyRequestLocation']),
+    ...mapState([
+      'auth',
+      'studyRequest',
+      'studyRequestComments',
+      'studyRequestLocation',
+    ]),
   },
   beforeRouteEnter(to, from, next) {
     next((vm) => {
@@ -157,7 +170,6 @@ export default {
 <style lang="postcss">
 .fc-display-request-study-view {
   & > .nav-links {
-    padding: var(--space-l) var(--space-xl) var(--space-s) var(--space-xl);
     text-transform: uppercase;
     & > a {
       text-decoration: none;

--- a/web/components/FcDisplayRequestStudyView.vue
+++ b/web/components/FcDisplayRequestStudyView.vue
@@ -11,7 +11,7 @@
         <hr />
       </div>
       <div
-        v-if="studyRequest === null"
+        v-if="loadingStudyRequest || studyRequest === null"
         class="request-loading-spinner ml-l mt-l">
         <TdsLoadingSpinner />
       </div>
@@ -93,6 +93,7 @@ export default {
   },
   data() {
     return {
+      loadingStudyRequest: false,
       location: null,
     };
   },
@@ -151,9 +152,11 @@ export default {
     },
     syncFromRoute(to) {
       const { id } = to.params;
+      this.loadingStudyRequest = true;
       return this.fetchStudyRequest({ id })
         .then(() => {
           this.setLocation(this.studyRequestLocation);
+          this.loadingStudyRequest = false;
         })
         .catch((err) => {
           const toast = getToast(err);

--- a/web/components/FcDisplayViewDataAtLocation.vue
+++ b/web/components/FcDisplayViewDataAtLocation.vue
@@ -3,7 +3,7 @@
     <div class="flex-container-column">
       <header>
         <h1 class="my-l">View Data</h1>
-        <div class="bar-actions-bulk flex-container-row p-l mb-xl">
+        <div class="bar-actions-bulk flex-container-row p-l mb-l">
           <label class="tds-checkbox mr-l">
             <input
               type="checkbox"

--- a/web/components/FcDisplayViewDataAtLocation.vue
+++ b/web/components/FcDisplayViewDataAtLocation.vue
@@ -1,23 +1,28 @@
 <template>
   <div class="fc-display-view-data-at-location">
     <div class="flex-container-column">
-      <FcFiltersViewDataAtLocation />
-      <header class="flex-container-row">
-        <label class="tds-checkbox">
-          <input
-            type="checkbox"
-            name="selectAll"
-            :checked="selectionAll"
-            :indeterminate.prop="selectionIndeterminate"
-            @change="onChangeSelectAll" />
-        </label>
-        <div class="flex-fill"></div>
-        <button
-          class="tds-button-primary"
-          @click="onActionBulk('request-study')">
-          <i class="fa fa-plus"></i>
-          <span> Request Study</span>
-        </button>
+      <header>
+        <h1 class="my-l">View Data</h1>
+        <div class="bar-actions-bulk flex-container-row p-l mb-xl">
+          <label class="tds-checkbox mr-l">
+            <input
+              type="checkbox"
+              name="selectAll"
+              :checked="selectionAll"
+              :indeterminate.prop="selectionIndeterminate"
+              @change="onChangeSelectAll" />
+          </label>
+          <div class="py-s">
+            <button
+              class="font-size-l tds-button-primary uppercase"
+              @click="onActionBulk('request-study')">
+              <i class="fa fa-plus"></i>
+              <span> Request Study</span>
+            </button>
+          </div>
+          <div class="flex-fill"></div>
+          <FcFiltersViewDataAtLocation class="py-s" />
+        </div>
       </header>
       <div
         v-if="loadingLocationData"
@@ -260,16 +265,12 @@ export default {
   max-height: 100%;
   overflow: auto;
   padding: var(--space-m) var(--space-l);
-  & > .flex-container-column > header {
+  header > h1 {
+    font-size: 3rem;
+  }
+  .bar-actions-bulk {
     align-items: center;
     background-color: var(--base-lighter);
-    padding: var(--space-m) var(--space-l);
-    & > * {
-      margin-right: var(--space-m);
-      &:last-child {
-        margin-right: 0;
-      }
-    }
   }
   .location-data-loading-spinner {
     height: var(--space-2xl);

--- a/web/components/FcFiltersViewDataAtLocation.vue
+++ b/web/components/FcFiltersViewDataAtLocation.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="py-m">
+<div>
   <button
     class="font-size-l mr-m"
     :class="{
@@ -23,7 +23,7 @@
     }"
     size="l" />
   <FcFilterDayOfWeek
-    class="font-size-l mr-m"
+    class="font-size-l"
     :class="{
       'tds-button-success': hasFilterDayOfWeek,
     }" />

--- a/web/components/FcSummaryStudyRequest.vue
+++ b/web/components/FcSummaryStudyRequest.vue
@@ -8,7 +8,7 @@
         <TdsLabel
           class="font-size-l uppercase"
           v-bind="RequestStatus[studyRequest.status]">
-          {{studyRequest.status}}
+          {{RequestStatus[studyRequest.status].text}}
         </TdsLabel>
       </div>
       <div class="flex-1 px-m">

--- a/web/components/PaneMapPopup.vue
+++ b/web/components/PaneMapPopup.vue
@@ -9,9 +9,10 @@
       </div>
       <template v-if="featureSelectable">
         <button
-          class="font-size-l mt-s"
+          class="font-size-l mt-s uppercase"
           @click="onViewData">
-          View Data
+          <i class="fa fa-eye"></i>
+          <span> View Data</span>
         </button>
       </template>
     </TdsPanel>

--- a/web/main.js
+++ b/web/main.js
@@ -15,6 +15,7 @@ Vue.use(Vuelidate);
 Vue.filter('durationHuman', formatDuration);
 
 Vue.filter('date', TimeFormatters.formatDefault);
+Vue.filter('dateTime', TimeFormatters.formatDateTime);
 Vue.filter('dayOfWeek', TimeFormatters.formatDayOfWeek);
 Vue.filter('d3Format', (value, formatSpec) => format(formatSpec)(value));
 Vue.filter('timeOfDay', TimeFormatters.formatTimeOfDay);

--- a/web/store.js
+++ b/web/store.js
@@ -748,6 +748,9 @@ export default new Vuex.Store({
     },
     // USERS
     async fetchUsersBySubjects(_, subjects) {
+      if (subjects.length === 0) {
+        return new Map();
+      }
       const options = {
         data: {
           subject: subjects,

--- a/web/views/FcLogin.vue
+++ b/web/views/FcLogin.vue
@@ -16,7 +16,7 @@
     </div>
     <h1>Log in to MOVE</h1>
     <div class="flex-container-row">
-      <div class="flex-1 px-l">
+      <div class="flex-1">
         <TdsPanel
           class="font-size-l"
           variant="info">


### PR DESCRIPTION
This PR closes #284 by implementing the study request commenting interface from latest design mocks.

Since we already had the CRUD endpoints from before here, the main difficulty was dependent fetching of users who submitted comments.