### PR TITLE
Domain-aware configuration for MOVE

### DIFF
--- a/lib/config/MoveConfig.js
+++ b/lib/config/MoveConfig.js
@@ -14,7 +14,8 @@ import { ENV } from '@/lib/config/Env';
  */
 
 /*
- * On AWS, we get PostgreSQL connection parameters from environment variable files.
+ * On AWS, we get PostgreSQL connection parameters and domain name information from
+ * environment variable files.
  *
  * We don't have such files in local development, but it doesn't matter there - we use
  * the `development` or `test` environments below in those cases.
@@ -23,10 +24,27 @@ const {
   PGDATABASE = 'PGDATABASE',
   PGHOST = 'PGHOST',
   PGUSER = 'PGUSER',
+  DomainName: DOMAIN_NAME = 'DomainName',
 } = process.env;
 const productionDb = `postgres://${PGUSER}@${PGHOST}/${PGDATABASE}`;
 
 const testPort = 'API_TEST_HEADLESS' in process.env ? 8080 : 8081;
+
+function getAdfsIssuerUrl(domainName) {
+  switch (domainName) {
+    case 'move.intra.dev-toronto.ca':
+    default:
+      return 'https://adfs.lab.intra.sandbox-toronto.ca/adfs';
+  }
+}
+
+function getEmailSender(domainName) {
+  switch (domainName) {
+    case 'move.intra.dev-toronto.ca':
+    default:
+      return 'move-team@email1.dev-toronto.ca';
+  }
+}
 
 const config = {
   development: {
@@ -35,6 +53,7 @@ const config = {
      * the system to have a properly configured `.pgpass` containing the correct password.
      */
     db: 'postgres://flashcrow@localhost:5432/flashcrow',
