### PR TITLE
Use MOVE Joi wrapper application-wide

### DIFF
--- a/lib/config/MoveConfig.js
+++ b/lib/config/MoveConfig.js
@@ -1,5 +1,5 @@
-import Joi from '@hapi/joi';
 import path from 'path';
+import Joi from '@/lib/model/Joi';
 
 import privateConfig from '@/lib/config/private';
 import vueConfig from '@/vue.config';

--- a/lib/controller/AuthController.js
+++ b/lib/controller/AuthController.js
@@ -1,6 +1,6 @@
 import Boom from '@hapi/boom';
-import Joi from '@hapi/joi';
 import uuid from 'uuid/v4';
+import Joi from '@/lib/model/Joi';
 
 import OpenIdClient from '@/lib/auth/OpenIdClient';
 import config from '@/lib/config/MoveConfig';

--- a/lib/controller/DynamicTileController.js
+++ b/lib/controller/DynamicTileController.js
@@ -1,5 +1,5 @@
-import Joi from '@hapi/joi';
 import vtpbf from 'vt-pbf';
+import Joi from '@/lib/model/Joi';
 
 import DynamicTileDAO from '@/lib/db/DynamicTileDAO';
 import VectorTile from '@/lib/geo/VectorTile';

--- a/lib/controller/LocationController.js
+++ b/lib/controller/LocationController.js
@@ -1,6 +1,6 @@
 import Boom from '@hapi/boom';
-import Joi from '@hapi/joi';
 import rp from 'request-promise-native';
+import Joi from '@/lib/model/Joi';
 
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import { CentrelineType } from '@/lib/Constants';

--- a/lib/controller/SignalSuggestionController.js
+++ b/lib/controller/SignalSuggestionController.js
@@ -1,4 +1,4 @@
-import Joi from '@hapi/joi';
+import Joi from '@/lib/model/Joi';
 
 import SignalDAO from '@/lib/db/SignalDAO';
 

--- a/lib/controller/StudyController.js
+++ b/lib/controller/StudyController.js
@@ -1,4 +1,4 @@
-import Joi from '@hapi/joi';
+import Joi from '@/lib/model/Joi';
 
 import StudyDAO from '@/lib/db/StudyDAO';
 import Study from '@/lib/model/Study';

--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -1,5 +1,5 @@
 import Boom from '@hapi/boom';
-import Joi from '@hapi/joi';
+import Joi from '@/lib/model/Joi';
 
 import { StudyRequestStatus } from '@/lib/Constants';
 import StudyRequestDAO from '@/lib/db/StudyRequestDAO';

--- a/reporter/reporter.js
+++ b/reporter/reporter.js
@@ -1,7 +1,7 @@
 import Boom from '@hapi/boom';
 import Good from '@hapi/good';
 import Hapi from '@hapi/hapi';
-import Joi from '@hapi/joi';
+import Joi from '@/lib/model/Joi';
 
 import config from '@/lib/config/MoveConfig';
 import ReportController from '@/lib/controller/ReportController';

--- a/web/components/FcDrawerViewRequest.vue
+++ b/web/components/FcDrawerViewRequest.vue
@@ -16,7 +16,7 @@
         </span>
       </div>
       <v-btn
-        v-if="auth.user.id === studyRequest.userId || isSupervisor"
+        v-if="!loading && (auth.user.id === studyRequest.userId || isSupervisor)"
         outlined
         @click="actionEdit">
         <v-icon left>mdi-pencil</v-icon> Edit

--- a/web/server.js
+++ b/web/server.js
@@ -3,9 +3,9 @@ import Crumb from '@hapi/crumb';
 import hapiAuthCookie from '@hapi/cookie';
 import Good from '@hapi/good';
 import Hapi from '@hapi/hapi';
-import Joi from '@hapi/joi';
 import Scooter from '@hapi/scooter';
 import Blankie from 'blankie';
+import Joi from '@/lib/model/Joi';
 
 import config from '@/lib/config/MoveConfig';
 import AuthController from '@/lib/controller/AuthController';


### PR DESCRIPTION
This PR closes #310 by using `@/lib/model/Joi` instead of directly importing `@hapi/joi`.

By using the MOVE Joi wrapper, we allow all callsites to get the benefit of our custom `DateTime` and `Enum` handling, as well as any future improvements (e.g. if we add `Map` / `Set` types as well).