### PR TITLE
Switch from PostCSS to SASS

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ This web application was originally generated from the following [Vue CLI preset
   "router": true,
   "routerHistoryMode": true,
   "vuex": true,
-  "cssPreprocessor": "postcss"
+  "cssPreprocessor": "sass"
 }
 ```
 
@@ -156,6 +156,5 @@ These files configure various tools used in MOVE:
 - `jest.config.js`: Jest configuration for unit, database, and REST API tests;
 - `LICENSE`: open-source license that MOVE is released under;
 - `package.json`: `npm` package configuration and dependencies;
-- `postcss.config.js`: PostCSS configuration for preprocessing CSS;
 - `requirements.txt`: Python dependencies;
 - `vue.config.js`: Vue project configuration, including webpack configuration for `webpack-dev-server` in development.

--- a/bdit-flashcrow.code-workspace
+++ b/bdit-flashcrow.code-workspace
@@ -1,7 +1,6 @@
 {
 	"extensions": {
 		"recommendations": [
-			"cpylua.language-postcss",
 			"dbaeumer.vscode-eslint",
 			"ms-python.python",
       "ms-vscode-remote.vscode-remote-extensionpack",

--- a/lib/reports/format/FormatCss.js
+++ b/lib/reports/format/FormatCss.js
@@ -64,21 +64,21 @@ class FormatCss {
     FormatCss.vars = new Map();
     return new Promise((resolve, reject) => {
       try {
-        const tdsPostcssPath = path.resolve(
+        const stylesPath = path.resolve(
           __dirname,
           '../../../web/css/main.scss',
         );
-        const tdsPostcss = readline.createInterface({
-          input: fs.createReadStream(tdsPostcssPath),
+        const styles = readline.createInterface({
+          input: fs.createReadStream(stylesPath),
         });
-        tdsPostcss.on('line', (line) => {
+        styles.on('line', (line) => {
           const variableDeclaration = FormatCss.getVariableDeclarationFromLine(line);
           if (variableDeclaration !== null) {
             const { name, value } = variableDeclaration;
             FormatCss.vars.set(name, value);
           }
         });
-        tdsPostcss.on('close', resolve);
+        styles.on('close', resolve);
       } catch (err) {
         reject(err);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22749,61 +22749,6 @@
         "postcss": "^7.0.6"
       }
     },
-    "postcss-nested": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-4.2.1.tgz",
-      "integrity": "sha512-AMayXX8tS0HCp4O4lolp4ygj9wBn32DJWXvG6gCv+ZvJrEa00GUxJcJEEzMh87BIe6FrWdYkpR2cuyqHKrxmXw==",
-      "dev": true,
-      "requires": {
-        "postcss": "^7.0.21",
-        "postcss-selector-parser": "^6.0.2"
-      },
-      "dependencies": {
-        "cssesc": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-          "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-          "dev": true
-        },
-        "postcss": {
-          "version": "7.0.21",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-          "integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "postcss-selector-parser": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
-          "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
-          "dev": true,
-          "requires": {
-            "cssesc": "^3.0.0",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
     "postcss-normalize-charset": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "lint-staged": "^10.0.2",
     "node-blob": "0.0.2",
     "npm-run-all": "^4.1.5",
-    "postcss-nested": "^4.2.1",
     "sass": "^1.25.0",
     "sass-loader": "^8.0.2",
     "stylelint": "^13.0.0",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  plugins: {
-    autoprefixer: {},
-    'postcss-nested': {},
-  },
-};

--- a/web/components/FcDrawerRequestStudy.vue
+++ b/web/components/FcDrawerRequestStudy.vue
@@ -348,7 +348,7 @@ export default {
 };
 </script>
 
-<style lang="postcss">
+<style lang="scss">
 .fc-drawer-request-study {
   max-height: 100vh;
 }

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -327,7 +327,7 @@ export default {
 };
 </script>
 
-<style lang="postcss">
+<style lang="scss">
 .fc-drawer-view-data {
   max-height: 100vh;
 }

--- a/web/components/FcDrawerViewReports.vue
+++ b/web/components/FcDrawerViewReports.vue
@@ -357,7 +357,7 @@ export default {
 };
 </script>
 
-<style lang="postcss">
+<style lang="scss">
 .fc-drawer-view-reports {
   max-height: 50vh;
 

--- a/web/components/FcDrawerViewRequest.vue
+++ b/web/components/FcDrawerViewRequest.vue
@@ -141,7 +141,7 @@ export default {
 };
 </script>
 
-<style lang="postcss">
+<style lang="scss">
 .fc-drawer-view-request {
   max-height: 100vh;
 }

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -710,7 +710,7 @@ export default {
 };
 </script>
 
-<style lang="postcss">
+<style lang="scss">
 .pane-map {
   background-color: var(--white);
   &.mapboxgl-map {

--- a/web/components/FcPaneMapPopup.vue
+++ b/web/components/FcPaneMapPopup.vue
@@ -201,7 +201,7 @@ export default {
 };
 </script>
 
-<style lang="postcss">
+<style lang="scss">
 .pane-map-popup {
   position: absolute;
   right: var(--space-l);

--- a/web/components/inputs/FcSearchBarLocation.vue
+++ b/web/components/inputs/FcSearchBarLocation.vue
@@ -69,7 +69,7 @@ export default {
 };
 </script>
 
-<style lang="postcss">
+<style lang="scss">
 .fc-search-bar-location {
   width: 392px;
   &.v-select.v-select--is-menu-active .v-input__icon--append .v-icon {

--- a/web/components/nav/FcDashboardNavItem.vue
+++ b/web/components/nav/FcDashboardNavItem.vue
@@ -49,7 +49,7 @@ export default {
 };
 </script>
 
-<style lang="postcss">
+<style lang="scss">
 .fc-nav-item.v-list-item {
   flex: 0;
   &.fc-nav-item-active {

--- a/web/components/reports/FcReport.vue
+++ b/web/components/reports/FcReport.vue
@@ -53,7 +53,7 @@ export default {
 };
 </script>
 
-<style lang="postcss">
+<style lang="scss">
 .fc-report {
   & > .fc-report-header {
     border-bottom: 1px solid var(--primary-dark);

--- a/web/components/reports/FcReportBarChart.vue
+++ b/web/components/reports/FcReportBarChart.vue
@@ -68,7 +68,7 @@ export default {
 };
 </script>
 
-<style lang="postcss">
+<style lang="scss">
 .fc-report-bar-chart {
   height: calc(var(--space-3xl) * 4);
   & > svg {

--- a/web/components/reports/FcReportTable.vue
+++ b/web/components/reports/FcReportTable.vue
@@ -228,7 +228,7 @@ export default {
 };
 </script>
 
-<style lang="postcss">
+<style lang="scss">
 .fc-report-table {
   & > table {
     border-collapse: separate;

--- a/web/views/FcLayoutDrawerMap.vue
+++ b/web/views/FcLayoutDrawerMap.vue
@@ -83,7 +83,7 @@ export default {
 };
 </script>
 
-<style lang="postcss">
+<style lang="scss">
 .fc-layout-drawer-map {
   position: relative;
   width: 100%;

--- a/web/views/FcRequestsTrack.vue
+++ b/web/views/FcRequestsTrack.vue
@@ -437,7 +437,7 @@ export default {
 };
 </script>
 
-<style lang="postcss">
+<style lang="scss">
 .fc-requests-track {
   max-height: 100vh;
   width: 100%;


### PR DESCRIPTION
This PR closes #323 by switching to SCSS, a CSS-compatible variant of SASS.

This was a relatively trivial search-replace change, thanks to our pre-existing SCSS-compatible syntax.