+    emailSender: 'move-team@email1.dev-toronto.ca',
     host: '0.0.0.0',
     https: vueConfig.devServer.https,
     openId: {
@@ -51,6 +70,7 @@ const config = {
   },
   test: {
     db: 'postgres://flashcrow@localhost:5433/flashcrow',
+    emailSender: 'move-team@email1.dev-toronto.ca',
     host: '0.0.0.0',
     https: vueConfig.devServer.https,
     openId: {
@@ -73,15 +93,16 @@ const config = {
   },
   production: {
     db: productionDb,
+    emailSender: getEmailSender(DOMAIN_NAME),
     host: 'localhost',
     https: null,
     openId: {
       clientMetadata: {
         redirect_uris: [
-          'https://move.intra.dev-toronto.ca/api/auth/adfs-callback',
+          `https://${DOMAIN_NAME}/api/auth/adfs-callback`,
         ],
       },
-      issuerUrl: 'https://adfs.lab.intra.sandbox-toronto.ca/adfs',
+      issuerUrl: getAdfsIssuerUrl(DOMAIN_NAME),
     },
     port: 8081,
     session: {
@@ -89,7 +110,7 @@ const config = {
        * In production, we need the cookie to be tied to our ELB domain
        * name, not localhost.
        */
-      domain: 'move.intra.dev-toronto.ca',
+      domain: DOMAIN_NAME,
     },
     webPort: 443,
   },
@@ -101,6 +122,7 @@ const configSchema = Joi.object().keys({
   db: Joi.string().uri({
     scheme: 'postgres',
   }),
+  emailSender: Joi.string().required(),
   host: Joi.string().hostname(),
   https: Joi.object().keys({
     /*
@@ -131,30 +153,33 @@ const configSchema = Joi.object().keys({
   webPort: Joi.number().integer().positive().required(),
 });
 
-Object.keys(config).forEach((key) => {
-  /* eslint-disable-next-line camelcase */
-  config[key].openId.clientMetadata = {
-    ...config[key].openId.clientMetadata,
-    ...privateConfig[key].openId.clientMetadata,
-  };
-  config[key].sendGrid = privateConfig[key].sendGrid;
-  config[key].session.password = privateConfig[key].session.password;
-  Joi.assert(config[key], configSchema, { convert: false });
-});
-
 // CONFIG SELECTION BASED ON ENVIRONMENT
 
-if (!config[ENV]) {
-  throw new Error(`missing configuration for ${ENV}`);
+const MoveConfig = config[ENV];
+if (!MoveConfig) {
+  throw new Error(`missing public configuration for ${ENV}`);
 }
+
+let privateConfigDomain = privateConfig[ENV];
+if (ENV === 'production') {
+  privateConfigDomain = privateConfigDomain[DOMAIN_NAME];
+}
+if (!privateConfigDomain) {
+  throw new Error(`missing private configuration for ${ENV} (${DOMAIN_NAME})`);
+}
+
+MoveConfig.openId.clientMetadata = {
+  ...MoveConfig.openId.clientMetadata,
+  ...privateConfigDomain.openId.clientMetadata,
+};
+MoveConfig.sendGrid = privateConfigDomain.sendGrid;
+MoveConfig.session.password = privateConfigDomain.session.password;
+Joi.assert(MoveConfig, configSchema, { convert: false });
 
 const BASE_DIR = path.resolve(__dirname, '../..');
 
-const MoveConfig = {
-  ...config[ENV],
-  BASE_DIR,
-  ENV,
-  PUBLIC_PATH: vueConfig.publicPath,
-};
+MoveConfig.BASE_DIR = BASE_DIR;
+MoveConfig.ENV = ENV;
+MoveConfig.PUBLIC_PATH = vueConfig.publicPath;
 
 export default MoveConfig;

--- a/lib/config/MoveConfig.js
+++ b/lib/config/MoveConfig.js
@@ -11,14 +11,28 @@ import { ENV } from '@/lib/config/Env';
  * Note that this file *is* checked into source control.  Do *NOT* put
  * credentials in here!  Those belong in `lib/config/private.js`, which
  * is `.gitignore`'d.
+ *
+ * `MoveConfig` provides three build types for MOVE to run in:
+ *
+ * - development: within Vagrant on local dev machines;
+ * - test: like development, but with a separate test database;
+ * - production: any of the AWS environments, *including* AWS development, QA, and staging
+ *   environments.
+ *
+ * This follows the convention of using `NODE_ENV=development` vs. `NODE_ENV=production` to
+ * switch between development (i.e. debug) and production (i.e. release) builds, especially
+ * when using webpack.
+ *
+ * All AWS environments use the production (i.e. release) build.  `lib/config/private` contains
+ * AWS environment-specific configurations, such as credentials and keys that are provisioned
+ * separately for dev, QA, staging, and production.
  */
 
 /*
  * On AWS, we get PostgreSQL connection parameters and domain name information from
  * environment variable files.
  *
- * We don't have such files in local development, but it doesn't matter there - we use
- * the `development` or `test` environments below in those cases.
+ * In local development and test, we use the corresponding build configurations below.
  */
 const {
   PGDATABASE = 'PGDATABASE',
@@ -162,6 +176,9 @@ if (!MoveConfig) {
 
 let privateConfigDomain = privateConfig[ENV];
 if (ENV === 'production') {
+  /*
+   * As mentioned, the
+   */
   privateConfigDomain = privateConfigDomain[DOMAIN_NAME];
 }
 if (!privateConfigDomain) {
@@ -177,9 +194,11 @@ MoveConfig.session.password = privateConfigDomain.session.password;
 Joi.assert(MoveConfig, configSchema, { convert: false });
 
 const BASE_DIR = path.resolve(__dirname, '../..');
+const PUBLIC_PATH = vueConfig.publicPath;
 
-MoveConfig.BASE_DIR = BASE_DIR;
-MoveConfig.ENV = ENV;
-MoveConfig.PUBLIC_PATH = vueConfig.publicPath;
-
-export default MoveConfig;
+export default {
+  ...MoveConfig,
+  BASE_DIR,
+  ENV,
+  PUBLIC_PATH,
+};

--- a/lib/email/EmailBase.js
+++ b/lib/email/EmailBase.js
@@ -3,6 +3,7 @@ import vueConfig from '@/vue.config';
 
 const PORT_HTTPS_DEFAULT = 443;
 const {
+  emailSender,
   session: { domain = 'localhost' },
   webPort = PORT_HTTPS_DEFAULT,
 } = config;
@@ -75,8 +76,7 @@ class EmailBase {
    * @returns {string} sender
    */
   static getSender() {
-    // TODO: as other tiers are spun up, add corresponding email addresses here
-    return 'move-team@email1.dev-toronto.ca';
+    return emailSender;
   }
 
   /* eslint-disable class-methods-use-this */

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
   "gitHooks": {
     "pre-commit": "npm-run-all pre-commit:*"
   },
-  "homepage": "https://move.intra.dev-toronto.ca",
   "license": "MIT",
   "lint-staged": {
     "lib/**/*.js": [

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -101,24 +101,11 @@ const PAINT_WIDTH_MIDBLOCKS = interactionAttr(3, 5, 5);
 const PAINT_RADIUS_INTERSECTIONS = interactionAttr(8, 10, 10);
 const PAINT_RADIUS_COUNTS = interactionAttr(10, 12, 12);
 
-function getTileOrigin() {
-  const { origin } = window.location;
-  if (origin.startsWith('https://localhost')) {
-    return 'https://move.intra.dev-toronto.ca';
-  }
-  /*
-   * TODO: verify whether we need to serve these under a different domain in different
-   * AWS environments
-   */
-  return origin;
-}
-const TILE_ORIGIN = getTileOrigin();
-
 function addTippecanoeSource(style, id, minLevel, maxLevel, crossfade = 0) {
   /* eslint-disable-next-line no-param-reassign */
   style.sources[id] = {
     type: 'vector',
-    tiles: [`${TILE_ORIGIN}/tiles/${id}/{z}/{x}/{y}.pbf`],
+    tiles: [`https://flashcrow-etladmin.intra.dev-toronto.ca/tiles/${id}/{z}/{x}/{y}.pbf`],
     minzoom: minLevel.minzoom,
     maxzoom: maxLevel.maxzoomSource + crossfade,
   };
@@ -151,7 +138,7 @@ function addLayer(style, id, type, options) {
 function injectSourcesAndLayers(rawStyle) {
   const STYLE = { ...rawStyle };
 
-  STYLE.glyphs = `${TILE_ORIGIN}/glyphs/{fontstack}/{range}.pbf`;
+  STYLE.glyphs = 'https://flashcrow-etladmin.intra.dev-toronto.ca/glyphs/{fontstack}/{range}.pbf';
 
   addTippecanoeSource(STYLE, 'collisionsLevel3', MapZoom.LEVEL_3, MapZoom.LEVEL_3, 2);
   addTippecanoeSource(STYLE, 'collisionsLevel2', MapZoom.LEVEL_2, MapZoom.LEVEL_2);

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -101,11 +101,24 @@ const PAINT_WIDTH_MIDBLOCKS = interactionAttr(3, 5, 5);
 const PAINT_RADIUS_INTERSECTIONS = interactionAttr(8, 10, 10);
 const PAINT_RADIUS_COUNTS = interactionAttr(10, 12, 12);
 
+function getTileOrigin() {
+  const { origin } = window.location;
+  if (origin.startsWith('https://localhost')) {
+    return 'https://move.intra.dev-toronto.ca';
+  }
+  /*
+   * TODO: verify whether we need to serve these under a different domain in different
+   * AWS environments
+   */
+  return origin;
+}
+const TILE_ORIGIN = getTileOrigin();
+
 function addTippecanoeSource(style, id, minLevel, maxLevel, crossfade = 0) {
   /* eslint-disable-next-line no-param-reassign */
   style.sources[id] = {
     type: 'vector',
-    tiles: [`https://move.intra.dev-toronto.ca/tiles/${id}/{z}/{x}/{y}.pbf`],
+    tiles: [`${TILE_ORIGIN}/tiles/${id}/{z}/{x}/{y}.pbf`],
     minzoom: minLevel.minzoom,
     maxzoom: maxLevel.maxzoomSource + crossfade,
   };
@@ -138,7 +151,7 @@ function addLayer(style, id, type, options) {
 function injectSourcesAndLayers(rawStyle) {
   const STYLE = { ...rawStyle };
 
-  STYLE.glyphs = 'https://move.intra.dev-toronto.ca/glyphs/{fontstack}/{range}.pbf';
+  STYLE.glyphs = `${TILE_ORIGIN}/glyphs/{fontstack}/{range}.pbf`;
 
   addTippecanoeSource(STYLE, 'collisionsLevel3', MapZoom.LEVEL_3, MapZoom.LEVEL_3, 2);
   addTippecanoeSource(STYLE, 'collisionsLevel2', MapZoom.LEVEL_2, MapZoom.LEVEL_2);


### PR DESCRIPTION
This PR makes progress on #292 by updating `MoveConfig` and related configuration modules to allow for multiple AWS domains.