### PR TITLE
Show filter button if there are active filters

### DIFF
--- a/lib/db/CountDAO.js
+++ b/lib/db/CountDAO.js
@@ -154,6 +154,9 @@ function getCountInfoFilters(
   }
   if (studyTypes !== null) {
     const categoryIds = toCategoryIds(studyTypes, categories);
+    if (categoryIds.length === 0) {
+      return null;
+    }
     params.categoryIds = categoryIds;
     filters.push('ci."CATEGORY_ID" IN ($(categoryIds:csv))');
   }
@@ -229,7 +232,7 @@ class CountDAO {
     offset,
   ) {
     const categories = await CategoryDAO.all();
-    const { filters, params } = getCountInfoFilters(
+    const countInfoFilters = getCountInfoFilters(
       centrelineId,
       centrelineType,
       dateRange,
@@ -237,6 +240,10 @@ class CountDAO {
       [studyType],
       categories,
     );
+    if (countInfoFilters === null) {
+      return [];
+    }
+    const { filters, params } = countInfoFilters;
     const sqlFilters = filters.join('\n  AND ');
 
     params.limit = limit;
@@ -269,7 +276,7 @@ class CountDAO {
     studyTypes,
   ) {
     const categories = await CategoryDAO.all();
-    const { filters, params } = getCountInfoFilters(
+    const countInfoFilters = getCountInfoFilters(
       centrelineId,
       centrelineType,
       dateRange,
@@ -277,6 +284,10 @@ class CountDAO {
       studyTypes,
       categories,
     );
+    if (countInfoFilters === null) {
+      return [];
+    }
+    const { filters, params } = countInfoFilters;
     const sqlFilters = filters.join('\n  AND ');
 
     const sqlMostRecent = `SELECT * FROM (

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -72,7 +72,7 @@
                 @set-filters="setFilters">
               </FcDialogStudyFilters>
               <FcButton
-                v-if="countSummary.length > 0"
+                v-if="countSummary.length > 0 || filterChips.length > 0"
                 type="secondary"
                 @click.stop="showFilters = true">
                 <v-icon


### PR DESCRIPTION
This PR closes #356 by fixing a small logic bug around when the "Filter" button is shown in View Data.

It also fixes a bug in `CountDAO` where passing a `studyType` with no corresponding category would result in invalid SQL, due to an empty `IN` clause for `CATEGORY_ID`.