### PR TITLE
ADFS integration [QA]

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -388,11 +388,11 @@ const SearchKeys = {
       return rLower.indexOf(qLower) !== -1;
     },
     REQUESTER: (q, r) => {
-      if (!r.requestedBy || !r.requestedBy.name) {
+      if (!r.requestedBy || !r.requestedBy.uniqueName) {
         return q === '';
       }
       const qLower = q.toLowerCase();
-      const rLower = r.requestedBy.name.toLowerCase();
+      const rLower = r.requestedBy.uniqueName.toLowerCase();
       return rLower.indexOf(qLower) !== -1;
     },
     STATUS: (q, r) => {
@@ -430,7 +430,7 @@ const SortKeys = {
     ID: r => r.id,
     LOCATION: r => r.location.description,
     PRIORITY: r => (r.priority === 'STANDARD' ? 0 : 1),
-    REQUESTER: r => r.requestedBy.name,
+    REQUESTER: r => r.requestedBy.uniqueName,
     STATUS: r => r.status,
   },
   Studies: {

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -72,16 +72,16 @@ async function getLocationByFeature(feature) {
   return locationsMap.get(key);
 }
 
-async function getUsersBySubjects(subjects) {
-  if (subjects.length === 0) {
+async function getUsersByIds(ids) {
+  if (ids.length === 0) {
     return new Map();
   }
   const options = {
     data: {
-      subject: subjects,
+      id: ids,
     },
   };
-  const users = await apiClient.fetch('/users/bySubject', options);
+  const users = await apiClient.fetch('/users/byId', options);
   return new Map(users);
 }
 
@@ -94,19 +94,19 @@ async function getUserStudyRequests(isSupervisor) {
 
   const centrelineKeys = new Set();
   const centrelineIdsAndTypes = [];
-  let subjects = new Set();
-  studyRequests.forEach(({ centrelineId, centrelineType, userSubject }) => {
+  let ids = new Set();
+  studyRequests.forEach(({ centrelineId, centrelineType, userId }) => {
     const key = centrelineKey(centrelineId, centrelineType);
     if (!centrelineKeys.has(key)) {
       centrelineKeys.add(key);
       centrelineIdsAndTypes.push({ centrelineId, centrelineType });
     }
-    subjects.add(userSubject);
+    ids.add(userId);
   });
-  subjects = Array.from(subjects);
+  ids = Array.from(ids);
 
   const promiseLocations = getLocationsByFeature(centrelineIdsAndTypes);
-  const promiseUsers = getUsersBySubjects(subjects);
+  const promiseUsers = getUsersByIds(ids);
   const [
     studyRequestLocations,
     studyRequestUsers,
@@ -144,7 +144,7 @@ const WebApi = {
   getLocationByFeature,
   getLocationsByFeature,
   getUserStudyRequests,
-  getUsersBySubjects,
+  getUsersByIds,
   putStudyRequests,
 };
 
@@ -155,6 +155,6 @@ export {
   getLocationByFeature,
   getLocationsByFeature,
   getUserStudyRequests,
-  getUsersBySubjects,
+  getUsersByIds,
   putStudyRequests,
 };

--- a/lib/auth/ClientNonce.js
+++ b/lib/auth/ClientNonce.js
@@ -1,0 +1,18 @@
+const HEX = '0123456789abcdef';
+
+class ClientNonce {
+  static get(numBytes) {
+    const bytes = new Uint8Array(numBytes);
+    const random = window.crypto.getRandomValues(bytes);
+    const result = [];
+    random.forEach((c) => {
+      const hi = HEX[Math.floor(c / 16)];
+      result.push(hi);
+      const lo = HEX[c % 16];
+      result.push(lo);
+    });
+    return result.join('');
+  }
+}
+
+export default ClientNonce;

--- a/lib/auth/OpenIdClient.js
+++ b/lib/auth/OpenIdClient.js
@@ -1,0 +1,50 @@
+import { custom, generators, Issuer } from 'openid-client';
+
+import config from '@/lib/config/MoveConfig';
+
+if (config.ENV === 'development') {
+  custom.setHttpOptionsDefaults({
+    rejectUnauthorized: false,
+  });
+}
+
+let CLIENT = null;
+const SCOPE = 'email openid telephoneNumber title displayName';
+
+class OpenIdClient {
+  constructor(client) {
+    this.client = client;
+  }
+
+  authorizationUrl() {
+    const nonce = generators.nonce();
+    console.log(nonce);
+    const authorizationUrl = this.client.authorizationUrl({
+      nonce,
+      response_type: 'id_token',
+      scope: SCOPE,
+    });
+    return { authorizationUrl, nonce };
+  }
+
+  async callback(request) {
+    const [redirectUri] = config.openId.clientMetadata.redirect_uris;
+    const parameters = this.client.callbackParams(request.raw.req);
+    const { nonce } = request.payload;
+    return this.client.callback(redirectUri, parameters, {
+      nonce,
+      response_type: 'id_token',
+    });
+  }
+
+  static async get() {
+    if (CLIENT === null) {
+      const issuer = await Issuer.discover(config.openId.issuerUrl);
+      const client = new issuer.Client(config.openId.clientMetadata);
+      CLIENT = new OpenIdClient(client);
+    }
+    return CLIENT;
+  }
+}
+
+export default OpenIdClient;

--- a/lib/auth/OpenIdClient.js
+++ b/lib/auth/OpenIdClient.js
@@ -1,4 +1,4 @@
-import { custom, generators, Issuer } from 'openid-client';
+import { custom, Issuer } from 'openid-client';
 
 import config from '@/lib/config/MoveConfig';
 
@@ -16,22 +16,19 @@ class OpenIdClient {
     this.client = client;
   }
 
-  authorizationUrl() {
-    const nonce = generators.nonce();
-    console.log(nonce);
-    const authorizationUrl = this.client.authorizationUrl({
+  authorizationUrl(nonce) {
+    return this.client.authorizationUrl({
       nonce,
       response_type: 'id_token',
       scope: SCOPE,
     });
-    return { authorizationUrl, nonce };
   }
 
   async callback(request) {
     const [redirectUri] = config.openId.clientMetadata.redirect_uris;
-    const parameters = this.client.callbackParams(request.raw.req);
-    const { nonce } = request.payload;
-    return this.client.callback(redirectUri, parameters, {
+    /* eslint-disable-next-line camelcase */
+    const { id_token, nonce } = request.payload;
+    return this.client.callback(redirectUri, { id_token }, {
       nonce,
       response_type: 'id_token',
     });

--- a/lib/auth/OpenIdClient.js
+++ b/lib/auth/OpenIdClient.js
@@ -1,8 +1,14 @@
 import { custom, Issuer } from 'openid-client';
 
 import config from '@/lib/config/MoveConfig';
+import { InvalidOpenIdTokenError } from '@/lib/error/MoveErrors';
 
-if (config.ENV === 'development') {
+/*
+ * TODO: remove this once we figure out how to configure Vagrant to respect the host OS
+ * certificate trust store.  It would be a much better solution to add all certificates
+ * in the `https://ma-qa.toronto.ca` chain there.
+ */
+if (config.ENV === 'development' || config.env === 'test') {
   custom.setHttpOptionsDefaults({
     rejectUnauthorized: false,
   });
@@ -16,7 +22,8 @@ class OpenIdClient {
     this.client = client;
   }
 
-  authorizationUrl(nonce) {
+  authorizationUrl(request) {
+    const { nonce } = request.payload;
     return this.client.authorizationUrl({
       nonce,
       response_type: 'id_token',
@@ -28,10 +35,30 @@ class OpenIdClient {
     const [redirectUri] = config.openId.clientMetadata.redirect_uris;
     /* eslint-disable-next-line camelcase */
     const { id_token, nonce } = request.payload;
-    return this.client.callback(redirectUri, { id_token }, {
+    const tokenSet = await this.client.callback(redirectUri, { id_token }, {
       nonce,
       response_type: 'id_token',
     });
+
+    if (tokenSet.expired()) {
+      throw new InvalidOpenIdTokenError('token expired!');
+    }
+
+    const {
+      aud,
+      sub,
+      unique_name: uniqueName,
+      upn: email,
+    } = tokenSet.claims();
+    /*
+     * See https://auth0.com/docs/tokens/guides/id-token/validate-id-token for more details:
+     * `this.client.callback` validates the `nonce`, but we must also validate `aud`.
+     */
+    if (aud !== config.openId.clientMetadata.client_id) {
+      throw new InvalidOpenIdTokenError(`invalid audience ${aud} in ADFS token!`);
+    }
+
+    return { email, sub, uniqueName };
   }
 
   static async get() {

--- a/lib/config/MoveConfig.js
+++ b/lib/config/MoveConfig.js
@@ -26,6 +26,8 @@ const {
 } = process.env;
 const productionDb = `postgres://${PGUSER}@${PGHOST}/${PGDATABASE}`;
 
+const testPort = 'API_TEST_HEADLESS' in process.env ? 8080 : 8081;
+
 const config = {
   development: {
     /*
@@ -35,6 +37,14 @@ const config = {
     db: 'postgres://flashcrow@localhost:5432/flashcrow',
     host: '0.0.0.0',
     https: vueConfig.devServer.https,
+    openId: {
+      clientMetadata: {
+        redirect_uris: [
+          'https://localhost:8080/auth/adfs-callback',
+        ],
+      },
+      issuerUrl: 'https://ma-qa.toronto.ca/adfs',
+    },
     port: 8081,
     session: {},
     webPort: 8080,
@@ -43,13 +53,21 @@ const config = {
     db: 'postgres://flashcrow@localhost:5433/flashcrow',
     host: '0.0.0.0',
     https: vueConfig.devServer.https,
+    openId: {
+      clientMetadata: {
+        redirect_uris: [
+          `https://localhost:${testPort}/auth/adfs-callback`,
+        ],
+      },
+      issuerUrl: 'https://ma-qa.toronto.ca/adfs',
+    },
     /*
      * The npm script `backend:test-api` runs `web/server.js` with the `API_TEST_HEADLESS`
      * environment variable, which instructs the server to start up directly on port
      * 8080.  (Here we're not testing the frontend, so we don't need `webpack-dev-server`
      * to proxy for us!)
      */
-    port: 'API_TEST_HEADLESS' in process.env ? 8080 : 8081,
+    port: testPort,
     session: {},
     webPort: 8080,
   },
@@ -57,6 +75,14 @@ const config = {
     db: productionDb,
     host: 'localhost',
     https: null,
+    openId: {
+      clientMetadata: {
+        redirect_uris: [
+          'https://move.intra.dev-toronto.ca/auth/adfs-callback',
+        ],
+      },
+      issuerUrl: 'https://cotauth.toronto.ca/adfs',
+    },
     port: 8081,
     session: {
       /*
@@ -80,6 +106,15 @@ const configSchema = Joi.object().keys({
     key: Joi.binary().required(),
     cert: Joi.binary().required(),
   }).allow(null).required(),
+  openId: Joi.object().keys({
+    clientMetadata: Joi.object().keys({
+      client_id: Joi.string().uuid().required(),
+      redirect_uris: Joi.array().items(
+        Joi.string().required(),
+      ).required(),
+    }),
+    issuerUrl: Joi.string().uri().required(),
+  }),
   port: Joi.number().integer().positive().required(),
   sendGrid: Joi.string().required(),
   session: Joi.object().keys({
@@ -90,6 +125,8 @@ const configSchema = Joi.object().keys({
 });
 
 Object.keys(config).forEach((key) => {
+  /* eslint-disable-next-line camelcase */
+  config[key].openId.clientMetadata.client_id = privateConfig[key].openId.clientMetadata.client_id;
   config[key].sendGrid = privateConfig[key].sendGrid;
   config[key].session.password = privateConfig[key].session.password;
   const { error } = Joi.validate(config[key], configSchema, {

--- a/lib/config/MoveConfig.js
+++ b/lib/config/MoveConfig.js
@@ -40,7 +40,7 @@ const config = {
     openId: {
       clientMetadata: {
         redirect_uris: [
-          'https://localhost:8080/api/auth/adfs-callback',
+          'https://localhost:8080/auth/adfs-callback',
         ],
       },
       issuerUrl: 'https://ma-qa.toronto.ca/adfs',
@@ -56,7 +56,7 @@ const config = {
     openId: {
       clientMetadata: {
         redirect_uris: [
-          `https://localhost:${testPort}/api/auth/adfs-callback`,
+          `https://localhost:${testPort}/auth/adfs-callback`,
         ],
       },
       issuerUrl: 'https://ma-qa.toronto.ca/adfs',
@@ -78,7 +78,7 @@ const config = {
     openId: {
       clientMetadata: {
         redirect_uris: [
-          'https://move.intra.dev-toronto.ca/api/auth/adfs-callback',
+          'https://move.intra.dev-toronto.ca/auth/adfs-callback',
         ],
       },
       issuerUrl: 'https://cotauth.toronto.ca/adfs',

--- a/lib/config/MoveConfig.js
+++ b/lib/config/MoveConfig.js
@@ -40,7 +40,7 @@ const config = {
     openId: {
       clientMetadata: {
         redirect_uris: [
-          'https://localhost:8080/auth/adfs-callback',
+          'https://localhost:8080/api/auth/adfs-callback',
         ],
       },
       issuerUrl: 'https://ma-qa.toronto.ca/adfs',
@@ -56,7 +56,7 @@ const config = {
     openId: {
       clientMetadata: {
         redirect_uris: [
-          `https://localhost:${testPort}/auth/adfs-callback`,
+          `https://localhost:${testPort}/api/auth/adfs-callback`,
         ],
       },
       issuerUrl: 'https://ma-qa.toronto.ca/adfs',
@@ -78,7 +78,7 @@ const config = {
     openId: {
       clientMetadata: {
         redirect_uris: [
-          'https://move.intra.dev-toronto.ca/auth/adfs-callback',
+          'https://move.intra.dev-toronto.ca/api/auth/adfs-callback',
         ],
       },
       issuerUrl: 'https://cotauth.toronto.ca/adfs',

--- a/lib/config/MoveConfig.js
+++ b/lib/config/MoveConfig.js
@@ -40,7 +40,7 @@ const config = {
     openId: {
       clientMetadata: {
         redirect_uris: [
-          'https://localhost:8080/auth/adfs-callback',
+          'https://localhost:8080/api/auth/adfs-callback',
         ],
       },
       issuerUrl: 'https://ma-qa.toronto.ca/adfs',

--- a/lib/controller/AuthController.js
+++ b/lib/controller/AuthController.js
@@ -1,4 +1,3 @@
-import Boom from '@hapi/boom';
 import Joi from '@hapi/joi';
 import uuid from 'uuid/v4';
 
@@ -13,74 +12,6 @@ import LogTag from '@/lib/log/LogTag';
  * @type {Array<HapiRoute>}
  */
 const AuthController = [];
-
-/**
- * Stub authentication method, used as temporary solution while we prepare to integrate
- * ADFS from Cloud Services.
- *
- * TODO: remove this once ADFS is integrated
- *
- * @memberof AuthController
- * @name postStub
- */
-AuthController.push({
-  method: 'POST',
-  path: '/auth/stub',
-  options: {
-    auth: { mode: 'try' },
-    plugins: {
-      crumb: {
-        restful: false,
-      },
-    },
-    validate: {
-      payload: {
-        email: Joi.string().email().required(),
-        name: Joi.string().required(),
-        path: Joi.string().uri({ relativeOnly: true }).default(config.PUBLIC_PATH),
-      },
-    },
-  },
-  handler: async (request, h) => {
-    if (request.auth.isAuthenticated) {
-      /*
-       * The user is already logged in, so we should redirect them to home.
-       */
-      return h.redirect(config.PUBLIC_PATH);
-    }
-    const { email, name, path } = request.payload;
-    /*
-     * We must check for scheme-relative URIs here, as otherwise we'd be vulnerable
-     * to open-redirect attacks:
-     *
-     * > Joi.string().uri({ relativeOnly: true }).validate('//evil.com');
-     * { error: null,
-     *   value: '//evil.com',
-     *   then: [Function: then],
-     *   catch: [Function: catch] }
-     */
-    if (path.startsWith('//')) {
-      return Boom.badRequest('Scheme-relative URIs not accepted for path!');
-    }
-    // upgrade to application session ID
-    let user = await UserDAO.byEmail(email);
-    if (user === null) {
-      user = {
-        subject: uuid(),
-        email,
-        name,
-        token: '',
-      };
-      await UserDAO.create(user);
-    }
-    const sessionId = uuid();
-    await request.server.app.cache.set(sessionId, { user }, 0);
-    request.cookieAuth.set({ sessionId });
-
-    // redirect to home
-    return h.redirect(path);
-  },
-});
 
 /**
  * Start the ADFS flow by redirecting to the authorization endpoint, where the user will
@@ -99,16 +30,17 @@ AuthController.push({
         restful: false,
       },
     },
+    validate: {
+      payload: {
+        nonce: Joi.string().hex().required(),
+      },
+    },
   },
   handler: async (request, h) => {
-    if (request.auth.isAuthenticated) {
-      /*
-       * The user is already logged in, so we should redirect them to home.
-       */
-      return h.redirect(config.PUBLIC_PATH);
-    }
+    const { nonce } = request.payload;
+
     const client = await OpenIdClient.get();
-    const { authorizationUrl } = client.authorizationUrl();
+    const authorizationUrl = client.authorizationUrl(nonce);
     request.log(LogTag.DEBUG, `redirecting to: ${authorizationUrl}`);
     return h.redirect(authorizationUrl);
   },
@@ -139,25 +71,47 @@ AuthController.push({
     },
   },
   handler: async (request, h) => {
-    if (request.auth.isAuthenticated) {
-      /*
-       * The user is already logged in, so we should redirect them to home.
-       */
-      return h.redirect(config.PUBLIC_PATH);
-    }
     const client = await OpenIdClient.get();
     try {
       const tokenSet = await client.callback(request);
       if (tokenSet.expired()) {
+        request.log(LogTag.ERROR, 'token expired!');
         return h.redirect('/login');
       }
-      const claims = tokenSet.claims();
-      // TODO: validate claims
 
-      // TODO: upgrade token into MOVE session
+      const {
+        aud,
+        sub,
+        unique_name: uniqueName,
+        upn: email,
+      } = tokenSet.claims();
+      /*
+       * See https://auth0.com/docs/tokens/guides/id-token/validate-id-token for more details;
+       * `OpenIdClient` already validates the `nonce`, but we must validate `aud` here.
+       */
+      if (aud !== config.openId.clientMetadata.client_id) {
+        request.log(LogTag.ERROR, `invalid audience ${aud} in ADFS token!`);
+        return h.redirect('/login');
+      }
 
-      console.log(claims);
-      return h.redirect('/login');
+      /*
+       * The token is valid, so upgrade it to a MOVE session.
+       */
+      let user = await UserDAO.bySub(sub);
+      if (user === null) {
+        user = {
+          email,
+          sub,
+          uniqueName,
+        };
+        user = await UserDAO.create(user);
+      }
+      const sessionId = uuid();
+      await request.server.app.cache.set(sessionId, { user }, 0);
+      request.cookieAuth.set({ sessionId });
+
+      // TODO: path redirect?
+      return h.redirect(config.PUBLIC_PATH);
     } catch (err) {
       request.log(LogTag.ERROR, err);
       return h.redirect('/login');
@@ -185,55 +139,9 @@ AuthController.push({
       user: null,
     };
     if (out.loggedIn) {
-      const { email, name, subject } = request.auth.credentials;
-      out.user = { email, name, subject };
+      out.user = request.auth.credentials;
     }
     return out;
-  },
-});
-
-/**
- * Bypasses the OpenID Connect flow in testing, allowing us to run REST
- * API tests.
- *
- * TODO: remove this and replace with something more robust if possible
- * once ADFS is integrated
- *
- * @memberof AuthController
- * @name postTestLogin
- */
-AuthController.push({
-  method: 'POST',
-  path: '/auth/test-login',
-  options: {
-    auth: false,
-  },
-  handler: async (request) => {
-    if (config.ENV === 'production') {
-      throw new Error('nope.');
-    }
-
-    // "authenticate" test user
-    const sub = '0123456789';
-    const email = 'flashcrow.tester@gmail.com';
-    const name = 'Flashcrow Tester';
-    const token = 'HEADER.PAYLOAD.SIGNATURE';
-    let user = await UserDAO.bySubject(sub);
-    if (user === null) {
-      user = {
-        subject: sub,
-        email,
-        name,
-        token,
-      };
-      await UserDAO.create(user);
-    } else {
-      Object.assign(user, { email, name, token });
-      await UserDAO.update(user);
-    }
-    const sessionId = uuid();
-    await request.server.app.cache.set(sessionId, { user }, 0);
-    request.cookieAuth.set({ sessionId });
   },
 });
 

--- a/lib/controller/AuthController.js
+++ b/lib/controller/AuthController.js
@@ -8,6 +8,28 @@ import UserDAO from '@/lib/db/UserDAO';
 import LogTag from '@/lib/log/LogTag';
 import { generateUser } from '@/lib/test/random/UserGenerator';
 
+async function login(request, { email, sub, uniqueName }) {
+  let user = await UserDAO.bySub(sub);
+  if (user === null) {
+    user = {
+      email,
+      sub,
+      uniqueName,
+    };
+    user = await UserDAO.create(user);
+  }
+  const sessionId = uuid();
+  await request.server.app.cache.set(sessionId, { user }, 0);
+  request.cookieAuth.set({ sessionId });
+  return user;
+}
+
+async function logout(request) {
+  const { sessionId } = request.state.session;
+  request.server.app.cache.drop(sessionId);
+  request.cookieAuth.clear();
+}
+
 /**
  * Authentication-related routes.
  *
@@ -39,11 +61,8 @@ AuthController.push({
     },
   },
   handler: async (request, h) => {
-    const { nonce } = request.payload;
-
     const client = await OpenIdClient.get();
-    const authorizationUrl = client.authorizationUrl(nonce);
-    request.log(LogTag.DEBUG, `redirecting to: ${authorizationUrl}`);
+    const authorizationUrl = client.authorizationUrl(request);
     return h.redirect(authorizationUrl);
   },
 });
@@ -75,43 +94,8 @@ AuthController.push({
   handler: async (request, h) => {
     const client = await OpenIdClient.get();
     try {
-      const tokenSet = await client.callback(request);
-      if (tokenSet.expired()) {
-        request.log(LogTag.ERROR, 'token expired!');
-        return h.redirect('/login');
-      }
-
-      const {
-        aud,
-        sub,
-        unique_name: uniqueName,
-        upn: email,
-      } = tokenSet.claims();
-      /*
-       * See https://auth0.com/docs/tokens/guides/id-token/validate-id-token for more details;
-       * `OpenIdClient` already validates the `nonce`, but we must validate `aud` here.
-       */
-      if (aud !== config.openId.clientMetadata.client_id) {
-        request.log(LogTag.ERROR, `invalid audience ${aud} in ADFS token!`);
-        return h.redirect('/login');
-      }
-
-      /*
-       * The token is valid, so upgrade it to a MOVE session.
-       */
-      let user = await UserDAO.bySub(sub);
-      if (user === null) {
-        user = {
-          email,
-          sub,
-          uniqueName,
-        };
-        user = await UserDAO.create(user);
-      }
-      const sessionId = uuid();
-      await request.server.app.cache.set(sessionId, { user }, 0);
-      request.cookieAuth.set({ sessionId });
-
+      const user = await client.callback(request);
+      await login(request, user);
       // TODO: path redirect?
       return h.redirect(config.PUBLIC_PATH);
     } catch (err) {
@@ -158,12 +142,7 @@ AuthController.push({
   path: '/auth/logout',
   options: {
     handler: async (request, h) => {
-      // clear session
-      const { sessionId } = request.state.session;
-      request.server.app.cache.drop(sessionId);
-      request.cookieAuth.clear();
-
-      // redirect home
+      await logout(request);
       return h.redirect(config.PUBLIC_PATH);
     },
     plugins: {
@@ -191,14 +170,8 @@ AuthController.push({
     if (config.ENV !== 'test') {
       return Boom.forbidden('cannot access test login endpoint in non-test environment!');
     }
-
     let user = generateUser();
-    user = await UserDAO.create(user);
-
-    const sessionId = uuid();
-    await request.server.app.cache.set(sessionId, { user }, 0);
-    request.cookieAuth.set({ sessionId });
-
+    user = await login(request, user);
     return user;
   },
 });

--- a/lib/controller/AuthController.js
+++ b/lib/controller/AuthController.js
@@ -1,3 +1,4 @@
+import Boom from '@hapi/boom';
 import Joi from '@hapi/joi';
 import uuid from 'uuid/v4';
 
@@ -5,6 +6,7 @@ import OpenIdClient from '@/lib/auth/OpenIdClient';
 import config from '@/lib/config/MoveConfig';
 import UserDAO from '@/lib/db/UserDAO';
 import LogTag from '@/lib/log/LogTag';
+import { generateUser } from '@/lib/test/random/UserGenerator';
 
 /**
  * Authentication-related routes.
@@ -169,6 +171,35 @@ AuthController.push({
         restful: false,
       },
     },
+  },
+});
+
+/**
+ * Bypasses the OpenID Connect flow in testing, allowing us to run REST
+ * API tests.
+ *
+ * @memberof AuthController
+ * @name postTestLogin
+ */
+AuthController.push({
+  method: 'POST',
+  path: '/auth/test-login',
+  options: {
+    auth: false,
+  },
+  handler: async (request) => {
+    if (config.ENV !== 'test') {
+      return Boom.forbidden('cannot access test login endpoint in non-test environment!');
+    }
+
+    let user = generateUser();
+    user = await UserDAO.create(user);
+
+    const sessionId = uuid();
+    await request.server.app.cache.set(sessionId, { user }, 0);
+    request.cookieAuth.set({ sessionId });
+
+    return user;
   },
 });
 

--- a/lib/controller/AuthController.js
+++ b/lib/controller/AuthController.js
@@ -2,8 +2,10 @@ import Boom from '@hapi/boom';
 import Joi from '@hapi/joi';
 import uuid from 'uuid/v4';
 
+import OpenIdClient from '@/lib/auth/OpenIdClient';
 import config from '@/lib/config/MoveConfig';
 import UserDAO from '@/lib/db/UserDAO';
+import LogTag from '@/lib/log/LogTag';
 
 /**
  * Authentication-related routes.
@@ -77,6 +79,89 @@ AuthController.push({
 
     // redirect to home
     return h.redirect(path);
+  },
+});
+
+/**
+ * Start the ADFS flow by redirecting to the authorization endpoint, where the user will
+ * log in.
+ *
+ * @memberof AuthController
+ * @name getAdfsInit
+ */
+AuthController.push({
+  method: 'POST',
+  path: '/auth/adfs-init',
+  options: {
+    auth: { mode: 'try' },
+    plugins: {
+      crumb: {
+        restful: false,
+      },
+    },
+  },
+  handler: async (request, h) => {
+    if (request.auth.isAuthenticated) {
+      /*
+       * The user is already logged in, so we should redirect them to home.
+       */
+      return h.redirect(config.PUBLIC_PATH);
+    }
+    const client = await OpenIdClient.get();
+    const { authorizationUrl } = client.authorizationUrl();
+    request.log(LogTag.DEBUG, `redirecting to: ${authorizationUrl}`);
+    return h.redirect(authorizationUrl);
+  },
+});
+
+/**
+ * ADFS callback, used to continue the ADFS flow by exchanging the authorization code received
+ * for an access token.  If valid, this access token is then upgraded to a MOVE session.
+ *
+ * @memberof AuthController
+ * @name postAdfsCallback
+ */
+AuthController.push({
+  method: 'POST',
+  path: '/auth/adfs-callback',
+  options: {
+    auth: { mode: 'try' },
+    plugins: {
+      crumb: {
+        restful: false,
+      },
+    },
+    validate: {
+      payload: {
+        id_token: Joi.string().regex(/^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_.+/=]*$/),
+        nonce: Joi.string().hex().required(),
+      },
+    },
+  },
+  handler: async (request, h) => {
+    if (request.auth.isAuthenticated) {
+      /*
+       * The user is already logged in, so we should redirect them to home.
+       */
+      return h.redirect(config.PUBLIC_PATH);
+    }
+    const client = await OpenIdClient.get();
+    try {
+      const tokenSet = await client.callback(request);
+      if (tokenSet.expired()) {
+        return h.redirect('/login');
+      }
+      const claims = tokenSet.claims();
+      // TODO: validate claims
+
+      // TODO: upgrade token into MOVE session
+
+      console.log(claims);
+      return h.redirect('/login');
+    } catch (err) {
+      request.log(LogTag.ERROR, err);
+      return h.redirect('/login');
+    }
   },
 });
 

--- a/lib/controller/LocationController.js
+++ b/lib/controller/LocationController.js
@@ -13,8 +13,6 @@ import { CentrelineType } from '@/lib/Constants';
 const LocationController = [];
 
 /**
- * Get user names and emails for the given auth provider subjects.
- *
  * @memberof LocationController
  * @name getCotGeocoderSuggestions
  * @type {Hapi.ServerRoute}
@@ -43,8 +41,6 @@ LocationController.push({
 });
 
 /**
- * Get user names and emails for the given auth provider subjects.
- *
  * @memberof LocationController
  * @name getCotGeocoderAddressCandidates
  * @type {Hapi.ServerRoute}
@@ -81,8 +77,6 @@ LocationController.push({
 });
 
 /**
- * Get user names and emails for the given auth provider subjects.
- *
  * @memberof LocationController
  * @name getLocationsByFeature
  * @type {Hapi.ServerRoute}

--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -43,9 +43,9 @@ StudyRequestController.push({
   },
   handler: async (request) => {
     const user = request.auth.credentials;
-    const { subject } = user;
+    const { id } = user;
     const studyRequest = await StudyRequestDAO.create({
-      userSubject: subject,
+      userId: id,
       status: 'REQUESTED',
       closed: false,
       ...request.payload,
@@ -166,11 +166,11 @@ StudyRequestController.push({
     if (!studyRequestNew.createdAt.equals(studyRequestOld.createdAt)) {
       return Boom.badRequest('cannot change creation timestamp for study request');
     }
-    if (studyRequestNew.userSubject !== studyRequestOld.userSubject) {
+    if (studyRequestNew.userId !== studyRequestOld.userId) {
       return Boom.badRequest('cannot change owner for study request');
     }
 
-    if (studyRequestOld.userSubject !== user.subject && !isSupervisor) {
+    if (studyRequestOld.userId !== user.id && !isSupervisor) {
       return Boom.forbidden('not authorized to change study request owned by another user');
     }
     if (studyRequestNew.assignedTo !== studyRequestOld.assignedTo && !isSupervisor) {
@@ -253,14 +253,14 @@ StudyRequestController.push({
     },
   },
   handler: async (request) => {
-    const { subject } = request.auth.credentials;
+    const { id: userId } = request.auth.credentials;
     const { studyRequestId } = request.params;
     const studyRequest = await StudyRequestDAO.byId(studyRequestId);
     if (studyRequest === null) {
       return Boom.notFound(`no study request found with ID ${studyRequestId}`);
     }
     return StudyRequestCommentDAO.create(studyRequest, {
-      userSubject: subject,
+      userId,
       ...request.payload,
     });
   },
@@ -344,14 +344,14 @@ StudyRequestController.push({
     if (!commentOld.createdAt.equals(commentNew.createdAt)) {
       return Boom.badRequest('cannot change creation timestamp for study request');
     }
-    if (commentOld.userSubject !== commentNew.userSubject) {
+    if (commentOld.userId !== commentNew.userId) {
       return Boom.badRequest('cannot change owner for study request');
     }
     if (commentOld.studyRequestId !== commentNew.studyRequestId) {
       return Boom.badRequest('cannot change owner for study request');
     }
 
-    if (commentOld.userSubject !== user.subject) {
+    if (commentOld.userId !== user.id) {
       return Boom.forbidden('cannot update comment owned by another user');
     }
 
@@ -395,7 +395,7 @@ StudyRequestController.push({
       );
     }
 
-    if (comment.userSubject !== user.subject) {
+    if (comment.userId !== user.id) {
       return Boom.forbidden('cannot delete comment owned by another user');
     }
     const success = await StudyRequestCommentDAO.delete(comment);

--- a/lib/controller/UserController.js
+++ b/lib/controller/UserController.js
@@ -10,40 +10,35 @@ import User from '@/lib/model/User';
 const UserController = [];
 
 /**
- * Get user names and emails for the given auth provider subjects.
+ * Get user names and emails for the given user IDs.
  *
  * @memberof UserController
- * @name getUsersBySubjects
+ * @name getUsersByIds
  * @type {Hapi.ServerRoute}
  */
 UserController.push({
   method: 'GET',
-  path: '/users/bySubject',
+  path: '/users/byId',
   options: {
     response: {
       schema: Joi.array().items(
         Joi.array().ordered(
-          Joi.string().uuid().required(),
+          Joi.number().integer().positive().required(),
           User.read,
         ),
       ),
     },
     validate: {
       query: {
-        subject: Joi.array().single().items(
-          Joi.string().uuid().required(),
+        id: Joi.array().single().items(
+          Joi.number().integer().positive().required(),
         ).required(),
       },
     },
   },
   handler: async (request) => {
-    const { subject } = request.query;
-    const users = await UserDAO.bySubjects(subject);
-    const filteredUsers = new Map();
-    users.forEach(({ email, name }, userSubject) => {
-      filteredUsers.set(userSubject, { email, name });
-    });
-    return Array.from(filteredUsers);
+    const { id: ids } = request.query;
+    return UserDAO.byIds(ids);
   },
 });
 

--- a/lib/controller/UserController.js
+++ b/lib/controller/UserController.js
@@ -38,7 +38,8 @@ UserController.push({
   },
   handler: async (request) => {
     const { id: ids } = request.query;
-    return UserDAO.byIds(ids);
+    const users = await UserDAO.byIds(ids);
+    return Array.from(users);
   },
 });
 

--- a/lib/db/StudyDAO.js
+++ b/lib/db/StudyDAO.js
@@ -53,7 +53,7 @@ SELECT
     const sql = `
 INSERT INTO "studies" (
   "createdAt",
-  "userSubject",
+  "userId",
   "studyRequestId",
   "studyType",
   "daysOfWeek",
@@ -62,7 +62,7 @@ INSERT INTO "studies" (
   "notes"
 ) VALUES (
   $(createdAt),
-  $(userSubject),
+  $(userId),
   $(studyRequestId),
   $(studyType),
   $(daysOfWeek),
@@ -71,17 +71,17 @@ INSERT INTO "studies" (
   $(notes)
 ) RETURNING "id"`;
     const createdAt = DateTime.local();
-    const { userSubject, id: studyRequestId } = studyRequest;
+    const { userId, id: studyRequestId } = studyRequest;
     const { id } = await db.one(sql, {
       createdAt,
-      userSubject,
+      userId,
       studyRequestId,
       ...study,
     });
     return {
       id,
       createdAt,
-      userSubject,
+      userId,
       studyRequestId,
       ...study,
     };
@@ -96,7 +96,7 @@ INSERT INTO "studies" (
   static async update(study) {
     const sql = `
 UPDATE "studies" SET
-  "userSubject" = $(userSubject),
+  "userId" = $(userId),
   "studyRequestId" = $(studyRequestId),
   "studyType" = $(studyType),
   "daysOfWeek" = $(daysOfWeek),

--- a/lib/db/StudyRequestCommentDAO.js
+++ b/lib/db/StudyRequestCommentDAO.js
@@ -16,12 +16,12 @@ class StudyRequestCommentDAO {
     const sql = `
 INSERT INTO "study_request_comments" (
   "createdAt",
-  "userSubject",
+  "userId",
   "studyRequestId",
   "comment"
 ) VALUES (
   $(createdAt),
-  $(userSubject),
+  $(userId),
   $(studyRequestId),
   $(comment)
 ) RETURNING "id"`;

--- a/lib/db/StudyRequestDAO.js
+++ b/lib/db/StudyRequestDAO.js
@@ -19,7 +19,7 @@ class StudyRequestDAO {
 SELECT
   "id",
   "createdAt",
-  "userSubject",
+  "userId",
   "status",
   "closed",
   "serviceRequestId",
@@ -46,15 +46,15 @@ SELECT
    * Fetch study requests owned by the given user.
    *
    * @param {Object} user - user object
-   * @param {string} user.subject - user "subject", as returned by OpenID Connect
+   * @param {string} user.id - user ID
    * @returns {Array<Object>} array of study request objects owned by the given user
    */
-  static async byUser({ subject }) {
+  static async byUser({ id: userId }) {
     const sql = `
 SELECT
   "id",
   "createdAt",
-  "userSubject",
+  "userId",
   "status",
   "closed",
   "serviceRequestId",
@@ -67,8 +67,8 @@ SELECT
   "centrelineId",
   "centrelineType",
   ST_AsGeoJSON("geom")::json AS "geom"
-  FROM "study_requests" WHERE "userSubject" = $(subject)`;
-    const studyRequests = await db.manyOrNone(sql, { subject });
+  FROM "study_requests" WHERE "userId" = $(userId)`;
+    const studyRequests = await db.manyOrNone(sql, { userId });
     if (studyRequests.length === 0) {
       return studyRequests;
     }
@@ -93,7 +93,7 @@ SELECT
 SELECT
   "id",
   "createdAt",
-  "userSubject",
+  "userId",
   "status",
   "closed",
   "serviceRequestId",
@@ -135,7 +135,7 @@ SELECT
 SELECT
   "id",
   "createdAt",
-  "userSubject",
+  "userId",
   "status",
   "closed",
   "serviceRequestId",
@@ -177,7 +177,7 @@ SELECT
     const sql = `
 INSERT INTO "study_requests" (
   "createdAt",
-  "userSubject",
+  "userId",
   "status",
   "closed",
   "serviceRequestId",
@@ -192,7 +192,7 @@ INSERT INTO "study_requests" (
   "geom"
 ) VALUES (
   $(createdAt),
-  $(userSubject),
+  $(userId),
   $(status),
   $(closed),
   $(serviceRequestId),
@@ -233,7 +233,7 @@ INSERT INTO "study_requests" (
     const studies = await StudyDAO.updateByStudyRequest(studyRequest);
     const sql = `
 UPDATE "study_requests" SET
-  "userSubject" = $(userSubject),
+  "userId" = $(userId),
   "status" = $(status),
   "closed" = $(closed),
   "serviceRequestId" = $(serviceRequestId),

--- a/lib/db/UserDAO.js
+++ b/lib/db/UserDAO.js
@@ -18,6 +18,9 @@ class UserDAO {
    */
   static async byIds(ids) {
     const uniqueIds = Array.from(new Set(ids));
+    if (uniqueIds.length === 0) {
+      return new Map();
+    }
     const sql = 'SELECT * FROM "users" WHERE "id" IN ($(uniqueIds:csv))';
     const rows = await db.manyOrNone(sql, { uniqueIds });
     return new Map(rows.map(user => [user.id, user]));

--- a/lib/db/UserDAO.js
+++ b/lib/db/UserDAO.js
@@ -1,25 +1,31 @@
 import db from '@/lib/db/db';
+import DateTime from '@/lib/time/DateTime';
 
 /**
  * Data access layer for users.
  */
 class UserDAO {
-  static async bySubject(subject) {
-    const sql = 'SELECT * FROM "users" WHERE "subject" = $(subject)';
-    return db.oneOrNone(sql, { subject });
+  static async byId(id) {
+    const sql = 'SELECT * FROM "users" WHERE "id" = $(id)';
+    return db.oneOrNone(sql, { id });
   }
 
   /**
-   * Map user subjects to users.
+   * Map user IDs to users.
    *
-   * @param {Array<string>} subjects - array of user subjects
-   * @returns {Promise<Map<string, Object>>} map from user subjects to users
+   * @param {Array<number>} ids - array of IDs
+   * @returns {Promise<Map<number, Object>>} map from IDs to users
    */
-  static async bySubjects(subjects) {
-    const uniqueSubjects = Array.from(new Set(subjects));
-    const sql = 'SELECT * FROM "users" WHERE "subject" IN ($(uniqueSubjects:csv))';
-    const rows = await db.manyOrNone(sql, { uniqueSubjects });
-    return new Map(rows.map(user => [user.subject, user]));
+  static async byIds(ids) {
+    const uniqueIds = Array.from(new Set(ids));
+    const sql = 'SELECT * FROM "users" WHERE "id" IN ($(uniqueIds:csv))';
+    const rows = await db.manyOrNone(sql, { uniqueIds });
+    return new Map(rows.map(user => [user.id, user]));
+  }
+
+  static async bySub(sub) {
+    const sql = 'SELECT * FROM "users" WHERE "sub" = $(sub)';
+    return db.oneOrNone(sql, { sub });
   }
 
   static async byEmail(email) {
@@ -29,24 +35,33 @@ class UserDAO {
 
   static async create(user) {
     const sql = `
-INSERT INTO "users" ("subject", "email", "name", "token")
-  VALUES ($(subject), $(email), $(name), $(token))`;
-    await db.query(sql, user);
-    return user;
+INSERT INTO "users" ("createdAt", "email", "sub", "uniqueName")
+VALUES ($(createdAt), $(email), $(sub), $(uniqueName))
+RETURNING "id"`;
+    const createdAt = DateTime.local();
+    const { id } = await db.one(sql, {
+      createdAt,
+      ...user,
+    });
+    return {
+      id,
+      createdAt,
+      ...user,
+    };
   }
 
   static async update(user) {
     const sql = `
 UPDATE "users"
-  SET "email" = $(email), "name" = $(name), "token" = $(token)
-  WHERE "subject" = $(subject)`;
+  SET "email" = $(email), "uniqueName" = $(uniqueName)
+  WHERE "id" = $(id)`;
     const rowsUpdated = await db.result(sql, user, r => r.rowCount);
     return rowsUpdated === 1;
   }
 
-  static async delete({ subject }) {
-    const sql = 'DELETE FROM "users" WHERE "subject" = $(subject)';
-    const rowsDeleted = await db.result(sql, { subject }, r => r.rowCount);
+  static async delete({ id }) {
+    const sql = 'DELETE FROM "users" WHERE "id" = $(id)';
+    const rowsDeleted = await db.result(sql, { id }, r => r.rowCount);
     return rowsDeleted === 1;
   }
 }

--- a/lib/email/EmailStudyRequestConfirmation.js
+++ b/lib/email/EmailStudyRequestConfirmation.js
@@ -45,11 +45,9 @@ class EmailStudyRequestConfirmation extends EmailBase {
   }
 
   getRecipients() {
-    const { email, name } = this.user;
+    const { email } = this.user;
     const { ccEmails } = this.studyRequest;
-    return [
-      `${name} <${email}>`,
-    ].concat(ccEmails);
+    return [email].concat(ccEmails);
   }
 
   getSubject() {

--- a/lib/error/MoveErrors.js
+++ b/lib/error/MoveErrors.js
@@ -50,6 +50,14 @@ class InvalidCssVariableError extends Error {}
 class InvalidDynamicTileLayerError extends Error {}
 
 /**
+ * Thrown by {@link OpenIdClient#callback} for invalid OpenID Connect identity tokens.
+ *
+ * @memberof MoveErrors
+ * @see OpenIdClient#callback
+ */
+class InvalidOpenIdTokenError extends Error {}
+
+/**
  * Thrown by {@link ReportBase#generate} for invalid report formats.
  *
  * @memberof MoveErrors
@@ -91,6 +99,7 @@ const MoveErrors = {
   InvalidCentrelineTypeError,
   InvalidCssVariableError,
   InvalidDynamicTileLayerError,
+  InvalidOpenIdTokenError,
   InvalidReportFormatError,
   InvalidReportIdError,
   InvalidReportTypeError,
@@ -104,6 +113,7 @@ export {
   InvalidCentrelineTypeError,
   InvalidCssVariableError,
   InvalidDynamicTileLayerError,
+  InvalidOpenIdTokenError,
   InvalidReportFormatError,
   InvalidReportIdError,
   InvalidReportTypeError,

--- a/lib/model/Study.js
+++ b/lib/model/Study.js
@@ -4,14 +4,14 @@ import Joi from '@/lib/model/Joi';
 const PERSISTED_COLUMNS = {
   id: Joi.number().integer().positive().required(),
   createdAt: Joi.dateTime().required(),
-  userSubject: Joi.string().required(),
+  userId: Joi.number().integer().positive().required(),
   studyRequestId: Joi.number().integer().positive().required(),
 };
 
 const PERSISTED_COLUMNS_OPTIONAL = {
   id: Joi.number().integer().positive().optional(),
   createdAt: Joi.dateTime().optional(),
-  userSubject: Joi.string().optional(),
+  userId: Joi.number().integer().positive().required(),
   studyRequestId: Joi.number().integer().positive().optional(),
 };
 

--- a/lib/model/StudyRequest.js
+++ b/lib/model/StudyRequest.js
@@ -6,7 +6,7 @@ import { CentrelineType } from '@/lib/Constants';
 const PERSISTED_COLUMNS = {
   id: Joi.number().integer().positive().required(),
   createdAt: Joi.dateTime().required(),
-  userSubject: Joi.string().required(),
+  userId: Joi.number().integer().positive().required(),
   status: Joi.string().required(),
   closed: Joi.boolean().required(),
 };

--- a/lib/model/StudyRequestComment.js
+++ b/lib/model/StudyRequestComment.js
@@ -3,7 +3,7 @@ import Joi from '@/lib/model/Joi';
 const PERSISTED_COLUMNS = {
   id: Joi.number().integer().positive().required(),
   createdAt: Joi.dateTime().required(),
-  userSubject: Joi.string().required(),
+  userId: Joi.number().integer().positive().required(),
   studyRequestId: Joi.number().integer().positive().required(),
 };
 

--- a/lib/model/User.js
+++ b/lib/model/User.js
@@ -2,7 +2,10 @@ import Joi from '@/lib/model/Joi';
 
 export default {
   read: {
+    id: Joi.number().integer().positive().required(),
+    createdAt: Joi.dateTime().required(),
     email: Joi.string().email().required(),
-    name: Joi.string().required(),
+    sub: Joi.string().required(),
+    uniqueName: Joi.string().required(),
   },
 };

--- a/lib/test/DAOTestUtils.js
+++ b/lib/test/DAOTestUtils.js
@@ -67,15 +67,13 @@ class DAOTestUtils {
   }
 
   static randomUser() {
-    const subject = uuid();
-    const token = uuid();
+    const sub = uuid();
     const name = DAOTestUtils.randomUserName();
     const email = DAOTestUtils.randomUserEmail(name);
     return {
-      subject,
-      token,
-      name: name.full,
       email,
+      sub,
+      uniqueName: name.full,
     };
   }
 }

--- a/lib/test/DAOTestUtils.js
+++ b/lib/test/DAOTestUtils.js
@@ -1,34 +1,11 @@
 import childProcess from 'child_process';
 import path from 'path';
 import util from 'util';
-import uuid from 'uuid/v4';
 
 import db from '@/lib/db/db';
-import Random from '@/lib/Random';
 
 const execFile = util.promisify(childProcess.execFile);
 const GIT_ROOT = path.resolve(__dirname, '../..');
-
-const FIRST_NAMES = [
-  'Jane',
-  'John',
-  'Jorge',
-  'Javier',
-  'Jie',
-  'Janis',
-  'Jale',
-];
-
-const LAST_NAMES = [
-  'Doe',
-  'Doherty',
-  'Duende',
-  'Dortmund',
-  'Daichi',
-  'Devan',
-  'Dagher',
-  'Dimitriou',
-];
 
 class DAOTestUtils {
   // TEST LIFECYCLE
@@ -50,31 +27,6 @@ class DAOTestUtils {
     const scriptShutdown = path.resolve(GIT_ROOT, 'scripts/test/db/shutdown.sh');
     const { stdout } = await execFile(scriptShutdown);
     console.log(stdout);
-  }
-
-  // RANDOM GENERATORS
-
-  static randomUserName() {
-    const first = Random.choice(FIRST_NAMES);
-    const last = Random.choice(LAST_NAMES);
-    const full = `${first} ${last}`;
-    return { first, last, full };
-  }
-
-  static randomUserEmail({ first, last }) {
-    const suffix = Random.range(1000, 10000);
-    return `${first}.${last}${suffix}@toronto.ca`;
-  }
-
-  static randomUser() {
-    const sub = uuid();
-    const name = DAOTestUtils.randomUserName();
-    const email = DAOTestUtils.randomUserEmail(name);
-    return {
-      email,
-      sub,
-      uniqueName: name.full,
-    };
   }
 }
 DAOTestUtils.TIMEOUT = 60000;

--- a/lib/test/RestApiTestUtils.js
+++ b/lib/test/RestApiTestUtils.js
@@ -56,27 +56,29 @@ class RestApiTestUtils {
   // API WRAPPER
 
   static async callApi(uri, options) {
-    const requestOptions = {
+    const defaultOptions = {
       ca,
       getCookies: false,
+      headers: {},
       jar: COOKIE_JAR,
       json: true,
       method: 'GET',
       uri: `${HOST}${uri}`,
     };
-    if (CSRF !== null) {
-      requestOptions.headers = {
-        'X-CSRF-Token': CSRF,
-      };
+    const requestOptions = {
+      ...defaultOptions,
+      ...options,
+    };
+
+    const { getCookies, method } = requestOptions;
+    delete requestOptions.getCookies;
+    if (CSRF !== null && method !== 'GET') {
+      requestOptions.headers['X-CSRF-Token'] = CSRF;
     }
-    if (options !== undefined) {
-      Object.assign(requestOptions, options);
-      const { getCookies } = requestOptions;
-      delete requestOptions.getCookies;
-      if (getCookies) {
-        requestOptions.transform = transformGetCookies;
-      }
+    if (getCookies) {
+      requestOptions.transform = transformGetCookies;
     }
+
     return request(requestOptions);
   }
 

--- a/lib/test/random/UserGenerator.js
+++ b/lib/test/random/UserGenerator.js
@@ -27,7 +27,12 @@ function generateName() {
   const last = Random.choice(LAST_NAMES);
   const full = `${first} ${last}`;
   const suffix = Random.range(1000, 10000);
-  return { first, last, full, suffix };
+  return {
+    first,
+    last,
+    full,
+    suffix,
+  };
 }
 
 function generateUniqueName({ first, last, suffix }) {

--- a/lib/test/random/UserGenerator.js
+++ b/lib/test/random/UserGenerator.js
@@ -1,0 +1,68 @@
+import uuid from 'uuid/v4';
+import Random from '@/lib/Random';
+
+const FIRST_NAMES = [
+  'Jane',
+  'John',
+  'Jorge',
+  'Javier',
+  'Jie',
+  'Janis',
+  'Jale',
+];
+
+const LAST_NAMES = [
+  'Doe',
+  'Doherty',
+  'Duende',
+  'Dortmund',
+  'Daichi',
+  'Devan',
+  'Dagher',
+  'Dimitriou',
+];
+
+function generateName() {
+  const first = Random.choice(FIRST_NAMES);
+  const last = Random.choice(LAST_NAMES);
+  const full = `${first} ${last}`;
+  const suffix = Random.range(1000, 10000);
+  return { first, last, full, suffix };
+}
+
+function generateUniqueName({ first, last, suffix }) {
+  const firstInitial = first[0].toLowerCase();
+  const lastLower = last.toLowerCase();
+  return `MOVE-TEST\\${firstInitial}${lastLower}${suffix}`;
+}
+
+function generateEmail({ first, last, suffix }) {
+  return `${first}.${last}${suffix}@toronto.ca`;
+}
+
+function generateUser() {
+  const sub = uuid();
+  const name = generateName();
+  const email = generateEmail(name);
+  const uniqueName = generateUniqueName(name);
+  return {
+    email,
+    sub,
+    uniqueName,
+  };
+}
+
+const UserGenerator = {
+  generateName,
+  generateUniqueName,
+  generateEmail,
+  generateUser,
+};
+
+export {
+  UserGenerator as default,
+  generateName,
+  generateUniqueName,
+  generateEmail,
+  generateUser,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -3625,6 +3625,11 @@
         "@sendgrid/helpers": "^6.4.0"
       }
     },
+    "@sindresorhus/is": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
+    },
     "@soda/friendly-errors-webpack-plugin": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@soda/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.7.1.tgz",
@@ -3676,6 +3681,14 @@
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
+      }
+    },
+    "@szmarczak/http-timer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+      "requires": {
+        "defer-to-connect": "^1.0.1"
       }
     },
     "@types/accepts": {
@@ -3833,6 +3846,16 @@
         "@types/events": "*",
         "@types/minimatch": "*",
         "@types/node": "*"
+      }
+    },
+    "@types/got": {
+      "version": "9.6.9",
+      "resolved": "https://registry.npmjs.org/@types/got/-/got-9.6.9.tgz",
+      "integrity": "sha512-w+ZE+Ovp6fM+1sHwJB7RN3f3pTJHZkyABuULqbtknqezQyWadFEp5BzOXaZzRqAw2md6/d3ybxQJt+BNgpvzOg==",
+      "requires": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
       }
     },
     "@types/graphql-upload": {
@@ -6166,6 +6189,27 @@
       "integrity": "sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==",
       "dev": true
     },
+    "aggregate-error": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "dependencies": {
+        "clean-stack": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+          "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
+        },
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+        }
+      }
+    },
     "ajv": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -7873,6 +7917,11 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
       "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
     },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+    },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -7959,8 +8008,7 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-      "dev": true
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "body": {
       "version": "5.1.0",
@@ -8634,6 +8682,44 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
+        }
+      }
+    },
+    "cacheable-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^3.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^1.0.2"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "lowercase-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
         }
       }
     },
@@ -9440,6 +9526,14 @@
           "integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
           "dev": true
         }
+      }
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "requires": {
+        "mimic-response": "^1.0.0"
       }
     },
     "clone-stats": {
@@ -10606,6 +10700,14 @@
         }
       }
     },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
     "decompress-tar": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
@@ -10853,6 +10955,11 @@
       "requires": {
         "clone": "^1.0.2"
       }
+    },
+    "defer-to-connect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.1.tgz",
+      "integrity": "sha512-J7thop4u3mRTkYRQ+Vpfwy2G5Ehoy82I14+14W4YMDLKdWloI9gSzRbV30s/NckQGVJtPkWNcW4oMAUigTdqiQ=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -11637,8 +11744,7 @@
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-      "dev": true
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "duplexify": {
       "version": "3.7.1",
@@ -14328,6 +14434,43 @@
         "delegate": "^3.1.2"
       }
     },
+    "got": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+      "requires": {
+        "@sindresorhus/is": "^0.14.0",
+        "@szmarczak/http-timer": "^1.1.2",
+        "cacheable-request": "^6.0.0",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^4.1.0",
+        "lowercase-keys": "^1.0.1",
+        "mimic-response": "^1.0.1",
+        "p-cancelable": "^1.0.0",
+        "to-readable-stream": "^1.0.0",
+        "url-parse-lax": "^3.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
+      }
+    },
     "graceful-fs": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
@@ -14880,6 +15023,11 @@
           }
         }
       }
+    },
+    "http-cache-semantics": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
+      "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew=="
     },
     "http-call": {
       "version": "5.2.5",
@@ -16553,6 +16701,27 @@
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
+    "jose": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-1.18.1.tgz",
+      "integrity": "sha512-JRPxDCY48qjP9QVVwLVfq/nNuVdd3UPpyBDY0eDSPMtkDtCEISPy4Zx8anv5Zc2rebPrlenX2fca5rISNKDWXQ==",
+      "requires": {
+        "asn1.js": "^5.2.0"
+      },
+      "dependencies": {
+        "asn1.js": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.3.0.tgz",
+          "integrity": "sha512-WHnQJFcOrIWT1RLOkFFBQkFVvyt9BPOOrH+Dp152Zk4R993rSzXUGPmkybIcUFhHE2d/iHH+nCaOWVCDbO8fgA==",
+          "requires": {
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "safer-buffer": "^2.1.0"
+          }
+        }
+      }
+    },
     "js-beautify": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.10.1.tgz",
@@ -16738,6 +16907,11 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -16830,6 +17004,14 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
       "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
+    },
+    "keyv": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+      "requires": {
+        "json-buffer": "3.0.0"
+      }
     },
     "killable": {
       "version": "1.0.1",
@@ -17759,8 +17941,7 @@
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-      "dev": true
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
     },
     "lru-cache": {
       "version": "4.1.5",
@@ -17811,8 +17992,7 @@
     "make-error": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
-      "dev": true
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
     },
     "makeerror": {
       "version": "1.0.11",
@@ -18239,6 +18419,11 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+    },
     "mini-css-extract-plugin": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.8.0.tgz",
@@ -18293,8 +18478,7 @@
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
@@ -18928,6 +19112,11 @@
       "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
       "dev": true
     },
+    "normalize-url": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
+    },
     "now-and-later": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.1.tgz",
@@ -19164,6 +19353,11 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
     },
+    "oidc-token-hash": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.0.tgz",
+      "integrity": "sha512-8Yr4CZSv+Tn8ZkN3iN2i2w2G92mUKClp4z7EGUfdsERiYSbj7P4i/NHm72ft+aUdsiFx9UdIPSTwbyzQ6C4URg=="
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -19210,6 +19404,48 @@
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
       "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
       "dev": true
+    },
+    "openid-client": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-3.10.1.tgz",
+      "integrity": "sha512-GeoIDdg6G4N+Rt4ww2RAjlftuAgsKSCEupk6Y4xcd/njS0oOqHB0Bx3JSHcupYWxRfNUE4sGNeHarRX44wSqbA==",
+      "requires": {
+        "@types/got": "^9.6.9",
+        "base64url": "^3.0.1",
+        "got": "^9.6.0",
+        "jose": "^1.18.1",
+        "lodash": "^4.17.15",
+        "lru-cache": "^5.1.1",
+        "make-error": "^1.3.5",
+        "object-hash": "^2.0.1",
+        "oidc-token-hash": "^5.0.0",
+        "p-any": "^2.1.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "object-hash": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.0.1.tgz",
+          "integrity": "sha512-HgcGMooY4JC2PBt9sdUdJ6PMzpin+YtY3r/7wg0uTifP+HJWW8rammseSEHuyt0UeShI183UGssCJqm1bJR7QA=="
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+        }
+      }
     },
     "opn": {
       "version": "5.5.0",
@@ -19330,6 +19566,33 @@
         "os-tmpdir": "^1.0.0"
       }
     },
+    "p-any": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-any/-/p-any-2.1.0.tgz",
+      "integrity": "sha512-JAERcaMBLYKMq+voYw36+x5Dgh47+/o7yuv2oQYuSSUml4YeqJEFznBrY2UeEkoSHqBua6hz518n/PsowTYLLg==",
+      "requires": {
+        "p-cancelable": "^2.0.0",
+        "p-some": "^4.0.0",
+        "type-fest": "^0.3.0"
+      },
+      "dependencies": {
+        "p-cancelable": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
+          "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg=="
+        },
+        "type-fest": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
+        }
+      }
+    },
+    "p-cancelable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
+    },
     "p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -19388,6 +19651,22 @@
       "dev": true,
       "requires": {
         "retry": "^0.12.0"
+      }
+    },
+    "p-some": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-some/-/p-some-4.1.0.tgz",
+      "integrity": "sha512-MF/HIbq6GeBqTrTIl5OJubzkGU+qfFhAFi0gnTAK6rgEIJIknEiABHOTtQu4e6JiXjIwuMPMUFQzyHh5QjCl1g==",
+      "requires": {
+        "aggregate-error": "^3.0.0",
+        "p-cancelable": "^2.0.0"
+      },
+      "dependencies": {
+        "p-cancelable": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
+          "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg=="
+        }
       }
     },
     "p-try": {
@@ -20823,6 +21102,11 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
+    "prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+    },
     "prettier": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
@@ -21794,6 +22078,14 @@
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
+    },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "requires": {
+        "lowercase-keys": "^1.0.0"
+      }
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -24436,6 +24728,11 @@
         }
       }
     },
+    "to-readable-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
+    },
     "to-regex": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
@@ -25198,6 +25495,14 @@
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "url-parse-lax": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "requires": {
+        "prepend-http": "^2.0.0"
       }
     },
     "url-to-options": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "mapbox-gl": "^1.6.0",
     "module-alias": "^2.2.2",
     "mustache": "^3.2.0",
+    "openid-client": "^3.10.1",
     "pdfmake": "^0.1.63",
     "pg-promise": "^10.3.1",
     "request": "^2.88.0",

--- a/scripts/db/schema-7.down.sql
+++ b/scripts/db/schema-7.down.sql
@@ -1,0 +1,62 @@
+BEGIN;
+
+DROP TABLE "study_request_comments" CASCADE;
+DROP TABLE "studies" CASCADE;
+DROP TABLE "study_requests" CASCADE;
+DROP TABLE "users" CASCADE;
+
+CREATE TABLE "users" (
+  "subject" VARCHAR NOT NULL,
+  "email" VARCHAR NOT NULL,
+  "name" VARCHAR NOT NULL,
+  "token" TEXT NOT NULL,
+  PRIMARY KEY ("subject"),
+  UNIQUE ("email")
+);
+
+CREATE TABLE "study_requests" (
+  "id" BIGSERIAL PRIMARY KEY NOT NULL,
+  "createdAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  "userSubject" VARCHAR NOT NULL REFERENCES "users" ("subject"),
+  "status" VARCHAR NOT NULL REFERENCES "study_request_status" ("value"),
+  "closed" BOOLEAN DEFAULT FALSE,
+  "assignedTo" VARCHAR DEFAULT NULL,
+  "serviceRequestId" VARCHAR DEFAULT NULL,
+  "priority" VARCHAR NOT NULL,
+  "dueDate" TIMESTAMP NOT NULL,
+  "estimatedDeliveryDate" TIMESTAMP NOT NULL,
+  "reasons" VARCHAR[] NOT NULL,
+  "ccEmails" VARCHAR[] NOT NULL,
+  "centrelineId" BIGINT NOT NULL,
+  "centrelineType" SMALLINT NOT NULL,
+  "geom" GEOMETRY(POINT, 4326) NOT NULL
+);
+CREATE INDEX "study_requests_userSubject" ON "study_requests" ("userSubject");
+CREATE INDEX "study_requests_centreline" ON "study_requests" ("centrelineId", "centrelineType");
+CREATE INDEX "study_requests_geom" ON "study_requests" USING GIST ("geom");
+
+CREATE TABLE "studies" (
+  "id" BIGSERIAL PRIMARY KEY NOT NULL,
+  "createdAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  "userSubject" VARCHAR NOT NULL REFERENCES "users" ("subject"),
+  "studyRequestId" BIGINT NOT NULL REFERENCES "study_requests" ("id"),
+  "studyType" VARCHAR NOT NULL,
+  "daysOfWeek" SMALLINT[] NOT NULL,
+  "duration" SMALLINT DEFAULT NULL,
+  "hours" VARCHAR DEFAULT NULL,
+  "notes" VARCHAR NOT NULL
+);
+CREATE INDEX "studies_userSubject" ON "studies" ("userSubject");
+CREATE INDEX "studies_studyRequestId" ON "studies" ("studyRequestId");
+
+CREATE TABLE "study_request_comments" (
+  "id" BIGSERIAL PRIMARY KEY NOT NULL,
+  "createdAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  "userSubject" VARCHAR NOT NULL REFERENCES "users" ("subject"),
+  "studyRequestId" BIGINT NOT NULL REFERENCES "study_requests" ("id"),
+  "comment" VARCHAR NOT NULL
+);
+CREATE INDEX "study_request_comments_studyRequestId_createdAt" ON "study_request_comments" ("studyRequestId", "createdAt");
+
+UPDATE "APP_META"."DB_UPDATE" SET "currentVersion" = 6;
+COMMIT;

--- a/scripts/db/schema-7.up.sql
+++ b/scripts/db/schema-7.up.sql
@@ -1,0 +1,62 @@
+BEGIN;
+
+DROP TABLE "study_request_comments" CASCADE;
+DROP TABLE "studies" CASCADE;
+DROP TABLE "study_requests" CASCADE;
+DROP TABLE "users" CASCADE;
+
+CREATE TABLE "users" (
+  "id" BIGSERIAL PRIMARY KEY NOT NULL,
+  "createdAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  "email" VARCHAR NOT NULL,
+  "sub" VARCHAR NOT NULL,
+  "uniqueName" VARCHAR NOT NULL
+);
+CREATE UNIQUE INDEX users_sub ON "users" ("sub");
+
+CREATE TABLE "study_requests" (
+  "id" BIGSERIAL PRIMARY KEY NOT NULL,
+  "createdAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  "userId" BIGINT NOT NULL REFERENCES "users" ("id"),
+  "status" VARCHAR NOT NULL REFERENCES "study_request_status" ("value"),
+  "closed" BOOLEAN DEFAULT FALSE,
+  "assignedTo" VARCHAR DEFAULT NULL,
+  "serviceRequestId" VARCHAR DEFAULT NULL,
+  "priority" VARCHAR NOT NULL,
+  "dueDate" TIMESTAMP NOT NULL,
+  "estimatedDeliveryDate" TIMESTAMP NOT NULL,
+  "reasons" VARCHAR[] NOT NULL,
+  "ccEmails" VARCHAR[] NOT NULL,
+  "centrelineId" BIGINT NOT NULL,
+  "centrelineType" SMALLINT NOT NULL,
+  "geom" GEOMETRY(POINT, 4326) NOT NULL
+);
+CREATE INDEX "study_requests_userId" ON "study_requests" ("userId");
+CREATE INDEX "study_requests_centreline" ON "study_requests" ("centrelineId", "centrelineType");
+CREATE INDEX "study_requests_geom" ON "study_requests" USING GIST ("geom");
+
+CREATE TABLE "studies" (
+  "id" BIGSERIAL PRIMARY KEY NOT NULL,
+  "createdAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  "userId" BIGINT NOT NULL REFERENCES "users" ("id"),
+  "studyRequestId" BIGINT NOT NULL REFERENCES "study_requests" ("id"),
+  "studyType" VARCHAR NOT NULL,
+  "daysOfWeek" SMALLINT[] NOT NULL,
+  "duration" SMALLINT DEFAULT NULL,
+  "hours" VARCHAR DEFAULT NULL,
+  "notes" VARCHAR NOT NULL
+);
+CREATE INDEX "studies_userId" ON "studies" ("userId");
+CREATE INDEX "studies_studyRequestId" ON "studies" ("studyRequestId");
+
+CREATE TABLE "study_request_comments" (
+  "id" BIGSERIAL PRIMARY KEY NOT NULL,
+  "createdAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  "userId" BIGINT NOT NULL REFERENCES "users" ("id"),
+  "studyRequestId" BIGINT NOT NULL REFERENCES "study_requests" ("id"),
+  "comment" VARCHAR NOT NULL
+);
+CREATE INDEX "study_request_comments_studyRequestId_createdAt" ON "study_request_comments" ("studyRequestId", "createdAt");
+
+UPDATE "APP_META"."DB_UPDATE" SET "currentVersion" = 7;
+COMMIT;

--- a/tests/jest/db/DAO.spec.js
+++ b/tests/jest/db/DAO.spec.js
@@ -25,6 +25,12 @@ import StudyRequest from '@/lib/model/StudyRequest';
 import StudyRequestComment from '@/lib/model/StudyRequestComment';
 import DAOTestUtils from '@/lib/test/DAOTestUtils';
 import { loadJsonSync } from '@/lib/test/TestDataLoader';
+import {
+  generateEmail,
+  generateName,
+  generateUniqueName,
+  generateUser,
+} from '@/lib/test/random/UserGenerator';
 import DateTime from '@/lib/time/DateTime';
 
 beforeAll(DAOTestUtils.startupWithDevData, DAOTestUtils.TIMEOUT);
@@ -385,7 +391,7 @@ test('CountDataDAO', async () => {
 });
 
 test('StudyRequestDAO', async () => {
-  const transientUser = DAOTestUtils.randomUser();
+  const transientUser = generateUser();
   const persistedUser = await UserDAO.create(transientUser);
   const now = DateTime.local();
   const transientStudyRequest = {
@@ -495,7 +501,7 @@ test('StudyRequestDAO', async () => {
 });
 
 test('StudyRequestCommentDAO', async () => {
-  const user1 = DAOTestUtils.randomUser();
+  const user1 = generateUser();
   const userCreated1 = await UserDAO.create(user1);
   const now = DateTime.local();
   const transientStudyRequest = {
@@ -530,7 +536,7 @@ test('StudyRequestCommentDAO', async () => {
     comment: 'We don\'t normally do this study here.',
   };
 
-  const user2 = DAOTestUtils.randomUser();
+  const user2 = generateUser();
   const userCreated2 = await UserDAO.create(user2);
   const transientComment2 = {
     userId: userCreated2.id,
@@ -623,14 +629,15 @@ test('StudyRequestStatusDAO', async () => {
 });
 
 test('UserDAO', async () => {
-  const transientUser = DAOTestUtils.randomUser();
+  const transientUser = generateUser();
   await expect(UserDAO.bySub(transientUser.sub)).resolves.toBeNull();
   const persistedUser = await UserDAO.create(transientUser);
   expect(persistedUser.sub).toEqual(transientUser.sub);
   await expect(UserDAO.bySub(transientUser.sub)).resolves.toEqual(persistedUser);
-  const name = DAOTestUtils.randomUserName();
-  const email = DAOTestUtils.randomUserEmail(name);
-  Object.assign(persistedUser, { email, uniqueName: name.full });
+  const name = generateName();
+  const email = generateEmail(name);
+  const uniqueName = generateUniqueName(name);
+  Object.assign(persistedUser, { email, uniqueName });
   await expect(UserDAO.update(persistedUser)).resolves.toEqual(true);
   await expect(UserDAO.bySub(transientUser.sub)).resolves.toEqual(persistedUser);
   await expect(UserDAO.delete(persistedUser)).resolves.toEqual(true);

--- a/tests/jest/unit/Constants.spec.js
+++ b/tests/jest/unit/Constants.spec.js
@@ -21,8 +21,11 @@ test('Constants.SearchKeys', () => {
     lat: 0,
   };
   const requestedBy = {
+    id: 42,
+    createdAt: DateTime.local(),
+    sub: '0123456789',
     email: 'Baz.Quux@toronto.ca',
-    name: 'Baz Quux',
+    uniqueName: 'ORG\\BazQuux',
   };
   const REQUEST = {
     dueDate,
@@ -107,8 +110,11 @@ test('Constants.SortKeys', () => {
     lat: 0,
   };
   const requestedBy = {
+    id: 42,
+    createdAt: DateTime.local(),
+    sub: '0123456789',
     email: 'Baz.Quux@toronto.ca',
-    name: 'Baz Quux',
+    uniqueName: 'ORG\\BazQuux',
   };
   const REQUEST_STANDARD = {
     dueDate: now,
@@ -139,7 +145,7 @@ test('Constants.SortKeys', () => {
   expect(SortKeys.Requests.PRIORITY(REQUEST_URGENT))
     .toEqual(1);
   expect(SortKeys.Requests.REQUESTER(REQUEST_STANDARD))
-    .toEqual(REQUEST_STANDARD.requestedBy.name);
+    .toEqual(REQUEST_STANDARD.requestedBy.uniqueName);
   expect(SortKeys.Requests.STATUS(REQUEST_STANDARD))
     .toEqual(REQUEST_STANDARD.status);
 

--- a/web/components/FcCommentsStudyRequest.vue
+++ b/web/components/FcCommentsStudyRequest.vue
@@ -45,11 +45,11 @@
           <div class="mt-m">
             <strong
               v-if="comment.userId === auth.user.id">
-              {{auth.user.name}}
+              {{auth.user.uniqueName}}
             </strong>
             <strong
               v-else-if="studyRequestCommentUsers.has(comment.userId)">
-              {{studyRequestCommentUsers.get(comment.userId).name}}
+              {{studyRequestCommentUsers.get(comment.userId).uniqueName}}
             </strong>
             <span v-else class="text-muted">
               Author unknown

--- a/web/components/FcCommentsStudyRequest.vue
+++ b/web/components/FcCommentsStudyRequest.vue
@@ -44,12 +44,12 @@
         <div>
           <div class="mt-m">
             <strong
-              v-if="comment.userSubject === auth.user.subject">
+              v-if="comment.userId === auth.user.id">
               {{auth.user.name}}
             </strong>
             <strong
-              v-else-if="studyRequestCommentUsers.has(comment.userSubject)">
-              {{studyRequestCommentUsers.get(comment.userSubject).name}}
+              v-else-if="studyRequestCommentUsers.has(comment.userId)">
+              {{studyRequestCommentUsers.get(comment.userId).name}}
             </strong>
             <span v-else class="text-muted">
               Author unknown
@@ -61,7 +61,7 @@
         </div>
         <div class="flex-fill"></div>
         <button
-          v-if="auth.user.subject === comment.userSubject"
+          v-if="auth.user.id === comment.userId"
           class="font-size-m uppercase"
           @click="actionDelete(comment)">
           <i class="fa fa-trash" />

--- a/web/components/FcDisplayRequestStudyView.vue
+++ b/web/components/FcDisplayRequestStudyView.vue
@@ -31,7 +31,7 @@
           </h2>
           <div class="flex-fill"></div>
           <button
-            v-if="auth.user.subject === studyRequest.userSubject || isSupervisor"
+            v-if="auth.user.id === studyRequest.userId || isSupervisor"
             class="font-size-l uppercase"
             @click="onActionEdit">
             <i class="fa fa-edit" />

--- a/web/router.js
+++ b/web/router.js
@@ -18,9 +18,18 @@ const router = new Router({
       name: 'login',
       meta: {
         auth: false,
-        title: 'Log in',
+        title: 'Log In',
       },
       component: () => import(/* webpackChunkName: "login" */ '@/web/views/FcLogin.vue'),
+    },
+    {
+      path: '/auth/adfs-callback',
+      name: 'adfsCallback',
+      meta: {
+        auth: false,
+        title: 'Log In: City of Toronto',
+      },
+      component: () => import(/* webpackChunkName: "login" */ '@/web/views/FcAdfsCallback.vue'),
     },
     {
       path: '/requests/track',

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -62,8 +62,8 @@ export default new Vuex.Store({
     // AUTH / HELPERS STATE
     username(state) {
       if (state.auth.loggedIn) {
-        const { email, name } = state.auth.user;
-        return name || email;
+        const { email, uniqueName } = state.auth.user;
+        return uniqueName || email;
       }
       return 'Guest';
     },

--- a/web/store/modules/requestStudy.js
+++ b/web/store/modules/requestStudy.js
@@ -4,7 +4,7 @@ import {
   COUNT_TYPES,
 } from '@/lib/Constants';
 import { apiFetch } from '@/lib/api/BackendClient';
-import { getLocationByFeature, getUsersBySubjects } from '@/lib/api/WebApi';
+import { getLocationByFeature, getUsersByIds } from '@/lib/api/WebApi';
 import { STUDY_DUPLICATE, STUDY_IRRELEVANT_TYPE } from '@/lib/i18n/ConfirmDialog';
 
 function makeStudy(studyType) {
@@ -169,12 +169,12 @@ export default {
 
       commit('setStudyRequestLocation', studyRequestLocation);
 
-      let subjects = new Set();
-      studyRequestComments.forEach(({ userSubject }) => {
-        subjects.add(userSubject);
+      let ids = new Set();
+      studyRequestComments.forEach(({ userId }) => {
+        ids.add(userId);
       });
-      subjects = Array.from(subjects);
-      const studyRequestCommentUsers = await getUsersBySubjects(subjects);
+      ids = Array.from(ids);
+      const studyRequestCommentUsers = await getUsersByIds(ids);
       commit('setStudyRequestCommentUsers', studyRequestCommentUsers);
 
       return {

--- a/web/views/FcAdfsCallback.vue
+++ b/web/views/FcAdfsCallback.vue
@@ -64,6 +64,7 @@ export default {
   mounted() {
     if (this.idToken === null || this.nonce === null) {
       this.$router.push({ name: 'login' });
+      return;
     }
     this.$refs.form.submit();
   },

--- a/web/views/FcAdfsCallback.vue
+++ b/web/views/FcAdfsCallback.vue
@@ -62,11 +62,8 @@ export default {
     ...mapState(['auth']),
   },
   mounted() {
-    if (this.idToken === null) {
-      // TODO: redirect back to login
-    }
-    if (this.nonce === null) {
-      // TODO: redirect back to login
+    if (this.idToken === null || this.nonce === null) {
+      this.$router.push({ name: 'login' });
     }
     this.$refs.form.submit();
   },

--- a/web/views/FcAdfsCallback.vue
+++ b/web/views/FcAdfsCallback.vue
@@ -1,0 +1,83 @@
+<template>
+  <div class="fc-adfs-callback mt-m px-l">
+    <div class="hide">
+      <form
+        ref="form"
+        id="form_fc_adfs_callback"
+        method="POST"
+        action="/api/auth/adfs-callback">
+        <input
+          v-if="$route.query.path"
+          type="hidden"
+          name="path"
+          :value="$route.query.path" />
+        <input type="hidden" name="csrf" :value="auth.csrf" />
+        <input type="hidden" name="id_token" :value="idToken" />
+        <input type="hidden" name="nonce" :value="nonce" />
+      </form>
+    </div>
+    <h1>Log In: City of Toronto</h1>
+    <div class="adfs-loading-spinner mt-l">
+      <TdsLoadingSpinner />
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+
+import TdsLoadingSpinner from '@/web/components/tds/TdsLoadingSpinner.vue';
+
+function getIdToken() {
+  const hashQuery = window.location.hash.slice(1);
+  const parts = hashQuery.split('=');
+  if (parts.length !== 2) {
+    return null;
+  }
+  const [key, value] = parts;
+  if (key !== 'id_token') {
+    return null;
+  }
+  return value;
+}
+
+function getNonce() {
+  return window.localStorage.getItem('nonce');
+}
+
+export default {
+  name: 'FcAdfsCallback',
+  components: {
+    TdsLoadingSpinner,
+  },
+  data() {
+    const idToken = getIdToken();
+    const nonce = getNonce();
+    return {
+      idToken,
+      nonce,
+    };
+  },
+  computed: {
+    ...mapState(['auth']),
+  },
+  mounted() {
+    if (this.idToken === null) {
+      // TODO: redirect back to login
+    }
+    if (this.nonce === null) {
+      // TODO: redirect back to login
+    }
+    this.$refs.form.submit();
+  },
+};
+</script>
+
+<style lang="postcss">
+.fc-adfs-callback {
+  .adfs-loading-spinner {
+    height: var(--space-2xl);
+    width: var(--space-2xl);
+  }
+}
+</style>

--- a/web/views/FcLogin.vue
+++ b/web/views/FcLogin.vue
@@ -24,23 +24,10 @@
 <script>
 import { mapState } from 'vuex';
 
-const HEX = '0123456789abcdef';
-
-function randomNonce(length) {
-  const bytes = new Uint8Array(length);
-  const random = window.crypto.getRandomValues(bytes);
-  const result = [];
-  random.forEach((c) => {
-    const hi = HEX[Math.floor(c / 16)];
-    result.push(hi);
-    const lo = HEX[c % 16];
-    result.push(lo);
-  });
-  return result.join('');
-}
+import ClientNonce from '@/lib/auth/ClientNonce';
 
 function setNonce() {
-  const nonce = randomNonce(16);
+  const nonce = ClientNonce.get(16);
   window.localStorage.setItem('nonce', nonce);
   return nonce;
 }

--- a/web/views/FcLogin.vue
+++ b/web/views/FcLogin.vue
@@ -6,11 +6,6 @@
         id="form_fc_login"
         method="POST"
         action="/api/auth/adfs-init">
-        <input
-          v-if="$route.query.path"
-          type="hidden"
-          name="path"
-          :value="$route.query.path" />
         <input type="hidden" name="csrf" :value="auth.csrf" />
         <input type="hidden" name="nonce" :value="nonce" />
       </form>

--- a/web/views/FcLogin.vue
+++ b/web/views/FcLogin.vue
@@ -5,123 +5,61 @@
         ref="form"
         id="form_fc_login"
         method="POST"
-        action="/api/auth/stub">
+        action="/api/auth/adfs-init">
         <input
           v-if="$route.query.path"
           type="hidden"
           name="path"
           :value="$route.query.path" />
         <input type="hidden" name="csrf" :value="auth.csrf" />
+        <input type="hidden" name="nonce" :value="nonce" />
       </form>
     </div>
-    <h1>Log in to MOVE</h1>
-    <div class="flex-container-row">
-      <div class="flex-1">
-        <TdsPanel
-          class="font-size-l"
-          variant="info">
-          <p>
-            To log in, enter your name and <strong>@toronto.ca</strong> email address.
-          </p>
-        </TdsPanel>
-        <div class="form-group">
-          <label>
-            <span>Name</span>
-            <input
-              v-model="$v.name.$model"
-              class="font-size-xl full-width mb-m"
-              :class="{
-                invalid: $v.name.$error,
-              }"
-              form="form_fc_login"
-              name="name"
-              tabindex="1"
-              type="text" />
-          </label>
-          <TdsPanel
-            v-if="$v.name.$error"
-            variant="error">
-            <p>
-              Please enter your name.
-            </p>
-          </TdsPanel>
-        </div>
-        <div class="form-group">
-          <label>
-            <span>Email</span>
-            <input
-              v-model="$v.email.$model"
-              class="font-size-xl full-width mb-m"
-              :class="{
-                invalid: $v.email.$error,
-              }"
-              form="form_fc_login"
-              name="email"
-              tabindex="2"
-              type="text" />
-          </label>
-          <TdsPanel
-            v-if="$v.email.$error"
-            variant="error">
-            <p>
-              Please enter a valid
-              <strong>@toronto.ca</strong> email address.
-            </p>
-          </TdsPanel>
-        </div>
-        <button
-          class="tds-button-primary font-size-2xl"
-          :disabled="loading || $v.$invalid"
-          form="form_fc_login"
-          tabindex="3"
-          type="submit"
-          @click="onClickLogin">
-          Log in
-        </button>
-      </div>
-      <div class="flex-1 px-l"></div>
-    </div>
+    <h1>Welcome to MOVE</h1>
+    <button
+      class="tds-button-primary font-size-2xl"
+      form="form_fc_login"
+      tabindex="1"
+      type="submit">
+      Log in
+    </button>
   </div>
 </template>
 
 <script>
-import { email, required } from 'vuelidate/lib/validators';
 import { mapState } from 'vuex';
 
-import TdsPanel from '@/web/components/tds/TdsPanel.vue';
+const HEX = '0123456789abcdef';
+
+function randomNonce(length) {
+  const bytes = new Uint8Array(length);
+  const random = window.crypto.getRandomValues(bytes);
+  const result = [];
+  random.forEach((c) => {
+    const hi = HEX[Math.floor(c / 16)];
+    result.push(hi);
+    const lo = HEX[c % 16];
+    result.push(lo);
+  });
+  return result.join('');
+}
+
+function setNonce() {
+  const nonce = randomNonce(16);
+  window.localStorage.setItem('nonce', nonce);
+  return nonce;
+}
 
 export default {
   name: 'FcLogin',
-  components: {
-    TdsPanel,
-  },
   data() {
+    const nonce = setNonce();
     return {
-      name: '',
-      email: '',
-      loading: false,
+      nonce,
     };
   },
   computed: {
     ...mapState(['auth']),
-  },
-  validations: {
-    email: {
-      required,
-      email,
-      torontoInternal(value) {
-        return value.endsWith('@toronto.ca');
-      },
-    },
-    name: {
-      required,
-    },
-  },
-  methods: {
-    onClickLogin() {
-      this.loading = true;
-      this.$refs.form.submit();
-    },
   },
 };
 </script>

--- a/web/views/FcRequestsTrack.vue
+++ b/web/views/FcRequestsTrack.vue
@@ -142,7 +142,7 @@
             N/A
           </span>
           <span v-else>
-            {{item.requestedBy.name}}
+            {{item.requestedBy.uniqueName}}
           </span>
         </template>
         <template v-slot:DATE="{ item }">
@@ -281,7 +281,7 @@ function getItemFields(item) {
   } = item;
   let [lng, lat] = item.geom.coordinates;
   const location = (item.location && item.location.description) || null;
-  const requester = (item.requestedBy && item.requestedBy.name) || null;
+  const requester = (item.requestedBy && item.requestedBy.uniqueName) || null;
   const dueDate = TimeFormatters.formatDefault(item.dueDate);
   const estimatedDeliveryDate = TimeFormatters.formatDefault(item.estimatedDeliveryDate);
   if (centrelineType !== CentrelineType.INTERSECTION) {

--- a/web/views/FcRequestsTrack.vue
+++ b/web/views/FcRequestsTrack.vue
@@ -434,7 +434,7 @@ export default {
         const {
           centrelineId,
           centrelineType,
-          userSubject,
+          userId,
         } = studyRequest;
 
         const key = centrelineKey(centrelineType, centrelineId);
@@ -444,8 +444,8 @@ export default {
         }
 
         let requestedBy = null;
-        if (this.studyRequestUsers.has(userSubject)) {
-          requestedBy = this.studyRequestUsers.get(userSubject);
+        if (this.studyRequestUsers.has(userId)) {
+          requestedBy = this.studyRequestUsers.get(userId);
         }
 
         return {


### PR DESCRIPTION
This PR closes #162 by providing a working end-to-end implementation of ADFS authentication in MOVE.

It includes changes to the `users` schema, as well as to study request-related tables that refer to `users`.  Since we're not yet putting this in front of people longer-term, and since the `sub` UUIDs previously generated won't line up with ADFS `sub` claim values, we simply drop and remake these tables.

Note that this depends on #293 to be fully functional.  Until that change is made, log in will not work, as the ADFS auth endpoint relies on a whitelist of callback URIs.  We have, however, tested it with the following flow:

- temporarily change the callback URI in `MoveConfig` to `/api/auth/adfs-callback`;
- when it redirects to `/api/auth/adfs-callback`, delete the leading `/api` from the path and load that page.

This should complete the ADFS flow as intended.