### PR TITLE
Map popup rework: dynamic content, card-like layout

### DIFF
--- a/lib/StringFormatters.js
+++ b/lib/StringFormatters.js
@@ -18,6 +18,28 @@ const UPPERCASE_WORDS = [
 ];
 
 /**
+ *
+ * @param {?string} name (e.g. Lawrence)
+ * @param {?string} type (e.g. Ave)
+ * @param {?string} dir (e.g. W)
+ * @returns {string} combined street name (e.g. Lawrence Ave W), or `null`
+ * if `name` is empty
+ */
+function formatCombinedStreet(name, type, dir) {
+  if (!name) {
+    return null;
+  }
+  const parts = [name];
+  if (type) {
+    parts.push(type);
+    if (dir) {
+      parts.push(dir);
+    }
+  }
+  return parts.map(part => part.trim()).join(' ');
+}
+
+/**
  * Normalizes location descriptions.
  *
  * @param {string} description - raw description from centreline / FLOW
@@ -81,6 +103,7 @@ function formatOxfordCommaList(parts) {
 }
 
 const StringFormatters = {
+  formatCombinedStreet,
   formatCountLocationDescription,
   formatDuration,
   formatOxfordCommaList,
@@ -88,6 +111,7 @@ const StringFormatters = {
 
 export {
   StringFormatters as default,
+  formatCombinedStreet,
   formatCountLocationDescription,
   formatDuration,
   formatOxfordCommaList,

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -41,6 +41,10 @@ async function deleteStudyRequestComment(csrf, studyRequest, comment) {
   return SuccessResponse.validateAsync(result);
 }
 
+async function getCollisionPopupDetails(id) {
+  return apiClient.fetch(`/collisions/${id}/popupDetails`);
+}
+
 async function getCollisionsByCentrelineSummary(feature, filters) {
   const { centrelineId, centrelineType } = feature;
   const data = {
@@ -324,6 +328,7 @@ async function putStudyRequestComment(csrf, studyRequest, comment) {
 const WebApi = {
   deleteStudyRequests,
   deleteStudyRequestComment,
+  getCollisionPopupDetails,
   getCollisionsByCentrelineSummary,
   getCountsByCentreline,
   getCountsByCentrelineSummary,
@@ -345,6 +350,7 @@ export {
   WebApi as default,
   deleteStudyRequests,
   deleteStudyRequestComment,
+  getCollisionPopupDetails,
   getCollisionsByCentrelineSummary,
   getCountsByCentreline,
   getCountsByCentrelineSummary,

--- a/lib/controller/CollisionController.js
+++ b/lib/controller/CollisionController.js
@@ -1,3 +1,5 @@
+import Boom from '@hapi/boom';
+
 import {
   CentrelineType,
 } from '@/lib/Constants';
@@ -5,6 +7,27 @@ import CollisionDAO from '@/lib/db/CollisionDAO';
 import Joi from '@/lib/model/Joi';
 
 const CollisionController = [];
+
+CollisionController.push({
+  method: 'GET',
+  path: '/collisions/{id}/popupDetails',
+  options: {
+    auth: { mode: 'try' },
+    validate: {
+      params: {
+        id: Joi.number().integer().positive().required(),
+      },
+    },
+  },
+  handler: async (request) => {
+    const { id } = request.params;
+    const collision = await CollisionDAO.byIdPopupDetails(id);
+    if (collision.event === null) {
+      return Boom.notFound(`no collision found with ID ${id}`);
+    }
+    return collision;
+  },
+});
 
 CollisionController.push({
   method: 'GET',

--- a/lib/db/ArteryDAO.js
+++ b/lib/db/ArteryDAO.js
@@ -1,4 +1,5 @@
 import { CardinalDirection } from '@/lib/Constants';
+import { formatCombinedStreet } from '@/lib/StringFormatters';
 import db from '@/lib/db/db';
 
 /**
@@ -10,28 +11,6 @@ import db from '@/lib/db/db';
  * uses this metadata as part of the 24-Hour Count Summary Report.
  */
 class ArteryDAO {
-  /**
-   *
-   * @param {?string} name (e.g. Lawrence)
-   * @param {?string} type (e.g. Ave)
-   * @param {?string} dir (e.g. W)
-   * @returns {string} combined street name (e.g. Lawrence Ave W), or `null`
-   * if `name` is empty
-   */
-  static getCombinedStreet(name, type, dir) {
-    if (!name) {
-      return null;
-    }
-    const parts = [name];
-    if (type) {
-      parts.push(type);
-      if (dir) {
-        parts.push(dir);
-      }
-    }
-    return parts.map(part => part.trim()).join(' ');
-  }
-
   /**
    *
    * @param {string} sideOfIntersection - `"SIDEOFINT"` column from `"ARTERYDATA"` table
@@ -87,9 +66,9 @@ class ArteryDAO {
     geom,
   }) {
     const approachDir = ArteryDAO.getApproachDirection(sideOfIntersection);
-    const street1 = ArteryDAO.getCombinedStreet(street1Name, street1Type, street1Dir);
-    const street2 = ArteryDAO.getCombinedStreet(street2Name, street2Type, street2Dir);
-    const street3 = ArteryDAO.getCombinedStreet(street3Name, street3Type, street3Dir);
+    const street1 = formatCombinedStreet(street1Name, street1Type, street1Dir);
+    const street2 = formatCombinedStreet(street2Name, street2Type, street2Dir);
+    const street3 = formatCombinedStreet(street3Name, street3Type, street3Dir);
     return {
       approachDir,
       arteryCode,

--- a/lib/db/CollisionDAO.js
+++ b/lib/db/CollisionDAO.js
@@ -1,6 +1,85 @@
+import { formatCombinedStreet } from '@/lib/StringFormatters';
 import db from '@/lib/db/db';
+import DateTime from '@/lib/time/DateTime';
+
+const INVAGE_BUCKET = 5;
+
+const COLLISION_EVENT_FIELDS = `
+  e.collision_id,
+  e.accdate, e.acctime,
+  e.stname1, e.streetype1, e.dir1,
+  e.stname2, e.streetype2, e.dir2,
+  e.stname3, e.streetype3, e.dir3,
+  e.longitude, e.latitude,
+  ec.centreline_id, ec.centreline_type
+  FROM collisions.events e
+  JOIN collisions.events_centreline ec ON e.collision_id = ec.collision_id`;
+
+function normalizeEvent({
+  collision_id: collisionId,
+  accdate,
+  acctime,
+  stname1: street1Name,
+  streetype1: street1Type,
+  dir1: street1Dir,
+  stname2: street2Name,
+  streetype2: street2Type,
+  dir2: street2Dir,
+  stname3: street3Name,
+  streetype3: street3Type,
+  dir3: street3Dir,
+  longitude: lng,
+  latitude: lat,
+  centreline_id: centrelineId,
+  centreline_type: centrelineType,
+}) {
+  let dateTime = DateTime.fromJSON(accdate);
+  const hhmm = parseInt(acctime, 10);
+  const hour = Math.floor(hhmm / 100);
+  const minute = hhmm % 100;
+  dateTime = dateTime.set({ hour, minute });
+
+  const street1 = formatCombinedStreet(street1Name, street1Type, street1Dir);
+  const street2 = formatCombinedStreet(street2Name, street2Type, street2Dir);
+  const street3 = formatCombinedStreet(street3Name, street3Type, street3Dir);
+
+  return {
+    collisionId,
+    dateTime,
+    street1,
+    street2,
+    street3,
+    lng,
+    lat,
+    centrelineId,
+    centrelineType,
+  };
+}
+
+function normalizeInvolved(involved) {
+  let { invtype, invage } = involved;
+  invtype = parseInt(invtype, 10);
+  invage = Math.floor(invage / INVAGE_BUCKET) * INVAGE_BUCKET;
+  return { invtype, invage };
+}
 
 class CollisionDAO {
+  static async byIdPopupDetails(id) {
+    const sqlEvent = `SELECT ${COLLISION_EVENT_FIELDS} WHERE e.collision_id = $(id)`;
+    let event = await db.oneOrNone(sqlEvent, { id });
+    if (event === null) {
+      return { event: null, involved: [] };
+    }
+    event = normalizeEvent(event);
+    const sqlInvolved = `
+SELECT invtype, invage
+FROM collisions.involved
+WHERE collision_id = $(id)`;
+    const rows = await db.manyOrNone(sqlInvolved, { id });
+    const involved = rows.map(normalizeInvolved);
+    return { event, involved };
+  }
+
   static async byCentrelineSummary(
     centrelineId,
     centrelineType,

--- a/lib/geo/CentrelineUtils.js
+++ b/lib/geo/CentrelineUtils.js
@@ -1,0 +1,32 @@
+import {
+  CentrelineType,
+  RoadIntersectionType,
+  RoadSegmentType,
+} from '@/lib/Constants';
+import { InvalidCentrelineTypeError } from '@/lib/error/MoveErrors';
+
+function getLocationFeatureType(location) {
+  if (location === null) {
+    return null;
+  }
+  const { centrelineType, featureCode = null } = location;
+  if (featureCode === null) {
+    return null;
+  }
+  if (centrelineType === CentrelineType.SEGMENT) {
+    return RoadSegmentType.enumValueOf(featureCode, 'featureCode');
+  }
+  if (centrelineType === CentrelineType.INTERSECTION) {
+    return RoadIntersectionType.enumValueOf(featureCode, 'featureCode');
+  }
+  throw new InvalidCentrelineTypeError(centrelineType);
+}
+
+const CentrelineUtils = {
+  getLocationFeatureType,
+};
+
+export {
+  CentrelineUtils as default,
+  getLocationFeatureType,
+};

--- a/lib/geo/GeometryUtils.js
+++ b/lib/geo/GeometryUtils.js
@@ -83,6 +83,30 @@ function getLineStringMidpoint(coordinates) {
 }
 
 /**
+ * Estimate the point halfway along this line.
+ *
+ * TODO: make this do the same thing as ST_Closest(geom, ST_Centroid(geom)), which we
+ * use in our Airflow jobs and backend API as a (better) estimate of halfway points.
+ *
+ * @memberof GeometryUtils
+ * @param {*} geometry - GeoJSON geometry
+ * @returns {GeoJsonPoint} [lng, lat] coordinates of estimated halfway point
+ */
+function getGeometryMidpoint({ coordinates, type }) {
+  if (type === 'Point') {
+    return coordinates;
+  }
+  if (type === 'LineString') {
+    return getLineStringMidpoint(coordinates);
+  }
+  if (type === 'MultiLineString') {
+    const midpoints = coordinates.map(getLineStringMidpoint);
+    return getLineStringMidpoint(midpoints);
+  }
+  throw new Error(`invalid geometry type ${type}!`);
+}
+
+/**
  * It is expected that `lineString` has `point` as one of its endpoints.
  *
  * @memberof GeometryUtils
@@ -164,6 +188,7 @@ const GeometryUtils = {
   DEG_TO_RAD,
   getBearingDifference,
   getDirectionCandidatesFrom,
+  getGeometryMidpoint,
   getGreatCircleBearing,
   getLineStringBearingFrom,
   getLineStringMidpoint,
@@ -175,6 +200,7 @@ export {
   DEG_TO_RAD,
   getBearingDifference,
   getDirectionCandidatesFrom,
+  getGeometryMidpoint,
   getGreatCircleBearing,
   getLineStringBearingFrom,
   getLineStringMidpoint,

--- a/tests/jest/db/DAO.spec.js
+++ b/tests/jest/db/DAO.spec.js
@@ -58,36 +58,6 @@ test('ArteryDAO.getApproachDirection', async () => {
   expect(ArteryDAO.getApproachDirection('W')).toBe(CardinalDirection.EAST);
 });
 
-test('ArteryDAO.getCombinedStreet', async () => {
-  expect(ArteryDAO.getCombinedStreet(null, null, null)).toBe(null);
-  expect(ArteryDAO.getCombinedStreet(null, 'Ave', 'W')).toBe(null);
-
-  expect(ArteryDAO.getCombinedStreet(
-    'BROWNS LINE',
-    null,
-    null,
-  )).toBe('BROWNS LINE');
-  expect(ArteryDAO.getCombinedStreet(
-    'ADANAC',
-    'DR',
-    null,
-  )).toBe('ADANAC DR');
-  expect(ArteryDAO.getCombinedStreet(
-    'DUNDAS',
-    'ST',
-    'W',
-  )).toBe('DUNDAS ST W');
-
-  /*
-   * Some of the `ARTERYDATA` entries have spaces in street names.
-   */
-  expect(ArteryDAO.getCombinedStreet(
-    'CACTUS ',
-    'AVE',
-    null,
-  )).toBe('CACTUS AVE');
-});
-
 test('ArteryDAO.byArteryCode', async () => {
   // intersection
   let result = await ArteryDAO.byArteryCode(1146);

--- a/tests/jest/unit/StringFormatters.spec.js
+++ b/tests/jest/unit/StringFormatters.spec.js
@@ -1,8 +1,39 @@
 import {
+  formatCombinedStreet,
   formatCountLocationDescription,
   formatDuration,
   formatOxfordCommaList,
 } from '@/lib/StringFormatters';
+
+test('StringFormatters.formatCombinedStreet', async () => {
+  expect(formatCombinedStreet(null, null, null)).toBe(null);
+  expect(formatCombinedStreet(null, 'Ave', 'W')).toBe(null);
+
+  expect(formatCombinedStreet(
+    'BROWNS LINE',
+    null,
+    null,
+  )).toBe('BROWNS LINE');
+  expect(formatCombinedStreet(
+    'ADANAC',
+    'DR',
+    null,
+  )).toBe('ADANAC DR');
+  expect(formatCombinedStreet(
+    'DUNDAS',
+    'ST',
+    'W',
+  )).toBe('DUNDAS ST W');
+
+  /*
+   * Some of the `ARTERYDATA` entries have spaces in street names.
+   */
+  expect(formatCombinedStreet(
+    'CACTUS ',
+    'AVE',
+    null,
+  )).toBe('CACTUS AVE');
+});
 
 test('StringFormatters.formatCountLocationDescription', () => {
   expect(formatCountLocationDescription('')).toEqual('');

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -23,14 +23,8 @@
       </FcButton>
     </div>
     <FcPaneMapPopup
-      v-if="hoveredFeature"
-      :feature="hoveredFeature"
-      :hover="true"
-      @mouseenter.native="clearHoveredFeature" />
-    <FcPaneMapPopup
-      v-else-if="selectedFeature"
-      :feature="selectedFeature"
-      :hover="false" />
+      v-if="popupFeature"
+      :feature="popupFeature" />
   </div>
 </template>
 
@@ -42,7 +36,7 @@ import { mapMutations, mapState } from 'vuex';
 import { Enum } from '@/lib/ClassUtils';
 import { CentrelineType } from '@/lib/Constants';
 import { debounce } from '@/lib/FunctionUtils';
-import { getLineStringMidpoint } from '@/lib/geo/GeometryUtils';
+import { getGeometryMidpoint } from '@/lib/geo/GeometryUtils';
 import rootStyleDark from '@/lib/geo/theme/dark/root.json';
 import metadataDark from '@/lib/geo/theme/dark/metadata.json';
 import GeoStyle from '@/lib/geo/GeoStyle';
@@ -316,6 +310,9 @@ export default {
     };
   },
   computed: {
+    popupFeature() {
+      return this.hoveredFeature || this.selectedFeature;
+    },
     ...mapState(['drawerOpen', 'location']),
   },
   created() {
@@ -632,8 +629,7 @@ export default {
       this.setLocation(elementInfo);
     },
     onMidblocksClick(feature) {
-      const { coordinates } = feature.geometry;
-      const [lng, lat] = getLineStringMidpoint(coordinates);
+      const [lng, lat] = getGeometryMidpoint(feature.geometry);
       const elementInfo = {
         centrelineId: feature.properties.geo_id,
         centrelineType: CentrelineType.SEGMENT,

--- a/web/components/FcPaneMapPopup.vue
+++ b/web/components/FcPaneMapPopup.vue
@@ -1,22 +1,27 @@
 <template>
   <v-card width="220">
     <v-card-title>
-      <div class="display-1">
-        <span v-if="description">{{description}}</span>
-        <span
-          v-else
-          class="unselected--text">name unknown</span>
-      </div>
+      <div class="display-1">{{title}}</div>
       <v-spacer></v-spacer>
       <v-icon v-if="icon">{{icon}}</v-icon>
     </v-card-title>
     <v-card-text>
-      <span>TODO: description</span>
+      <v-progress-linear
+        v-if="loading"
+        indeterminate />
+      <template v-else>
+        <div
+          v-for="(line, i) in description"
+          :key="i"
+          class="body-1">
+          {{line}}
+        </div>
+      </template>
     </v-card-text>
-    <v-card-actions v-if="featureSelectable">
+    <v-card-actions v-if="!loading && featureSelectable">
       <FcButton
         type="tertiary"
-        @click="onViewData">
+        @click="actionViewData">
         View Data
       </FcButton>
     </v-card-actions>
@@ -40,6 +45,67 @@ const SELECTABLE_LAYERS = [
   'midblocks',
 ];
 
+async function getCollisionDescription(layerId, feature) {
+  const { accdate, acctime } = feature.properties;
+  let dt;
+  if (layerId === 'collisionsLevel2') {
+    dt = DateTime.fromISO(accdate);
+  } else {
+    dt = DateTime.fromJSON(accdate);
+  }
+
+  const hhmm = parseInt(acctime, 10);
+  const hour = Math.floor(hhmm / 100);
+  const minute = hhmm % 100;
+  dt = dt.set({ hour, minute });
+  const dtStr = TimeFormatters.formatDateTime(dt);
+  return [dtStr];
+}
+
+async function getCountDescription(/* layerId, feature */) {
+  return [];
+}
+
+async function getIntersectionDescription(layerId, feature) {
+  let description = feature.properties.intersec5;
+  if (description) {
+    description = formatCountLocationDescription(description);
+  }
+  return [description];
+}
+
+async function getMidblockDescription(layerId, feature) {
+  let description = feature.properties.lf_name;
+  if (description) {
+    description = formatCountLocationDescription(description);
+  }
+  return [description];
+}
+
+async function getSchoolDescription(layerId, feature) {
+  return [feature.properties.name];
+}
+
+async function getFeatureDescription(layerId, feature) {
+  await new Promise(resolve => setTimeout(resolve, 500));
+  if (layerId === 'collisionsLevel2' || layerId === 'collisionsLevel1') {
+    return getCollisionDescription(layerId, feature);
+  }
+  if (layerId === 'counts') {
+    return getCountDescription(layerId, feature);
+  }
+  if (layerId === 'intersections') {
+    return getIntersectionDescription(layerId, feature);
+  }
+  if (layerId === 'midblocks') {
+    return getMidblockDescription(layerId, feature);
+  }
+  if (layerId === 'schoolsLevel2' || layerId === 'schoolsLevel1') {
+    return getSchoolDescription(layerId, feature);
+  }
+  return [];
+}
+
 export default {
   name: 'PaneMapPopup',
   components: {
@@ -52,6 +118,12 @@ export default {
     map: {
       default: null,
     },
+  },
+  data() {
+    return {
+      description: [],
+      loading: true,
+    };
   },
   computed: {
     centrelineId() {
@@ -81,62 +153,6 @@ export default {
     coordinates() {
       return getGeometryMidpoint(this.feature.geometry);
     },
-    description() {
-      if (this.layerId === 'collisionsLevel2' || this.layerId === 'collisionsLevel1') {
-        const { accdate, acctime, injury } = this.feature.properties;
-        let dt;
-        if (this.layerId === 'collisionsLevel2') {
-          dt = DateTime.fromISO(accdate);
-        } else {
-          dt = DateTime.fromJSON(accdate);
-        }
-
-        const hhmm = parseInt(acctime, 10);
-        const hour = Math.floor(hhmm / 100);
-        const minute = hhmm % 100;
-        dt = dt.set({ hour, minute });
-        const dtStr = TimeFormatters.formatDateTime(dt);
-
-        if (injury === 4) {
-          return `${dtStr}: Fatal`;
-        }
-        if (injury === 3) {
-          return `${dtStr}: Serious Injury`;
-        }
-        return dtStr;
-      }
-      if (this.layerId === 'counts') {
-        const { numArteryCodes } = this.feature.properties;
-        if (numArteryCodes === 1) {
-          return '1 count station';
-        }
-        return `${numArteryCodes} count stations`;
-      }
-      if (this.layerId === 'intersections') {
-        const description = this.feature.properties.intersec5;
-        if (!description) {
-          return description;
-        }
-        return formatCountLocationDescription(description);
-      }
-      if (this.layerId === 'midblocks') {
-        const description = this.feature.properties.lf_name;
-        if (!description) {
-          return description;
-        }
-        return formatCountLocationDescription(description);
-      }
-      if (this.layerId === 'schoolsLevel2' || this.layerId === 'schoolsLevel1') {
-        return this.feature.properties.name;
-      }
-      return null;
-    },
-    descriptionFormatted() {
-      if (this.description) {
-        return formatCountLocationDescription(this.description);
-      }
-      return null;
-    },
     featureCode() {
       if (this.layerId === 'intersections') {
         return this.feature.properties.elevatio9;
@@ -150,15 +166,20 @@ export default {
        */
       return null;
     },
+    featureKey() {
+      const { layerId } = this;
+      const { id } = this.feature.properties.id;
+      return `${layerId}:${id}`;
+    },
     featureSelectable() {
       return SELECTABLE_LAYERS.includes(this.layerId);
     },
     icon() {
       if (this.layerId === 'collisionsLevel2' || this.layerId === 'collisionsLevel1') {
-        return 'mdi-car-brake-alert';
-      }
-      if (this.layerId === 'counts') {
-        return this.hover ? 'mdi-format-list-numbered' : 'mdi-map-marker';
+        // TODO: determine if pedestrian, cyclist, etc. was involved
+        // pedestrian: 'mdi-walk'
+        // cyclist: 'mdi-bike'
+        return null;
       }
       if (this.layerId === 'schoolsLevel2' || this.layerId === 'schoolsLevel1') {
         const { schoolType } = this.feature.properties;
@@ -167,15 +188,57 @@ export default {
         }
         return 'mdi-teach';
       }
-      return this.hover ? 'mdi-road-variant' : 'mdi-map-marker';
+      return null;
     },
     layerId() {
       return this.feature.layer.id;
+    },
+    title() {
+      if (this.layerId === 'collisionsLevel2' || this.layerId === 'collisionsLevel1') {
+        const { injury } = this.feature.properties;
+        if (injury === 4) {
+          return 'Fatality';
+        }
+        if (injury === 3) {
+          return 'Serious Injury';
+        }
+        return 'Collision';
+      }
+      if (this.layerId === 'counts') {
+        const { numArteryCodes } = this.feature.properties;
+        if (numArteryCodes === 1) {
+          return '1 Station';
+        }
+        return `${numArteryCodes} Stations`;
+      }
+      if (this.layerId === 'intersections') {
+        return 'Intersection';
+      }
+      if (this.layerId === 'midblocks') {
+        return 'Midblock';
+      }
+      if (this.layerId === 'schoolsLevel2' || this.layerId === 'schoolsLevel1') {
+        const { schoolType } = this.feature.properties;
+        if (schoolType === 'U') {
+          return 'University';
+        }
+        if (schoolType === 'C') {
+          return 'College';
+        }
+        return 'School';
+      }
+      return null;
     },
   },
   watch: {
     coordinates() {
       this.popup.setLngLat(this.coordinates);
+    },
+    featureKey: {
+      handler() {
+        this.loadAsyncForFeature();
+      },
+      immediate: true,
     },
   },
   created() {
@@ -195,7 +258,7 @@ export default {
     this.popup.remove();
   },
   methods: {
-    onViewData() {
+    actionViewData() {
       // update location
       const [lng, lat] = this.coordinates;
       const elementInfo = {
@@ -206,7 +269,6 @@ export default {
         lng,
         lat,
       };
-      this.setDrawerOpen(true);
       this.setLocation(elementInfo);
 
       // open the view data window
@@ -219,7 +281,12 @@ export default {
         params: routerParameters,
       });
     },
-    ...mapMutations(['setDrawerOpen', 'setLocation']),
+    async loadAsyncForFeature() {
+      this.loading = true;
+      this.description = await getFeatureDescription(this.layerId, this.feature);
+      this.loading = false;
+    },
+    ...mapMutations(['setLocation']),
   },
 };
 </script>

--- a/web/components/nav/FcDashboardNavBrand.vue
+++ b/web/components/nav/FcDashboardNavBrand.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    class="pa-2 pt-3"
-    v-on="on">
+  <div class="pa-2 pt-3">
     <h1 class="sr-only">MOVE</h1>
     <v-img
       alt="MOVE Logo"

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -1,13 +1,8 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 
-import {
-  CentrelineType,
-  RoadIntersectionType,
-  RoadSegmentType,
-} from '@/lib/Constants';
 import { apiFetch } from '@/lib/api/BackendClient';
-import { InvalidCentrelineTypeError } from '@/lib/error/MoveErrors';
+import { getLocationFeatureType } from '@/lib/geo/CentrelineUtils';
 import {
   REQUEST_STUDY_SUBMITTED,
   REQUEST_STUDY_UPDATED,
@@ -51,20 +46,7 @@ export default new Vuex.Store({
     // LOCATION
     locationFeatureType(state) {
       const { location } = state;
-      if (location === null) {
-        return null;
-      }
-      const { centrelineType, featureCode = null } = location;
-      if (featureCode === null) {
-        return null;
-      }
-      if (centrelineType === CentrelineType.SEGMENT) {
-        return RoadSegmentType.enumValueOf(featureCode, 'featureCode');
-      }
-      if (centrelineType === CentrelineType.INTERSECTION) {
-        return RoadIntersectionType.enumValueOf(featureCode, 'featureCode');
-      }
-      throw new InvalidCentrelineTypeError(centrelineType);
+      return getLocationFeatureType(location);
     },
   },
   mutations: {


### PR DESCRIPTION
This PR closes #335 by making fairly extensive changes in `PaneMapPopup`, which controls the contextual popup when hovering on map features.

To start with, it brings back previous `mapbox-gl` popup behaviorr where the popup snaps to the active feature being inspected, rather than floating at top-right.  It also hooks a bit more deeply into that popup system, removing parts of `mapbox-gl`'s style in favour of the card-like layout from our designs.