### PR TITLE
Update to use ADFS sandbox provisioned by Cloud Services

### DIFF
--- a/lib/config/MoveConfig.js
+++ b/lib/config/MoveConfig.js
@@ -48,7 +48,7 @@ function getAdfsIssuerUrl(domainName) {
   switch (domainName) {
     case 'move.intra.dev-toronto.ca':
     default:
-      return 'https://adfs.lab.intra.sandbox-toronto.ca/adfs';
+      return 'https://adfs.move.intra.sandbox-toronto.ca/adfs/';
   }
 }
 


### PR DESCRIPTION
This PR makes further progress on #293 by using `adfs.move.intra.sandbox-toronto.ca` while the network change request to access City QA ADFS instances proceeds.