### PR TITLE
Use FcMixinVModelProxy throughout application

### DIFF
--- a/web/components/FcDataTable.vue
+++ b/web/components/FcDataTable.vue
@@ -21,6 +21,8 @@
 </template>
 
 <script>
+import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+
 function compareKeys(ka, kb, kf) {
   const n = ka.length;
   for (let i = 0; i < n; i++) {
@@ -36,6 +38,7 @@ function compareKeys(ka, kb, kf) {
 
 export default {
   name: 'FcDataTable',
+  mixins: [FcMixinVModelProxy(Array)],
   props: {
     caption: {
       type: String,
@@ -59,7 +62,6 @@ export default {
       type: Object,
       default() { return {}; },
     },
-    value: Array,
   },
   computed: {
     headers() {
@@ -71,14 +73,6 @@ export default {
           ...options,
         };
       });
-    },
-    internalValue: {
-      get() {
-        return this.value;
-      },
-      set(value) {
-        this.$emit('input', value);
-      },
     },
   },
   methods: {

--- a/web/components/dialogs/FcDialogReportParameters.vue
+++ b/web/components/dialogs/FcDialogReportParameters.vue
@@ -31,32 +31,23 @@
 import { ReportType } from '@/lib/Constants';
 import FcReportParametersWarrantTrafficSignalControl
   from '@/web/components/reports/FcReportParametersWarrantTrafficSignalControl.vue';
+import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
 export default {
   name: 'FcDialogReportParameters',
+  mixins: [FcMixinVModelProxy(Boolean)],
   components: {
     FcReportParametersWarrantTrafficSignalControl,
   },
   props: {
     reportParameters: Object,
     reportType: ReportType,
-    value: Boolean,
   },
   data() {
     const internalReportParameters = JSON.parse(JSON.stringify(this.reportParameters));
     return {
       internalReportParameters,
     };
-  },
-  computed: {
-    internalValue: {
-      get() {
-        return this.value;
-      },
-      set(value) {
-        this.$emit('input', value);
-      },
-    },
   },
   methods: {
     onClickSave() {

--- a/web/components/dialogs/FcDialogStudyFilters.vue
+++ b/web/components/dialogs/FcDialogStudyFilters.vue
@@ -45,7 +45,7 @@
           v-model="internalHours"
           class="mt-2"
           hide-details
-          :label="description"
+          :label="studyHours.description"
           :value="studyHours"></v-checkbox>
       </v-card-text>
       <v-divider></v-divider>
@@ -70,15 +70,16 @@ import {
   StudyHours,
 } from '@/lib/Constants';
 import TimeFormatters from '@/lib/time/TimeFormatters';
+import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
 export default {
   name: 'FcDialogStudyFilters',
+  mixins: [FcMixinVModelProxy(Boolean)],
   props: {
     datesFrom: Number,
     daysOfWeek: Array,
     hours: Array,
     studyTypes: Array,
-    value: Boolean,
   },
   data() {
     return {
@@ -99,14 +100,6 @@ export default {
         hours: this.internalHours,
         studyTypes: this.internalStudyTypes,
       };
-    },
-    internalValue: {
-      get() {
-        return this.value;
-      },
-      set(value) {
-        this.$emit('input', value);
-      },
     },
   },
   methods: {

--- a/web/components/reports/FcReportParametersWarrantTrafficSignalControl.vue
+++ b/web/components/reports/FcReportParametersWarrantTrafficSignalControl.vue
@@ -33,20 +33,10 @@
 </template>
 
 <script>
+import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+
 export default {
   name: 'FcReportParametersWarrantTrafficSignalControl',
-  props: {
-    value: Object,
-  },
-  computed: {
-    internalValue: {
-      get() {
-        return this.value;
-      },
-      set(value) {
-        this.$emit('input', value);
-      },
-    },
-  },
+  mixins: [FcMixinVModelProxy(Object)],
 };
 </script>


### PR DESCRIPTION
This PR closes #312 by using `FcMixinVModelProxy` to replace a common pattern where a prop `value` is passed in, then proxied to a `v-model`-style interface via computed property `internalValue`.