### PR TITLE
Last edited user / timestamp for study requests

### DIFF
--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -198,11 +198,20 @@ async function getStudyRequest(id) {
   const studyRequestCommentsSchema = Joi.array().items(StudyRequestComment.read);
   studyRequestComments = await studyRequestCommentsSchema.validateAsync(studyRequestComments);
 
-  const { centrelineId, centrelineType } = studyRequest;
-  const ids = new Set(studyRequestComments.map(({ userId }) => userId));
+  const {
+    centrelineId,
+    centrelineType,
+    lastEditorId,
+    userId,
+  } = studyRequest;
+  const ids = new Set(studyRequestComments.map(({ userId: commentUserId }) => commentUserId));
+  if (lastEditorId !== null) {
+    ids.add(lastEditorId);
+  }
+  ids.add(userId);
   const [
     studyRequestLocation,
-    studyRequestCommentUsers,
+    studyRequestUsers,
   ] = await Promise.all([
     getLocationByFeature({ centrelineId, centrelineType }),
     getUsersByIds(ids),
@@ -211,8 +220,8 @@ async function getStudyRequest(id) {
   return {
     studyRequest,
     studyRequestComments,
-    studyRequestCommentUsers,
     studyRequestLocation,
+    studyRequestUsers,
   };
 }
 

--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -172,7 +172,11 @@ StudyRequestController.push({
     if (studyRequestNew.lastEditorId !== studyRequestOld.lastEditorId) {
       return Boom.badRequest('cannot change last editor for study request');
     }
-    if (!studyRequestNew.lastEditedAt.equals(studyRequestOld.lastEditedAt)) {
+    if (studyRequestNew.lastEditedAt === null) {
+      if (studyRequestOld.lastEditedAt !== null) {
+        return Boom.badRequest('cannot change last edit timestamp for study request');
+      }
+    } else if (!studyRequestNew.lastEditedAt.equals(studyRequestOld.lastEditedAt)) {
       return Boom.badRequest('cannot change last edit timestamp for study request');
     }
 

--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -169,6 +169,12 @@ StudyRequestController.push({
     if (studyRequestNew.userId !== studyRequestOld.userId) {
       return Boom.badRequest('cannot change owner for study request');
     }
+    if (studyRequestNew.lastEditorId !== studyRequestOld.lastEditorId) {
+      return Boom.badRequest('cannot change last editor for study request');
+    }
+    if (!studyRequestNew.lastEditedAt.equals(studyRequestOld.lastEditedAt)) {
+      return Boom.badRequest('cannot change last edit timestamp for study request');
+    }
 
     if (studyRequestOld.userId !== user.id && !isSupervisor) {
       return Boom.forbidden('not authorized to change study request owned by another user');
@@ -180,7 +186,7 @@ StudyRequestController.push({
       return Boom.forbidden('not authorized to change status for study request');
     }
 
-    return StudyRequestDAO.update(studyRequestNew);
+    return StudyRequestDAO.update(studyRequestNew, user);
   },
 });
 

--- a/lib/db/StudyRequestDAO.js
+++ b/lib/db/StudyRequestDAO.js
@@ -17,6 +17,8 @@ const STUDY_REQUESTS_FIELDS = `
   "userId",
   "status",
   "closed",
+  "lastEditorId",
+  "lastEditedAt",
   "serviceRequestId",
   "urgent",
   "urgentReason",
@@ -121,6 +123,8 @@ INSERT INTO "study_requests" (
   "userId",
   "status",
   "closed",
+  "lastEditorId",
+  "lastEditedAt",
   "serviceRequestId",
   "urgent",
   "urgentReason",
@@ -137,6 +141,8 @@ INSERT INTO "study_requests" (
   $(userId),
   $(status),
   $(closed),
+  $(lastEditorId),
+  $(lastEditedAt),
   $(serviceRequestId),
   $(urgent),
   $(urgentReason),
@@ -149,16 +155,14 @@ INSERT INTO "study_requests" (
   $(centrelineType),
   ST_SetSRID(ST_GeomFromGeoJSON($(geom)), 4326)
 ) RETURNING "id"`;
-    const createdAt = DateTime.local();
-    const { id } = await db.one(sql, {
-      createdAt,
-      ...studyRequest,
-    });
     const persistedStudyRequest = {
-      id,
-      createdAt,
+      createdAt: DateTime.local(),
+      lastEditorId: null,
+      lastEditedAt: null,
       ...studyRequest,
     };
+    const { id } = await db.one(sql, persistedStudyRequest);
+    persistedStudyRequest.id = id;
     const studyPromises = studyRequest.studies.map(
       study => StudyDAO.create(persistedStudyRequest, study),
     );
@@ -172,13 +176,15 @@ INSERT INTO "study_requests" (
    * @param {Object} studyRequest - desired study request state
    * @returns {boolean} whether any rows were updated
    */
-  static async update(studyRequest) {
+  static async update(studyRequest, editor) {
     const studies = await StudyDAO.updateByStudyRequest(studyRequest);
     const sql = `
 UPDATE "study_requests" SET
   "userId" = $(userId),
   "status" = $(status),
   "closed" = $(closed),
+  "lastEditorId" = $(lastEditorId),
+  "lastEditedAt" = $(lastEditedAt),
   "serviceRequestId" = $(serviceRequestId),
   "urgent" = $(urgent),
   "urgentReason" = $(urgentReason),
@@ -191,13 +197,18 @@ UPDATE "study_requests" SET
   "centrelineType" = $(centrelineType),
   "geom" = ST_SetSRID(ST_GeomFromGeoJSON($(geom)), 4326)
   WHERE "id" = $(id)`;
-    await db.query(sql, studyRequest);
-    const studyRequestAttached = {
+    const editedStudyRequest = {
       ...studyRequest,
+      lastEditorId: editor.id,
+      lastEditedAt: DateTime.local(),
+    };
+    await db.query(sql, editedStudyRequest);
+    const editedStudyRequestAttached = {
+      ...editedStudyRequest,
       studies,
     };
     const studyRequestSchema = StudyRequest.read;
-    return studyRequestSchema.validateAsync(studyRequestAttached);
+    return studyRequestSchema.validateAsync(editedStudyRequestAttached);
   }
 
   /**

--- a/lib/model/Joi.js
+++ b/lib/model/Joi.js
@@ -14,6 +14,13 @@ const EXTENDED_JOI = Joi.extend({
     if (value === undefined) {
       return { value };
     }
+    const { _valids: valids } = helpers.schema;
+    if (valids !== null) {
+      const { _values: values } = valids;
+      if (values.has(value)) {
+        return { value };
+      }
+    }
     let dt = null;
     if (typeof value === 'string') {
       dt = DateTime.fromSQL(value);
@@ -41,6 +48,13 @@ const EXTENDED_JOI = Joi.extend({
   coerce(value, helpers) {
     if (value === undefined) {
       return { value };
+    }
+    const { _valids: valids } = helpers.schema;
+    if (valids !== null) {
+      const { _values: values } = valids;
+      if (values.has(value)) {
+        return { value };
+      }
     }
     if (value instanceof Enum) {
       return { value };

--- a/lib/model/StudyRequest.js
+++ b/lib/model/StudyRequest.js
@@ -14,6 +14,13 @@ const PERSISTED_COLUMNS = {
   userId: Joi.number().integer().positive().required(),
   status: Joi.enum().ofType(StudyRequestStatus).required(),
   closed: Joi.boolean().required(),
+  lastEditorId: Joi
+    .number()
+    .integer()
+    .positive()
+    .allow(null)
+    .required(),
+  lastEditedAt: Joi.dateTime().allow(null).required(),
 };
 
 const COLUMNS = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21014,14 +21014,14 @@
       "dev": true
     },
     "openid-client": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-3.13.0.tgz",
-      "integrity": "sha512-IhkIYjnmlnwX0tZc1r6MINXdYyyK0XLHLU31GecKXS6u2MPauStwakL2Vi0sjyLqAnqOp49BZ6VZmAdJmvb2cA==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-3.11.0.tgz",
+      "integrity": "sha512-0ADlGIwSdeDhySMzUtnmfBFmqb22XTMaSH97QLNQWfxw6YwPJ8rU6m58AsRJ62bPVRnHZxmOPuxIS3obN2jSVQ==",
       "requires": {
         "@types/got": "^9.6.9",
         "base64url": "^3.0.1",
         "got": "^9.6.0",
-        "jose": "^1.23.0",
+        "jose": "^1.18.1",
         "lodash": "^4.17.15",
         "lru-cache": "^5.1.1",
         "make-error": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "backend:test-api": "NODE_ENV=test PGPASSFILE=/mnt/ramdisk_move_test/.pgpass API_TEST_HEADLESS=1 node  -r ./globalWindowShim -r esm -r module-alias/register web/server.js",
     "ci:jest-coverage": "NODE_ENV=test PGPASSFILE=/mnt/ramdisk_move_test/.pgpass jest --coverage",
     "ci:npm-audit": "npm audit",
-    "ci:npm-outdated": "npm outdated",
+    "ci:npm-outdated": "npm outdated || true",
     "ci:test-unit": "NODE_ENV=test PGPASSFILE=/mnt/ramdisk_move_test/.pgpass TEST_DIR=\"unit/**\" jest",
     "docs:js": "documentation serve --babel babel.config.js --favicon public/favicon.ico --port 9080 --sort-order alpha --watch web/server.js lib/**",
     "frontend": "vue-cli-service serve",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "mapbox-gl": "^1.7.0",
     "module-alias": "^2.2.2",
     "mustache": "^4.0.0",
-    "openid-client": "^3.13.0",
+    "openid-client": "^3.11.0",
     "pdfmake": "^0.1.64",
     "pg-promise": "^10.4.3",
     "request": "^2.88.2",

--- a/scripts/db/schema-9.down.sql
+++ b/scripts/db/schema-9.down.sql
@@ -1,6 +1,5 @@
 BEGIN;
 
--- backward migration SQL goes here
 ALTER TABLE "study_requests" DROP COLUMN "lastEditedAt";
 ALTER TABLE "study_requests" DROP COLUMN "lastEditorId";
 

--- a/scripts/db/schema-9.down.sql
+++ b/scripts/db/schema-9.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+-- backward migration SQL goes here
+ALTER TABLE "study_requests" DROP COLUMN "lastEditedAt";
+ALTER TABLE "study_requests" DROP COLUMN "lastEditorId";
+
+UPDATE "APP_META"."DB_UPDATE" SET "currentVersion" = 8;
+COMMIT;

--- a/scripts/db/schema-9.up.sql
+++ b/scripts/db/schema-9.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE "study_requests" ADD COLUMN "lastEditorId" BIGINT DEFAULT NULL REFERENCES "users" ("id");
+ALTER TABLE "study_requests" ADD COLUMN "lastEditedAt" TIMESTAMP DEFAULT NULL;
+
+UPDATE "APP_META"."DB_UPDATE" SET "currentVersion" = 9;
+COMMIT;

--- a/tests/jest/db/DAO.spec.js
+++ b/tests/jest/db/DAO.spec.js
@@ -528,26 +528,26 @@ test('StudyRequestDAO', async () => {
   persistedStudyRequest.studies[0].daysOfWeek = [3, 4];
   persistedStudyRequest.studies[0].hours = StudyHours.SCHOOL;
   persistedStudyRequest.studies[0].notes = 'oops, this is actually a school count';
-  persistedStudyRequest = await StudyRequestDAO.update(persistedStudyRequest);
+  persistedStudyRequest = await StudyRequestDAO.update(persistedStudyRequest, persistedUser);
   fetchedStudyRequest = await StudyRequestDAO.byId(persistedStudyRequest.id);
   expect(fetchedStudyRequest).toEqual(persistedStudyRequest);
 
   // set as urgent
   persistedStudyRequest.urgent = true;
   persistedStudyRequest.urgentReason = 'because I said so';
-  persistedStudyRequest = await StudyRequestDAO.update(persistedStudyRequest);
+  persistedStudyRequest = await StudyRequestDAO.update(persistedStudyRequest, persistedUser);
   fetchedStudyRequest = await StudyRequestDAO.byId(persistedStudyRequest.id);
   expect(fetchedStudyRequest).toEqual(persistedStudyRequest);
 
   // close
   persistedStudyRequest.closed = true;
-  persistedStudyRequest = await StudyRequestDAO.update(persistedStudyRequest);
+  persistedStudyRequest = await StudyRequestDAO.update(persistedStudyRequest, persistedUser);
   fetchedStudyRequest = await StudyRequestDAO.byId(persistedStudyRequest.id);
   expect(fetchedStudyRequest).toEqual(persistedStudyRequest);
 
   // reopen
   persistedStudyRequest.closed = false;
-  persistedStudyRequest = await StudyRequestDAO.update(persistedStudyRequest);
+  persistedStudyRequest = await StudyRequestDAO.update(persistedStudyRequest, persistedUser);
   fetchedStudyRequest = await StudyRequestDAO.byId(persistedStudyRequest.id);
   expect(fetchedStudyRequest).toEqual(persistedStudyRequest);
 
@@ -559,13 +559,13 @@ test('StudyRequestDAO', async () => {
     hours: StudyHours.OTHER,
     notes: 'complete during shopping mall peak hours',
   });
-  persistedStudyRequest = await StudyRequestDAO.update(persistedStudyRequest);
+  persistedStudyRequest = await StudyRequestDAO.update(persistedStudyRequest, persistedUser);
   fetchedStudyRequest = await StudyRequestDAO.byId(persistedStudyRequest.id);
   expect(fetchedStudyRequest).toEqual(persistedStudyRequest);
 
   // remove study from study request
   persistedStudyRequest.studies.pop();
-  persistedStudyRequest = await StudyRequestDAO.update(persistedStudyRequest);
+  persistedStudyRequest = await StudyRequestDAO.update(persistedStudyRequest, persistedUser);
   fetchedStudyRequest = await StudyRequestDAO.byId(persistedStudyRequest.id);
   expect(fetchedStudyRequest).toEqual(persistedStudyRequest);
 

--- a/tests/jest/db/DAO.spec.js
+++ b/tests/jest/db/DAO.spec.js
@@ -501,6 +501,10 @@ test('StudyRequestDAO', async () => {
     }],
   };
 
+  // generate second user for multi-user updates
+  const transientUser2 = generateUser();
+  const persistedUser2 = await UserDAO.create(transientUser2);
+
   // save study request
   let persistedStudyRequest = await StudyRequestDAO.create(transientStudyRequest);
   expect(persistedStudyRequest.id).not.toBeNull();
@@ -531,19 +535,22 @@ test('StudyRequestDAO', async () => {
   persistedStudyRequest = await StudyRequestDAO.update(persistedStudyRequest, persistedUser);
   fetchedStudyRequest = await StudyRequestDAO.byId(persistedStudyRequest.id);
   expect(fetchedStudyRequest).toEqual(persistedStudyRequest);
+  expect(fetchedStudyRequest.lastEditorId).toEqual(persistedUser.id);
 
-  // set as urgent
+  // set as urgent with second user
   persistedStudyRequest.urgent = true;
   persistedStudyRequest.urgentReason = 'because I said so';
-  persistedStudyRequest = await StudyRequestDAO.update(persistedStudyRequest, persistedUser);
+  persistedStudyRequest = await StudyRequestDAO.update(persistedStudyRequest, persistedUser2);
   fetchedStudyRequest = await StudyRequestDAO.byId(persistedStudyRequest.id);
   expect(fetchedStudyRequest).toEqual(persistedStudyRequest);
+  expect(fetchedStudyRequest.lastEditorId).toEqual(persistedUser2.id);
 
-  // close
+  // close with first user
   persistedStudyRequest.closed = true;
   persistedStudyRequest = await StudyRequestDAO.update(persistedStudyRequest, persistedUser);
   fetchedStudyRequest = await StudyRequestDAO.byId(persistedStudyRequest.id);
   expect(fetchedStudyRequest).toEqual(persistedStudyRequest);
+  expect(fetchedStudyRequest.lastEditorId).toEqual(persistedUser.id);
 
   // reopen
   persistedStudyRequest.closed = false;

--- a/tests/jest/unit/model/Joi.spec.js
+++ b/tests/jest/unit/model/Joi.spec.js
@@ -50,6 +50,12 @@ test('Joi.dateTime [optional / required]', () => {
 
   result = Joi.dateTime().required().validate(undefined);
   expect(result.error).not.toBeUndefined();
+
+  result = Joi.dateTime().allow(null).required().validate(null);
+  expect(result.error).toBeUndefined();
+
+  result = Joi.dateTime().required().validate(null);
+  expect(result.error).not.toBeUndefined();
 });
 
 test('Joi.enum', () => {
@@ -110,5 +116,18 @@ test('Joi.enum [optional / required]', () => {
   expect(result.error).toBeUndefined();
 
   result = Joi.enum().ofType(Color).required().validate(undefined);
+  expect(result.error).not.toBeUndefined();
+
+  result = Joi.enum().allow(null).required().validate(null);
+  expect(result.error).toBeUndefined();
+
+  result = Joi.enum().required().validate(null);
+  expect(result.error).not.toBeUndefined();
+
+  result = Joi.enum().ofType(Color).allow(null).required()
+    .validate(null);
+  expect(result.error).toBeUndefined();
+
+  result = Joi.enum().ofType(Color).required().validate(null);
   expect(result.error).not.toBeUndefined();
 });

--- a/web/components/FcCommentsStudyRequest.vue
+++ b/web/components/FcCommentsStudyRequest.vue
@@ -33,8 +33,8 @@
               {{auth.user.uniqueName}}
             </span>
             <span
-              v-else-if="studyRequestCommentUsers.has(comment.userId)">
-              {{studyRequestCommentUsers.get(comment.userId).uniqueName}}
+              v-else-if="studyRequestUsers.has(comment.userId)">
+              {{studyRequestUsers.get(comment.userId).uniqueName}}
             </span>
           </div>
           <div class="subtitle-1 mt-1">
@@ -74,7 +74,7 @@ export default {
     sizeLimit: Number,
     studyRequest: Object,
     studyRequestComments: Array,
-    studyRequestCommentUsers: Map,
+    studyRequestUsers: Map,
   },
   data() {
     return {

--- a/web/components/FcDrawerRequestStudy.vue
+++ b/web/components/FcDrawerRequestStudy.vue
@@ -251,14 +251,18 @@ export default {
     location() {
       this.updateStudyRequestLocation();
     },
-    studyTypes(studyTypes, studyTypesPrev) {
-      studyTypes.forEach((studyType) => {
+    studyTypes() {
+      let studyTypesPrev = [];
+      if (this.studyRequest !== null) {
+        studyTypesPrev = this.studyRequest.studies.map(({ studyType }) => studyType);
+      }
+      this.studyTypes.forEach((studyType) => {
         if (!studyTypesPrev.includes(studyType)) {
           this.actionAddStudy(studyType);
         }
       });
       studyTypesPrev.forEach((studyType) => {
-        if (!studyTypes.includes(studyType)) {
+        if (!this.studyTypes.includes(studyType)) {
           this.actionRemoveStudy(studyType);
         }
       });
@@ -314,6 +318,7 @@ export default {
         studyRequestLocation = result.studyRequestLocation;
       }
       this.studyRequest = studyRequest;
+      this.studyTypes = studyRequest.studies.map(({ studyType }) => studyType);
       this.setLocation(studyRequestLocation);
       this.updateStudyRequestLocation();
     },

--- a/web/components/FcDrawerViewRequest.vue
+++ b/web/components/FcDrawerViewRequest.vue
@@ -29,6 +29,13 @@
         indeterminate />
       <div v-else>
         <div class="pl-5">
+          <div
+            v-if="studyRequest.lastEditorId !== null
+              && studyRequestUsers.has(studyRequest.lastEditorId)"
+            class="subtitle-2 mt-4 mb-3">
+            Last edited by {{studyRequestUsers.get(studyRequest.lastEditorId).uniqueName}}
+            on {{studyRequest.lastEditedAt | dateTime}}.
+          </div>
           <FcSummaryStudyRequest
             class="pr-5"
             :study-request="studyRequest" />
@@ -45,7 +52,7 @@
           :size-limit="240"
           :study-request="studyRequest"
           :study-request-comments="studyRequestComments"
-          :study-request-comment-users="studyRequestCommentUsers"
+          :study-request-users="studyRequestUsers"
           @add-comment="onAddComment"
           @delete-comment="onDeleteComment" />
       </div>
@@ -78,7 +85,7 @@ export default {
     return {
       studyRequest: null,
       studyRequestComments: [],
-      studyRequestCommentUsers: new Map(),
+      studyRequestUsers: new Map(),
     };
   },
   computed: {
@@ -121,12 +128,12 @@ export default {
       const {
         studyRequest,
         studyRequestComments,
-        studyRequestCommentUsers,
         studyRequestLocation,
+        studyRequestUsers,
       } = await getStudyRequest(id);
       this.studyRequest = studyRequest;
       this.studyRequestComments = studyRequestComments;
-      this.studyRequestCommentUsers = studyRequestCommentUsers;
+      this.studyRequestUsers = studyRequestUsers;
       this.setLocation(studyRequestLocation);
     },
     onAddComment(comment) {

--- a/web/components/inputs/FcRadioGroup.vue
+++ b/web/components/inputs/FcRadioGroup.vue
@@ -5,15 +5,10 @@
     <template v-for="(item, i) in items">
       <v-radio
         :key="'radio_' + item.value"
-        :class="{
-          'mb-6': !!item.sublabel && i !== items.length - 1
-        }"
         :hint="item.hint"
         :value="item.value">
         <template v-slot:label>
-          <div :class="{
-            'pt-5': !!item.sublabel,
-          }">
+          <div>
             <span>{{item.label}}</span>
             <template v-if="item.sublabel">
               <br>


### PR DESCRIPTION
This PR closes #321 by adding the `lastEditorId`, `lastEditedAt` columns to `study_requests`, then updating the backend / frontend to handle / render these new columns.

As per discussion: we went with a lightweight approach here, mostly out of a sense that building more robust update tracking / auditing logic would be premature at this point.