### PR TITLE
ADFS QA integration with MOVE

### DIFF
--- a/lib/auth/OpenIdClient.js
+++ b/lib/auth/OpenIdClient.js
@@ -1,18 +1,7 @@
-import { custom, Issuer } from 'openid-client';
+import { Issuer } from 'openid-client';
 
 import config from '@/lib/config/MoveConfig';
 import { InvalidOpenIdTokenError } from '@/lib/error/MoveErrors';
-
-/*
- * TODO: remove this once we figure out how to configure Vagrant to respect the host OS
- * certificate trust store.  It would be a much better solution to add all certificates
- * in the `https://ma-qa.toronto.ca` chain there.
- */
-if (config.ENV === 'development' || config.env === 'test') {
-  custom.setHttpOptionsDefaults({
-    rejectUnauthorized: false,
-  });
-}
 
 let CLIENT = null;
 const SCOPE = 'email openid telephoneNumber title displayName';

--- a/lib/config/MoveConfig.js
+++ b/lib/config/MoveConfig.js
@@ -48,7 +48,7 @@ function getAdfsIssuerUrl(domainName) {
   switch (domainName) {
     case 'move.intra.dev-toronto.ca':
     default:
-      return 'https://adfs.move.intra.sandbox-toronto.ca/adfs/';
+      return 'https://ma-qa.toronto.ca/adfs';
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "backend": "node -r ./globalWindowShim -r esm -r module-alias/register web/server.js",
-    "backend:inspect": "node -r ./globalWindowShim -r esm -r module-alias/register --inspect=0.0.0.0:9281 web/server.js",
-    "backend:inspect-brk": "node -r ./globalWindowShim -r esm -r module-alias/register --inspect-brk=0.0.0.0:9281 web/server.js",
-    "backend:test-api": "NODE_ENV=test PGPASSFILE=/mnt/ramdisk_move_test/.pgpass API_TEST_HEADLESS=1 node  -r ./globalWindowShim -r esm -r module-alias/register web/server.js",
+    "backend": "NODE_EXTRA_CA_CERTS=./ssl/extra-ca-certs.cer node -r ./globalWindowShim -r esm -r module-alias/register web/server.js",
+    "backend:inspect": "NODE_EXTRA_CA_CERTS=./ssl/extra-ca-certs.cer node -r ./globalWindowShim -r esm -r module-alias/register --inspect=0.0.0.0:9281 web/server.js",
+    "backend:inspect-brk": "NODE_EXTRA_CA_CERTS=./ssl/extra-ca-certs.cer node -r ./globalWindowShim -r esm -r module-alias/register --inspect-brk=0.0.0.0:9281 web/server.js",
+    "backend:test-api": "NODE_EXTRA_CA_CERTS=./ssl/extra-ca-certs.cer NODE_ENV=test PGPASSFILE=/mnt/ramdisk_move_test/.pgpass API_TEST_HEADLESS=1 node  -r ./globalWindowShim -r esm -r module-alias/register web/server.js",
     "ci:jest-coverage": "NODE_ENV=test PGPASSFILE=/mnt/ramdisk_move_test/.pgpass jest --coverage",
     "ci:npm-audit": "npm audit || true",
     "ci:npm-outdated": "npm outdated || true",
@@ -19,12 +19,12 @@
     "frontend:build": "vue-cli-service build",
     "pre-commit:lint-staged": "lint-staged",
     "pre-commit:test-unit-staged": "NODE_ENV=test PGPASSFILE=/mnt/ramdisk_move_test/.pgpass TEST_DIR=\"unit/**\" jest --changedSince=master",
-    "reporter": "node  -r ./globalWindowShim -r esm -r module-alias/register reporter/reporter.js",
-    "reporter:inspect": "node -r ./globalWindowShim -r esm -r module-alias/register --inspect=0.0.0.0:9282 reporter/reporter.js",
-    "reporter:inspect-brk": "node -r ./globalWindowShim -r esm -r module-alias/register --inspect-brk=0.0.0.0:9282 reporter/reporter.js",
-    "reporter:test-api": "NODE_ENV=test PGPASSFILE=/mnt/ramdisk_move_test/.pgpass node -r ./globalWindowShim -r esm -r module-alias/register reporter/reporter.js",
-    "test:test-api": "NODE_ENV=test PGPASSFILE=/mnt/ramdisk_move_test/.pgpass TEST_DIR=\"api/**\" jest",
-    "test:test-db": "NODE_ENV=test PGPASSFILE=/mnt/ramdisk_move_test/.pgpass TEST_DIR=\"db/**\" jest"
+    "reporter": "NODE_EXTRA_CA_CERTS=./ssl/extra-ca-certs.cer node -r ./globalWindowShim -r esm -r module-alias/register reporter/reporter.js",
+    "reporter:inspect": "NODE_EXTRA_CA_CERTS=./ssl/extra-ca-certs.cer node -r ./globalWindowShim -r esm -r module-alias/register --inspect=0.0.0.0:9282 reporter/reporter.js",
+    "reporter:inspect-brk": "NODE_EXTRA_CA_CERTS=./ssl/extra-ca-certs.cer node -r ./globalWindowShim -r esm -r module-alias/register --inspect-brk=0.0.0.0:9282 reporter/reporter.js",
+    "reporter:test-api": "NODE_EXTRA_CA_CERTS=./ssl/extra-ca-certs.cer NODE_ENV=test PGPASSFILE=/mnt/ramdisk_move_test/.pgpass node -r ./globalWindowShim -r esm -r module-alias/register reporter/reporter.js",
+    "test:test-api": "NODE_EXTRA_CA_CERTS=./ssl/extra-ca-certs.cer NODE_ENV=test PGPASSFILE=/mnt/ramdisk_move_test/.pgpass TEST_DIR=\"api/**\" jest",
+    "test:test-db": "NODE_EXTRA_CA_CERTS=./ssl/extra-ca-certs.cer NODE_ENV=test PGPASSFILE=/mnt/ramdisk_move_test/.pgpass TEST_DIR=\"db/**\" jest"
   },
   "dependencies": {
     "@hapi/boom": "^9.0.0",

--- a/ssl/.gitignore
+++ b/ssl/.gitignore
@@ -1,3 +1,4 @@
 *.txt.attr
 *.txt.old
 01.pem
+extra-ca-certs.cer


### PR DESCRIPTION
This PR closes #293 by switching back to `ma-qa.toronto.ca` for our ADFS authentication in AWS dev / QA environments.

As part of this, we also update `OpenIdClient` to properly verify self-signed SSL certificates on `ma-qa.toronto.ca`.  This involves providing a file containing any root CA and intermediate CA certificates in the `ma-qa.toronto.ca` certificate chain at `ssl/extra-ca-certs.cer`.  If this file is missing, MOVE will continue to function; however, login via `ma-qa.toronto.ca` ADFS will not work.