### PR TITLE
More readable labels in both aerial and map modes 

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -87,6 +87,36 @@ HttpStatus.init({
 });
 
 /**
+ * Map zoom hierarchy.  These are divided into three "levels", corresponding to zoom level
+ * ranges in which different features make sense:
+ *
+ * - Level 3: city-wide;
+ * - Level 2: ward level;
+ * - Level 1: neighbourhood / block level.
+ */
+class MapZoom extends Enum {
+  get maxzoomSource() {
+    return this.maxzoomLayer - 1;
+  }
+}
+MapZoom.init({
+  LEVEL_3: {
+    minzoom: 10,
+    maxzoomLayer: 14,
+  },
+  LEVEL_2: {
+    minzoom: 14,
+    maxzoomLayer: 17,
+  },
+  LEVEL_1: {
+    minzoom: 17,
+    maxzoomLayer: 20,
+  },
+});
+MapZoom.MIN = MapZoom.LEVEL_3.minzoom;
+MapZoom.MAX = MapZoom.LEVEL_1.maxzoomSource;
+
+/**
  * Page orientations for printed documents.  Used by {@link FormatGenerator.pdf} to
  * render reports to pages, but can be used anywhere you want to print something.
  *
@@ -713,6 +743,7 @@ const Constants = {
   CentrelineType,
   FeatureCode,
   HttpStatus,
+  MapZoom,
   PageOrientation,
   PT_PER_IN,
   ReportBlock,
@@ -742,6 +773,7 @@ export {
   CentrelineType,
   FeatureCode,
   HttpStatus,
+  MapZoom,
   PageOrientation,
   PT_PER_IN,
   ReportBlock,

--- a/lib/geo/GeoStyle.js
+++ b/lib/geo/GeoStyle.js
@@ -34,27 +34,87 @@ function mergeRootAndMetadata(root, metadata) {
   return style;
 }
 
+const TEXT_FONT_MAP = new Map([
+  ['Ubuntu Bold', 'Roboto Bold'],
+  ['Ubuntu Italic', 'Roboto Italic'],
+  ['Ubuntu Light Regular', 'Roboto Regular'],
+  ['Ubuntu Regular', 'Roboto Medium'],
+]);
+
+function mapTextFont(textFont) {
+  return textFont.map((font) => {
+    if (TEXT_FONT_MAP.has(font)) {
+      return TEXT_FONT_MAP.get(font);
+    }
+    return font;
+  });
+}
+
+const TEXT_SIZE_FACTOR = 1.15;
+
+function mapTextSize(textSize) {
+  if (Number.isFinite(textSize)) {
+    // single number
+    return textSize * TEXT_SIZE_FACTOR;
+  }
+  if (Object.prototype.hasOwnProperty.call(textSize, 'stops')) {
+    // stops expression
+    let { stops } = textSize;
+    stops = stops.map(([zoom, value]) => [zoom, value * TEXT_SIZE_FACTOR]);
+    return {
+      ...textSize,
+      stops,
+    };
+  }
+  return textSize;
+}
+
 function separateLayers(style) {
   const nonSymbolLayers = [];
   const symbolLayers = [];
+
   style.layers.forEach((layer) => {
-    const { type } = layer;
-    if (type === 'symbol') {
+    const { layout = {}, type } = layer;
+    const { 'text-field': textField = null } = layout;
+    if (type === 'symbol' && textField !== null) {
       symbolLayers.push(layer);
     } else {
       nonSymbolLayers.push(layer);
     }
   });
+
+  symbolLayers.forEach((layer) => {
+    const { layout, paint } = layer;
+
+    layout['text-font'] = mapTextFont(layout['text-font']);
+    layout['text-size'] = mapTextSize(layout['text-size']);
+
+    paint['text-color'] = '#272727';
+    paint['text-halo-blur'] = 0;
+    paint['text-halo-color'] = '#ffffff';
+    paint['text-halo-width'] = 1;
+  });
+
   /* eslint-disable-next-line no-param-reassign */
   style.layers = [];
   return [nonSymbolLayers, symbolLayers];
 }
 
-const STYLE_BASE_MAP_DARK = mergeRootAndMetadata(rootStyleDark, metadataDark);
-const [
-  LAYERS_NON_SYMBOL_MAP_DARK,
-  LAYERS_SYMBOL_DARK,
-] = separateLayers(STYLE_BASE_MAP_DARK);
+function generateBasemapStyle(root, metadata) {
+  const style = mergeRootAndMetadata(root, metadata);
+  const [nonSymbolLayers, symbolLayers] = separateLayers(style);
+  return {
+    style,
+    nonSymbolLayers,
+    symbolLayers,
+  };
+}
+
+const {
+  style: STYLE_BASE_MAP_DARK,
+  nonSymbolLayers: LAYERS_NON_SYMBOL_MAP_DARK,
+  symbolLayers: LAYERS_SYMBOL_DARK,
+} = generateBasemapStyle(rootStyleDark, metadataDark);
 
 const STYLE_BASE_MAP_LIGHT = mergeRootAndMetadata(rootStyleLight, metadataLight);
 const [
@@ -83,6 +143,9 @@ const LAYERS_NON_SYMBOL_AERIAL = [
     source: 'gcc-ortho-webm',
     minzoom: MapZoom.LEVEL_3.minzoom,
     maxzoom: MapZoom.LEVEL_1.maxzoomLayer,
+    paint: {
+      'raster-opacity': 0.8,
+    },
   },
 ];
 

--- a/lib/geo/GeoStyle.js
+++ b/lib/geo/GeoStyle.js
@@ -1,3 +1,11 @@
+import { MapZoom } from '@/lib/Constants';
+import rootStyleDark from '@/lib/geo/theme/dark/root.json';
+import metadataDark from '@/lib/geo/theme/dark/metadata.json';
+import rootStyleLight from '@/lib/geo/theme/light/root.json';
+import metadataLight from '@/lib/geo/theme/light/metadata.json';
+
+// BASEMAP LAYERS
+
 /**
  * Normalizes map styles from ArcGIS / ESRI into the Mapbox GL Style Specification format.
  * These styles are loaded into `bdit_flashcrow` via `scripts/geo/fetch-esri-style.sh`,
@@ -6,34 +14,333 @@
  *
  * @see https://docs.mapbox.com/mapbox-gl-js/style-spec/
  * @see http://bl.ocks.org/jgravois/51e2b30e3d6cf6c00f06b263a29108a2
- * @param {Object} style - ArcGIS / ESRI map style
+ * @param {Object} root - ArcGIS / ESRI map root style
  * @param {Object} metadata - ArcGIS / ESRI map style metadata
  */
-class GeoStyle {
-  constructor(style, metadata) {
-    this.style = JSON.parse(JSON.stringify(style));
-    this.style.sources.esri = {
-      type: 'vector',
-      scheme: 'xyz',
-      tilejson: metadata.tilejson || '2.0.0',
-      format: (metadata.tileInfo && metadata.tileInfo.format) || 'pbf',
-      maxzoom: 15,
+function mergeRootAndMetadata(root, metadata) {
+  const style = JSON.parse(JSON.stringify(root));
+  style.sources.esri = {
+    type: 'vector',
+    scheme: 'xyz',
+    tilejson: metadata.tilejson || '2.0.0',
+    format: (metadata.tileInfo && metadata.tileInfo.format) || 'pbf',
+    maxzoom: 15,
+    tiles: [
+      `${style.sources.esri.url}${metadata.tiles[0]}`,
+    ],
+    description: metadata.description || '',
+    name: metadata.name,
+  };
+  return style;
+}
+
+function separateLayers(style) {
+  const nonSymbolLayers = [];
+  const symbolLayers = [];
+  style.layers.forEach((layer) => {
+    const { type } = layer;
+    if (type === 'symbol') {
+      symbolLayers.push(layer);
+    } else {
+      nonSymbolLayers.push(layer);
+    }
+  });
+  /* eslint-disable-next-line no-param-reassign */
+  style.layers = [];
+  return [nonSymbolLayers, symbolLayers];
+}
+
+const STYLE_BASE_MAP_DARK = mergeRootAndMetadata(rootStyleDark, metadataDark);
+const [
+  LAYERS_NON_SYMBOL_MAP_DARK,
+  LAYERS_SYMBOL_DARK,
+] = separateLayers(STYLE_BASE_MAP_DARK);
+
+const STYLE_BASE_MAP_LIGHT = mergeRootAndMetadata(rootStyleLight, metadataLight);
+const [
+  LAYERS_NON_SYMBOL_MAP_LIGHT,
+  LAYERS_SYMBOL_LIGHT,
+] = separateLayers(STYLE_BASE_MAP_LIGHT);
+
+const STYLE_BASE_AERIAL = {
+  version: 8,
+  sources: {
+    ...STYLE_BASE_MAP_LIGHT.sources,
+    'gcc-ortho-webm': {
+      type: 'raster',
       tiles: [
-        `${style.sources.esri.url}${metadata.tiles[0]}`,
+        'https://gis.toronto.ca/arcgis/rest/services/primary/cot_ortho_webm/MapServer/tile/{z}/{y}/{x}',
       ],
-      description: metadata.description || '',
-      name: metadata.name,
-    };
+      tileSize: 256,
+    },
+  },
+  layers: [],
+};
+const LAYERS_NON_SYMBOL_AERIAL = [
+  {
+    id: 'gcc-ortho-webm',
+    type: 'raster',
+    source: 'gcc-ortho-webm',
+    minzoom: MapZoom.LEVEL_3.minzoom,
+    maxzoom: MapZoom.LEVEL_1.maxzoomLayer,
+  },
+];
+
+
+// MOVE FEATURE LAYERS
+
+function interactionAttr(base, hovered, selected) {
+  return [
+    'case',
+    ['boolean', ['feature-state', 'selected'], false], selected,
+    ['boolean', ['feature-state', 'hover'], false], hovered,
+    base,
+  ];
+}
+
+const PAINT_OPACITY = interactionAttr(0.45, 0.6, 0.6);
+const PAINT_COLOR_CENTRELINE = interactionAttr(
+  '#dcdee0',
+  '#e5a000',
+  '#00a91c',
+);
+const PAINT_COLOR_COUNTS = interactionAttr(
+  '#00bde3',
+  '#e5a000',
+  '#00a91c',
+);
+const PAINT_WIDTH_MIDBLOCKS = interactionAttr(3, 5, 5);
+const PAINT_RADIUS_INTERSECTIONS = interactionAttr(8, 10, 10);
+const PAINT_RADIUS_COUNTS = interactionAttr(10, 12, 12);
+
+function addTippecanoeSource(style, id, minLevel, maxLevel, crossfade = 0) {
+  /* eslint-disable-next-line no-param-reassign */
+  style.sources[id] = {
+    type: 'vector',
+    tiles: [`https://flashcrow-etladmin.intra.dev-toronto.ca/tiles/${id}/{z}/{x}/{y}.pbf`],
+    minzoom: minLevel.minzoom,
+    maxzoom: maxLevel.maxzoomSource + crossfade,
+  };
+}
+
+function addDynamicTileSource(style, id, minLevel, maxLevel) {
+  const { origin } = window.location;
+  /* eslint-disable-next-line no-param-reassign */
+  style.sources[id] = {
+    type: 'vector',
+    tiles: [`${origin}/api/dynamicTiles/${id}/{z}/{x}/{y}.pbf`],
+    minzoom: minLevel.minzoom,
+    maxzoom: maxLevel.maxzoomSource,
+  };
+}
+
+function addLayer(style, id, type, options) {
+  const source = style.sources[id];
+  style.layers.push({
+    id,
+    source: id,
+    'source-layer': id,
+    type,
+    minzoom: source.minzoom,
+    maxzoom: source.maxzoom + 1,
+    ...options,
+  });
+}
+
+function injectSourcesAndLayers(style) {
+  addTippecanoeSource(style, 'collisionsLevel3', MapZoom.LEVEL_3, MapZoom.LEVEL_3, 2);
+  addTippecanoeSource(style, 'collisionsLevel2', MapZoom.LEVEL_2, MapZoom.LEVEL_2);
+  addDynamicTileSource(style, 'collisionsLevel1', MapZoom.LEVEL_1, MapZoom.LEVEL_1);
+  addDynamicTileSource(style, 'counts', MapZoom.LEVEL_2, MapZoom.LEVEL_1);
+  addTippecanoeSource(style, 'intersections', MapZoom.LEVEL_3, MapZoom.LEVEL_1);
+  addTippecanoeSource(style, 'midblocks', MapZoom.LEVEL_3, MapZoom.LEVEL_1);
+  addTippecanoeSource(style, 'schoolsLevel2', MapZoom.LEVEL_2, MapZoom.LEVEL_2);
+  addDynamicTileSource(style, 'schoolsLevel1', MapZoom.LEVEL_1, MapZoom.LEVEL_1);
+
+  addLayer(style, 'midblocks', 'line', {
+    paint: {
+      'line-color': PAINT_COLOR_CENTRELINE,
+      'line-width': PAINT_WIDTH_MIDBLOCKS,
+      'line-opacity': PAINT_OPACITY,
+    },
+  });
+  addLayer(style, 'intersections', 'circle', {
+    paint: {
+      'circle-color': PAINT_COLOR_CENTRELINE,
+      'circle-radius': PAINT_RADIUS_INTERSECTIONS,
+      'circle-opacity': PAINT_OPACITY,
+    },
+  });
+  addLayer(style, 'counts', 'circle', {
+    paint: {
+      'circle-color': PAINT_COLOR_COUNTS,
+      'circle-radius': PAINT_RADIUS_COUNTS,
+      'circle-opacity': PAINT_OPACITY,
+    },
+  });
+  addLayer(style, 'collisionsLevel3', 'heatmap', {
+    paint: {
+      'heatmap-color': [
+        'interpolate',
+        ['linear'],
+        ['heatmap-density'],
+        0, 'rgba(244, 227, 219, 0)',
+        0.5, '#f39268',
+        1, '#d63e04',
+      ],
+      'heatmap-intensity': [
+        'interpolate',
+        ['linear'],
+        ['zoom'],
+        style.sources.collisionsLevel3.minzoom, 1,
+        style.sources.collisionsLevel3.maxzoom, 3,
+      ],
+      'heatmap-opacity': [
+        'interpolate',
+        ['linear'],
+        ['zoom'],
+        style.sources.collisionsLevel3.maxzoom, 0.8,
+        style.sources.collisionsLevel3.maxzoom + 1, 0,
+      ],
+      'heatmap-radius': [
+        'interpolate',
+        ['linear'],
+        ['zoom'],
+        style.sources.collisionsLevel3.minzoom, 5,
+        style.sources.collisionsLevel3.maxzoom, 10,
+      ],
+      'heatmap-weight': ['get', 'heatmap_weight'],
+    },
+  });
+  addLayer(style, 'collisionsLevel2', 'circle', {
+    layout: {
+      'circle-sort-key': ['get', 'injury'],
+    },
+    paint: {
+      'circle-color': [
+        'case',
+        ['>=', ['get', 'injury'], 3], '#b51d09',
+        '#d63e04',
+      ],
+      'circle-opacity': [
+        'interpolate',
+        ['linear'],
+        ['zoom'],
+        style.sources.collisionsLevel2.minzoom, 0.2,
+        style.sources.collisionsLevel2.minzoom + 1, [
+          'case',
+          ['>=', ['get', 'injury'], 3], 0.8,
+          0.6,
+        ],
+      ],
+      'circle-radius': [
+        'case',
+        ['>=', ['get', 'injury'], 3], 10,
+        5,
+      ],
+    },
+  });
+  addLayer(style, 'collisionsLevel1', 'circle', {
+    layout: {
+      'circle-sort-key': ['get', 'injury'],
+    },
+    paint: {
+      'circle-color': [
+        'case',
+        ['>=', ['get', 'injury'], 3], '#b51d09',
+        '#d63e04',
+      ],
+      'circle-opacity': [
+        'case',
+        ['>=', ['get', 'injury'], 3], 0.8,
+        0.6,
+      ],
+      'circle-radius': [
+        'case',
+        ['>=', ['get', 'injury'], 3], 10,
+        5,
+      ],
+    },
+  });
+  addLayer(style, 'schoolsLevel2', 'symbol', {
+    layout: {
+      'text-field': [
+        'match',
+        ['get', 'schoolType'],
+        'U', '\uf19d',
+        'C', '\uf19d',
+        '\uf549',
+      ],
+      'text-font': ['literal', ['Font Awesome 5 Free']],
+      'text-size': 16,
+    },
+    paint: {
+      'text-color': '#00a91c',
+    },
+  });
+  addLayer(style, 'schoolsLevel1', 'symbol', {
+    layout: {
+      'text-field': [
+        'match',
+        ['get', 'schoolType'],
+        'U', '\uf19d',
+        'C', '\uf19d',
+        '\uf549',
+      ],
+      'text-font': ['literal', ['Font Awesome 5 Free']],
+      'text-size': 20,
+    },
+    paint: {
+      'text-color': '#00a91c',
+    },
+  });
+  return style;
+}
+
+class GeoStyle {
+  static getBaseStyle({ aerial, dark }) {
+    if (aerial) {
+      return STYLE_BASE_AERIAL;
+    }
+    if (dark) {
+      return STYLE_BASE_MAP_DARK;
+    }
+    return STYLE_BASE_MAP_LIGHT;
   }
 
-  /**
-   * Get a deep copy of `this.style`, so that you can further mutate it without
-   * affecting the style on which it's based.
-   *
-   * @returns a deep copy of `this.style`
-   */
-  get() {
-    return JSON.parse(JSON.stringify(this.style));
+  static getNonSymbolLayers({ aerial, dark }) {
+    if (aerial) {
+      return LAYERS_NON_SYMBOL_AERIAL;
+    }
+    if (dark) {
+      return LAYERS_NON_SYMBOL_MAP_DARK;
+    }
+    return LAYERS_NON_SYMBOL_MAP_LIGHT;
+  }
+
+  static getSymbolLayers({ dark }) {
+    if (dark) {
+      return LAYERS_SYMBOL_DARK;
+    }
+    return LAYERS_SYMBOL_LIGHT;
+  }
+
+  static get(options) {
+    const baseStyle = GeoStyle.getBaseStyle(options);
+    const nonSymbolLayers = GeoStyle.getNonSymbolLayers(options);
+    const symbolLayers = GeoStyle.getSymbolLayers(options);
+
+    const style = {
+      ...baseStyle,
+      glyphs: 'https://flashcrow-etladmin.intra.dev-toronto.ca/glyphs/{fontstack}/{range}.pbf',
+      layers: [
+        ...nonSymbolLayers,
+      ],
+    };
+    injectSourcesAndLayers(style);
+    style.layers = style.layers.concat(symbolLayers);
+
+    return style;
   }
 }
 

--- a/lib/geo/theme/dark/metadata.json
+++ b/lib/geo/theme/dark/metadata.json
@@ -1,1 +1,179 @@
-{"currentVersion":10.61,"name":"World_Basemap_v2","capabilities":"TilesOnly,Tilemap","type":"indexedVector","tileMap":"/tilemap","defaultStyles":"/resources/styles","tiles":["/tile/{z}/{y}/{x}.pbf"],"exportTilesAllowed":true,"initialExtent":{"xmin":-2.0037507067161843E7,"ymin":-2.0037507067161843E7,"xmax":2.0037507067161843E7,"ymax":2.0037507067161843E7,"spatialReference":{"cs":"pcs","wkid":102100}},"fullExtent":{"xmin":-2.0037507067161843E7,"ymin":-2.0037507067161843E7,"xmax":2.0037507067161843E7,"ymax":2.0037507067161843E7,"spatialReference":{"cs":"pcs","wkid":102100}},"minScale":0.0,"maxScale":0.0,"tileInfo":{"rows":512,"cols":512,"dpi":96,"format":"pbf","origin":{"x":-2.0037508342787E7,"y":2.0037508342787E7},"spatialReference":{"wkid":102100,"latestWkid":3857},"lods":[{"level":0,"resolution":78271.51696399994,"scale":2.95828763795777E8},{"level":1,"resolution":39135.75848200009,"scale":1.47914381897889E8},{"level":2,"resolution":19567.87924099992,"scale":7.3957190948944E7},{"level":3,"resolution":9783.93962049996,"scale":3.6978595474472E7},{"level":4,"resolution":4891.96981024998,"scale":1.8489297737236E7},{"level":5,"resolution":2445.98490512499,"scale":9244648.868618},{"level":6,"resolution":1222.992452562495,"scale":4622324.434309},{"level":7,"resolution":611.4962262813797,"scale":2311162.217155},{"level":8,"resolution":305.74811314055756,"scale":1155581.108577},{"level":9,"resolution":152.87405657041106,"scale":577790.554289},{"level":10,"resolution":76.43702828507324,"scale":288895.277144},{"level":11,"resolution":38.21851414253662,"scale":144447.638572},{"level":12,"resolution":19.10925707126831,"scale":72223.819286},{"level":13,"resolution":9.554628535634155,"scale":36111.909643},{"level":14,"resolution":4.77731426794937,"scale":18055.954822},{"level":15,"resolution":2.388657133974685,"scale":9027.977411},{"level":16,"resolution":1.1943285668550503,"scale":4513.988705},{"level":17,"resolution":0.5971642835598172,"scale":2256.994353},{"level":18,"resolution":0.29858214164761665,"scale":1128.497176},{"level":19,"resolution":0.14929107082380833,"scale":564.248588},{"level":20,"resolution":0.07464553541190416,"scale":282.124294},{"level":21,"resolution":0.03732276770595208,"scale":141.062147},{"level":22,"resolution":0.01866138385297604,"scale":70.5310735}]},"resourceInfo":{"styleVersion":8,"tileCompression":"gzip","cacheInfo":{"storageInfo":{"packetSize":128,"storageFormat":"compactV2"}}},"serviceItemId":"274684d7a9d74ca4b87f529776feb3a2","minLOD":0,"maxLOD":16,"maxExportTilesCount":10000}
+{
+  "currentVersion": 10.61,
+  "name": "World_Basemap_v2",
+  "capabilities": "TilesOnly,Tilemap",
+  "type": "indexedVector",
+  "tileMap": "/tilemap",
+  "defaultStyles": "/resources/styles",
+  "tiles": [
+    "/tile/{z}/{y}/{x}.pbf"
+  ],
+  "exportTilesAllowed": true,
+  "initialExtent": {
+    "xmin": -20037507.067161843,
+    "ymin": -20037507.067161843,
+    "xmax": 20037507.067161843,
+    "ymax": 20037507.067161843,
+    "spatialReference": {
+      "cs": "pcs",
+      "wkid": 102100
+    }
+  },
+  "fullExtent": {
+    "xmin": -20037507.067161843,
+    "ymin": -20037507.067161843,
+    "xmax": 20037507.067161843,
+    "ymax": 20037507.067161843,
+    "spatialReference": {
+      "cs": "pcs",
+      "wkid": 102100
+    }
+  },
+  "minScale": 0,
+  "maxScale": 0,
+  "tileInfo": {
+    "rows": 512,
+    "cols": 512,
+    "dpi": 96,
+    "format": "pbf",
+    "origin": {
+      "x": -20037508.342787,
+      "y": 20037508.342787
+    },
+    "spatialReference": {
+      "wkid": 102100,
+      "latestWkid": 3857
+    },
+    "lods": [
+      {
+        "level": 0,
+        "resolution": 78271.51696399994,
+        "scale": 295828763.795777
+      },
+      {
+        "level": 1,
+        "resolution": 39135.75848200009,
+        "scale": 147914381.897889
+      },
+      {
+        "level": 2,
+        "resolution": 19567.87924099992,
+        "scale": 73957190.948944
+      },
+      {
+        "level": 3,
+        "resolution": 9783.93962049996,
+        "scale": 36978595.474472
+      },
+      {
+        "level": 4,
+        "resolution": 4891.96981024998,
+        "scale": 18489297.737236
+      },
+      {
+        "level": 5,
+        "resolution": 2445.98490512499,
+        "scale": 9244648.868618
+      },
+      {
+        "level": 6,
+        "resolution": 1222.992452562495,
+        "scale": 4622324.434309
+      },
+      {
+        "level": 7,
+        "resolution": 611.4962262813797,
+        "scale": 2311162.217155
+      },
+      {
+        "level": 8,
+        "resolution": 305.74811314055756,
+        "scale": 1155581.108577
+      },
+      {
+        "level": 9,
+        "resolution": 152.87405657041106,
+        "scale": 577790.554289
+      },
+      {
+        "level": 10,
+        "resolution": 76.43702828507324,
+        "scale": 288895.277144
+      },
+      {
+        "level": 11,
+        "resolution": 38.21851414253662,
+        "scale": 144447.638572
+      },
+      {
+        "level": 12,
+        "resolution": 19.10925707126831,
+        "scale": 72223.819286
+      },
+      {
+        "level": 13,
+        "resolution": 9.554628535634155,
+        "scale": 36111.909643
+      },
+      {
+        "level": 14,
+        "resolution": 4.77731426794937,
+        "scale": 18055.954822
+      },
+      {
+        "level": 15,
+        "resolution": 2.388657133974685,
+        "scale": 9027.977411
+      },
+      {
+        "level": 16,
+        "resolution": 1.1943285668550503,
+        "scale": 4513.988705
+      },
+      {
+        "level": 17,
+        "resolution": 0.5971642835598172,
+        "scale": 2256.994353
+      },
+      {
+        "level": 18,
+        "resolution": 0.29858214164761665,
+        "scale": 1128.497176
+      },
+      {
+        "level": 19,
+        "resolution": 0.14929107082380833,
+        "scale": 564.248588
+      },
+      {
+        "level": 20,
+        "resolution": 0.07464553541190416,
+        "scale": 282.124294
+      },
+      {
+        "level": 21,
+        "resolution": 0.03732276770595208,
+        "scale": 141.062147
+      },
+      {
+        "level": 22,
+        "resolution": 0.01866138385297604,
+        "scale": 70.5310735
+      }
+    ]
+  },
+  "resourceInfo": {
+    "styleVersion": 8,
+    "tileCompression": "gzip",
+    "cacheInfo": {
+      "storageInfo": {
+        "packetSize": 128,
+        "storageFormat": "compactV2"
+      }
+    }
+  },
+  "serviceItemId": "274684d7a9d74ca4b87f529776feb3a2",
+  "minLOD": 0,
+  "maxLOD": 16,
+  "maxExportTilesCount": 10000
+}

--- a/lib/geo/theme/dark/root.json
+++ b/lib/geo/theme/dark/root.json
@@ -1,1 +1,8824 @@
-{"layers": [{"paint": {"background-color": "#1d2224"}, "type": "background", "id": "background"}, {"layout": {}, "paint": {"fill-color": {"stops": [[0, "#3b3c3c"], [12, "#353636"], [15, "#323333"]]}}, "source": "esri", "minzoom": 0, "source-layer": "Land", "type": "fill", "id": "Land"}, {"layout": {}, "paint": {"fill-color": {"stops": [[5, "#2F3030"], [10, "#323333"]]}}, "source": "esri", "minzoom": 5, "source-layer": "Urban area", "maxzoom": 15, "type": "fill", "id": "Urban area"}, {"layout": {}, "paint": {"fill-outline-color": "#373938", "fill-color": {"stops": [[7, "#373837"], [9, "#373938"]]}}, "source": "esri", "minzoom": 12, "source-layer": "Openspace or forest", "type": "fill", "id": "Openspace or forest"}, {"layout": {}, "paint": {"fill-outline-color": "#373938", "fill-color": {"stops": [[7, "#373837"], [9, "#373938"]]}}, "source": "esri", "minzoom": 7, "source-layer": "Admin0 forest or park", "type": "fill", "id": "Admin0 forest or park"}, {"layout": {}, "paint": {"fill-outline-color": "#373938", "fill-color": {"stops": [[7, "#373837"], [9, "#373938"]]}}, "source": "esri", "minzoom": 8, "source-layer": "Admin1 forest or park", "type": "fill", "id": "Admin1 forest or park"}, {"layout": {}, "paint": {"fill-color": "#373938"}, "source": "esri", "minzoom": 12, "source-layer": "Zoo", "type": "fill", "id": "Zoo"}, {"layout": {}, "paint": {"fill-color": "#373838"}, "filter": ["==", "_symbol", 1], "source": "esri", "minzoom": 9, "source-layer": "Airport", "type": "fill", "id": "Airport/Airport property"}, {"layout": {}, "paint": {"fill-color": "#2d2e2e"}, "filter": ["==", "_symbol", 0], "source": "esri", "minzoom": 11, "source-layer": "Airport", "type": "fill", "id": "Airport/Airport runway"}, {"layout": {}, "paint": {"fill-color": "#353636"}, "source": "esri", "minzoom": 14, "source-layer": "Pedestrian", "type": "fill", "id": "Pedestrian"}, {"layout": {}, "paint": {"fill-color": "#373938"}, "source": "esri", "minzoom": 12, "source-layer": "Park or farming", "type": "fill", "id": "Park or farming"}, {"layout": {}, "paint": {"fill-pattern": "Special area of interest/Sand"}, "source": "esri", "minzoom": 13, "source-layer": "Beach", "type": "fill", "id": "Beach"}, {"layout": {"visibility": "none"}, "paint": {"fill-outline-color": "#EBE8E8", "fill-color": "#353636"}, "filter": ["==", "_symbol", 12], "source": "esri", "minzoom": 14, "source-layer": "Special area of interest", "type": "fill", "id": "Special area of interest/Garden path"}, {"layout": {}, "paint": {"fill-color": "#353636"}, "filter": ["==", "_symbol", 15], "source": "esri", "minzoom": 14, "source-layer": "Special area of interest", "type": "fill", "id": "Special area of interest/Parking"}, {"layout": {}, "paint": {"fill-color": "#343635"}, "filter": ["==", "_symbol", 11], "source": "esri", "minzoom": 14, "source-layer": "Special area of interest", "type": "fill", "id": "Special area of interest/Green openspace"}, {"layout": {}, "paint": {"fill-color": "#3c3e3d"}, "filter": ["==", "_symbol", 8], "source": "esri", "minzoom": 14, "source-layer": "Special area of interest", "type": "fill", "id": "Special area of interest/Grass"}, {"layout": {}, "paint": {"fill-color": "#3a3b3a"}, "filter": ["==", "_symbol", 1], "source": "esri", "minzoom": 14, "source-layer": "Special area of interest", "type": "fill", "id": "Special area of interest/Baseball field or other grounds"}, {"layout": {}, "paint": {"fill-pattern": "Special area of interest/Groundcover", "fill-opacity": 0.5}, "filter": ["==", "_symbol", 13], "source": "esri", "minzoom": 14, "source-layer": "Special area of interest", "type": "fill", "id": "Special area of interest/Groundcover"}, {"layout": {}, "paint": {"fill-color": "#404140"}, "filter": ["==", "_symbol", 5], "source": "esri", "minzoom": 14, "source-layer": "Special area of interest", "type": "fill", "id": "Special area of interest/Field or court exterior"}, {"layout": {}, "paint": {"fill-outline-color": "#353636", "fill-color": "#3a3b3a"}, "filter": ["==", "_symbol", 4], "source": "esri", "minzoom": 14, "source-layer": "Special area of interest", "type": "fill", "id": "Special area of interest/Football field or court"}, {"layout": {}, "paint": {"fill-outline-color": "#353636", "fill-color": "#2a2c2b"}, "filter": ["==", "_symbol", 10], "source": "esri", "minzoom": 14, "source-layer": "Special area of interest", "type": "fill", "id": "Special area of interest/Hardcourt"}, {"layout": {}, "paint": {"fill-color": "#4c4d49"}, "filter": ["==", "_symbol", 14], "source": "esri", "minzoom": 14, "source-layer": "Special area of interest", "type": "fill", "id": "Special area of interest/Mulch or dirt"}, {"layout": {}, "paint": {"fill-outline-color": "#333232", "fill-color": "#3b3b3b"}, "filter": ["==", "_symbol", 0], "source": "esri", "minzoom": 14, "source-layer": "Special area of interest", "type": "fill", "id": "Special area of interest/Athletic track"}, {"layout": {}, "paint": {"fill-pattern": "Special area of interest/Sand"}, "filter": ["==", "_symbol", 6], "source": "esri", "minzoom": 14, "source-layer": "Special area of interest", "type": "fill", "id": "Special area of interest/Sand"}, {"layout": {}, "paint": {"fill-pattern": "Special area of interest/Rock or gravel"}, "filter": ["==", "_symbol", 16], "source": "esri", "minzoom": 14, "source-layer": "Special area of interest", "type": "fill", "id": "Special area of interest/Rock or gravel"}, {"layout": {}, "paint": {"fill-color": "#1d2224"}, "filter": ["==", "_symbol", 7], "source": "esri", "minzoom": 15, "source-layer": "Special area of interest", "type": "fill", "id": "Special area of interest/Water"}, {"layout": {"line-join": "round", "visibility": "none"}, "paint": {"line-color": "#2B2E2F", "line-width": 0.5}, "source": "esri", "minzoom": 1, "source-layer": "Water line small scale", "maxzoom": 5, "type": "line", "id": "Water line small scale"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#2B2E2F", "line-width": {"base": 1.2, "stops": [[5, 0.5], [7, 0.7]]}}, "source": "esri", "minzoom": 6, "source-layer": "Water line medium scale", "maxzoom": 7, "type": "line", "id": "Water line medium scale"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": {"stops": [[7, "#2B2E2F"], [10, "#272A2B"]]}, "line-width": {"base": 1.2, "stops": [[7, 0.7], [11, 0.8]]}}, "source": "esri", "minzoom": 7, "source-layer": "Water line large scale", "maxzoom": 11, "type": "line", "id": "Water line large scale"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#222628", "line-dasharray": [5, 5], "line-width": 0.8}, "filter": ["==", "_symbol", 5], "source": "esri", "minzoom": 11, "source-layer": "Water line", "type": "line", "id": "Water line/Waterfall"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#262525", "line-width": {"base": 1.2, "stops": [[11, 0.7], [14, 0.7], [17, 2]]}}, "filter": ["==", "_symbol", 2], "source": "esri", "minzoom": 11, "source-layer": "Water line", "type": "line", "id": "Water line/Dam or weir"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#222628", "line-width": {"base": 1.2, "stops": [[11, 0.7], [14, 0.7], [17, 2]]}}, "filter": ["==", "_symbol", 3], "source": "esri", "minzoom": 11, "source-layer": "Water line", "type": "line", "id": "Water line/Levee/1"}, {"layout": {"symbol-avoid-edges": true, "symbol-placement": "line", "icon-padding": 1, "icon-image": "Water line/Levee/0", "icon-allow-overlap": true, "icon-rotation-alignment": "map", "symbol-spacing": 15}, "paint": {}, "filter": ["==", "_symbol", 3], "source": "esri", "minzoom": 13, "source-layer": "Water line", "type": "symbol", "id": "Water line/Levee/0"}, {"layout": {"line-cap": "round"}, "paint": {"line-color": "#222628", "line-width": {"base": 1.2, "stops": [[11, 0.8], [14, 0.8], [17, 2]]}}, "filter": ["==", "_symbol", 1], "source": "esri", "minzoom": 11, "source-layer": "Water line", "type": "line", "id": "Water line/Canal or ditch"}, {"layout": {}, "paint": {"line-color": "#222628", "line-dasharray": [7, 3], "line-width": {"base": 1.2, "stops": [[11, 0.8], [14, 0.8], [17, 2]]}}, "filter": ["==", "_symbol", 4], "source": "esri", "minzoom": 11, "source-layer": "Water line", "type": "line", "id": "Water line/Stream or river intermittent"}, {"layout": {"line-cap": "round"}, "paint": {"line-color": "#222628", "line-width": {"base": 1.2, "stops": [[11, 0.8], [14, 0.8], [17, 2]]}}, "filter": ["==", "_symbol", 0], "source": "esri", "minzoom": 11, "source-layer": "Water line", "type": "line", "id": "Water line/Stream or river"}, {"layout": {}, "paint": {"fill-color": "#1d2224"}, "source": "esri", "minzoom": 4, "source-layer": "Marine area", "type": "fill", "id": "Marine area"}, {"layout": {}, "paint": {"fill-color": "#1d2224"}, "source": "esri", "minzoom": 1, "source-layer": "Water area small scale", "maxzoom": 5, "type": "fill", "id": "Water area small scale"}, {"layout": {}, "paint": {"fill-pattern": "Water area/Lake or river intermittent"}, "filter": ["==", "_symbol", 1], "source": "esri", "minzoom": 5, "source-layer": "Water area medium scale", "maxzoom": 7, "type": "fill", "id": "Water area medium scale/Lake intermittent"}, {"layout": {}, "paint": {"fill-color": "#1d2224"}, "filter": ["==", "_symbol", 0], "source": "esri", "minzoom": 5, "source-layer": "Water area medium scale", "maxzoom": 7, "type": "fill", "id": "Water area medium scale/Lake or river"}, {"layout": {}, "paint": {"fill-pattern": "Water area/Lake or river intermittent"}, "filter": ["==", "_symbol", 1], "source": "esri", "minzoom": 7, "source-layer": "Water area large scale", "maxzoom": 11, "type": "fill", "id": "Water area large scale/Lake intermittent"}, {"layout": {}, "paint": {"fill-color": "#1d2224"}, "filter": ["==", "_symbol", 0], "source": "esri", "minzoom": 7, "source-layer": "Water area large scale", "maxzoom": 11, "type": "fill", "id": "Water area large scale/Lake or river"}, {"layout": {}, "paint": {"fill-color": "#1d2224"}, "filter": ["==", "_symbol", 7], "source": "esri", "minzoom": 11, "source-layer": "Water area", "type": "fill", "id": "Water area/Lake, river or bay"}, {"layout": {}, "paint": {"fill-pattern": "Water area/Lake or river intermittent"}, "filter": ["==", "_symbol", 6], "source": "esri", "minzoom": 11, "source-layer": "Water area", "type": "fill", "id": "Water area/Lake or river intermittent"}, {"layout": {}, "paint": {"fill-pattern": "Water area/Inundated area"}, "filter": ["==", "_symbol", 4], "source": "esri", "minzoom": 11, "source-layer": "Water area", "type": "fill", "id": "Water area/Inundated area"}, {"layout": {}, "paint": {"fill-pattern": "Water area/Swamp or marsh"}, "filter": ["==", "_symbol", 3], "source": "esri", "minzoom": 11, "source-layer": "Water area", "type": "fill", "id": "Water area/Swamp or marsh"}, {"layout": {}, "paint": {"fill-pattern": "Water area/Playa"}, "filter": ["==", "_symbol", 1], "source": "esri", "minzoom": 11, "source-layer": "Water area", "type": "fill", "id": "Water area/Playa"}, {"layout": {}, "paint": {"fill-outline-color": "#2e2f2f", "fill-color": "#383939"}, "filter": ["==", "_symbol", 5], "source": "esri", "minzoom": 11, "source-layer": "Water area", "type": "fill", "id": "Water area/Dam or weir"}, {"layout": {}, "paint": {"fill-color": "#353636"}, "filter": ["==", "_symbol", 2], "source": "esri", "minzoom": 14, "source-layer": "Special area of interest", "type": "fill", "id": "Special area of interest/Bike, walk or pedestrian"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#3a3b3b", "line-width": {"base": 1.2, "stops": [[12, 1.5], [14, 2.5], [17, 3]]}}, "source": "esri", "minzoom": 12, "source-layer": "Railroad", "type": "line", "id": "Railroad/2"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#292828", "line-width": {"base": 1.2, "stops": [[12, 0.5], [14, 1], [17, 1.75]]}}, "source": "esri", "minzoom": 12, "source-layer": "Railroad", "type": "line", "id": "Railroad/1"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#3a3b3b", "line-width": {"base": 1.2, "stops": [[12, 1.5], [14, 2.5], [17, 3]]}}, "filter": ["all", ["==", "_symbol", 1], ["!in", "Viz", 3]], "source": "esri", "minzoom": 12, "source-layer": "Ferry", "type": "line", "id": "Ferry/Rail ferry/2"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#292828", "line-width": {"base": 1.2, "stops": [[12, 0.5], [14, 1], [17, 1.75]]}}, "filter": ["all", ["==", "_symbol", 1], ["!in", "Viz", 3]], "source": "esri", "minzoom": 12, "source-layer": "Ferry", "type": "line", "id": "Ferry/Rail ferry/1"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#353636", "line-width": {"base": 1.2, "stops": [[15, 0.7], [17, 1.2]]}}, "filter": ["==", "_symbol", 0], "source": "esri", "minzoom": 15, "source-layer": "Special area of interest line", "type": "line", "id": "Special area of interest line/Dock or pier"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#353636", "line-width": {"base": 1.2, "stops": [[15, 0.7], [17, 1.2]]}}, "filter": ["==", "_symbol", 6], "source": "esri", "minzoom": 15, "source-layer": "Special area of interest line", "type": "line", "id": "Special area of interest line/Sports field"}, {"layout": {}, "paint": {"fill-translate": {"stops": [[15, [0, 0]], [18, [2, 2]]]}, "fill-translate-anchor": "viewport", "fill-color": "#2e2f2f"}, "source": "esri", "minzoom": 16, "source-layer": "Building", "type": "fill", "id": "Building/Shadow"}, {"layout": {}, "paint": {"fill-outline-color": "#2e2f2f", "fill-color": "#383939"}, "source": "esri", "minzoom": 15, "source-layer": "Building", "type": "fill", "id": "Building"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#434444", "line-width": {"base": 1.2, "stops": [[15, 0.7], [17, 1.2]]}}, "filter": ["==", "_symbol", 5], "source": "esri", "minzoom": 15, "source-layer": "Special area of interest line", "type": "line", "id": "Special area of interest line/Parking lot"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#303131", "line-width": {"base": 1.2, "stops": [[14, 1.5], [16, 3.3], [18, 4]]}}, "source": "esri", "minzoom": 15, "source-layer": "Trail or path", "type": "line", "id": "Trail or path/1"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#2A2B2B", "line-dasharray": [2.0, 1.0], "line-width": {"base": 1.2, "stops": [[11, 1.5], [14, 3.3], [18, 8.3]]}}, "filter": ["all", ["==", "_symbol", 10], ["!in", "Viz", 3]], "source": "esri", "minzoom": 13, "source-layer": "Road", "type": "line", "id": "Road/4WD/1"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#2A2B2B", "line-width": {"base": 1.2, "stops": [[11, 1.5], [14, 3.3], [18, 8.3]]}}, "filter": ["all", ["==", "_symbol", 8], ["!in", "Viz", 3]], "source": "esri", "minzoom": 13, "source-layer": "Road", "type": "line", "id": "Road/Service/1"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#2A2B2B", "line-width": {"base": 1.4, "stops": [[11, 1.5], [14, 4], [16, 6], [18, 17.3]]}}, "filter": ["all", ["==", "_symbol", 7], ["!in", "Viz", 3]], "source": "esri", "minzoom": 12, "source-layer": "Road", "type": "line", "id": "Road/Local/1"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#303131", "line-width": {"base": 1.2, "stops": [[14, 1.5], [16, 3.3], [18, 4]]}}, "filter": ["all", ["==", "_symbol", 9], ["!in", "Viz", 3]], "source": "esri", "minzoom": 15, "source-layer": "Road", "type": "line", "id": "Road/Pedestrian/1"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#2A2B2B", "line-width": {"base": 1.2, "stops": [[11, 1], [14, 4], [16, 9.6], [18, 17.3]]}}, "filter": ["all", ["==", "_symbol", 6], ["!in", "Viz", 3]], "source": "esri", "minzoom": 11, "source-layer": "Road", "type": "line", "id": "Road/Minor, ramp or traffic circle/1"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#2A2B2B", "line-width": {"base": 1.2, "stops": [[11, 2.6], [14, 5.6], [16, 9.6], [18, 17.3]]}}, "filter": ["all", ["==", "_symbol", 5], ["!in", "Viz", 3]], "source": "esri", "minzoom": 11, "source-layer": "Road", "type": "line", "id": "Road/Minor/1"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#2A2B2B", "line-width": {"base": 1.2, "stops": [[9, 1.5], [14, 7.3], [16, 10.3], [18, 18]]}}, "filter": ["all", ["==", "_symbol", 4], ["!in", "Viz", 3]], "source": "esri", "minzoom": 9, "source-layer": "Road", "type": "line", "id": "Road/Major, ramp or traffic circle/1"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#2A2B2B", "line-width": {"base": 1.0, "stops": [[9, 1.5], [14, 7.3], [16, 10.3], [18, 18]]}}, "filter": ["all", ["==", "_symbol", 3], ["!in", "Viz", 3]], "source": "esri", "minzoom": 9, "source-layer": "Road", "type": "line", "id": "Road/Major/1"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#2A2B2B", "line-width": {"base": 1.0, "stops": [[9, 0.3], [14, 8.3], [16, 12.3], [18, 26]]}}, "filter": ["all", ["==", "_symbol", 2], ["!in", "Viz", 3]], "source": "esri", "minzoom": 7, "source-layer": "Road", "type": "line", "id": "Road/Freeway Motorway, ramp or traffic circle/1"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#2A2B2B", "line-width": {"base": 1.2, "stops": [[8, 0.3], [14, 8.3], [16, 12.3], [18, 26]]}}, "filter": ["all", ["==", "_symbol", 1], ["!in", "Viz", 3]], "source": "esri", "minzoom": 8, "source-layer": "Road", "type": "line", "id": "Road/Highway/1"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#2A2B2B", "line-width": {"base": 1.2, "stops": [[5, 0.3], [14, 8.3], [16, 12.3], [18, 26]]}}, "filter": ["all", ["==", "_symbol", 0], ["!in", "Viz", 3]], "source": "esri", "minzoom": 7, "source-layer": "Road", "type": "line", "id": "Road/Freeway Motorway/1"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#434444", "line-dasharray": [3, 1.5], "line-width": {"base": 1.2, "stops": [[14, 1.3], [16, 2], [18, 2.3]]}}, "source": "esri", "minzoom": 15, "source-layer": "Trail or path", "type": "line", "id": "Trail or path/0"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#434444", "line-dasharray": [3, 1.5], "line-width": {"base": 1.2, "stops": [[14, 1.3], [16, 2], [18, 2.3]]}}, "filter": ["all", ["==", "_symbol", 9], ["!in", "Viz", 3]], "source": "esri", "minzoom": 15, "source-layer": "Road", "type": "line", "id": "Road/Pedestrian/0"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#434444", "line-width": {"base": 1.2, "stops": [[11, 0.75], [14, 1.3], [18, 6.3]]}}, "filter": ["all", ["==", "_symbol", 10], ["!in", "Viz", 3]], "source": "esri", "minzoom": 13, "source-layer": "Road", "type": "line", "id": "Road/4WD/0"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#434444", "line-width": {"base": 1.2, "stops": [[11, 0.75], [14, 1.3], [18, 6.3]]}}, "filter": ["all", ["==", "_symbol", 8], ["!in", "Viz", 3]], "source": "esri", "minzoom": 13, "source-layer": "Road", "type": "line", "id": "Road/Service/0"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": {"stops": [[12, "#414242"], [13, "#434444"]]}, "line-width": {"base": 1.4, "stops": [[11, 1.1], [14, 2], [16, 4], [18, 15.3]]}}, "filter": ["all", ["==", "_symbol", 7], ["!in", "Viz", 3]], "source": "esri", "minzoom": 12, "source-layer": "Road", "type": "line", "id": "Road/Local/0"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#434444", "line-width": {"base": 1.2, "stops": [[11, 0.75], [14, 2], [16, 7.65], [18, 15.3]]}}, "filter": ["all", ["==", "_symbol", 6], ["!in", "Viz", 3]], "source": "esri", "minzoom": 11, "source-layer": "Road", "type": "line", "id": "Road/Minor, ramp or traffic circle/0"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#434444", "line-width": {"base": 1.2, "stops": [[11, 1.3], [14, 3.65], [16, 7.65], [18, 15.3]]}}, "filter": ["all", ["==", "_symbol", 5], ["!in", "Viz", 3]], "source": "esri", "minzoom": 11, "source-layer": "Road", "type": "line", "id": "Road/Minor/0"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#434444", "line-width": {"base": 1.2, "stops": [[9, 0.75], [14, 5.3], [16, 8.3], [18, 16]]}}, "filter": ["all", ["==", "_symbol", 4], ["!in", "Viz", 3]], "source": "esri", "minzoom": 9, "source-layer": "Road", "type": "line", "id": "Road/Major, ramp or traffic circle/0"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#434444", "line-width": {"base": 1.2, "stops": [[9, 0.75], [14, 5.3], [16, 8.3], [18, 16]]}}, "filter": ["all", ["==", "_symbol", 3], ["!in", "Viz", 3]], "source": "esri", "minzoom": 9, "source-layer": "Road", "type": "line", "id": "Road/Major/0"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#434444", "line-width": {"base": 1.2, "stops": [[9, 0.3], [14, 6.3], [16, 10.3], [18, 24]]}}, "filter": ["all", ["==", "_symbol", 2], ["!in", "Viz", 3]], "source": "esri", "minzoom": 7, "source-layer": "Road", "type": "line", "id": "Road/Freeway Motorway, ramp or traffic circle/0"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#434444", "line-width": {"base": 1.2, "stops": [[8, 0.3], [14, 6.3], [16, 10.3], [18, 24]]}}, "filter": ["all", ["==", "_symbol", 1], ["!in", "Viz", 3]], "source": "esri", "minzoom": 8, "source-layer": "Road", "type": "line", "id": "Road/Highway/0"}, {"layout": {"line-join": "round"}, "paint": {"line-color": {"stops": [[6, "#414242"], [7, "#434444"]]}, "line-width": {"base": 1.2, "stops": [[5, 0.3], [14, 6.3], [16, 10.3], [18, 24]]}}, "filter": ["all", ["==", "_symbol", 0], ["!in", "Viz", 3]], "source": "esri", "minzoom": 6, "source-layer": "Road", "type": "line", "id": "Road/Freeway Motorway/0"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#2A2B2B", "line-dasharray": [2.0, 1.0], "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[11, 1.5], [14, 3.3], [18, 8.3]]}}, "filter": ["all", ["==", "_symbol", 10], ["!in", "Viz", 3]], "source": "esri", "minzoom": 13, "source-layer": "Road tunnel", "type": "line", "id": "Road tunnel/4WD/1"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#2A2B2B", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[11, 1.5], [14, 3.3], [18, 8.3]]}}, "filter": ["all", ["==", "_symbol", 8], ["!in", "Viz", 3]], "source": "esri", "minzoom": 13, "source-layer": "Road tunnel", "type": "line", "id": "Road tunnel/Service/1"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#2A2B2B", "line-opacity": 0.5, "line-width": {"base": 1.4, "stops": [[11, 1.5], [14, 4], [16, 6], [18, 17.3]]}}, "filter": ["all", ["==", "_symbol", 7], ["!in", "Viz", 3]], "source": "esri", "minzoom": 12, "source-layer": "Road tunnel", "type": "line", "id": "Road tunnel/Local/1"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#2A2B2B", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[14, 1.5], [16, 3.3], [18, 4]]}}, "filter": ["all", ["==", "_symbol", 9], ["!in", "Viz", 3]], "source": "esri", "minzoom": 15, "source-layer": "Road tunnel", "type": "line", "id": "Road tunnel/Pedestrian/1"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#2A2B2B", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[11, 1], [14, 4], [16, 9.65], [18, 17.3]]}}, "filter": ["all", ["==", "_symbol", 6], ["!in", "Viz", 3]], "source": "esri", "minzoom": 11, "source-layer": "Road tunnel", "type": "line", "id": "Road tunnel/Minor, ramp or traffic circle/1"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#2A2B2B", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[11, 2.6], [14, 5.65], [16, 9.65], [18, 17.3]]}}, "filter": ["all", ["==", "_symbol", 5], ["!in", "Viz", 3]], "source": "esri", "minzoom": 11, "source-layer": "Road tunnel", "type": "line", "id": "Road tunnel/Minor/1"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#2A2B2B", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[9, 1.5], [14, 7.3], [16, 10.3], [18, 18]]}}, "filter": ["all", ["==", "_symbol", 4], ["!in", "Viz", 3]], "source": "esri", "minzoom": 9, "source-layer": "Road tunnel", "type": "line", "id": "Road tunnel/Major, ramp or traffic circle/1"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#2A2B2B", "line-opacity": 0.5, "line-width": {"base": 1.0, "stops": [[9, 1.5], [14, 7.3], [16, 10.3], [18, 18]]}}, "filter": ["all", ["==", "_symbol", 3], ["!in", "Viz", 3]], "source": "esri", "minzoom": 9, "source-layer": "Road tunnel", "type": "line", "id": "Road tunnel/Major/1"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#2A2B2B", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[9, 0.3], [14, 8.3], [16, 14.3], [18, 28]]}}, "filter": ["all", ["==", "_symbol", 2], ["!in", "Viz", 3]], "source": "esri", "minzoom": 7, "source-layer": "Road tunnel", "type": "line", "id": "Road tunnel/Freeway Motorway, ramp or traffic circle/1"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#2A2B2B", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[8, 0.3], [14, 8.3], [16, 14.3], [18, 28]]}}, "filter": ["all", ["==", "_symbol", 1], ["!in", "Viz", 3]], "source": "esri", "minzoom": 8, "source-layer": "Road tunnel", "type": "line", "id": "Road tunnel/Highway/1"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#2A2B2B", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[5, 0.3], [14, 8.3], [16, 14.3], [18, 28]]}}, "filter": ["all", ["==", "_symbol", 0], ["!in", "Viz", 3]], "source": "esri", "minzoom": 7, "source-layer": "Road tunnel", "type": "line", "id": "Road tunnel/Freeway Motorway/1"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#434444", "line-dasharray": [3, 1.5], "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[14, 1.3], [16, 2], [18, 2.3]]}}, "filter": ["all", ["==", "_symbol", 9], ["!in", "Viz", 3]], "source": "esri", "minzoom": 15, "source-layer": "Road tunnel", "type": "line", "id": "Road tunnel/Pedestrian/0"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#434444", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[11, 0.75], [14, 1.3], [18, 6.3]]}}, "filter": ["all", ["==", "_symbol", 10], ["!in", "Viz", 3]], "source": "esri", "minzoom": 13, "source-layer": "Road tunnel", "type": "line", "id": "Road tunnel/4WD/0"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#434444", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[11, 0.75], [14, 1.3], [18, 6.3]]}}, "filter": ["all", ["==", "_symbol", 8], ["!in", "Viz", 3]], "source": "esri", "minzoom": 13, "source-layer": "Road tunnel", "type": "line", "id": "Road tunnel/Service/0"}, {"layout": {"line-join": "round"}, "paint": {"line-color": {"stops": [[12, "#414242"], [13, "#434444"]]}, "line-opacity": 0.5, "line-width": {"base": 1.4, "stops": [[11, 1.1], [14, 2], [16, 4], [18, 15.3]]}}, "filter": ["all", ["==", "_symbol", 7], ["!in", "Viz", 3]], "source": "esri", "minzoom": 12, "source-layer": "Road tunnel", "type": "line", "id": "Road tunnel/Local/0"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#434444", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[11, 0.75], [14, 2], [16, 7.65], [18, 15.3]]}}, "filter": ["all", ["==", "_symbol", 6], ["!in", "Viz", 3]], "source": "esri", "minzoom": 11, "source-layer": "Road tunnel", "type": "line", "id": "Road tunnel/Minor, ramp or traffic circle/0"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#434444", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[11, 1.3], [14, 3.65], [16, 7.65], [18, 15.3]]}}, "filter": ["all", ["==", "_symbol", 5], ["!in", "Viz", 3]], "source": "esri", "minzoom": 11, "source-layer": "Road tunnel", "type": "line", "id": "Road tunnel/Minor/0"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#434444", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[9, 0.75], [14, 5.3], [16, 8.3], [18, 16]]}}, "filter": ["all", ["==", "_symbol", 4], ["!in", "Viz", 3]], "source": "esri", "minzoom": 9, "source-layer": "Road tunnel", "type": "line", "id": "Road tunnel/Major, ramp or traffic circle/0"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#434444", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[9, 0.75], [14, 5.3], [16, 8.3], [18, 16]]}}, "filter": ["all", ["==", "_symbol", 3], ["!in", "Viz", 3]], "source": "esri", "minzoom": 9, "source-layer": "Road tunnel", "type": "line", "id": "Road tunnel/Major/0"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#434444", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[9, 0.3], [14, 6.3], [16, 12.3], [18, 26]]}}, "filter": ["all", ["==", "_symbol", 2], ["!in", "Viz", 3]], "source": "esri", "minzoom": 7, "source-layer": "Road tunnel", "type": "line", "id": "Road tunnel/Freeway Motorway, ramp or traffic circle/0"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#434444", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[8, 0.3], [14, 6.3], [16, 12.3], [18, 26]]}}, "filter": ["all", ["==", "_symbol", 1], ["!in", "Viz", 3]], "source": "esri", "minzoom": 8, "source-layer": "Road tunnel", "type": "line", "id": "Road tunnel/Highway/0"}, {"layout": {"line-join": "round"}, "paint": {"line-color": {"stops": [[6, "#414242"], [7, "#434444"]]}, "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[5, 0.3], [14, 6.3], [16, 12.3], [18, 26]]}}, "filter": ["all", ["==", "_symbol", 0], ["!in", "Viz", 3]], "source": "esri", "minzoom": 6, "source-layer": "Road tunnel", "type": "line", "id": "Road tunnel/Freeway Motorway/0"}, {"layout": {}, "paint": {"fill-color": "#353636"}, "filter": ["==", "_symbol", 9], "source": "esri", "minzoom": 14, "source-layer": "Special area of interest", "type": "fill", "id": "Special area of interest/Gutter"}, {"layout": {}, "paint": {"fill-outline-color": "#2d2e2e", "fill-color": "#353636"}, "filter": ["==", "_symbol", 3], "source": "esri", "minzoom": 14, "source-layer": "Special area of interest", "type": "fill", "id": "Special area of interest/Curb"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#414242", "line-opacity": 0.95, "line-width": {"base": 1.0, "stops": [[4, 0.65], [14, 7], [17, 7]]}}, "filter": ["all", ["==", "_symbol", 8], ["!in", "Viz", 3]], "source": "esri", "minzoom": 9, "source-layer": "Boundary line", "type": "line", "id": "Boundary line/Disputed admin2/1"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#2D2E2E", "line-dasharray": [7.0, 5.0], "line-width": {"base": 1.2, "stops": [[1, 0.65], [14, 1.3], [17, 2.65]]}}, "filter": ["all", ["==", "_symbol", 8], ["!in", "Viz", 3]], "source": "esri", "minzoom": 9, "source-layer": "Boundary line", "type": "line", "id": "Boundary line/Disputed admin2/0"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#434444", "line-width": {"base": 1.0, "stops": [[4, 0.65], [14, 7]]}}, "filter": ["all", ["==", "_symbol", 7], ["!in", "Viz", 3]], "source": "esri", "minzoom": 4, "source-layer": "Boundary line", "type": "line", "id": "Boundary line/Disputed admin1/1"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#434444", "line-width": {"base": 1.0, "stops": [[1, 0.65], [14, 9.3]]}}, "filter": ["all", ["==", "_symbol", 6], ["!in", "Viz", 3], ["!in", "DisputeID", 8, 16, 90, 96, 0]], "source": "esri", "minzoom": 1, "source-layer": "Boundary line", "type": "line", "id": "Boundary line/Disputed admin0/1"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#2D2E2E", "line-dasharray": [6.0, 5.0], "line-width": {"base": 1.2, "stops": [[1, 0.65], [14, 1.3], [17, 2.65]]}}, "filter": ["all", ["==", "_symbol", 7], ["!in", "Viz", 3]], "source": "esri", "minzoom": 4, "source-layer": "Boundary line", "type": "line", "id": "Boundary line/Disputed admin1/0"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#2D2E2E", "line-dasharray": [7.0, 5.0], "line-width": {"base": 1.2, "stops": [[1, 0.65], [14, 1.3], [17, 2.65]]}}, "filter": ["all", ["==", "_symbol", 6], ["!in", "Viz", 3], ["!in", "DisputeID", 8, 16, 90, 96, 0]], "source": "esri", "minzoom": 1, "source-layer": "Boundary line", "type": "line", "id": "Boundary line/Disputed admin0/0"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#2D2E2E", "line-opacity": 0.6, "line-width": {"base": 1.2, "stops": [[8, 3], [14, 4.5]]}}, "filter": ["all", ["==", "_symbol", 2], ["!in", "Viz", 3]], "source": "esri", "minzoom": 9, "source-layer": "Boundary line", "type": "line", "id": "Boundary line/Admin2/1"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": {"stops": [[1, "#323333"], [12, "#2D2E2E"]]}, "line-width": {"base": 1.0, "stops": [[4, 0.73], [14, 8]]}}, "filter": ["all", ["==", "_symbol", 1], ["!in", "Viz", 3]], "source": "esri", "minzoom": 4, "source-layer": "Boundary line", "type": "line", "id": "Boundary line/Admin1/1"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": {"stops": [[1, "#323333"], [12, "#2D2E2E"]]}, "line-width": {"base": 1.0, "stops": [[1, 0.65], [14, 10.5]]}}, "filter": ["all", ["==", "_symbol", 0], ["!in", "Viz", 3]], "source": "esri", "minzoom": 1, "source-layer": "Boundary line", "type": "line", "id": "Boundary line/Admin0/1"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#515252", "line-dasharray": [5, 3], "line-width": 1}, "filter": ["all", ["==", "_symbol", 5], ["!in", "Viz", 3]], "source": "esri", "minzoom": 16, "source-layer": "Boundary line", "type": "line", "id": "Boundary line/Admin5"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#515252", "line-dasharray": [5, 3], "line-width": 1}, "filter": ["all", ["==", "_symbol", 4], ["!in", "Viz", 3]], "source": "esri", "minzoom": 16, "source-layer": "Boundary line", "type": "line", "id": "Boundary line/Admin4"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#515252", "line-dasharray": [5, 3], "line-width": 1}, "filter": ["all", ["==", "_symbol", 3], ["!in", "Viz", 3]], "source": "esri", "minzoom": 16, "source-layer": "Boundary line", "type": "line", "id": "Boundary line/Admin3"}, {"layout": {"line-join": "round"}, "paint": {"line-color": "#515252", "line-dasharray": [6, 4], "line-width": {"base": 1.2, "stops": [[8, 0.6], [14, 1.3]]}}, "filter": ["all", ["==", "_symbol", 2], ["!in", "Viz", 3]], "source": "esri", "minzoom": 9, "source-layer": "Boundary line", "type": "line", "id": "Boundary line/Admin2/0"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": {"stops": [[7, "#3F4040"], [12, "#444545"]]}, "line-dasharray": [7, 5.3], "line-width": {"base": 1.0, "stops": [[7, 0.3], [14, 1.3]]}}, "filter": ["all", ["==", "_symbol", 1], ["!in", "Viz", 3]], "source": "esri", "minzoom": 7, "source-layer": "Boundary line", "type": "line", "id": "Boundary line/Admin1/0"}, {"layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": {"stops": [[5, "#383939"], [7, "#4A4C4C"]]}, "line-dasharray": [7, 5.3], "line-width": {"base": 1.2, "stops": [[5, 0.7], [14, 1.3]]}}, "filter": ["all", ["==", "_symbol", 0], ["!in", "Viz", 3]], "source": "esri", "minzoom": 5, "source-layer": "Boundary line", "type": "line", "id": "Boundary line/Admin0/0"}, {"layout": {"text-letter-spacing": 0.3, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-line-height": 1.6, "text-font": ["Ubuntu Light Bold Italic"], "text-anchor": "center", "text-field": "{_name_global}", "text-padding": 15, "text-size": {"stops": [[9, 8.5], [15, 15.5]]}, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#707374", "text-halo-width": 1, "text-halo-color": "#1D2224"}, "filter": ["==", "_label_class", 0], "source": "esri", "minzoom": 9, "source-layer": "Water point", "type": "symbol", "id": "Water point/Sea or ocean"}, {"layout": {"text-letter-spacing": 0.1, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold Italic"], "text-anchor": "center", "text-field": "{_name_global}", "text-size": {"stops": [[9, 8.5], [15, 10]]}, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 7], "source": "esri", "minzoom": 9, "source-layer": "Water point", "type": "symbol", "id": "Water point/Island"}, {"layout": {"text-letter-spacing": 0.1, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-anchor": "center", "text-field": "{_name_global}", "text-size": {"stops": [[9, 8.5], [15, 10]]}, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 0.7, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 5], "source": "esri", "minzoom": 9, "source-layer": "Water point", "type": "symbol", "id": "Water point/Dam or weir"}, {"layout": {"text-letter-spacing": 0.1, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold Italic"], "text-anchor": "center", "text-field": "{_name_global}", "text-size": {"stops": [[9, 8.5], [15, 10]]}, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 0.7, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 6], "source": "esri", "minzoom": 9, "source-layer": "Water point", "type": "symbol", "id": "Water point/Playa"}, {"layout": {"text-letter-spacing": 0.13, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold Italic"], "text-anchor": "center", "text-field": "{_name_global}", "text-size": {"stops": [[9, 8.5], [15, 10]]}, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#707374", "text-halo-width": 1, "text-halo-color": "#1D2224"}, "filter": ["==", "_label_class", 4], "source": "esri", "minzoom": 9, "source-layer": "Water point", "type": "symbol", "id": "Water point/Canal or ditch"}, {"layout": {"text-letter-spacing": 0.1, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold Italic"], "text-anchor": "center", "text-field": "{_name_global}", "text-size": {"stops": [[9, 8.5], [15, 10]]}, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#707374", "text-halo-width": 0.5, "text-halo-color": "#1D2224"}, "filter": ["==", "_label_class", 3], "source": "esri", "minzoom": 9, "source-layer": "Water point", "type": "symbol", "id": "Water point/Stream or river"}, {"layout": {"text-letter-spacing": 0.1, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold Italic"], "text-anchor": "center", "text-field": "{_name_global}", "text-size": {"stops": [[9, 8.5], [15, 10]]}, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#707374", "text-halo-width": 0.5, "text-halo-color": "#1D2224"}, "filter": ["==", "_label_class", 2], "source": "esri", "minzoom": 9, "source-layer": "Water point", "type": "symbol", "id": "Water point/Lake or reservoir"}, {"layout": {"text-letter-spacing": 0.1, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold Italic"], "text-anchor": "center", "text-field": "{_name_global}", "text-size": {"stops": [[9, 8.5], [15, 10]]}, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#707374", "text-halo-width": 1, "text-halo-color": "#1D2224"}, "filter": ["==", "_label_class", 1], "source": "esri", "minzoom": 9, "source-layer": "Water point", "type": "symbol", "id": "Water point/Bay or inlet"}, {"layout": {"text-letter-spacing": 0.07, "symbol-avoid-edges": true, "text-max-angle": 18, "symbol-placement": "line", "text-padding": 1, "text-font": ["Ubuntu Italic"], "text-field": "{_name_global}", "text-offset": [0, -0.5], "text-size": 9, "text-max-width": 6, "symbol-spacing": 800}, "paint": {"text-halo-blur": 1, "text-color": "#707374", "text-halo-width": 0.5, "text-halo-color": "#1D2224"}, "source": "esri", "minzoom": 11, "source-layer": "Water line/label", "type": "symbol", "id": "Water line/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-color": "#707374"}, "source": "esri", "minzoom": 16, "source-layer": "Marine park/label", "type": "symbol", "id": "Marine park/label/Default"}, {"layout": {"text-letter-spacing": 0.08, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 8], "source": "esri", "minzoom": 11, "source-layer": "Water area/label", "type": "symbol", "id": "Water area/label/Dam or weir"}, {"layout": {"text-letter-spacing": 0.08, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold Italic"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 9], "source": "esri", "minzoom": 11, "source-layer": "Water area/label", "type": "symbol", "id": "Water area/label/Playa"}, {"layout": {"text-letter-spacing": 0.13, "symbol-avoid-edges": true, "text-allow-overlap": false, "symbol-placement": "line", "text-padding": 15, "text-font": ["Ubuntu Light Bold Italic"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 5, "symbol-spacing": 1000}, "paint": {"text-halo-blur": 1, "text-color": "#707374", "text-halo-width": 0.5, "text-halo-color": "#1D2224"}, "filter": ["==", "_label_class", 2], "source": "esri", "minzoom": 11, "source-layer": "Water area/label", "type": "symbol", "id": "Water area/label/Canal or ditch"}, {"layout": {"text-letter-spacing": 0.13, "symbol-avoid-edges": true, "text-allow-overlap": false, "symbol-placement": "line", "text-padding": 15, "text-font": ["Ubuntu Light Bold Italic"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 8, "symbol-spacing": 1000}, "paint": {"text-halo-blur": 1, "text-color": "#707374", "text-halo-width": 0.5, "text-halo-color": "#1D2224"}, "filter": ["==", "_label_class", 7], "source": "esri", "minzoom": 11, "source-layer": "Water area/label", "type": "symbol", "id": "Water area/label/Small river"}, {"layout": {"text-letter-spacing": 0.13, "symbol-avoid-edges": true, "text-allow-overlap": false, "symbol-placement": "line", "text-padding": 15, "text-font": ["Ubuntu Light Bold Italic"], "text-field": "{_name_global}", "text-size": 10, "text-max-width": 8, "symbol-spacing": 1000}, "paint": {"text-halo-blur": 1, "text-color": "#707374", "text-halo-width": 0.5, "text-halo-color": "#1D2224"}, "filter": ["==", "_label_class", 4], "source": "esri", "minzoom": 11, "source-layer": "Water area/label", "type": "symbol", "id": "Water area/label/Large river"}, {"layout": {"text-letter-spacing": 0.13, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold Italic"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#707374", "text-halo-width": 0.5, "text-halo-color": "#1D2224"}, "filter": ["==", "_label_class", 6], "source": "esri", "minzoom": 11, "source-layer": "Water area/label", "type": "symbol", "id": "Water area/label/Small lake or reservoir"}, {"layout": {"text-letter-spacing": 0.13, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-line-height": 1.15, "text-font": ["Ubuntu Light Bold Italic"], "text-field": "{_name_global}", "text-padding": 15, "text-size": 10, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#707374", "text-halo-width": 0.5, "text-halo-color": "#1D2224"}, "filter": ["==", "_label_class", 3], "source": "esri", "minzoom": 11, "source-layer": "Water area/label", "type": "symbol", "id": "Water area/label/Large lake or reservoir"}, {"layout": {"text-letter-spacing": 0.13, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-line-height": 1.15, "text-font": ["Ubuntu Light Bold Italic"], "text-field": "{_name_global}", "text-padding": 15, "text-size": 11, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#707374", "text-halo-width": 0.5, "text-halo-color": "#1D2224"}, "filter": ["==", "_label_class", 1], "source": "esri", "minzoom": 11, "source-layer": "Water area/label", "type": "symbol", "id": "Water area/label/Bay or inlet"}, {"layout": {"text-letter-spacing": 0.1, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Italic"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 0], "source": "esri", "minzoom": 11, "source-layer": "Water area/label", "type": "symbol", "id": "Water area/label/Small island"}, {"layout": {"text-letter-spacing": 0.13, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Italic"], "text-field": "{_name_global}", "text-size": 10, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 5], "source": "esri", "minzoom": 11, "source-layer": "Water area/label", "type": "symbol", "id": "Water area/label/Large island"}, {"layout": {"text-letter-spacing": 0.1, "symbol-avoid-edges": true, "text-allow-overlap": false, "symbol-placement": "line", "text-padding": 15, "text-font": ["Ubuntu Light Bold Italic"], "text-field": "{_name}", "text-size": 9, "text-max-width": 4, "symbol-spacing": 1000}, "paint": {"text-halo-blur": 1, "text-color": "#707374", "text-halo-width": 0.5, "text-halo-color": "#1D2224"}, "filter": ["==", "_label_class", 1], "source": "esri", "minzoom": 7, "source-layer": "Water area large scale/label", "maxzoom": 11, "type": "symbol", "id": "Water area large scale/label/River"}, {"layout": {"text-letter-spacing": 0.1, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold Italic"], "text-field": "{_name}", "text-size": 9.5, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#707374", "text-halo-width": 0.5, "text-halo-color": "#1D2224"}, "filter": ["==", "_label_class", 0], "source": "esri", "minzoom": 7, "source-layer": "Water area large scale/label", "maxzoom": 11, "type": "symbol", "id": "Water area large scale/label/Lake or lake intermittent"}, {"layout": {"text-letter-spacing": 0.08, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold Italic"], "text-field": "{_name}", "text-size": 9, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#707374", "text-halo-width": 0.5, "text-halo-color": "#1D2224"}, "source": "esri", "minzoom": 5, "source-layer": "Water area medium scale/label", "maxzoom": 7, "type": "symbol", "id": "Water area medium scale/label/Default"}, {"layout": {"text-letter-spacing": 0.08, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold Italic"], "text-field": "{_name}", "text-size": 9, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#707374", "text-halo-width": 0.5, "text-halo-color": "#1D2224"}, "source": "esri", "minzoom": 1, "source-layer": "Water area small scale/label", "maxzoom": 5, "type": "symbol", "id": "Water area small scale/label/Default"}, {"layout": {"text-letter-spacing": 0.13, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold Italic"], "text-field": "{_name_global}", "text-size": 10, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#707374", "text-halo-width": 0.5, "text-halo-color": "#1D2224"}, "source": "esri", "minzoom": 11, "source-layer": "Marine area/label", "type": "symbol", "id": "Marine area/label/Default"}, {"layout": {"text-letter-spacing": 0.12, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold Italic"], "text-size": {"stops": [[1, 9], [6, 11]]}, "text-field": "{_name}", "text-line-height": 1.2, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#707374", "text-halo-width": 0.5, "text-halo-color": "#1D2224"}, "filter": ["==", "_label_class", 4], "source": "esri", "minzoom": 4, "source-layer": "Marine waterbody/label", "maxzoom": 10, "type": "symbol", "id": "Marine waterbody/label/small"}, {"layout": {"text-letter-spacing": 0.15, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold Italic"], "text-size": {"stops": [[1, 9], [6, 11]]}, "text-field": "{_name}", "text-line-height": 1.2, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#707374", "text-halo-width": 0.5, "text-halo-color": "#1D2224"}, "filter": ["==", "_label_class", 3], "source": "esri", "minzoom": 4, "source-layer": "Marine waterbody/label", "maxzoom": 10, "type": "symbol", "id": "Marine waterbody/label/medium"}, {"layout": {"text-letter-spacing": 0.18, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold Italic"], "text-size": {"stops": [[1, 9], [6, 12]]}, "text-field": "{_name}", "text-line-height": 1.5, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#707374", "text-halo-width": 0.5, "text-halo-color": "#1D2224"}, "filter": ["==", "_label_class", 2], "source": "esri", "minzoom": 4, "source-layer": "Marine waterbody/label", "maxzoom": 10, "type": "symbol", "id": "Marine waterbody/label/large"}, {"layout": {"text-letter-spacing": 0.2, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold Italic"], "text-size": {"stops": [[1, 10], [6, 13]]}, "text-field": "{_name}", "text-line-height": 1.5, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#707374", "text-halo-width": 0.5, "text-halo-color": "#1D2224"}, "filter": ["==", "_label_class", 1], "source": "esri", "minzoom": 3, "source-layer": "Marine waterbody/label", "maxzoom": 10, "type": "symbol", "id": "Marine waterbody/label/x large"}, {"layout": {"text-letter-spacing": 0.3, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold Italic"], "text-size": {"stops": [[1, 11], [4, 14]]}, "text-field": "{_name}", "text-line-height": 1.6, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#707374", "text-halo-width": 0.5, "text-halo-color": "#1D2224"}, "filter": ["==", "_label_class", 0], "source": "esri", "minzoom": 2, "source-layer": "Marine waterbody/label", "maxzoom": 10, "type": "symbol", "id": "Marine waterbody/label/2x large"}, {"layout": {"text-letter-spacing": 0.1, "symbol-avoid-edges": true, "symbol-placement": "line", "text-padding": 5, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-offset": [0, -0.6], "text-size": 8.5, "text-max-width": 6, "symbol-spacing": 1000}, "paint": {"text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["all", ["==", "_label_class", 1], ["!in", "Viz", 3]], "source": "esri", "minzoom": 16, "source-layer": "Ferry/label", "type": "symbol", "id": "Ferry/label/Rail ferry"}, {"layout": {"text-letter-spacing": 0.1, "symbol-avoid-edges": true, "symbol-placement": "line", "text-padding": 5, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-offset": [0, -0.6], "text-size": 8.5, "text-max-width": 6, "symbol-spacing": 1000}, "paint": {"text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#323333"}, "source": "esri", "minzoom": 16, "source-layer": "Railroad/label", "type": "symbol", "id": "Railroad/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "symbol-placement": "line", "text-padding": 5, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.3, "text-max-width": 6, "symbol-spacing": 400}, "paint": {"text-halo-blur": 1, "text-color": "#a3a3a1", "text-halo-width": 1, "text-halo-color": "#212121"}, "filter": ["all", ["==", "_label_class", 6], ["!in", "Viz", 3]], "source": "esri", "minzoom": 15, "source-layer": "Road tunnel/label", "type": "symbol", "id": "Road tunnel/label/Pedestrian"}, {"layout": {"text-letter-spacing": 0.09, "symbol-avoid-edges": true, "symbol-placement": "line", "text-padding": 5, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6, "symbol-spacing": 400}, "paint": {"text-halo-blur": 1, "text-color": "#a3a3a1", "text-halo-width": 1, "text-halo-color": "#212121"}, "filter": ["all", ["==", "_label_class", 5], ["!in", "Viz", 3]], "source": "esri", "minzoom": 15, "source-layer": "Road tunnel/label", "type": "symbol", "id": "Road tunnel/label/Local, service, 4WD"}, {"layout": {"text-letter-spacing": 0.09, "symbol-avoid-edges": true, "symbol-placement": "line", "text-padding": 5, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6, "symbol-spacing": 400}, "paint": {"text-halo-blur": 1, "text-color": "#a3a3a1", "text-halo-width": 1, "text-halo-color": "#212121"}, "filter": ["all", ["==", "_label_class", 4], ["!in", "Viz", 3]], "source": "esri", "minzoom": 14, "source-layer": "Road tunnel/label", "type": "symbol", "id": "Road tunnel/label/Minor"}, {"layout": {"text-letter-spacing": 0.09, "symbol-avoid-edges": true, "symbol-placement": "line", "text-padding": 5, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name}", "text-size": 10.5, "text-max-width": 6, "symbol-spacing": 400}, "paint": {"text-halo-blur": 1, "text-color": "#a3a3a1", "text-halo-width": 1, "text-halo-color": "#212121"}, "filter": ["all", ["==", "_label_class", 3], ["!in", "Viz", 3]], "source": "esri", "minzoom": 14, "source-layer": "Road tunnel/label", "type": "symbol", "id": "Road tunnel/label/Major, alt name"}, {"layout": {"text-letter-spacing": 0.09, "symbol-avoid-edges": true, "symbol-placement": "line", "text-padding": 5, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name}", "text-size": 10.5, "text-max-width": 6, "symbol-spacing": 400}, "paint": {"text-halo-blur": 1, "text-color": "#a3a3a1", "text-halo-width": 1, "text-halo-color": "#212121"}, "filter": ["all", ["==", "_label_class", 2], ["!in", "Viz", 3]], "source": "esri", "minzoom": 14, "source-layer": "Road tunnel/label", "type": "symbol", "id": "Road tunnel/label/Major"}, {"layout": {"text-letter-spacing": 0.09, "symbol-avoid-edges": true, "symbol-placement": "line", "text-padding": 5, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 10.5, "text-max-width": 6, "symbol-spacing": 400}, "paint": {"text-halo-blur": 1, "text-color": "#a3a3a1", "text-halo-width": 1, "text-halo-color": "#212121"}, "filter": ["all", ["==", "_label_class", 7], ["!in", "Viz", 3]], "source": "esri", "minzoom": 13, "source-layer": "Road tunnel/label", "type": "symbol", "id": "Road tunnel/label/Highway"}, {"layout": {"text-letter-spacing": 0.09, "symbol-avoid-edges": true, "symbol-placement": "line", "text-padding": 5, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 10.5, "text-max-width": 6, "symbol-spacing": 400}, "paint": {"text-halo-blur": 1, "text-color": "#a3a3a1", "text-halo-width": 1, "text-halo-color": "#212121"}, "filter": ["all", ["==", "_label_class", 1], ["!in", "Viz", 3]], "source": "esri", "minzoom": 13, "source-layer": "Road tunnel/label", "type": "symbol", "id": "Road tunnel/label/Freeway Motorway, alt name"}, {"layout": {"text-letter-spacing": 0.09, "symbol-avoid-edges": true, "symbol-placement": "line", "text-padding": 5, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 10.5, "text-max-width": 6, "symbol-spacing": 400}, "paint": {"text-halo-blur": 1, "text-color": "#a3a3a1", "text-halo-width": 1, "text-halo-color": "#212121"}, "filter": ["all", ["==", "_label_class", 0], ["!in", "Viz", 3]], "source": "esri", "minzoom": 13, "source-layer": "Road tunnel/label", "type": "symbol", "id": "Road tunnel/label/Freeway Motorway"}, {"layout": {"text-letter-spacing": 0.08, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 0.7, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 17, "source-layer": "Building/label", "type": "symbol", "id": "Building/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "symbol-placement": "line", "text-padding": 5, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.3, "text-max-width": 6, "symbol-spacing": 400}, "paint": {"text-color": "#a3a3a1", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 15, "source-layer": "Trail or path/label", "type": "symbol", "id": "Trail or path/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "symbol-placement": "line", "text-padding": 5, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.3, "text-max-width": 6, "symbol-spacing": 400}, "paint": {"text-color": "#a3a3a1", "text-halo-width": 1, "text-halo-color": "#212121"}, "filter": ["all", ["==", "_label_class", 6], ["!in", "Viz", 3]], "source": "esri", "minzoom": 15, "source-layer": "Road/label", "type": "symbol", "id": "Road/label/Pedestrian"}, {"layout": {"text-letter-spacing": 0.09, "symbol-avoid-edges": true, "symbol-placement": "line", "text-padding": 5, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6, "symbol-spacing": 400}, "paint": {"text-color": "#a3a3a1", "text-halo-width": 1, "text-halo-color": "#212121"}, "filter": ["all", ["==", "_label_class", 5], ["!in", "Viz", 3]], "source": "esri", "minzoom": 15, "source-layer": "Road/label", "type": "symbol", "id": "Road/label/Local"}, {"layout": {"text-letter-spacing": 0.09, "symbol-avoid-edges": true, "symbol-placement": "line", "text-padding": 2, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 10, "text-max-width": 6, "symbol-spacing": 400}, "paint": {"text-color": "#a3a3a1", "text-halo-width": 1, "text-halo-color": "#212121"}, "filter": ["all", ["==", "_label_class", 4], ["!in", "Viz", 3]], "source": "esri", "minzoom": 14, "source-layer": "Road/label", "type": "symbol", "id": "Road/label/Minor"}, {"layout": {"text-letter-spacing": 0.09, "symbol-avoid-edges": true, "symbol-placement": "line", "text-padding": 2, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name}", "text-size": 10.5, "text-max-width": 6, "symbol-spacing": 400}, "paint": {"text-color": "#a3a3a1", "text-halo-width": 1, "text-halo-color": "#212121"}, "filter": ["all", ["==", "_label_class", 3], ["!in", "Viz", 3]], "source": "esri", "minzoom": 14, "source-layer": "Road/label", "type": "symbol", "id": "Road/label/Major, alt name"}, {"layout": {"text-letter-spacing": 0.09, "symbol-avoid-edges": true, "symbol-placement": "line", "text-padding": 2, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 10.5, "text-max-width": 6, "symbol-spacing": 400}, "paint": {"text-color": "#a3a3a1", "text-halo-width": 1, "text-halo-color": "#212121"}, "filter": ["all", ["==", "_label_class", 2], ["!in", "Viz", 3]], "source": "esri", "minzoom": 14, "source-layer": "Road/label", "type": "symbol", "id": "Road/label/Major"}, {"layout": {"text-letter-spacing": 0.09, "symbol-avoid-edges": true, "symbol-placement": "line", "text-padding": 2, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 10.5, "text-max-width": 6, "symbol-spacing": 400}, "paint": {"text-color": "#a3a3a1", "text-halo-width": 1, "text-halo-color": "#212121"}, "filter": ["all", ["==", "_label_class", 75], ["!in", "Viz", 3]], "source": "esri", "minzoom": 13, "source-layer": "Road/label", "type": "symbol", "id": "Road/label/Highway"}, {"layout": {"text-letter-spacing": 0.09, "symbol-avoid-edges": true, "symbol-placement": "line", "text-padding": 2, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name}", "text-size": 10.5, "text-max-width": 6, "symbol-spacing": 400}, "paint": {"text-color": "#a3a3a1", "text-halo-width": 1, "text-halo-color": "#212121"}, "filter": ["all", ["==", "_label_class", 1], ["!in", "Viz", 3]], "source": "esri", "minzoom": 13, "source-layer": "Road/label", "type": "symbol", "id": "Road/label/Freeway Motorway, alt name"}, {"layout": {"text-letter-spacing": 0.09, "symbol-avoid-edges": true, "symbol-placement": "line", "text-padding": 2, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 10.5, "text-max-width": 6, "symbol-spacing": 400}, "paint": {"text-color": "#a3a3a1", "text-halo-width": 1, "text-halo-color": "#212121"}, "filter": ["all", ["==", "_label_class", 0], ["!in", "Viz", 3]], "source": "esri", "minzoom": 13, "source-layer": "Road/label", "type": "symbol", "id": "Road/label/Freeway Motorway"}, {"layout": {"symbol-avoid-edges": true, "text-max-angle": 25, "symbol-placement": "line", "text-padding": 30, "text-font": ["Ubuntu Light Bold"], "icon-image": "Road/Rectangle white black (Alt)/{_len}", "text-field": "{_name}", "icon-rotation-alignment": "viewport", "text-offset": [0, 0.2], "text-rotation-alignment": "viewport", "text-size": 10, "text-max-width": 6, "symbol-spacing": 800}, "paint": {"text-color": "#a3a3a1", "text-halo-width": 1, "text-halo-color": "#404040"}, "filter": ["all", ["in", "_label_class", 8, 10, 12, 14, 16, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62, 64, 66, 68, 70, 72, 74], ["!in", "Viz", 3]], "source": "esri", "minzoom": 14, "source-layer": "Road/label", "type": "symbol", "id": "Road/label/Rectangle white black (Alt)"}, {"layout": {"symbol-avoid-edges": true, "text-max-angle": 25, "symbol-placement": "line", "text-padding": 30, "text-font": ["Ubuntu Light Bold"], "icon-image": "Road/Rectangle white black/{_len}", "text-field": "{_name}", "icon-rotation-alignment": "viewport", "text-offset": [0, 0.2], "text-rotation-alignment": "viewport", "text-size": 10, "text-max-width": 6, "symbol-spacing": 800}, "paint": {"text-color": "#a3a3a1", "text-halo-width": 1, "text-halo-color": "#404040"}, "filter": ["all", ["in", "_label_class", 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 33, 35, 37, 39, 41, 43, 45, 47, 49, 51, 53, 55, 57, 59, 61, 63, 65, 67, 69, 71, 73], ["!in", "Viz", 3]], "source": "esri", "minzoom": 14, "source-layer": "Road/label", "type": "symbol", "id": "Road/label/Rectangle white black"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#8c8e8d", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 16, "source-layer": "Cemetery/label", "type": "symbol", "id": "Cemetery/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 17, "source-layer": "Freight/label", "type": "symbol", "id": "Freight/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 17, "source-layer": "Water and wastewater/label", "type": "symbol", "id": "Water and wastewater/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 17, "source-layer": "Port/label", "type": "symbol", "id": "Port/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 17, "source-layer": "Industry/label", "type": "symbol", "id": "Industry/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": false, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 17, "source-layer": "Government/label", "type": "symbol", "id": "Government/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 17, "source-layer": "Finance/label", "type": "symbol", "id": "Finance/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 17, "source-layer": "Emergency/label", "type": "symbol", "id": "Emergency/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 17, "source-layer": "Indigenous/label", "type": "symbol", "id": "Indigenous/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 25, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 17, "source-layer": "Military/label", "type": "symbol", "id": "Military/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 17, "source-layer": "Transportation/label", "type": "symbol", "id": "Transportation/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": false, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 17, "source-layer": "Pedestrian/label", "type": "symbol", "id": "Pedestrian/label/Default"}, {"layout": {"text-letter-spacing": 0.08, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 17, "source-layer": "Beach/label", "type": "symbol", "id": "Beach/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#8c8e8d", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 17, "source-layer": "Golf course/label", "type": "symbol", "id": "Golf course/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#8c8e8d", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 15, "source-layer": "Zoo/label", "type": "symbol", "id": "Zoo/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 17, "source-layer": "Retail/label", "type": "symbol", "id": "Retail/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 17, "source-layer": "Landmark/label", "type": "symbol", "id": "Landmark/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": false, "text-allow-overlap": false, "text-padding": 25, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#8c8e8d", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 14, "source-layer": "Openspace or forest/label", "type": "symbol", "id": "Openspace or forest/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": false, "text-allow-overlap": false, "text-padding": 25, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#8c8e8d", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 14, "source-layer": "Park or farming/label", "type": "symbol", "id": "Park or farming/label/Default"}, {"layout": {"text-letter-spacing": 0.08, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-anchor": "center", "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#8c8e8d", "text-halo-width": 1, "text-halo-color": "#212121"}, "filter": ["==", "_label_class", 1], "source": "esri", "minzoom": 14, "source-layer": "Point of interest", "type": "symbol", "id": "Point of interest/Park"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 17, "source-layer": "Education/label", "type": "symbol", "id": "Education/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 17, "source-layer": "Medical/label", "type": "symbol", "id": "Medical/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": false, "text-allow-overlap": false, "text-padding": 25, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": {"stops": [[9, 8.5], [12, 9.5]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#8c8e8d", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 9, "source-layer": "Admin1 forest or park/label", "type": "symbol", "id": "Admin1 forest or park/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 25, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": {"stops": [[9, 8.5], [12, 9.5]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#8c8e8d", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 9, "source-layer": "Admin0 forest or park/label", "type": "symbol", "id": "Admin0 forest or park/label/Default"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": {"stops": [[9, 8.5], [12, 9.5]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#212121"}, "source": "esri", "minzoom": 9, "source-layer": "Airport/label", "type": "symbol", "id": "Airport/label/Airport property"}, {"layout": {"text-transform": "uppercase", "text-letter-spacing": 0.2, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name}", "text-size": 9, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#656564", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 1], "source": "esri", "minzoom": 9, "source-layer": "Admin2 area/label", "maxzoom": 11, "type": "symbol", "id": "Admin2 area/label/small"}, {"layout": {"text-transform": "uppercase", "text-letter-spacing": 0.2, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name}", "text-size": 10, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#656564", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 0], "source": "esri", "minzoom": 9, "source-layer": "Admin2 area/label", "maxzoom": 11, "type": "symbol", "id": "Admin2 area/label/large"}, {"layout": {"text-letter-spacing": {"stops": [[4, 0.1], [8, 0.18]]}, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Light Bold"], "text-size": {"stops": [[4, 9], [5, 9], [6, 9.5], [9, 10]]}, "text-field": "{_name}", "text-transform": "uppercase", "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#727271", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 5], "source": "esri", "minzoom": 5, "source-layer": "Admin1 area/label", "maxzoom": 10, "type": "symbol", "id": "Admin1 area/label/x small"}, {"layout": {"text-letter-spacing": {"stops": [[4, 0.1], [8, 0.18]]}, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Light Bold"], "text-size": {"stops": [[4, 9], [5, 9], [6, 9.5], [9, 11.5]]}, "text-field": "{_name}", "text-transform": "uppercase", "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#727271", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 4], "source": "esri", "minzoom": 5, "source-layer": "Admin1 area/label", "maxzoom": 10, "type": "symbol", "id": "Admin1 area/label/small"}, {"layout": {"text-letter-spacing": {"stops": [[4, 0.1], [8, 0.18]]}, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Light Bold"], "text-size": {"stops": [[4, 10], [5, 10], [6, 10.5], [9, 12]]}, "text-field": "{_name}", "text-transform": "uppercase", "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#727271", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 3], "source": "esri", "minzoom": 5, "source-layer": "Admin1 area/label", "maxzoom": 10, "type": "symbol", "id": "Admin1 area/label/medium"}, {"layout": {"text-letter-spacing": {"stops": [[4, 0.1], [8, 0.2]]}, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Light Bold"], "text-size": {"stops": [[4, 10], [5, 10.5], [6, 11], [9, 15]]}, "text-field": "{_name}", "text-transform": "uppercase", "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#727271", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 2], "source": "esri", "minzoom": 5, "source-layer": "Admin1 area/label", "maxzoom": 10, "type": "symbol", "id": "Admin1 area/label/large"}, {"layout": {"text-letter-spacing": {"stops": [[4, 0.13], [8, 0.3]]}, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Light Bold"], "text-size": {"stops": [[4, 10.5], [5, 11], [6, 11.5], [9, 17]]}, "text-field": "{_name}", "text-transform": "uppercase", "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#727271", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 1], "source": "esri", "minzoom": 5, "source-layer": "Admin1 area/label", "maxzoom": 10, "type": "symbol", "id": "Admin1 area/label/x large"}, {"layout": {"text-letter-spacing": {"stops": [[4, 0.13], [8, 0.4]]}, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Light Bold"], "text-size": {"stops": [[4, 11], [5, 11.5], [6, 12], [9, 17.5]]}, "text-field": "{_name}", "text-transform": "uppercase", "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#727271", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 0], "source": "esri", "minzoom": 5, "source-layer": "Admin1 area/label", "maxzoom": 10, "type": "symbol", "id": "Admin1 area/label/2x large"}, {"layout": {"text-letter-spacing": 0.08, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Light Bold"], "text-anchor": "center", "text-field": "{_name_global}", "text-size": 9, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#212121"}, "filter": ["==", "_label_class", 0], "source": "esri", "minzoom": 17, "source-layer": "Point of interest", "type": "symbol", "id": "Point of interest/General"}, {"layout": {"text-letter-spacing": 0.04, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 5, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-offset": [0, -0.9], "text-size": 9, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#212121"}, "filter": ["==", "_symbol", 2], "source": "esri", "minzoom": 17, "source-layer": "Point of interest", "type": "symbol", "id": "Point of interest/Bus station"}, {"layout": {"text-letter-spacing": 0.04, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 5, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-offset": [0, -0.9], "text-size": 9, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#212121"}, "filter": ["==", "_symbol", 3], "source": "esri", "minzoom": 17, "source-layer": "Point of interest", "type": "symbol", "id": "Point of interest/Rail station"}, {"layout": {"text-letter-spacing": 0.08, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Regular"], "text-field": "{_name_global}", "text-size": {"stops": [[10, 10], [16, 13]]}}, "paint": {"text-halo-blur": 1, "text-color": "#d6d8d4", "text-halo-width": 1, "text-halo-color": "#323333"}, "source": "esri", "minzoom": 15, "source-layer": "Neighborhood", "maxzoom": 17, "type": "symbol", "id": "Neighborhood"}, {"layout": {"text-letter-spacing": 0.08, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 15, "text-font": ["Ubuntu Regular"], "text-field": "{_name_global}", "text-size": {"stops": [[10, 10], [16, 13]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#d6d8d4", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 5], "source": "esri", "minzoom": 10, "source-layer": "City large scale", "maxzoom": 17, "type": "symbol", "id": "City large scale/town small"}, {"layout": {"text-letter-spacing": 0.09, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Regular"], "text-field": "{_name_global}", "text-size": {"stops": [[10, 10], [16, 15]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#d6d8d4", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 4], "source": "esri", "minzoom": 10, "source-layer": "City large scale", "maxzoom": 17, "type": "symbol", "id": "City large scale/town large"}, {"layout": {"text-letter-spacing": 0.1, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Regular"], "text-field": "{_name_global}", "text-size": {"stops": [[10, 11], [16, 16]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#d6d8d4", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 3], "source": "esri", "minzoom": 10, "source-layer": "City large scale", "maxzoom": 17, "type": "symbol", "id": "City large scale/small"}, {"layout": {"text-letter-spacing": 0.1, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": {"stops": [[10, 11], [16, 18.5]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#e1e3de", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 2], "source": "esri", "minzoom": 10, "source-layer": "City large scale", "maxzoom": 17, "type": "symbol", "id": "City large scale/medium"}, {"layout": {"text-letter-spacing": 0.1, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": {"stops": [[10, 14], [16, 22]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#e1e3de", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 1], "source": "esri", "minzoom": 10, "source-layer": "City large scale", "maxzoom": 17, "type": "symbol", "id": "City large scale/large"}, {"layout": {"text-letter-spacing": 0.1, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name_global}", "text-size": {"stops": [[10, 15], [16, 25]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#e1e3de", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 0], "source": "esri", "minzoom": 10, "source-layer": "City large scale", "maxzoom": 17, "type": "symbol", "id": "City large scale/x large"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Regular"], "text-field": "{_name}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#d6d8d4", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_symbol", 17], "source": "esri", "minzoom": 2, "source-layer": "City small scale", "maxzoom": 10, "type": "symbol", "id": "City small scale/town small non capital"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Regular"], "text-field": "{_name}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#d6d8d4", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_symbol", 15], "source": "esri", "minzoom": 2, "source-layer": "City small scale", "maxzoom": 10, "type": "symbol", "id": "City small scale/town large non capital"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Regular"], "text-field": "{_name}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#d6d8d4", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_symbol", 12], "source": "esri", "minzoom": 2, "source-layer": "City small scale", "maxzoom": 10, "type": "symbol", "id": "City small scale/small non capital"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Regular"], "text-field": "{_name}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#d6d8d4", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_symbol", 9], "source": "esri", "minzoom": 2, "source-layer": "City small scale", "maxzoom": 10, "type": "symbol", "id": "City small scale/medium non capital"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Regular"], "text-field": "{_name}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#d6d8d4", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_symbol", 18], "source": "esri", "minzoom": 2, "source-layer": "City small scale", "maxzoom": 10, "type": "symbol", "id": "City small scale/other capital"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Regular"], "text-field": "{_name}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#d6d8d4", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_symbol", 14], "source": "esri", "minzoom": 2, "source-layer": "City small scale", "maxzoom": 10, "type": "symbol", "id": "City small scale/town large other capital"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Regular"], "text-field": "{_name}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#d6d8d4", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_symbol", 11], "source": "esri", "minzoom": 2, "source-layer": "City small scale", "maxzoom": 10, "type": "symbol", "id": "City small scale/small other capital"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Regular"], "text-field": "{_name}", "text-size": 9.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#d6d8d4", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_symbol", 8], "source": "esri", "minzoom": 2, "source-layer": "City small scale", "maxzoom": 10, "type": "symbol", "id": "City small scale/medium other capital"}, {"layout": {"text-transform": "uppercase", "text-letter-spacing": {"stops": [[5, 0.13], [8, 0.5]]}, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Bold"], "text-field": "{_name}", "text-size": {"stops": [[5, 10], [10, 12.5]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#838381", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 5], "source": "esri", "minzoom": 5, "source-layer": "Admin0 point", "maxzoom": 10, "type": "symbol", "id": "Admin0 point/x small"}, {"layout": {"text-transform": "uppercase", "text-letter-spacing": {"stops": [[4, 0.13], [8, 0.5]]}, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Bold"], "text-field": "{_name}", "text-size": {"stops": [[4, 10], [10, 12.5]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#838381", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 4], "source": "esri", "minzoom": 4, "source-layer": "Admin0 point", "maxzoom": 10, "type": "symbol", "id": "Admin0 point/small"}, {"layout": {"text-transform": "uppercase", "text-letter-spacing": {"stops": [[2, 0.13], [8, 0.5]]}, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Bold"], "text-field": "{_name}", "text-size": {"stops": [[2, 8], [4, 10], [10, 16]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#838381", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 3], "source": "esri", "minzoom": 2, "source-layer": "Admin0 point", "maxzoom": 10, "type": "symbol", "id": "Admin0 point/medium"}, {"layout": {"text-transform": "uppercase", "text-letter-spacing": {"stops": [[2, 0.13], [8, 0.5]]}, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Bold"], "text-field": "{_name}", "text-size": {"stops": [[2, 9], [4, 10], [6, 16]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#838381", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 2], "source": "esri", "minzoom": 2, "source-layer": "Admin0 point", "maxzoom": 10, "type": "symbol", "id": "Admin0 point/large"}, {"layout": {"text-transform": "uppercase", "text-letter-spacing": {"stops": [[2, 0.15], [6, 0.5]]}, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Bold"], "text-size": {"stops": [[2, 9], [4, 10], [6, 16]]}, "text-field": "{_name}", "text-line-height": 1.5, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#838381", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 1], "source": "esri", "minzoom": 2, "source-layer": "Admin0 point", "maxzoom": 8, "type": "symbol", "id": "Admin0 point/x large"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name}", "text-size": {"stops": [[3, 10], [6, 10.5], [8, 13]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#e1e3de", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_symbol", 16], "source": "esri", "minzoom": 2, "source-layer": "City small scale", "maxzoom": 10, "type": "symbol", "id": "City small scale/town small admin0 capital"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name}", "text-size": {"stops": [[3, 10], [6, 10.5], [8, 13]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#e1e3de", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_symbol", 13], "source": "esri", "minzoom": 2, "source-layer": "City small scale", "maxzoom": 10, "type": "symbol", "id": "City small scale/town large admin0 capital"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name}", "text-size": {"stops": [[3, 10], [6, 10.5], [8, 13]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#e1e3de", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_symbol", 10], "source": "esri", "minzoom": 2, "source-layer": "City small scale", "maxzoom": 10, "type": "symbol", "id": "City small scale/small admin0 capital"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name}", "text-size": {"stops": [[3, 10], [6, 10.5], [8, 13]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#e1e3de", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_symbol", 7], "source": "esri", "minzoom": 2, "source-layer": "City small scale", "maxzoom": 10, "type": "symbol", "id": "City small scale/medium admin0 capital"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name}", "text-size": {"stops": [[3, 10], [6, 11], [8, 14]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#e1e3de", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_symbol", 5], "source": "esri", "minzoom": 2, "source-layer": "City small scale", "maxzoom": 10, "type": "symbol", "id": "City small scale/large other capital"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name}", "text-size": {"stops": [[3, 11], [6, 12], [8, 15]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#e1e3de", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_symbol", 2], "source": "esri", "minzoom": 2, "source-layer": "City small scale", "maxzoom": 10, "type": "symbol", "id": "City small scale/x large admin2 capital"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name}", "text-size": {"stops": [[3, 10], [6, 11], [8, 14]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#e1e3de", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_symbol", 6], "source": "esri", "minzoom": 2, "source-layer": "City small scale", "maxzoom": 10, "type": "symbol", "id": "City small scale/large non capital"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name}", "text-size": {"stops": [[3, 10], [6, 11], [8, 14]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#e1e3de", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_symbol", 4], "source": "esri", "minzoom": 2, "source-layer": "City small scale", "maxzoom": 10, "type": "symbol", "id": "City small scale/large admin0 capital"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name}", "text-size": {"stops": [[3, 11], [6, 12], [8, 15]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#e1e3de", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_symbol", 3], "source": "esri", "minzoom": 2, "source-layer": "City small scale", "maxzoom": 10, "type": "symbol", "id": "City small scale/x large non capital"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name}", "text-size": {"stops": [[3, 11], [6, 12], [8, 15]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#e1e3de", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_symbol", 1], "source": "esri", "minzoom": 2, "source-layer": "City small scale", "maxzoom": 10, "type": "symbol", "id": "City small scale/x large admin1 capital"}, {"layout": {"text-letter-spacing": 0.05, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Light Bold"], "text-field": "{_name}", "text-size": {"stops": [[3, 11], [6, 12], [8, 15]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#e1e3de", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_symbol", 0], "source": "esri", "minzoom": 2, "source-layer": "City small scale", "maxzoom": 10, "type": "symbol", "id": "City small scale/x large admin0 capital"}, {"layout": {"text-transform": "uppercase", "text-letter-spacing": {"stops": [[2, 0.3], [5, 0.5]]}, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-padding": 1, "text-font": ["Ubuntu Bold"], "text-size": {"stops": [[2, 12], [4, 15.5], [5, 18]]}, "text-field": "{_name}", "text-line-height": 1.7, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#838381", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["==", "_label_class", 0], "source": "esri", "minzoom": 2, "source-layer": "Admin0 point", "maxzoom": 6, "type": "symbol", "id": "Admin0 point/2x large"}, {"layout": {"text-letter-spacing": 0.13, "icon-allow-overlap": true, "text-font": ["Ubuntu Italic"], "text-anchor": "center", "icon-image": "Disputed label point", "text-field": "{_name}", "text-optional": true, "text-size": {"stops": [[6, 7], [15, 10]]}, "text-max-width": 4}, "paint": {"text-halo-blur": 1, "text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["all", ["==", "_label_class", 1], ["in", "DisputeID", 0]], "source": "esri", "minzoom": 6, "source-layer": "Disputed label point", "type": "symbol", "id": "Disputed label point/Island"}, {"layout": {"text-letter-spacing": 0.1, "icon-allow-overlap": true, "text-font": ["Ubuntu Light Bold Italic"], "text-anchor": "center", "icon-image": "Disputed label point", "text-field": "{_name}", "text-optional": true, "text-size": {"stops": [[2, 8], [6, 9.3]]}, "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#707374", "text-halo-width": 0.5, "text-halo-color": "#1D2224"}, "filter": ["all", ["==", "_label_class", 0], ["in", "DisputeID", 1006]], "source": "esri", "minzoom": 2, "source-layer": "Disputed label point", "maxzoom": 10, "type": "symbol", "id": "Disputed label point/Waterbody"}, {"layout": {"text-letter-spacing": {"stops": [[2, 0.13], [8, 0.5]]}, "icon-allow-overlap": true, "text-size": {"stops": [[2, 8], [4, 10], [10, 16]]}, "text-font": ["Ubuntu Bold"], "text-anchor": "center", "icon-image": "Disputed label point", "text-field": "{_name}", "text-optional": true, "text-transform": "uppercase", "text-max-width": 6}, "paint": {"text-halo-blur": 1, "text-color": "#838381", "text-halo-width": 1, "text-halo-color": "#323333"}, "filter": ["all", ["==", "_label_class", 2], ["in", "DisputeID", 1021]], "source": "esri", "minzoom": 2, "source-layer": "Disputed label point", "type": "symbol", "id": "Disputed label point/Admin0"}], "glyphs": "https://basemaps.arcgis.com/arcgis/rest/services/World_Basemap_v2/VectorTileServer/resources/fonts/{fontstack}/{range}.pbf", "version": 8, "sprite": "https://www.arcgis.com/sharing/rest/content/items/c11ce4f7801740b2905eb03ddc963ac8/resources/styles/../sprites/sprite", "sources": {"esri": {"url": "https://basemaps.arcgis.com/arcgis/rest/services/World_Basemap_v2/VectorTileServer", "type": "vector"}}}
+{
+  "layers": [
+    {
+      "paint": {
+        "background-color": "#1d2224"
+      },
+      "type": "background",
+      "id": "background"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-color": {
+          "stops": [
+            [
+              0,
+              "#3b3c3c"
+            ],
+            [
+              12,
+              "#353636"
+            ],
+            [
+              15,
+              "#323333"
+            ]
+          ]
+        }
+      },
+      "source": "esri",
+      "minzoom": 0,
+      "source-layer": "Land",
+      "type": "fill",
+      "id": "Land"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-color": {
+          "stops": [
+            [
+              5,
+              "#2F3030"
+            ],
+            [
+              10,
+              "#323333"
+            ]
+          ]
+        }
+      },
+      "source": "esri",
+      "minzoom": 5,
+      "source-layer": "Urban area",
+      "maxzoom": 15,
+      "type": "fill",
+      "id": "Urban area"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-outline-color": "#373938",
+        "fill-color": {
+          "stops": [
+            [
+              7,
+              "#373837"
+            ],
+            [
+              9,
+              "#373938"
+            ]
+          ]
+        }
+      },
+      "source": "esri",
+      "minzoom": 12,
+      "source-layer": "Openspace or forest",
+      "type": "fill",
+      "id": "Openspace or forest"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-outline-color": "#373938",
+        "fill-color": {
+          "stops": [
+            [
+              7,
+              "#373837"
+            ],
+            [
+              9,
+              "#373938"
+            ]
+          ]
+        }
+      },
+      "source": "esri",
+      "minzoom": 7,
+      "source-layer": "Admin0 forest or park",
+      "type": "fill",
+      "id": "Admin0 forest or park"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-outline-color": "#373938",
+        "fill-color": {
+          "stops": [
+            [
+              7,
+              "#373837"
+            ],
+            [
+              9,
+              "#373938"
+            ]
+          ]
+        }
+      },
+      "source": "esri",
+      "minzoom": 8,
+      "source-layer": "Admin1 forest or park",
+      "type": "fill",
+      "id": "Admin1 forest or park"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-color": "#373938"
+      },
+      "source": "esri",
+      "minzoom": 12,
+      "source-layer": "Zoo",
+      "type": "fill",
+      "id": "Zoo"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-color": "#373838"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        1
+      ],
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Airport",
+      "type": "fill",
+      "id": "Airport/Airport property"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-color": "#2d2e2e"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        0
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Airport",
+      "type": "fill",
+      "id": "Airport/Airport runway"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-color": "#353636"
+      },
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Pedestrian",
+      "type": "fill",
+      "id": "Pedestrian"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-color": "#373938"
+      },
+      "source": "esri",
+      "minzoom": 12,
+      "source-layer": "Park or farming",
+      "type": "fill",
+      "id": "Park or farming"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-pattern": "Special area of interest/Sand"
+      },
+      "source": "esri",
+      "minzoom": 13,
+      "source-layer": "Beach",
+      "type": "fill",
+      "id": "Beach"
+    },
+    {
+      "layout": {
+        "visibility": "none"
+      },
+      "paint": {
+        "fill-outline-color": "#EBE8E8",
+        "fill-color": "#353636"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        12
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Special area of interest",
+      "type": "fill",
+      "id": "Special area of interest/Garden path"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-color": "#353636"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        15
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Special area of interest",
+      "type": "fill",
+      "id": "Special area of interest/Parking"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-color": "#343635"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        11
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Special area of interest",
+      "type": "fill",
+      "id": "Special area of interest/Green openspace"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-color": "#3c3e3d"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        8
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Special area of interest",
+      "type": "fill",
+      "id": "Special area of interest/Grass"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-color": "#3a3b3a"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        1
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Special area of interest",
+      "type": "fill",
+      "id": "Special area of interest/Baseball field or other grounds"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-pattern": "Special area of interest/Groundcover",
+        "fill-opacity": 0.5
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        13
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Special area of interest",
+      "type": "fill",
+      "id": "Special area of interest/Groundcover"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-color": "#404140"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        5
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Special area of interest",
+      "type": "fill",
+      "id": "Special area of interest/Field or court exterior"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-outline-color": "#353636",
+        "fill-color": "#3a3b3a"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        4
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Special area of interest",
+      "type": "fill",
+      "id": "Special area of interest/Football field or court"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-outline-color": "#353636",
+        "fill-color": "#2a2c2b"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        10
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Special area of interest",
+      "type": "fill",
+      "id": "Special area of interest/Hardcourt"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-color": "#4c4d49"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        14
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Special area of interest",
+      "type": "fill",
+      "id": "Special area of interest/Mulch or dirt"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-outline-color": "#333232",
+        "fill-color": "#3b3b3b"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        0
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Special area of interest",
+      "type": "fill",
+      "id": "Special area of interest/Athletic track"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-pattern": "Special area of interest/Sand"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        6
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Special area of interest",
+      "type": "fill",
+      "id": "Special area of interest/Sand"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-pattern": "Special area of interest/Rock or gravel"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        16
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Special area of interest",
+      "type": "fill",
+      "id": "Special area of interest/Rock or gravel"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-color": "#1d2224"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        7
+      ],
+      "source": "esri",
+      "minzoom": 15,
+      "source-layer": "Special area of interest",
+      "type": "fill",
+      "id": "Special area of interest/Water"
+    },
+    {
+      "layout": {
+        "line-join": "round",
+        "visibility": "none"
+      },
+      "paint": {
+        "line-color": "#2B2E2F",
+        "line-width": 0.5
+      },
+      "source": "esri",
+      "minzoom": 1,
+      "source-layer": "Water line small scale",
+      "maxzoom": 5,
+      "type": "line",
+      "id": "Water line small scale"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2B2E2F",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              5,
+              0.5
+            ],
+            [
+              7,
+              0.7
+            ]
+          ]
+        }
+      },
+      "source": "esri",
+      "minzoom": 6,
+      "source-layer": "Water line medium scale",
+      "maxzoom": 7,
+      "type": "line",
+      "id": "Water line medium scale"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": {
+          "stops": [
+            [
+              7,
+              "#2B2E2F"
+            ],
+            [
+              10,
+              "#272A2B"
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              7,
+              0.7
+            ],
+            [
+              11,
+              0.8
+            ]
+          ]
+        }
+      },
+      "source": "esri",
+      "minzoom": 7,
+      "source-layer": "Water line large scale",
+      "maxzoom": 11,
+      "type": "line",
+      "id": "Water line large scale"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#222628",
+        "line-dasharray": [
+          5,
+          5
+        ],
+        "line-width": 0.8
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        5
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Water line",
+      "type": "line",
+      "id": "Water line/Waterfall"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#262525",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              0.7
+            ],
+            [
+              14,
+              0.7
+            ],
+            [
+              17,
+              2
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        2
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Water line",
+      "type": "line",
+      "id": "Water line/Dam or weir"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#222628",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              0.7
+            ],
+            [
+              14,
+              0.7
+            ],
+            [
+              17,
+              2
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        3
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Water line",
+      "type": "line",
+      "id": "Water line/Levee/1"
+    },
+    {
+      "layout": {
+        "symbol-avoid-edges": true,
+        "symbol-placement": "line",
+        "icon-padding": 1,
+        "icon-image": "Water line/Levee/0",
+        "icon-allow-overlap": true,
+        "icon-rotation-alignment": "map",
+        "symbol-spacing": 15
+      },
+      "paint": {},
+      "filter": [
+        "==",
+        "_symbol",
+        3
+      ],
+      "source": "esri",
+      "minzoom": 13,
+      "source-layer": "Water line",
+      "type": "symbol",
+      "id": "Water line/Levee/0"
+    },
+    {
+      "layout": {
+        "line-cap": "round"
+      },
+      "paint": {
+        "line-color": "#222628",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              0.8
+            ],
+            [
+              14,
+              0.8
+            ],
+            [
+              17,
+              2
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        1
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Water line",
+      "type": "line",
+      "id": "Water line/Canal or ditch"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "line-color": "#222628",
+        "line-dasharray": [
+          7,
+          3
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              0.8
+            ],
+            [
+              14,
+              0.8
+            ],
+            [
+              17,
+              2
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        4
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Water line",
+      "type": "line",
+      "id": "Water line/Stream or river intermittent"
+    },
+    {
+      "layout": {
+        "line-cap": "round"
+      },
+      "paint": {
+        "line-color": "#222628",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              0.8
+            ],
+            [
+              14,
+              0.8
+            ],
+            [
+              17,
+              2
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        0
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Water line",
+      "type": "line",
+      "id": "Water line/Stream or river"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-color": "#1d2224"
+      },
+      "source": "esri",
+      "minzoom": 4,
+      "source-layer": "Marine area",
+      "type": "fill",
+      "id": "Marine area"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-color": "#1d2224"
+      },
+      "source": "esri",
+      "minzoom": 1,
+      "source-layer": "Water area small scale",
+      "maxzoom": 5,
+      "type": "fill",
+      "id": "Water area small scale"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-pattern": "Water area/Lake or river intermittent"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        1
+      ],
+      "source": "esri",
+      "minzoom": 5,
+      "source-layer": "Water area medium scale",
+      "maxzoom": 7,
+      "type": "fill",
+      "id": "Water area medium scale/Lake intermittent"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-color": "#1d2224"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        0
+      ],
+      "source": "esri",
+      "minzoom": 5,
+      "source-layer": "Water area medium scale",
+      "maxzoom": 7,
+      "type": "fill",
+      "id": "Water area medium scale/Lake or river"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-pattern": "Water area/Lake or river intermittent"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        1
+      ],
+      "source": "esri",
+      "minzoom": 7,
+      "source-layer": "Water area large scale",
+      "maxzoom": 11,
+      "type": "fill",
+      "id": "Water area large scale/Lake intermittent"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-color": "#1d2224"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        0
+      ],
+      "source": "esri",
+      "minzoom": 7,
+      "source-layer": "Water area large scale",
+      "maxzoom": 11,
+      "type": "fill",
+      "id": "Water area large scale/Lake or river"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-color": "#1d2224"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        7
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Water area",
+      "type": "fill",
+      "id": "Water area/Lake, river or bay"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-pattern": "Water area/Lake or river intermittent"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        6
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Water area",
+      "type": "fill",
+      "id": "Water area/Lake or river intermittent"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-pattern": "Water area/Inundated area"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        4
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Water area",
+      "type": "fill",
+      "id": "Water area/Inundated area"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-pattern": "Water area/Swamp or marsh"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        3
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Water area",
+      "type": "fill",
+      "id": "Water area/Swamp or marsh"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-pattern": "Water area/Playa"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        1
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Water area",
+      "type": "fill",
+      "id": "Water area/Playa"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-outline-color": "#2e2f2f",
+        "fill-color": "#383939"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        5
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Water area",
+      "type": "fill",
+      "id": "Water area/Dam or weir"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-color": "#353636"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        2
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Special area of interest",
+      "type": "fill",
+      "id": "Special area of interest/Bike, walk or pedestrian"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#3a3b3b",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              1.5
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              17,
+              3
+            ]
+          ]
+        }
+      },
+      "source": "esri",
+      "minzoom": 12,
+      "source-layer": "Railroad",
+      "type": "line",
+      "id": "Railroad/2"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#292828",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              0.5
+            ],
+            [
+              14,
+              1
+            ],
+            [
+              17,
+              1.75
+            ]
+          ]
+        }
+      },
+      "source": "esri",
+      "minzoom": 12,
+      "source-layer": "Railroad",
+      "type": "line",
+      "id": "Railroad/1"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#3a3b3b",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              1.5
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              17,
+              3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          1
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 12,
+      "source-layer": "Ferry",
+      "type": "line",
+      "id": "Ferry/Rail ferry/2"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#292828",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              0.5
+            ],
+            [
+              14,
+              1
+            ],
+            [
+              17,
+              1.75
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          1
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 12,
+      "source-layer": "Ferry",
+      "type": "line",
+      "id": "Ferry/Rail ferry/1"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#353636",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              0.7
+            ],
+            [
+              17,
+              1.2
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        0
+      ],
+      "source": "esri",
+      "minzoom": 15,
+      "source-layer": "Special area of interest line",
+      "type": "line",
+      "id": "Special area of interest line/Dock or pier"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#353636",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              0.7
+            ],
+            [
+              17,
+              1.2
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        6
+      ],
+      "source": "esri",
+      "minzoom": 15,
+      "source-layer": "Special area of interest line",
+      "type": "line",
+      "id": "Special area of interest line/Sports field"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-translate": {
+          "stops": [
+            [
+              15,
+              [
+                0,
+                0
+              ]
+            ],
+            [
+              18,
+              [
+                2,
+                2
+              ]
+            ]
+          ]
+        },
+        "fill-translate-anchor": "viewport",
+        "fill-color": "#2e2f2f"
+      },
+      "source": "esri",
+      "minzoom": 16,
+      "source-layer": "Building",
+      "type": "fill",
+      "id": "Building/Shadow"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-outline-color": "#2e2f2f",
+        "fill-color": "#383939"
+      },
+      "source": "esri",
+      "minzoom": 15,
+      "source-layer": "Building",
+      "type": "fill",
+      "id": "Building"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#434444",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              0.7
+            ],
+            [
+              17,
+              1.2
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        5
+      ],
+      "source": "esri",
+      "minzoom": 15,
+      "source-layer": "Special area of interest line",
+      "type": "line",
+      "id": "Special area of interest line/Parking lot"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#303131",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              14,
+              1.5
+            ],
+            [
+              16,
+              3.3
+            ],
+            [
+              18,
+              4
+            ]
+          ]
+        }
+      },
+      "source": "esri",
+      "minzoom": 15,
+      "source-layer": "Trail or path",
+      "type": "line",
+      "id": "Trail or path/1"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2A2B2B",
+        "line-dasharray": [
+          2,
+          1
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              1.5
+            ],
+            [
+              14,
+              3.3
+            ],
+            [
+              18,
+              8.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          10
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 13,
+      "source-layer": "Road",
+      "type": "line",
+      "id": "Road/4WD/1"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2A2B2B",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              1.5
+            ],
+            [
+              14,
+              3.3
+            ],
+            [
+              18,
+              8.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          8
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 13,
+      "source-layer": "Road",
+      "type": "line",
+      "id": "Road/Service/1"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2A2B2B",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              11,
+              1.5
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              16,
+              6
+            ],
+            [
+              18,
+              17.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          7
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 12,
+      "source-layer": "Road",
+      "type": "line",
+      "id": "Road/Local/1"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#303131",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              14,
+              1.5
+            ],
+            [
+              16,
+              3.3
+            ],
+            [
+              18,
+              4
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          9
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 15,
+      "source-layer": "Road",
+      "type": "line",
+      "id": "Road/Pedestrian/1"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2A2B2B",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              1
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              16,
+              9.6
+            ],
+            [
+              18,
+              17.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          6
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Road",
+      "type": "line",
+      "id": "Road/Minor, ramp or traffic circle/1"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2A2B2B",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              2.6
+            ],
+            [
+              14,
+              5.6
+            ],
+            [
+              16,
+              9.6
+            ],
+            [
+              18,
+              17.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          5
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Road",
+      "type": "line",
+      "id": "Road/Minor/1"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2A2B2B",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              9,
+              1.5
+            ],
+            [
+              14,
+              7.3
+            ],
+            [
+              16,
+              10.3
+            ],
+            [
+              18,
+              18
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          4
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Road",
+      "type": "line",
+      "id": "Road/Major, ramp or traffic circle/1"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2A2B2B",
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              9,
+              1.5
+            ],
+            [
+              14,
+              7.3
+            ],
+            [
+              16,
+              10.3
+            ],
+            [
+              18,
+              18
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          3
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Road",
+      "type": "line",
+      "id": "Road/Major/1"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2A2B2B",
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              9,
+              0.3
+            ],
+            [
+              14,
+              8.3
+            ],
+            [
+              16,
+              12.3
+            ],
+            [
+              18,
+              26
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          2
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 7,
+      "source-layer": "Road",
+      "type": "line",
+      "id": "Road/Freeway Motorway, ramp or traffic circle/1"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2A2B2B",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              8,
+              0.3
+            ],
+            [
+              14,
+              8.3
+            ],
+            [
+              16,
+              12.3
+            ],
+            [
+              18,
+              26
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          1
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 8,
+      "source-layer": "Road",
+      "type": "line",
+      "id": "Road/Highway/1"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2A2B2B",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              5,
+              0.3
+            ],
+            [
+              14,
+              8.3
+            ],
+            [
+              16,
+              12.3
+            ],
+            [
+              18,
+              26
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          0
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 7,
+      "source-layer": "Road",
+      "type": "line",
+      "id": "Road/Freeway Motorway/1"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#434444",
+        "line-dasharray": [
+          3,
+          1.5
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              14,
+              1.3
+            ],
+            [
+              16,
+              2
+            ],
+            [
+              18,
+              2.3
+            ]
+          ]
+        }
+      },
+      "source": "esri",
+      "minzoom": 15,
+      "source-layer": "Trail or path",
+      "type": "line",
+      "id": "Trail or path/0"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#434444",
+        "line-dasharray": [
+          3,
+          1.5
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              14,
+              1.3
+            ],
+            [
+              16,
+              2
+            ],
+            [
+              18,
+              2.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          9
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 15,
+      "source-layer": "Road",
+      "type": "line",
+      "id": "Road/Pedestrian/0"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#434444",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              0.75
+            ],
+            [
+              14,
+              1.3
+            ],
+            [
+              18,
+              6.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          10
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 13,
+      "source-layer": "Road",
+      "type": "line",
+      "id": "Road/4WD/0"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#434444",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              0.75
+            ],
+            [
+              14,
+              1.3
+            ],
+            [
+              18,
+              6.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          8
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 13,
+      "source-layer": "Road",
+      "type": "line",
+      "id": "Road/Service/0"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": {
+          "stops": [
+            [
+              12,
+              "#414242"
+            ],
+            [
+              13,
+              "#434444"
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              11,
+              1.1
+            ],
+            [
+              14,
+              2
+            ],
+            [
+              16,
+              4
+            ],
+            [
+              18,
+              15.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          7
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 12,
+      "source-layer": "Road",
+      "type": "line",
+      "id": "Road/Local/0"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#434444",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              0.75
+            ],
+            [
+              14,
+              2
+            ],
+            [
+              16,
+              7.65
+            ],
+            [
+              18,
+              15.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          6
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Road",
+      "type": "line",
+      "id": "Road/Minor, ramp or traffic circle/0"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#434444",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              1.3
+            ],
+            [
+              14,
+              3.65
+            ],
+            [
+              16,
+              7.65
+            ],
+            [
+              18,
+              15.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          5
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Road",
+      "type": "line",
+      "id": "Road/Minor/0"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#434444",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              9,
+              0.75
+            ],
+            [
+              14,
+              5.3
+            ],
+            [
+              16,
+              8.3
+            ],
+            [
+              18,
+              16
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          4
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Road",
+      "type": "line",
+      "id": "Road/Major, ramp or traffic circle/0"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#434444",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              9,
+              0.75
+            ],
+            [
+              14,
+              5.3
+            ],
+            [
+              16,
+              8.3
+            ],
+            [
+              18,
+              16
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          3
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Road",
+      "type": "line",
+      "id": "Road/Major/0"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#434444",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              9,
+              0.3
+            ],
+            [
+              14,
+              6.3
+            ],
+            [
+              16,
+              10.3
+            ],
+            [
+              18,
+              24
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          2
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 7,
+      "source-layer": "Road",
+      "type": "line",
+      "id": "Road/Freeway Motorway, ramp or traffic circle/0"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#434444",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              8,
+              0.3
+            ],
+            [
+              14,
+              6.3
+            ],
+            [
+              16,
+              10.3
+            ],
+            [
+              18,
+              24
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          1
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 8,
+      "source-layer": "Road",
+      "type": "line",
+      "id": "Road/Highway/0"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": {
+          "stops": [
+            [
+              6,
+              "#414242"
+            ],
+            [
+              7,
+              "#434444"
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              5,
+              0.3
+            ],
+            [
+              14,
+              6.3
+            ],
+            [
+              16,
+              10.3
+            ],
+            [
+              18,
+              24
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          0
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 6,
+      "source-layer": "Road",
+      "type": "line",
+      "id": "Road/Freeway Motorway/0"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2A2B2B",
+        "line-dasharray": [
+          2,
+          1
+        ],
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              1.5
+            ],
+            [
+              14,
+              3.3
+            ],
+            [
+              18,
+              8.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          10
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 13,
+      "source-layer": "Road tunnel",
+      "type": "line",
+      "id": "Road tunnel/4WD/1"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2A2B2B",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              1.5
+            ],
+            [
+              14,
+              3.3
+            ],
+            [
+              18,
+              8.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          8
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 13,
+      "source-layer": "Road tunnel",
+      "type": "line",
+      "id": "Road tunnel/Service/1"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2A2B2B",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              11,
+              1.5
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              16,
+              6
+            ],
+            [
+              18,
+              17.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          7
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 12,
+      "source-layer": "Road tunnel",
+      "type": "line",
+      "id": "Road tunnel/Local/1"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2A2B2B",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              14,
+              1.5
+            ],
+            [
+              16,
+              3.3
+            ],
+            [
+              18,
+              4
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          9
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 15,
+      "source-layer": "Road tunnel",
+      "type": "line",
+      "id": "Road tunnel/Pedestrian/1"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2A2B2B",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              1
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              16,
+              9.65
+            ],
+            [
+              18,
+              17.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          6
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Road tunnel",
+      "type": "line",
+      "id": "Road tunnel/Minor, ramp or traffic circle/1"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2A2B2B",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              2.6
+            ],
+            [
+              14,
+              5.65
+            ],
+            [
+              16,
+              9.65
+            ],
+            [
+              18,
+              17.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          5
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Road tunnel",
+      "type": "line",
+      "id": "Road tunnel/Minor/1"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2A2B2B",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              9,
+              1.5
+            ],
+            [
+              14,
+              7.3
+            ],
+            [
+              16,
+              10.3
+            ],
+            [
+              18,
+              18
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          4
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Road tunnel",
+      "type": "line",
+      "id": "Road tunnel/Major, ramp or traffic circle/1"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2A2B2B",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              9,
+              1.5
+            ],
+            [
+              14,
+              7.3
+            ],
+            [
+              16,
+              10.3
+            ],
+            [
+              18,
+              18
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          3
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Road tunnel",
+      "type": "line",
+      "id": "Road tunnel/Major/1"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2A2B2B",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              9,
+              0.3
+            ],
+            [
+              14,
+              8.3
+            ],
+            [
+              16,
+              14.3
+            ],
+            [
+              18,
+              28
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          2
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 7,
+      "source-layer": "Road tunnel",
+      "type": "line",
+      "id": "Road tunnel/Freeway Motorway, ramp or traffic circle/1"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2A2B2B",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              8,
+              0.3
+            ],
+            [
+              14,
+              8.3
+            ],
+            [
+              16,
+              14.3
+            ],
+            [
+              18,
+              28
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          1
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 8,
+      "source-layer": "Road tunnel",
+      "type": "line",
+      "id": "Road tunnel/Highway/1"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2A2B2B",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              5,
+              0.3
+            ],
+            [
+              14,
+              8.3
+            ],
+            [
+              16,
+              14.3
+            ],
+            [
+              18,
+              28
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          0
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 7,
+      "source-layer": "Road tunnel",
+      "type": "line",
+      "id": "Road tunnel/Freeway Motorway/1"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#434444",
+        "line-dasharray": [
+          3,
+          1.5
+        ],
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              14,
+              1.3
+            ],
+            [
+              16,
+              2
+            ],
+            [
+              18,
+              2.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          9
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 15,
+      "source-layer": "Road tunnel",
+      "type": "line",
+      "id": "Road tunnel/Pedestrian/0"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#434444",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              0.75
+            ],
+            [
+              14,
+              1.3
+            ],
+            [
+              18,
+              6.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          10
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 13,
+      "source-layer": "Road tunnel",
+      "type": "line",
+      "id": "Road tunnel/4WD/0"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#434444",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              0.75
+            ],
+            [
+              14,
+              1.3
+            ],
+            [
+              18,
+              6.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          8
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 13,
+      "source-layer": "Road tunnel",
+      "type": "line",
+      "id": "Road tunnel/Service/0"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": {
+          "stops": [
+            [
+              12,
+              "#414242"
+            ],
+            [
+              13,
+              "#434444"
+            ]
+          ]
+        },
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              11,
+              1.1
+            ],
+            [
+              14,
+              2
+            ],
+            [
+              16,
+              4
+            ],
+            [
+              18,
+              15.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          7
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 12,
+      "source-layer": "Road tunnel",
+      "type": "line",
+      "id": "Road tunnel/Local/0"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#434444",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              0.75
+            ],
+            [
+              14,
+              2
+            ],
+            [
+              16,
+              7.65
+            ],
+            [
+              18,
+              15.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          6
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Road tunnel",
+      "type": "line",
+      "id": "Road tunnel/Minor, ramp or traffic circle/0"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#434444",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              1.3
+            ],
+            [
+              14,
+              3.65
+            ],
+            [
+              16,
+              7.65
+            ],
+            [
+              18,
+              15.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          5
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Road tunnel",
+      "type": "line",
+      "id": "Road tunnel/Minor/0"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#434444",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              9,
+              0.75
+            ],
+            [
+              14,
+              5.3
+            ],
+            [
+              16,
+              8.3
+            ],
+            [
+              18,
+              16
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          4
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Road tunnel",
+      "type": "line",
+      "id": "Road tunnel/Major, ramp or traffic circle/0"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#434444",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              9,
+              0.75
+            ],
+            [
+              14,
+              5.3
+            ],
+            [
+              16,
+              8.3
+            ],
+            [
+              18,
+              16
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          3
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Road tunnel",
+      "type": "line",
+      "id": "Road tunnel/Major/0"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#434444",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              9,
+              0.3
+            ],
+            [
+              14,
+              6.3
+            ],
+            [
+              16,
+              12.3
+            ],
+            [
+              18,
+              26
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          2
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 7,
+      "source-layer": "Road tunnel",
+      "type": "line",
+      "id": "Road tunnel/Freeway Motorway, ramp or traffic circle/0"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#434444",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              8,
+              0.3
+            ],
+            [
+              14,
+              6.3
+            ],
+            [
+              16,
+              12.3
+            ],
+            [
+              18,
+              26
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          1
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 8,
+      "source-layer": "Road tunnel",
+      "type": "line",
+      "id": "Road tunnel/Highway/0"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": {
+          "stops": [
+            [
+              6,
+              "#414242"
+            ],
+            [
+              7,
+              "#434444"
+            ]
+          ]
+        },
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              5,
+              0.3
+            ],
+            [
+              14,
+              6.3
+            ],
+            [
+              16,
+              12.3
+            ],
+            [
+              18,
+              26
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          0
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 6,
+      "source-layer": "Road tunnel",
+      "type": "line",
+      "id": "Road tunnel/Freeway Motorway/0"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-color": "#353636"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        9
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Special area of interest",
+      "type": "fill",
+      "id": "Special area of interest/Gutter"
+    },
+    {
+      "layout": {},
+      "paint": {
+        "fill-outline-color": "#2d2e2e",
+        "fill-color": "#353636"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        3
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Special area of interest",
+      "type": "fill",
+      "id": "Special area of interest/Curb"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#414242",
+        "line-opacity": 0.95,
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              4,
+              0.65
+            ],
+            [
+              14,
+              7
+            ],
+            [
+              17,
+              7
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          8
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Boundary line",
+      "type": "line",
+      "id": "Boundary line/Disputed admin2/1"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2D2E2E",
+        "line-dasharray": [
+          7,
+          5
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              1,
+              0.65
+            ],
+            [
+              14,
+              1.3
+            ],
+            [
+              17,
+              2.65
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          8
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Boundary line",
+      "type": "line",
+      "id": "Boundary line/Disputed admin2/0"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#434444",
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              4,
+              0.65
+            ],
+            [
+              14,
+              7
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          7
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 4,
+      "source-layer": "Boundary line",
+      "type": "line",
+      "id": "Boundary line/Disputed admin1/1"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#434444",
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              1,
+              0.65
+            ],
+            [
+              14,
+              9.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          6
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ],
+        [
+          "!in",
+          "DisputeID",
+          8,
+          16,
+          90,
+          96,
+          0
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 1,
+      "source-layer": "Boundary line",
+      "type": "line",
+      "id": "Boundary line/Disputed admin0/1"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2D2E2E",
+        "line-dasharray": [
+          6,
+          5
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              1,
+              0.65
+            ],
+            [
+              14,
+              1.3
+            ],
+            [
+              17,
+              2.65
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          7
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 4,
+      "source-layer": "Boundary line",
+      "type": "line",
+      "id": "Boundary line/Disputed admin1/0"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2D2E2E",
+        "line-dasharray": [
+          7,
+          5
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              1,
+              0.65
+            ],
+            [
+              14,
+              1.3
+            ],
+            [
+              17,
+              2.65
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          6
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ],
+        [
+          "!in",
+          "DisputeID",
+          8,
+          16,
+          90,
+          96,
+          0
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 1,
+      "source-layer": "Boundary line",
+      "type": "line",
+      "id": "Boundary line/Disputed admin0/0"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2D2E2E",
+        "line-opacity": 0.6,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              8,
+              3
+            ],
+            [
+              14,
+              4.5
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          2
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Boundary line",
+      "type": "line",
+      "id": "Boundary line/Admin2/1"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": {
+          "stops": [
+            [
+              1,
+              "#323333"
+            ],
+            [
+              12,
+              "#2D2E2E"
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              4,
+              0.73
+            ],
+            [
+              14,
+              8
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          1
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 4,
+      "source-layer": "Boundary line",
+      "type": "line",
+      "id": "Boundary line/Admin1/1"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": {
+          "stops": [
+            [
+              1,
+              "#323333"
+            ],
+            [
+              12,
+              "#2D2E2E"
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              1,
+              0.65
+            ],
+            [
+              14,
+              10.5
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          0
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 1,
+      "source-layer": "Boundary line",
+      "type": "line",
+      "id": "Boundary line/Admin0/1"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#515252",
+        "line-dasharray": [
+          5,
+          3
+        ],
+        "line-width": 1
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          5
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 16,
+      "source-layer": "Boundary line",
+      "type": "line",
+      "id": "Boundary line/Admin5"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#515252",
+        "line-dasharray": [
+          5,
+          3
+        ],
+        "line-width": 1
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          4
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 16,
+      "source-layer": "Boundary line",
+      "type": "line",
+      "id": "Boundary line/Admin4"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#515252",
+        "line-dasharray": [
+          5,
+          3
+        ],
+        "line-width": 1
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          3
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 16,
+      "source-layer": "Boundary line",
+      "type": "line",
+      "id": "Boundary line/Admin3"
+    },
+    {
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#515252",
+        "line-dasharray": [
+          6,
+          4
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              8,
+              0.6
+            ],
+            [
+              14,
+              1.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          2
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Boundary line",
+      "type": "line",
+      "id": "Boundary line/Admin2/0"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": {
+          "stops": [
+            [
+              7,
+              "#3F4040"
+            ],
+            [
+              12,
+              "#444545"
+            ]
+          ]
+        },
+        "line-dasharray": [
+          7,
+          5.3
+        ],
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              7,
+              0.3
+            ],
+            [
+              14,
+              1.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          1
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 7,
+      "source-layer": "Boundary line",
+      "type": "line",
+      "id": "Boundary line/Admin1/0"
+    },
+    {
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": {
+          "stops": [
+            [
+              5,
+              "#383939"
+            ],
+            [
+              7,
+              "#4A4C4C"
+            ]
+          ]
+        },
+        "line-dasharray": [
+          7,
+          5.3
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              5,
+              0.7
+            ],
+            [
+              14,
+              1.3
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          0
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 5,
+      "source-layer": "Boundary line",
+      "type": "line",
+      "id": "Boundary line/Admin0/0"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.3,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-line-height": 1.6,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-anchor": "center",
+        "text-field": "{_name_global}",
+        "text-padding": 15,
+        "text-size": {
+          "stops": [
+            [
+              9,
+              8.5
+            ],
+            [
+              15,
+              15.5
+            ]
+          ]
+        },
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#707374",
+        "text-halo-width": 1,
+        "text-halo-color": "#1D2224"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        0
+      ],
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Water point",
+      "type": "symbol",
+      "id": "Water point/Sea or ocean"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.1,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-anchor": "center",
+        "text-field": "{_name_global}",
+        "text-size": {
+          "stops": [
+            [
+              9,
+              8.5
+            ],
+            [
+              15,
+              10
+            ]
+          ]
+        },
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        7
+      ],
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Water point",
+      "type": "symbol",
+      "id": "Water point/Island"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.1,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-anchor": "center",
+        "text-field": "{_name_global}",
+        "text-size": {
+          "stops": [
+            [
+              9,
+              8.5
+            ],
+            [
+              15,
+              10
+            ]
+          ]
+        },
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 0.7,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        5
+      ],
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Water point",
+      "type": "symbol",
+      "id": "Water point/Dam or weir"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.1,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-anchor": "center",
+        "text-field": "{_name_global}",
+        "text-size": {
+          "stops": [
+            [
+              9,
+              8.5
+            ],
+            [
+              15,
+              10
+            ]
+          ]
+        },
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 0.7,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        6
+      ],
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Water point",
+      "type": "symbol",
+      "id": "Water point/Playa"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.13,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-anchor": "center",
+        "text-field": "{_name_global}",
+        "text-size": {
+          "stops": [
+            [
+              9,
+              8.5
+            ],
+            [
+              15,
+              10
+            ]
+          ]
+        },
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#707374",
+        "text-halo-width": 1,
+        "text-halo-color": "#1D2224"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        4
+      ],
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Water point",
+      "type": "symbol",
+      "id": "Water point/Canal or ditch"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.1,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-anchor": "center",
+        "text-field": "{_name_global}",
+        "text-size": {
+          "stops": [
+            [
+              9,
+              8.5
+            ],
+            [
+              15,
+              10
+            ]
+          ]
+        },
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#707374",
+        "text-halo-width": 0.5,
+        "text-halo-color": "#1D2224"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        3
+      ],
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Water point",
+      "type": "symbol",
+      "id": "Water point/Stream or river"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.1,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-anchor": "center",
+        "text-field": "{_name_global}",
+        "text-size": {
+          "stops": [
+            [
+              9,
+              8.5
+            ],
+            [
+              15,
+              10
+            ]
+          ]
+        },
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#707374",
+        "text-halo-width": 0.5,
+        "text-halo-color": "#1D2224"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        2
+      ],
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Water point",
+      "type": "symbol",
+      "id": "Water point/Lake or reservoir"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.1,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-anchor": "center",
+        "text-field": "{_name_global}",
+        "text-size": {
+          "stops": [
+            [
+              9,
+              8.5
+            ],
+            [
+              15,
+              10
+            ]
+          ]
+        },
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#707374",
+        "text-halo-width": 1,
+        "text-halo-color": "#1D2224"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        1
+      ],
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Water point",
+      "type": "symbol",
+      "id": "Water point/Bay or inlet"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.07,
+        "symbol-avoid-edges": true,
+        "text-max-angle": 18,
+        "symbol-placement": "line",
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-field": "{_name_global}",
+        "text-offset": [
+          0,
+          -0.5
+        ],
+        "text-size": 9,
+        "text-max-width": 6,
+        "symbol-spacing": 800
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#707374",
+        "text-halo-width": 0.5,
+        "text-halo-color": "#1D2224"
+      },
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Water line/label",
+      "type": "symbol",
+      "id": "Water line/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-color": "#707374"
+      },
+      "source": "esri",
+      "minzoom": 16,
+      "source-layer": "Marine park/label",
+      "type": "symbol",
+      "id": "Marine park/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.08,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        8
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Water area/label",
+      "type": "symbol",
+      "id": "Water area/label/Dam or weir"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.08,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        9
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Water area/label",
+      "type": "symbol",
+      "id": "Water area/label/Playa"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.13,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "symbol-placement": "line",
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 5,
+        "symbol-spacing": 1000
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#707374",
+        "text-halo-width": 0.5,
+        "text-halo-color": "#1D2224"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        2
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Water area/label",
+      "type": "symbol",
+      "id": "Water area/label/Canal or ditch"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.13,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "symbol-placement": "line",
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 8,
+        "symbol-spacing": 1000
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#707374",
+        "text-halo-width": 0.5,
+        "text-halo-color": "#1D2224"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        7
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Water area/label",
+      "type": "symbol",
+      "id": "Water area/label/Small river"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.13,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "symbol-placement": "line",
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 10,
+        "text-max-width": 8,
+        "symbol-spacing": 1000
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#707374",
+        "text-halo-width": 0.5,
+        "text-halo-color": "#1D2224"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        4
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Water area/label",
+      "type": "symbol",
+      "id": "Water area/label/Large river"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.13,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#707374",
+        "text-halo-width": 0.5,
+        "text-halo-color": "#1D2224"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        6
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Water area/label",
+      "type": "symbol",
+      "id": "Water area/label/Small lake or reservoir"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.13,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-line-height": 1.15,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-field": "{_name_global}",
+        "text-padding": 15,
+        "text-size": 10,
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#707374",
+        "text-halo-width": 0.5,
+        "text-halo-color": "#1D2224"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        3
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Water area/label",
+      "type": "symbol",
+      "id": "Water area/label/Large lake or reservoir"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.13,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-line-height": 1.15,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-field": "{_name_global}",
+        "text-padding": 15,
+        "text-size": 11,
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#707374",
+        "text-halo-width": 0.5,
+        "text-halo-color": "#1D2224"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        1
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Water area/label",
+      "type": "symbol",
+      "id": "Water area/label/Bay or inlet"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.1,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        0
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Water area/label",
+      "type": "symbol",
+      "id": "Water area/label/Small island"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.13,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 10,
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        5
+      ],
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Water area/label",
+      "type": "symbol",
+      "id": "Water area/label/Large island"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.1,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "symbol-placement": "line",
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-field": "{_name}",
+        "text-size": 9,
+        "text-max-width": 4,
+        "symbol-spacing": 1000
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#707374",
+        "text-halo-width": 0.5,
+        "text-halo-color": "#1D2224"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        1
+      ],
+      "source": "esri",
+      "minzoom": 7,
+      "source-layer": "Water area large scale/label",
+      "maxzoom": 11,
+      "type": "symbol",
+      "id": "Water area large scale/label/River"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.1,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-field": "{_name}",
+        "text-size": 9.5,
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#707374",
+        "text-halo-width": 0.5,
+        "text-halo-color": "#1D2224"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        0
+      ],
+      "source": "esri",
+      "minzoom": 7,
+      "source-layer": "Water area large scale/label",
+      "maxzoom": 11,
+      "type": "symbol",
+      "id": "Water area large scale/label/Lake or lake intermittent"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.08,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-field": "{_name}",
+        "text-size": 9,
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#707374",
+        "text-halo-width": 0.5,
+        "text-halo-color": "#1D2224"
+      },
+      "source": "esri",
+      "minzoom": 5,
+      "source-layer": "Water area medium scale/label",
+      "maxzoom": 7,
+      "type": "symbol",
+      "id": "Water area medium scale/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.08,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-field": "{_name}",
+        "text-size": 9,
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#707374",
+        "text-halo-width": 0.5,
+        "text-halo-color": "#1D2224"
+      },
+      "source": "esri",
+      "minzoom": 1,
+      "source-layer": "Water area small scale/label",
+      "maxzoom": 5,
+      "type": "symbol",
+      "id": "Water area small scale/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.13,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 10,
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#707374",
+        "text-halo-width": 0.5,
+        "text-halo-color": "#1D2224"
+      },
+      "source": "esri",
+      "minzoom": 11,
+      "source-layer": "Marine area/label",
+      "type": "symbol",
+      "id": "Marine area/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.12,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              1,
+              9
+            ],
+            [
+              6,
+              11
+            ]
+          ]
+        },
+        "text-field": "{_name}",
+        "text-line-height": 1.2,
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#707374",
+        "text-halo-width": 0.5,
+        "text-halo-color": "#1D2224"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        4
+      ],
+      "source": "esri",
+      "minzoom": 4,
+      "source-layer": "Marine waterbody/label",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "Marine waterbody/label/small"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.15,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              1,
+              9
+            ],
+            [
+              6,
+              11
+            ]
+          ]
+        },
+        "text-field": "{_name}",
+        "text-line-height": 1.2,
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#707374",
+        "text-halo-width": 0.5,
+        "text-halo-color": "#1D2224"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        3
+      ],
+      "source": "esri",
+      "minzoom": 4,
+      "source-layer": "Marine waterbody/label",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "Marine waterbody/label/medium"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.18,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              1,
+              9
+            ],
+            [
+              6,
+              12
+            ]
+          ]
+        },
+        "text-field": "{_name}",
+        "text-line-height": 1.5,
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#707374",
+        "text-halo-width": 0.5,
+        "text-halo-color": "#1D2224"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        2
+      ],
+      "source": "esri",
+      "minzoom": 4,
+      "source-layer": "Marine waterbody/label",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "Marine waterbody/label/large"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.2,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              1,
+              10
+            ],
+            [
+              6,
+              13
+            ]
+          ]
+        },
+        "text-field": "{_name}",
+        "text-line-height": 1.5,
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#707374",
+        "text-halo-width": 0.5,
+        "text-halo-color": "#1D2224"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        1
+      ],
+      "source": "esri",
+      "minzoom": 3,
+      "source-layer": "Marine waterbody/label",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "Marine waterbody/label/x large"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.3,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              1,
+              11
+            ],
+            [
+              4,
+              14
+            ]
+          ]
+        },
+        "text-field": "{_name}",
+        "text-line-height": 1.6,
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#707374",
+        "text-halo-width": 0.5,
+        "text-halo-color": "#1D2224"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        0
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "Marine waterbody/label",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "Marine waterbody/label/2x large"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.1,
+        "symbol-avoid-edges": true,
+        "symbol-placement": "line",
+        "text-padding": 5,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-offset": [
+          0,
+          -0.6
+        ],
+        "text-size": 8.5,
+        "text-max-width": 6,
+        "symbol-spacing": 1000
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          1
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 16,
+      "source-layer": "Ferry/label",
+      "type": "symbol",
+      "id": "Ferry/label/Rail ferry"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.1,
+        "symbol-avoid-edges": true,
+        "symbol-placement": "line",
+        "text-padding": 5,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-offset": [
+          0,
+          -0.6
+        ],
+        "text-size": 8.5,
+        "text-max-width": 6,
+        "symbol-spacing": 1000
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "source": "esri",
+      "minzoom": 16,
+      "source-layer": "Railroad/label",
+      "type": "symbol",
+      "id": "Railroad/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "symbol-placement": "line",
+        "text-padding": 5,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.3,
+        "text-max-width": 6,
+        "symbol-spacing": 400
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#a3a3a1",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          6
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 15,
+      "source-layer": "Road tunnel/label",
+      "type": "symbol",
+      "id": "Road tunnel/label/Pedestrian"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.09,
+        "symbol-avoid-edges": true,
+        "symbol-placement": "line",
+        "text-padding": 5,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6,
+        "symbol-spacing": 400
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#a3a3a1",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          5
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 15,
+      "source-layer": "Road tunnel/label",
+      "type": "symbol",
+      "id": "Road tunnel/label/Local, service, 4WD"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.09,
+        "symbol-avoid-edges": true,
+        "symbol-placement": "line",
+        "text-padding": 5,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6,
+        "symbol-spacing": 400
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#a3a3a1",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          4
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Road tunnel/label",
+      "type": "symbol",
+      "id": "Road tunnel/label/Minor"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.09,
+        "symbol-avoid-edges": true,
+        "symbol-placement": "line",
+        "text-padding": 5,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name}",
+        "text-size": 10.5,
+        "text-max-width": 6,
+        "symbol-spacing": 400
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#a3a3a1",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          3
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Road tunnel/label",
+      "type": "symbol",
+      "id": "Road tunnel/label/Major, alt name"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.09,
+        "symbol-avoid-edges": true,
+        "symbol-placement": "line",
+        "text-padding": 5,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name}",
+        "text-size": 10.5,
+        "text-max-width": 6,
+        "symbol-spacing": 400
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#a3a3a1",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          2
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Road tunnel/label",
+      "type": "symbol",
+      "id": "Road tunnel/label/Major"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.09,
+        "symbol-avoid-edges": true,
+        "symbol-placement": "line",
+        "text-padding": 5,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 10.5,
+        "text-max-width": 6,
+        "symbol-spacing": 400
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#a3a3a1",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          7
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 13,
+      "source-layer": "Road tunnel/label",
+      "type": "symbol",
+      "id": "Road tunnel/label/Highway"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.09,
+        "symbol-avoid-edges": true,
+        "symbol-placement": "line",
+        "text-padding": 5,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 10.5,
+        "text-max-width": 6,
+        "symbol-spacing": 400
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#a3a3a1",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          1
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 13,
+      "source-layer": "Road tunnel/label",
+      "type": "symbol",
+      "id": "Road tunnel/label/Freeway Motorway, alt name"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.09,
+        "symbol-avoid-edges": true,
+        "symbol-placement": "line",
+        "text-padding": 5,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 10.5,
+        "text-max-width": 6,
+        "symbol-spacing": 400
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#a3a3a1",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          0
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 13,
+      "source-layer": "Road tunnel/label",
+      "type": "symbol",
+      "id": "Road tunnel/label/Freeway Motorway"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.08,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 0.7,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 17,
+      "source-layer": "Building/label",
+      "type": "symbol",
+      "id": "Building/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "symbol-placement": "line",
+        "text-padding": 5,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.3,
+        "text-max-width": 6,
+        "symbol-spacing": 400
+      },
+      "paint": {
+        "text-color": "#a3a3a1",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 15,
+      "source-layer": "Trail or path/label",
+      "type": "symbol",
+      "id": "Trail or path/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "symbol-placement": "line",
+        "text-padding": 5,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.3,
+        "text-max-width": 6,
+        "symbol-spacing": 400
+      },
+      "paint": {
+        "text-color": "#a3a3a1",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          6
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 15,
+      "source-layer": "Road/label",
+      "type": "symbol",
+      "id": "Road/label/Pedestrian"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.09,
+        "symbol-avoid-edges": true,
+        "symbol-placement": "line",
+        "text-padding": 5,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6,
+        "symbol-spacing": 400
+      },
+      "paint": {
+        "text-color": "#a3a3a1",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          5
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 15,
+      "source-layer": "Road/label",
+      "type": "symbol",
+      "id": "Road/label/Local"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.09,
+        "symbol-avoid-edges": true,
+        "symbol-placement": "line",
+        "text-padding": 2,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 10,
+        "text-max-width": 6,
+        "symbol-spacing": 400
+      },
+      "paint": {
+        "text-color": "#a3a3a1",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          4
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Road/label",
+      "type": "symbol",
+      "id": "Road/label/Minor"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.09,
+        "symbol-avoid-edges": true,
+        "symbol-placement": "line",
+        "text-padding": 2,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name}",
+        "text-size": 10.5,
+        "text-max-width": 6,
+        "symbol-spacing": 400
+      },
+      "paint": {
+        "text-color": "#a3a3a1",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          3
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Road/label",
+      "type": "symbol",
+      "id": "Road/label/Major, alt name"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.09,
+        "symbol-avoid-edges": true,
+        "symbol-placement": "line",
+        "text-padding": 2,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 10.5,
+        "text-max-width": 6,
+        "symbol-spacing": 400
+      },
+      "paint": {
+        "text-color": "#a3a3a1",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          2
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Road/label",
+      "type": "symbol",
+      "id": "Road/label/Major"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.09,
+        "symbol-avoid-edges": true,
+        "symbol-placement": "line",
+        "text-padding": 2,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 10.5,
+        "text-max-width": 6,
+        "symbol-spacing": 400
+      },
+      "paint": {
+        "text-color": "#a3a3a1",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          75
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 13,
+      "source-layer": "Road/label",
+      "type": "symbol",
+      "id": "Road/label/Highway"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.09,
+        "symbol-avoid-edges": true,
+        "symbol-placement": "line",
+        "text-padding": 2,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name}",
+        "text-size": 10.5,
+        "text-max-width": 6,
+        "symbol-spacing": 400
+      },
+      "paint": {
+        "text-color": "#a3a3a1",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          1
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 13,
+      "source-layer": "Road/label",
+      "type": "symbol",
+      "id": "Road/label/Freeway Motorway, alt name"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.09,
+        "symbol-avoid-edges": true,
+        "symbol-placement": "line",
+        "text-padding": 2,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 10.5,
+        "text-max-width": 6,
+        "symbol-spacing": 400
+      },
+      "paint": {
+        "text-color": "#a3a3a1",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          0
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 13,
+      "source-layer": "Road/label",
+      "type": "symbol",
+      "id": "Road/label/Freeway Motorway"
+    },
+    {
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-max-angle": 25,
+        "symbol-placement": "line",
+        "text-padding": 30,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "icon-image": "Road/Rectangle white black (Alt)/{_len}",
+        "text-field": "{_name}",
+        "icon-rotation-alignment": "viewport",
+        "text-offset": [
+          0,
+          0.2
+        ],
+        "text-rotation-alignment": "viewport",
+        "text-size": 10,
+        "text-max-width": 6,
+        "symbol-spacing": 800
+      },
+      "paint": {
+        "text-color": "#a3a3a1",
+        "text-halo-width": 1,
+        "text-halo-color": "#404040"
+      },
+      "filter": [
+        "all",
+        [
+          "in",
+          "_label_class",
+          8,
+          10,
+          12,
+          14,
+          16,
+          20,
+          22,
+          24,
+          26,
+          28,
+          30,
+          32,
+          34,
+          36,
+          38,
+          40,
+          42,
+          44,
+          46,
+          48,
+          50,
+          52,
+          54,
+          56,
+          58,
+          60,
+          62,
+          64,
+          66,
+          68,
+          70,
+          72,
+          74
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Road/label",
+      "type": "symbol",
+      "id": "Road/label/Rectangle white black (Alt)"
+    },
+    {
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-max-angle": 25,
+        "symbol-placement": "line",
+        "text-padding": 30,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "icon-image": "Road/Rectangle white black/{_len}",
+        "text-field": "{_name}",
+        "icon-rotation-alignment": "viewport",
+        "text-offset": [
+          0,
+          0.2
+        ],
+        "text-rotation-alignment": "viewport",
+        "text-size": 10,
+        "text-max-width": 6,
+        "symbol-spacing": 800
+      },
+      "paint": {
+        "text-color": "#a3a3a1",
+        "text-halo-width": 1,
+        "text-halo-color": "#404040"
+      },
+      "filter": [
+        "all",
+        [
+          "in",
+          "_label_class",
+          7,
+          9,
+          11,
+          13,
+          15,
+          17,
+          19,
+          21,
+          23,
+          25,
+          27,
+          29,
+          31,
+          33,
+          35,
+          37,
+          39,
+          41,
+          43,
+          45,
+          47,
+          49,
+          51,
+          53,
+          55,
+          57,
+          59,
+          61,
+          63,
+          65,
+          67,
+          69,
+          71,
+          73
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Road/label",
+      "type": "symbol",
+      "id": "Road/label/Rectangle white black"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#8c8e8d",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 16,
+      "source-layer": "Cemetery/label",
+      "type": "symbol",
+      "id": "Cemetery/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 17,
+      "source-layer": "Freight/label",
+      "type": "symbol",
+      "id": "Freight/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 17,
+      "source-layer": "Water and wastewater/label",
+      "type": "symbol",
+      "id": "Water and wastewater/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 17,
+      "source-layer": "Port/label",
+      "type": "symbol",
+      "id": "Port/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 17,
+      "source-layer": "Industry/label",
+      "type": "symbol",
+      "id": "Industry/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": false,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 17,
+      "source-layer": "Government/label",
+      "type": "symbol",
+      "id": "Government/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 17,
+      "source-layer": "Finance/label",
+      "type": "symbol",
+      "id": "Finance/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 17,
+      "source-layer": "Emergency/label",
+      "type": "symbol",
+      "id": "Emergency/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 17,
+      "source-layer": "Indigenous/label",
+      "type": "symbol",
+      "id": "Indigenous/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 25,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 17,
+      "source-layer": "Military/label",
+      "type": "symbol",
+      "id": "Military/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 17,
+      "source-layer": "Transportation/label",
+      "type": "symbol",
+      "id": "Transportation/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": false,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 17,
+      "source-layer": "Pedestrian/label",
+      "type": "symbol",
+      "id": "Pedestrian/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.08,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 17,
+      "source-layer": "Beach/label",
+      "type": "symbol",
+      "id": "Beach/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#8c8e8d",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 17,
+      "source-layer": "Golf course/label",
+      "type": "symbol",
+      "id": "Golf course/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#8c8e8d",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 15,
+      "source-layer": "Zoo/label",
+      "type": "symbol",
+      "id": "Zoo/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 17,
+      "source-layer": "Retail/label",
+      "type": "symbol",
+      "id": "Retail/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 17,
+      "source-layer": "Landmark/label",
+      "type": "symbol",
+      "id": "Landmark/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": false,
+        "text-allow-overlap": false,
+        "text-padding": 25,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#8c8e8d",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Openspace or forest/label",
+      "type": "symbol",
+      "id": "Openspace or forest/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": false,
+        "text-allow-overlap": false,
+        "text-padding": 25,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#8c8e8d",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Park or farming/label",
+      "type": "symbol",
+      "id": "Park or farming/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.08,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-anchor": "center",
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#8c8e8d",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        1
+      ],
+      "source": "esri",
+      "minzoom": 14,
+      "source-layer": "Point of interest",
+      "type": "symbol",
+      "id": "Point of interest/Park"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 17,
+      "source-layer": "Education/label",
+      "type": "symbol",
+      "id": "Education/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 17,
+      "source-layer": "Medical/label",
+      "type": "symbol",
+      "id": "Medical/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": false,
+        "text-allow-overlap": false,
+        "text-padding": 25,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": {
+          "stops": [
+            [
+              9,
+              8.5
+            ],
+            [
+              12,
+              9.5
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#8c8e8d",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Admin1 forest or park/label",
+      "type": "symbol",
+      "id": "Admin1 forest or park/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 25,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": {
+          "stops": [
+            [
+              9,
+              8.5
+            ],
+            [
+              12,
+              9.5
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#8c8e8d",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Admin0 forest or park/label",
+      "type": "symbol",
+      "id": "Admin0 forest or park/label/Default"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": {
+          "stops": [
+            [
+              9,
+              8.5
+            ],
+            [
+              12,
+              9.5
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Airport/label",
+      "type": "symbol",
+      "id": "Airport/label/Airport property"
+    },
+    {
+      "layout": {
+        "text-transform": "uppercase",
+        "text-letter-spacing": 0.2,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name}",
+        "text-size": 9,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#656564",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        1
+      ],
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Admin2 area/label",
+      "maxzoom": 11,
+      "type": "symbol",
+      "id": "Admin2 area/label/small"
+    },
+    {
+      "layout": {
+        "text-transform": "uppercase",
+        "text-letter-spacing": 0.2,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name}",
+        "text-size": 10,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#656564",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        0
+      ],
+      "source": "esri",
+      "minzoom": 9,
+      "source-layer": "Admin2 area/label",
+      "maxzoom": 11,
+      "type": "symbol",
+      "id": "Admin2 area/label/large"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": {
+          "stops": [
+            [
+              4,
+              0.1
+            ],
+            [
+              8,
+              0.18
+            ]
+          ]
+        },
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              4,
+              9
+            ],
+            [
+              5,
+              9
+            ],
+            [
+              6,
+              9.5
+            ],
+            [
+              9,
+              10
+            ]
+          ]
+        },
+        "text-field": "{_name}",
+        "text-transform": "uppercase",
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#727271",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        5
+      ],
+      "source": "esri",
+      "minzoom": 5,
+      "source-layer": "Admin1 area/label",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "Admin1 area/label/x small"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": {
+          "stops": [
+            [
+              4,
+              0.1
+            ],
+            [
+              8,
+              0.18
+            ]
+          ]
+        },
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              4,
+              9
+            ],
+            [
+              5,
+              9
+            ],
+            [
+              6,
+              9.5
+            ],
+            [
+              9,
+              11.5
+            ]
+          ]
+        },
+        "text-field": "{_name}",
+        "text-transform": "uppercase",
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#727271",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        4
+      ],
+      "source": "esri",
+      "minzoom": 5,
+      "source-layer": "Admin1 area/label",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "Admin1 area/label/small"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": {
+          "stops": [
+            [
+              4,
+              0.1
+            ],
+            [
+              8,
+              0.18
+            ]
+          ]
+        },
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              4,
+              10
+            ],
+            [
+              5,
+              10
+            ],
+            [
+              6,
+              10.5
+            ],
+            [
+              9,
+              12
+            ]
+          ]
+        },
+        "text-field": "{_name}",
+        "text-transform": "uppercase",
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#727271",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        3
+      ],
+      "source": "esri",
+      "minzoom": 5,
+      "source-layer": "Admin1 area/label",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "Admin1 area/label/medium"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": {
+          "stops": [
+            [
+              4,
+              0.1
+            ],
+            [
+              8,
+              0.2
+            ]
+          ]
+        },
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              4,
+              10
+            ],
+            [
+              5,
+              10.5
+            ],
+            [
+              6,
+              11
+            ],
+            [
+              9,
+              15
+            ]
+          ]
+        },
+        "text-field": "{_name}",
+        "text-transform": "uppercase",
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#727271",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        2
+      ],
+      "source": "esri",
+      "minzoom": 5,
+      "source-layer": "Admin1 area/label",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "Admin1 area/label/large"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": {
+          "stops": [
+            [
+              4,
+              0.13
+            ],
+            [
+              8,
+              0.3
+            ]
+          ]
+        },
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              4,
+              10.5
+            ],
+            [
+              5,
+              11
+            ],
+            [
+              6,
+              11.5
+            ],
+            [
+              9,
+              17
+            ]
+          ]
+        },
+        "text-field": "{_name}",
+        "text-transform": "uppercase",
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#727271",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        1
+      ],
+      "source": "esri",
+      "minzoom": 5,
+      "source-layer": "Admin1 area/label",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "Admin1 area/label/x large"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": {
+          "stops": [
+            [
+              4,
+              0.13
+            ],
+            [
+              8,
+              0.4
+            ]
+          ]
+        },
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              4,
+              11
+            ],
+            [
+              5,
+              11.5
+            ],
+            [
+              6,
+              12
+            ],
+            [
+              9,
+              17.5
+            ]
+          ]
+        },
+        "text-field": "{_name}",
+        "text-transform": "uppercase",
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#727271",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        0
+      ],
+      "source": "esri",
+      "minzoom": 5,
+      "source-layer": "Admin1 area/label",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "Admin1 area/label/2x large"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.08,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-anchor": "center",
+        "text-field": "{_name_global}",
+        "text-size": 9,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        0
+      ],
+      "source": "esri",
+      "minzoom": 17,
+      "source-layer": "Point of interest",
+      "type": "symbol",
+      "id": "Point of interest/General"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.04,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 5,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-offset": [
+          0,
+          -0.9
+        ],
+        "text-size": 9,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        2
+      ],
+      "source": "esri",
+      "minzoom": 17,
+      "source-layer": "Point of interest",
+      "type": "symbol",
+      "id": "Point of interest/Bus station"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.04,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 5,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-offset": [
+          0,
+          -0.9
+        ],
+        "text-size": 9,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#212121"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        3
+      ],
+      "source": "esri",
+      "minzoom": 17,
+      "source-layer": "Point of interest",
+      "type": "symbol",
+      "id": "Point of interest/Rail station"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.08,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": {
+          "stops": [
+            [
+              10,
+              10
+            ],
+            [
+              16,
+              13
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#d6d8d4",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "source": "esri",
+      "minzoom": 15,
+      "source-layer": "Neighborhood",
+      "maxzoom": 17,
+      "type": "symbol",
+      "id": "Neighborhood"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.08,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": {
+          "stops": [
+            [
+              10,
+              10
+            ],
+            [
+              16,
+              13
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#d6d8d4",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        5
+      ],
+      "source": "esri",
+      "minzoom": 10,
+      "source-layer": "City large scale",
+      "maxzoom": 17,
+      "type": "symbol",
+      "id": "City large scale/town small"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.09,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": {
+          "stops": [
+            [
+              10,
+              10
+            ],
+            [
+              16,
+              15
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#d6d8d4",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        4
+      ],
+      "source": "esri",
+      "minzoom": 10,
+      "source-layer": "City large scale",
+      "maxzoom": 17,
+      "type": "symbol",
+      "id": "City large scale/town large"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.1,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": {
+          "stops": [
+            [
+              10,
+              11
+            ],
+            [
+              16,
+              16
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#d6d8d4",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        3
+      ],
+      "source": "esri",
+      "minzoom": 10,
+      "source-layer": "City large scale",
+      "maxzoom": 17,
+      "type": "symbol",
+      "id": "City large scale/small"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.1,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": {
+          "stops": [
+            [
+              10,
+              11
+            ],
+            [
+              16,
+              18.5
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#e1e3de",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        2
+      ],
+      "source": "esri",
+      "minzoom": 10,
+      "source-layer": "City large scale",
+      "maxzoom": 17,
+      "type": "symbol",
+      "id": "City large scale/medium"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.1,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": {
+          "stops": [
+            [
+              10,
+              14
+            ],
+            [
+              16,
+              22
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#e1e3de",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        1
+      ],
+      "source": "esri",
+      "minzoom": 10,
+      "source-layer": "City large scale",
+      "maxzoom": 17,
+      "type": "symbol",
+      "id": "City large scale/large"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.1,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name_global}",
+        "text-size": {
+          "stops": [
+            [
+              10,
+              15
+            ],
+            [
+              16,
+              25
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#e1e3de",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        0
+      ],
+      "source": "esri",
+      "minzoom": 10,
+      "source-layer": "City large scale",
+      "maxzoom": 17,
+      "type": "symbol",
+      "id": "City large scale/x large"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-field": "{_name}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#d6d8d4",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        17
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "City small scale",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "City small scale/town small non capital"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-field": "{_name}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#d6d8d4",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        15
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "City small scale",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "City small scale/town large non capital"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-field": "{_name}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#d6d8d4",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        12
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "City small scale",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "City small scale/small non capital"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-field": "{_name}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#d6d8d4",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        9
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "City small scale",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "City small scale/medium non capital"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-field": "{_name}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#d6d8d4",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        18
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "City small scale",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "City small scale/other capital"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-field": "{_name}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#d6d8d4",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        14
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "City small scale",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "City small scale/town large other capital"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-field": "{_name}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#d6d8d4",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        11
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "City small scale",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "City small scale/small other capital"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-field": "{_name}",
+        "text-size": 9.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#d6d8d4",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        8
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "City small scale",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "City small scale/medium other capital"
+    },
+    {
+      "layout": {
+        "text-transform": "uppercase",
+        "text-letter-spacing": {
+          "stops": [
+            [
+              5,
+              0.13
+            ],
+            [
+              8,
+              0.5
+            ]
+          ]
+        },
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Bold"
+        ],
+        "text-field": "{_name}",
+        "text-size": {
+          "stops": [
+            [
+              5,
+              10
+            ],
+            [
+              10,
+              12.5
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#838381",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        5
+      ],
+      "source": "esri",
+      "minzoom": 5,
+      "source-layer": "Admin0 point",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "Admin0 point/x small"
+    },
+    {
+      "layout": {
+        "text-transform": "uppercase",
+        "text-letter-spacing": {
+          "stops": [
+            [
+              4,
+              0.13
+            ],
+            [
+              8,
+              0.5
+            ]
+          ]
+        },
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Bold"
+        ],
+        "text-field": "{_name}",
+        "text-size": {
+          "stops": [
+            [
+              4,
+              10
+            ],
+            [
+              10,
+              12.5
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#838381",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        4
+      ],
+      "source": "esri",
+      "minzoom": 4,
+      "source-layer": "Admin0 point",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "Admin0 point/small"
+    },
+    {
+      "layout": {
+        "text-transform": "uppercase",
+        "text-letter-spacing": {
+          "stops": [
+            [
+              2,
+              0.13
+            ],
+            [
+              8,
+              0.5
+            ]
+          ]
+        },
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Bold"
+        ],
+        "text-field": "{_name}",
+        "text-size": {
+          "stops": [
+            [
+              2,
+              8
+            ],
+            [
+              4,
+              10
+            ],
+            [
+              10,
+              16
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#838381",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        3
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "Admin0 point",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "Admin0 point/medium"
+    },
+    {
+      "layout": {
+        "text-transform": "uppercase",
+        "text-letter-spacing": {
+          "stops": [
+            [
+              2,
+              0.13
+            ],
+            [
+              8,
+              0.5
+            ]
+          ]
+        },
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Bold"
+        ],
+        "text-field": "{_name}",
+        "text-size": {
+          "stops": [
+            [
+              2,
+              9
+            ],
+            [
+              4,
+              10
+            ],
+            [
+              6,
+              16
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#838381",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        2
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "Admin0 point",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "Admin0 point/large"
+    },
+    {
+      "layout": {
+        "text-transform": "uppercase",
+        "text-letter-spacing": {
+          "stops": [
+            [
+              2,
+              0.15
+            ],
+            [
+              6,
+              0.5
+            ]
+          ]
+        },
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Bold"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              2,
+              9
+            ],
+            [
+              4,
+              10
+            ],
+            [
+              6,
+              16
+            ]
+          ]
+        },
+        "text-field": "{_name}",
+        "text-line-height": 1.5,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#838381",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        1
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "Admin0 point",
+      "maxzoom": 8,
+      "type": "symbol",
+      "id": "Admin0 point/x large"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name}",
+        "text-size": {
+          "stops": [
+            [
+              3,
+              10
+            ],
+            [
+              6,
+              10.5
+            ],
+            [
+              8,
+              13
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#e1e3de",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        16
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "City small scale",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "City small scale/town small admin0 capital"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name}",
+        "text-size": {
+          "stops": [
+            [
+              3,
+              10
+            ],
+            [
+              6,
+              10.5
+            ],
+            [
+              8,
+              13
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#e1e3de",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        13
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "City small scale",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "City small scale/town large admin0 capital"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name}",
+        "text-size": {
+          "stops": [
+            [
+              3,
+              10
+            ],
+            [
+              6,
+              10.5
+            ],
+            [
+              8,
+              13
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#e1e3de",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        10
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "City small scale",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "City small scale/small admin0 capital"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name}",
+        "text-size": {
+          "stops": [
+            [
+              3,
+              10
+            ],
+            [
+              6,
+              10.5
+            ],
+            [
+              8,
+              13
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#e1e3de",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        7
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "City small scale",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "City small scale/medium admin0 capital"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name}",
+        "text-size": {
+          "stops": [
+            [
+              3,
+              10
+            ],
+            [
+              6,
+              11
+            ],
+            [
+              8,
+              14
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#e1e3de",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        5
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "City small scale",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "City small scale/large other capital"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name}",
+        "text-size": {
+          "stops": [
+            [
+              3,
+              11
+            ],
+            [
+              6,
+              12
+            ],
+            [
+              8,
+              15
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#e1e3de",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        2
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "City small scale",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "City small scale/x large admin2 capital"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name}",
+        "text-size": {
+          "stops": [
+            [
+              3,
+              10
+            ],
+            [
+              6,
+              11
+            ],
+            [
+              8,
+              14
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#e1e3de",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        6
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "City small scale",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "City small scale/large non capital"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name}",
+        "text-size": {
+          "stops": [
+            [
+              3,
+              10
+            ],
+            [
+              6,
+              11
+            ],
+            [
+              8,
+              14
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#e1e3de",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        4
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "City small scale",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "City small scale/large admin0 capital"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name}",
+        "text-size": {
+          "stops": [
+            [
+              3,
+              11
+            ],
+            [
+              6,
+              12
+            ],
+            [
+              8,
+              15
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#e1e3de",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        3
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "City small scale",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "City small scale/x large non capital"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name}",
+        "text-size": {
+          "stops": [
+            [
+              3,
+              11
+            ],
+            [
+              6,
+              12
+            ],
+            [
+              8,
+              15
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#e1e3de",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        1
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "City small scale",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "City small scale/x large admin1 capital"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.05,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Light Bold"
+        ],
+        "text-field": "{_name}",
+        "text-size": {
+          "stops": [
+            [
+              3,
+              11
+            ],
+            [
+              6,
+              12
+            ],
+            [
+              8,
+              15
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#e1e3de",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_symbol",
+        0
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "City small scale",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "City small scale/x large admin0 capital"
+    },
+    {
+      "layout": {
+        "text-transform": "uppercase",
+        "text-letter-spacing": {
+          "stops": [
+            [
+              2,
+              0.3
+            ],
+            [
+              5,
+              0.5
+            ]
+          ]
+        },
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-font": [
+          "Ubuntu Bold"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              2,
+              12
+            ],
+            [
+              4,
+              15.5
+            ],
+            [
+              5,
+              18
+            ]
+          ]
+        },
+        "text-field": "{_name}",
+        "text-line-height": 1.7,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#838381",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "==",
+        "_label_class",
+        0
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "Admin0 point",
+      "maxzoom": 6,
+      "type": "symbol",
+      "id": "Admin0 point/2x large"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.13,
+        "icon-allow-overlap": true,
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-anchor": "center",
+        "icon-image": "Disputed label point",
+        "text-field": "{_name}",
+        "text-optional": true,
+        "text-size": {
+          "stops": [
+            [
+              6,
+              7
+            ],
+            [
+              15,
+              10
+            ]
+          ]
+        },
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          1
+        ],
+        [
+          "in",
+          "DisputeID",
+          0
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 6,
+      "source-layer": "Disputed label point",
+      "type": "symbol",
+      "id": "Disputed label point/Island"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": 0.1,
+        "icon-allow-overlap": true,
+        "text-font": [
+          "Ubuntu Light Bold Italic"
+        ],
+        "text-anchor": "center",
+        "icon-image": "Disputed label point",
+        "text-field": "{_name}",
+        "text-optional": true,
+        "text-size": {
+          "stops": [
+            [
+              2,
+              8
+            ],
+            [
+              6,
+              9.3
+            ]
+          ]
+        },
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#707374",
+        "text-halo-width": 0.5,
+        "text-halo-color": "#1D2224"
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          0
+        ],
+        [
+          "in",
+          "DisputeID",
+          1006
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "Disputed label point",
+      "maxzoom": 10,
+      "type": "symbol",
+      "id": "Disputed label point/Waterbody"
+    },
+    {
+      "layout": {
+        "text-letter-spacing": {
+          "stops": [
+            [
+              2,
+              0.13
+            ],
+            [
+              8,
+              0.5
+            ]
+          ]
+        },
+        "icon-allow-overlap": true,
+        "text-size": {
+          "stops": [
+            [
+              2,
+              8
+            ],
+            [
+              4,
+              10
+            ],
+            [
+              10,
+              16
+            ]
+          ]
+        },
+        "text-font": [
+          "Ubuntu Bold"
+        ],
+        "text-anchor": "center",
+        "icon-image": "Disputed label point",
+        "text-field": "{_name}",
+        "text-optional": true,
+        "text-transform": "uppercase",
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-halo-blur": 1,
+        "text-color": "#838381",
+        "text-halo-width": 1,
+        "text-halo-color": "#323333"
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          2
+        ],
+        [
+          "in",
+          "DisputeID",
+          1021
+        ]
+      ],
+      "source": "esri",
+      "minzoom": 2,
+      "source-layer": "Disputed label point",
+      "type": "symbol",
+      "id": "Disputed label point/Admin0"
+    }
+  ],
+  "glyphs": "https://basemaps.arcgis.com/arcgis/rest/services/World_Basemap_v2/VectorTileServer/resources/fonts/{fontstack}/{range}.pbf",
+  "version": 8,
+  "sprite": "https://www.arcgis.com/sharing/rest/content/items/c11ce4f7801740b2905eb03ddc963ac8/resources/styles/../sprites/sprite",
+  "sources": {
+    "esri": {
+      "url": "https://basemaps.arcgis.com/arcgis/rest/services/World_Basemap_v2/VectorTileServer",
+      "type": "vector"
+    }
+  }
+}

--- a/lib/geo/theme/light/metadata.json
+++ b/lib/geo/theme/light/metadata.json
@@ -1,1 +1,179 @@
-{"currentVersion":10.7,"name":"World_Basemap_v2","capabilities":"TilesOnly,Tilemap","type":"indexedVector","tileMap":"/tilemap","defaultStyles":"/resources/styles","tiles":["/tile/{z}/{y}/{x}.pbf"],"exportTilesAllowed":true,"initialExtent":{"xmin":-2.0037507067161843E7,"ymin":-2.0037507067161843E7,"xmax":2.0037507067161843E7,"ymax":2.0037507067161843E7,"spatialReference":{"cs":"pcs","wkid":102100}},"fullExtent":{"xmin":-2.0037507067161843E7,"ymin":-2.0037507067161843E7,"xmax":2.0037507067161843E7,"ymax":2.0037507067161843E7,"spatialReference":{"cs":"pcs","wkid":102100}},"minScale":0.0,"maxScale":0.0,"tileInfo":{"rows":512,"cols":512,"dpi":96,"format":"pbf","origin":{"x":-2.0037508342787E7,"y":2.0037508342787E7},"spatialReference":{"wkid":102100,"latestWkid":3857},"lods":[{"level":0,"resolution":78271.51696399994,"scale":2.95828763795777E8},{"level":1,"resolution":39135.75848200009,"scale":1.47914381897889E8},{"level":2,"resolution":19567.87924099992,"scale":7.3957190948944E7},{"level":3,"resolution":9783.93962049996,"scale":3.6978595474472E7},{"level":4,"resolution":4891.96981024998,"scale":1.8489297737236E7},{"level":5,"resolution":2445.98490512499,"scale":9244648.868618},{"level":6,"resolution":1222.992452562495,"scale":4622324.434309},{"level":7,"resolution":611.4962262813797,"scale":2311162.217155},{"level":8,"resolution":305.74811314055756,"scale":1155581.108577},{"level":9,"resolution":152.87405657041106,"scale":577790.554289},{"level":10,"resolution":76.43702828507324,"scale":288895.277144},{"level":11,"resolution":38.21851414253662,"scale":144447.638572},{"level":12,"resolution":19.10925707126831,"scale":72223.819286},{"level":13,"resolution":9.554628535634155,"scale":36111.909643},{"level":14,"resolution":4.77731426794937,"scale":18055.954822},{"level":15,"resolution":2.388657133974685,"scale":9027.977411},{"level":16,"resolution":1.1943285668550503,"scale":4513.988705},{"level":17,"resolution":0.5971642835598172,"scale":2256.994353},{"level":18,"resolution":0.29858214164761665,"scale":1128.497176},{"level":19,"resolution":0.14929107082380833,"scale":564.248588},{"level":20,"resolution":0.07464553541190416,"scale":282.124294},{"level":21,"resolution":0.03732276770595208,"scale":141.062147},{"level":22,"resolution":0.01866138385297604,"scale":70.5310735}]},"resourceInfo":{"styleVersion":8,"tileCompression":"gzip","cacheInfo":{"storageInfo":{"packetSize":128,"storageFormat":"compactV2"}}},"serviceItemId":"274684d7a9d74ca4b87f529776feb3a2","minLOD":0,"maxLOD":16,"maxExportTilesCount":10000}
+{
+  "currentVersion": 10.7,
+  "name": "World_Basemap_v2",
+  "capabilities": "TilesOnly,Tilemap",
+  "type": "indexedVector",
+  "tileMap": "/tilemap",
+  "defaultStyles": "/resources/styles",
+  "tiles": [
+    "/tile/{z}/{y}/{x}.pbf"
+  ],
+  "exportTilesAllowed": true,
+  "initialExtent": {
+    "xmin": -20037507.067161843,
+    "ymin": -20037507.067161843,
+    "xmax": 20037507.067161843,
+    "ymax": 20037507.067161843,
+    "spatialReference": {
+      "cs": "pcs",
+      "wkid": 102100
+    }
+  },
+  "fullExtent": {
+    "xmin": -20037507.067161843,
+    "ymin": -20037507.067161843,
+    "xmax": 20037507.067161843,
+    "ymax": 20037507.067161843,
+    "spatialReference": {
+      "cs": "pcs",
+      "wkid": 102100
+    }
+  },
+  "minScale": 0,
+  "maxScale": 0,
+  "tileInfo": {
+    "rows": 512,
+    "cols": 512,
+    "dpi": 96,
+    "format": "pbf",
+    "origin": {
+      "x": -20037508.342787,
+      "y": 20037508.342787
+    },
+    "spatialReference": {
+      "wkid": 102100,
+      "latestWkid": 3857
+    },
+    "lods": [
+      {
+        "level": 0,
+        "resolution": 78271.51696399994,
+        "scale": 295828763.795777
+      },
+      {
+        "level": 1,
+        "resolution": 39135.75848200009,
+        "scale": 147914381.897889
+      },
+      {
+        "level": 2,
+        "resolution": 19567.87924099992,
+        "scale": 73957190.948944
+      },
+      {
+        "level": 3,
+        "resolution": 9783.93962049996,
+        "scale": 36978595.474472
+      },
+      {
+        "level": 4,
+        "resolution": 4891.96981024998,
+        "scale": 18489297.737236
+      },
+      {
+        "level": 5,
+        "resolution": 2445.98490512499,
+        "scale": 9244648.868618
+      },
+      {
+        "level": 6,
+        "resolution": 1222.992452562495,
+        "scale": 4622324.434309
+      },
+      {
+        "level": 7,
+        "resolution": 611.4962262813797,
+        "scale": 2311162.217155
+      },
+      {
+        "level": 8,
+        "resolution": 305.74811314055756,
+        "scale": 1155581.108577
+      },
+      {
+        "level": 9,
+        "resolution": 152.87405657041106,
+        "scale": 577790.554289
+      },
+      {
+        "level": 10,
+        "resolution": 76.43702828507324,
+        "scale": 288895.277144
+      },
+      {
+        "level": 11,
+        "resolution": 38.21851414253662,
+        "scale": 144447.638572
+      },
+      {
+        "level": 12,
+        "resolution": 19.10925707126831,
+        "scale": 72223.819286
+      },
+      {
+        "level": 13,
+        "resolution": 9.554628535634155,
+        "scale": 36111.909643
+      },
+      {
+        "level": 14,
+        "resolution": 4.77731426794937,
+        "scale": 18055.954822
+      },
+      {
+        "level": 15,
+        "resolution": 2.388657133974685,
+        "scale": 9027.977411
+      },
+      {
+        "level": 16,
+        "resolution": 1.1943285668550503,
+        "scale": 4513.988705
+      },
+      {
+        "level": 17,
+        "resolution": 0.5971642835598172,
+        "scale": 2256.994353
+      },
+      {
+        "level": 18,
+        "resolution": 0.29858214164761665,
+        "scale": 1128.497176
+      },
+      {
+        "level": 19,
+        "resolution": 0.14929107082380833,
+        "scale": 564.248588
+      },
+      {
+        "level": 20,
+        "resolution": 0.07464553541190416,
+        "scale": 282.124294
+      },
+      {
+        "level": 21,
+        "resolution": 0.03732276770595208,
+        "scale": 141.062147
+      },
+      {
+        "level": 22,
+        "resolution": 0.01866138385297604,
+        "scale": 70.5310735
+      }
+    ]
+  },
+  "resourceInfo": {
+    "styleVersion": 8,
+    "tileCompression": "gzip",
+    "cacheInfo": {
+      "storageInfo": {
+        "packetSize": 128,
+        "storageFormat": "compactV2"
+      }
+    }
+  },
+  "serviceItemId": "274684d7a9d74ca4b87f529776feb3a2",
+  "minLOD": 0,
+  "maxLOD": 16,
+  "maxExportTilesCount": 10000
+}

--- a/lib/geo/theme/light/root.json
+++ b/lib/geo/theme/light/root.json
@@ -1,1 +1,8832 @@
-{"version": 8, "sprite": "https://cdn.arcgis.com/sharing/rest/content/items/8a2cba3b0ebf4140b7c0dc5ee149549a/resources/styles/../sprites/sprite", "glyphs": "https://basemaps.arcgis.com/arcgis/rest/services/World_Basemap_v2/VectorTileServer/resources/fonts/{fontstack}/{range}.pbf", "sources": {"esri": {"type": "vector", "url": "https://basemaps.arcgis.com/arcgis/rest/services/World_Basemap_v2/VectorTileServer"}}, "layers": [{"id": "background", "type": "background", "paint": {"background-color": "#cfd3d4"}}, {"id": "Land", "type": "fill", "source": "esri", "source-layer": "Land", "minzoom": 0, "layout": {}, "paint": {"fill-color": {"stops": [[0, "#f4f4f4"], [7, "#efefef"]]}}}, {"id": "Urban area", "type": "fill", "source": "esri", "source-layer": "Urban area", "minzoom": 5, "maxzoom": 15, "layout": {}, "paint": {"fill-color": {"stops": [[5, "#e5e8e7"], [10, "#ECEDEC"]]}}}, {"id": "Openspace or forest", "type": "fill", "source": "esri", "source-layer": "Openspace or forest", "minzoom": 12, "layout": {}, "paint": {"fill-color": {"stops": [[6, "#ECEEEA"], [11, "#e4e8e4"]]}, "fill-outline-color": "#E7EAE6"}}, {"id": "Admin0 forest or park", "type": "fill", "source": "esri", "source-layer": "Admin0 forest or park", "minzoom": 7, "layout": {}, "paint": {"fill-color": {"stops": [[6, "#ECEEEA"], [11, "#e4e8e4"]]}, "fill-outline-color": "#E7EAE6"}}, {"id": "Admin1 forest or park", "type": "fill", "source": "esri", "source-layer": "Admin1 forest or park", "minzoom": 8, "layout": {}, "paint": {"fill-color": {"stops": [[6, "#ECEEEA"], [11, "#e4e8e4"]]}, "fill-outline-color": "#E7EAE6"}}, {"id": "Zoo", "type": "fill", "source": "esri", "source-layer": "Zoo", "minzoom": 12, "layout": {}, "paint": {"fill-color": "#e4e8e4"}}, {"id": "Airport/Airport property", "type": "fill", "source": "esri", "source-layer": "Airport", "filter": ["==", "_symbol", 1], "minzoom": 9, "layout": {}, "paint": {"fill-color": {"stops": [[11, "#edede9"], [15, "#efefef"]]}}}, {"id": "Airport/Airport runway", "type": "fill", "source": "esri", "source-layer": "Airport", "filter": ["==", "_symbol", 0], "minzoom": 11, "layout": {}, "paint": {"fill-color": "#e1e2dd"}}, {"id": "Pedestrian", "type": "fill", "source": "esri", "source-layer": "Pedestrian", "minzoom": 14, "layout": {}, "paint": {"fill-color": "#f2f2f1"}}, {"id": "Park or farming", "type": "fill", "source": "esri", "source-layer": "Park or farming", "minzoom": 12, "layout": {}, "paint": {"fill-color": "#e4e8e4"}}, {"id": "Beach", "type": "fill", "source": "esri", "source-layer": "Beach", "minzoom": 13, "layout": {}, "paint": {"fill-pattern": "Special area of interest/Sand"}}, {"id": "Special area of interest/Garden path", "type": "fill", "source": "esri", "source-layer": "Special area of interest", "filter": ["==", "_symbol", 12], "minzoom": 14, "layout": {"visibility": "none"}, "paint": {"fill-color": "#f7f7f7", "fill-outline-color": "#EBE8E8"}}, {"id": "Special area of interest/Parking", "type": "fill", "source": "esri", "source-layer": "Special area of interest", "filter": ["==", "_symbol", 15], "minzoom": 14, "layout": {}, "paint": {"fill-color": "#f2f2f1"}}, {"id": "Special area of interest/Green openspace", "type": "fill", "source": "esri", "source-layer": "Special area of interest", "filter": ["==", "_symbol", 11], "minzoom": 14, "layout": {}, "paint": {"fill-color": "#e5eae5"}}, {"id": "Special area of interest/Grass", "type": "fill", "source": "esri", "source-layer": "Special area of interest", "filter": ["==", "_symbol", 8], "minzoom": 14, "layout": {}, "paint": {"fill-color": "#e6eae6"}}, {"id": "Special area of interest/Baseball field or other grounds", "type": "fill", "source": "esri", "source-layer": "Special area of interest", "filter": ["==", "_symbol", 1], "minzoom": 14, "layout": {}, "paint": {"fill-color": "#E2E5E2"}}, {"id": "Special area of interest/Groundcover", "type": "fill", "source": "esri", "source-layer": "Special area of interest", "filter": ["==", "_symbol", 13], "minzoom": 14, "layout": {}, "paint": {"fill-pattern": "Special area of interest/Groundcover", "fill-opacity": 0.5}}, {"id": "Special area of interest/Field or court exterior", "type": "fill", "source": "esri", "source-layer": "Special area of interest", "filter": ["==", "_symbol", 5], "minzoom": 14, "layout": {}, "paint": {"fill-color": "#ECEEEC"}}, {"id": "Special area of interest/Football field or court", "type": "fill", "source": "esri", "source-layer": "Special area of interest", "filter": ["==", "_symbol", 4], "minzoom": 14, "layout": {}, "paint": {"fill-color": "#E2E5E2", "fill-outline-color": "#efefef"}}, {"id": "Special area of interest/Hardcourt", "type": "fill", "source": "esri", "source-layer": "Special area of interest", "filter": ["==", "_symbol", 10], "minzoom": 14, "layout": {}, "paint": {"fill-color": "#d3d3d3", "fill-outline-color": "#efefef"}}, {"id": "Special area of interest/Mulch or dirt", "type": "fill", "source": "esri", "source-layer": "Special area of interest", "filter": ["==", "_symbol", 14], "minzoom": 14, "layout": {}, "paint": {"fill-color": "#eaeaea"}}, {"id": "Special area of interest/Athletic track", "type": "fill", "source": "esri", "source-layer": "Special area of interest", "filter": ["==", "_symbol", 0], "minzoom": 14, "layout": {}, "paint": {"fill-color": "#e2e2e2", "fill-outline-color": "#f2f2f2"}}, {"id": "Special area of interest/Sand", "type": "fill", "source": "esri", "source-layer": "Special area of interest", "filter": ["==", "_symbol", 6], "minzoom": 14, "layout": {}, "paint": {"fill-pattern": "Special area of interest/Sand"}}, {"id": "Special area of interest/Rock or gravel", "type": "fill", "source": "esri", "source-layer": "Special area of interest", "filter": ["==", "_symbol", 16], "minzoom": 14, "layout": {}, "paint": {"fill-pattern": "Special area of interest/Rock or gravel"}}, {"id": "Special area of interest/Water", "type": "fill", "source": "esri", "source-layer": "Special area of interest", "filter": ["==", "_symbol", 7], "minzoom": 15, "layout": {}, "paint": {"fill-color": "#cfd3d4"}}, {"id": "Water line small scale", "type": "line", "source": "esri", "source-layer": "Water line small scale", "minzoom": 1, "maxzoom": 5, "layout": {"line-join": "round", "visibility": "none"}, "paint": {"line-color": "#d6dadb", "line-width": 0.5}}, {"id": "Water line medium scale", "type": "line", "source": "esri", "source-layer": "Water line medium scale", "minzoom": 6, "maxzoom": 7, "layout": {"line-join": "round"}, "paint": {"line-color": "#d6dadb", "line-width": {"base": 1.2, "stops": [[5, 0.5], [7, 0.7]]}}}, {"id": "Water line large scale", "type": "line", "source": "esri", "source-layer": "Water line large scale", "minzoom": 7, "maxzoom": 11, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#cfd3d4", "line-width": {"base": 1.2, "stops": [[7, 0.7], [11, 0.8]]}}}, {"id": "Water line/Waterfall", "type": "line", "source": "esri", "source-layer": "Water line", "filter": ["==", "_symbol", 5], "minzoom": 11, "layout": {"line-join": "round"}, "paint": {"line-color": "#cfd3d4", "line-width": 0.8, "line-dasharray": [5, 5]}}, {"id": "Water line/Dam or weir", "type": "line", "source": "esri", "source-layer": "Water line", "filter": ["==", "_symbol", 2], "minzoom": 11, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#c3c3c3", "line-width": {"base": 1.2, "stops": [[11, 0.7], [14, 0.7], [17, 2]]}}}, {"id": "Water line/Levee/1", "type": "line", "source": "esri", "source-layer": "Water line", "filter": ["==", "_symbol", 3], "minzoom": 11, "layout": {"line-join": "round"}, "paint": {"line-color": "#cfd3d4", "line-width": {"base": 1.2, "stops": [[11, 0.7], [14, 0.7], [17, 2]]}}}, {"id": "Water line/Levee/0", "type": "symbol", "source": "esri", "source-layer": "Water line", "filter": ["==", "_symbol", 3], "minzoom": 13, "layout": {"symbol-placement": "line", "symbol-avoid-edges": true, "icon-image": "Water line/Levee/0", "symbol-spacing": 15, "icon-rotation-alignment": "map", "icon-allow-overlap": true, "icon-padding": 1}, "paint": {}}, {"id": "Water line/Canal or ditch", "type": "line", "source": "esri", "source-layer": "Water line", "filter": ["==", "_symbol", 1], "minzoom": 11, "layout": {"line-cap": "round"}, "paint": {"line-color": "#cfd3d4", "line-width": {"base": 1.2, "stops": [[11, 0.8], [14, 0.8], [17, 2]]}}}, {"id": "Water line/Stream or river intermittent", "type": "line", "source": "esri", "source-layer": "Water line", "filter": ["==", "_symbol", 4], "minzoom": 11, "layout": {}, "paint": {"line-color": "#cfd3d4", "line-dasharray": [7, 3], "line-width": {"base": 1.2, "stops": [[11, 0.8], [14, 0.8], [17, 2]]}}}, {"id": "Water line/Stream or river", "type": "line", "source": "esri", "source-layer": "Water line", "filter": ["==", "_symbol", 0], "minzoom": 11, "layout": {"line-cap": "round"}, "paint": {"line-color": "#cfd3d4", "line-width": {"base": 1.2, "stops": [[11, 0.8], [14, 0.8], [17, 2]]}}}, {"id": "Marine area", "type": "fill", "source": "esri", "source-layer": "Marine area", "minzoom": 4, "layout": {}, "paint": {"fill-color": "#cfd3d4"}}, {"id": "Water area small scale", "type": "fill", "source": "esri", "source-layer": "Water area small scale", "minzoom": 1, "maxzoom": 5, "layout": {}, "paint": {"fill-color": "#cfd3d4"}}, {"id": "Water area medium scale/Lake intermittent", "type": "fill", "source": "esri", "source-layer": "Water area medium scale", "filter": ["==", "_symbol", 1], "minzoom": 5, "maxzoom": 7, "layout": {}, "paint": {"fill-pattern": "Water area/Lake or river intermittent"}}, {"id": "Water area medium scale/Lake or river", "type": "fill", "source": "esri", "source-layer": "Water area medium scale", "filter": ["==", "_symbol", 0], "minzoom": 5, "maxzoom": 7, "layout": {}, "paint": {"fill-color": "#cfd3d4"}}, {"id": "Water area large scale/Lake intermittent", "type": "fill", "source": "esri", "source-layer": "Water area large scale", "filter": ["==", "_symbol", 1], "minzoom": 7, "maxzoom": 11, "layout": {}, "paint": {"fill-pattern": "Water area/Lake or river intermittent"}}, {"id": "Water area large scale/Lake or river", "type": "fill", "source": "esri", "source-layer": "Water area large scale", "filter": ["==", "_symbol", 0], "minzoom": 7, "maxzoom": 11, "layout": {}, "paint": {"fill-color": "#cfd3d4"}}, {"id": "Water area/Lake, river or bay", "type": "fill", "source": "esri", "source-layer": "Water area", "filter": ["==", "_symbol", 7], "minzoom": 11, "layout": {}, "paint": {"fill-color": "#cfd3d4"}}, {"id": "Water area/Lake or river intermittent", "type": "fill", "source": "esri", "source-layer": "Water area", "filter": ["==", "_symbol", 6], "minzoom": 11, "layout": {}, "paint": {"fill-pattern": "Water area/Lake or river intermittent"}}, {"id": "Water area/Inundated area", "type": "fill", "source": "esri", "source-layer": "Water area", "filter": ["==", "_symbol", 4], "minzoom": 11, "layout": {}, "paint": {"fill-pattern": "Water area/Inundated area"}}, {"id": "Water area/Swamp or marsh", "type": "fill", "source": "esri", "source-layer": "Water area", "filter": ["==", "_symbol", 3], "minzoom": 11, "layout": {}, "paint": {"fill-pattern": "Water area/Swamp or marsh"}}, {"id": "Water area/Playa", "type": "fill", "source": "esri", "source-layer": "Water area", "filter": ["==", "_symbol", 1], "minzoom": 11, "layout": {}, "paint": {"fill-pattern": "Water area/Playa"}}, {"id": "Water area/Dam or weir", "type": "fill", "source": "esri", "source-layer": "Water area", "filter": ["==", "_symbol", 5], "minzoom": 11, "layout": {}, "paint": {"fill-color": "#DFE1E2", "fill-outline-color": "#efefef"}}, {"id": "Special area of interest/Bike, walk or pedestrian", "type": "fill", "source": "esri", "source-layer": "Special area of interest", "filter": ["==", "_symbol", 2], "minzoom": 14, "layout": {}, "paint": {"fill-color": "#f2f2f1"}}, {"id": "Railroad/2", "type": "line", "source": "esri", "source-layer": "Railroad", "minzoom": 12, "layout": {"line-join": "round"}, "paint": {"line-color": "#EFEFEF", "line-width": {"base": 1.2, "stops": [[12, 1.5], [14, 2.5], [17, 3]]}}}, {"id": "Railroad/1", "type": "line", "source": "esri", "source-layer": "Railroad", "minzoom": 12, "layout": {"line-join": "round"}, "paint": {"line-color": "#dcddda", "line-width": {"base": 1.2, "stops": [[12, 0.5], [14, 1], [17, 1.5]]}}}, {"id": "Ferry/Rail ferry/2", "type": "line", "source": "esri", "source-layer": "Ferry", "filter": ["all", ["==", "_symbol", 1], ["!in", "Viz", 3]], "minzoom": 12, "layout": {"line-join": "round"}, "paint": {"line-color": "#EFEFEF", "line-width": {"base": 1.2, "stops": [[12, 1.5], [14, 2.5], [17, 3]]}}}, {"id": "Ferry/Rail ferry/1", "type": "line", "source": "esri", "source-layer": "Ferry", "filter": ["all", ["==", "_symbol", 1], ["!in", "Viz", 3]], "minzoom": 12, "layout": {"line-join": "round"}, "paint": {"line-color": "#dcddda", "line-width": {"base": 1.2, "stops": [[12, 0.5], [14, 1], [17, 1.5]]}}}, {"id": "Special area of interest line/Dock or pier", "type": "line", "source": "esri", "source-layer": "Special area of interest line", "filter": ["==", "_symbol", 0], "minzoom": 15, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#efefef", "line-width": {"base": 1.2, "stops": [[15, 0.7], [17, 1.2]]}}}, {"id": "Special area of interest line/Sports field", "type": "line", "source": "esri", "source-layer": "Special area of interest line", "filter": ["==", "_symbol", 6], "minzoom": 15, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#efefef", "line-width": {"base": 1.2, "stops": [[15, 0.7], [17, 1.2]]}}}, {"id": "Building/Shadow", "type": "fill", "source": "esri", "source-layer": "Building", "minzoom": 16, "layout": {}, "paint": {"fill-color": "#dcddde", "fill-translate": {"stops": [[15, [0, 0]], [18, [2, 2]]]}, "fill-translate-anchor": "viewport"}}, {"id": "Building", "type": "fill", "source": "esri", "source-layer": "Building", "minzoom": 15, "layout": {}, "paint": {"fill-color": "#DFE1E2", "fill-outline-color": "#efefef"}}, {"id": "Special area of interest line/Parking lot", "type": "line", "source": "esri", "source-layer": "Special area of interest line", "filter": ["==", "_symbol", 5], "minzoom": 15, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#FFFFFF", "line-width": {"base": 1.2, "stops": [[15, 0.7], [17, 1.2]]}}}, {"id": "Trail or path/1", "type": "line", "source": "esri", "source-layer": "Trail or path", "minzoom": 15, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#E3E5E2", "line-width": {"base": 1.2, "stops": [[14, 1.5], [16, 3.3], [18, 4]]}}}, {"id": "Road/4WD/1", "type": "line", "source": "esri", "source-layer": "Road", "filter": ["all", ["==", "_symbol", 10], ["!in", "Viz", 3]], "minzoom": 13, "layout": {"line-join": "round"}, "paint": {"line-color": "#E3E5E2", "line-dasharray": [2.0, 1.0], "line-width": {"base": 1.2, "stops": [[11, 1.5], [14, 3.3], [18, 8.3]]}}}, {"id": "Road/Service/1", "type": "line", "source": "esri", "source-layer": "Road", "filter": ["all", ["==", "_symbol", 8], ["!in", "Viz", 3]], "minzoom": 13, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#E3E5E2", "line-width": {"base": 1.2, "stops": [[11, 1.5], [14, 3.3], [18, 8.3]]}}}, {"id": "Road/Local/1", "type": "line", "source": "esri", "source-layer": "Road", "filter": ["all", ["==", "_symbol", 7], ["!in", "Viz", 3]], "minzoom": 12, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#E3E5E2", "line-width": {"base": 1.4, "stops": [[11, 1.5], [14, 4], [16, 6], [18, 17.3]]}}}, {"id": "Road/Pedestrian/1", "type": "line", "source": "esri", "source-layer": "Road", "filter": ["all", ["==", "_symbol", 9], ["!in", "Viz", 3]], "minzoom": 15, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#E3E5E2", "line-width": {"base": 1.2, "stops": [[14, 1.5], [16, 3.3], [18, 4]]}}}, {"id": "Road/Minor, ramp or traffic circle/1", "type": "line", "source": "esri", "source-layer": "Road", "filter": ["all", ["==", "_symbol", 6], ["!in", "Viz", 3]], "minzoom": 11, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#E3E5E2", "line-width": {"base": 1.2, "stops": [[11, 1], [14, 4], [16, 9.6], [18, 17.3]]}}}, {"id": "Road/Minor/1", "type": "line", "source": "esri", "source-layer": "Road", "filter": ["all", ["==", "_symbol", 5], ["!in", "Viz", 3]], "minzoom": 11, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#E3E5E2", "line-width": {"base": 1.2, "stops": [[11, 2.6], [14, 5.6], [16, 9.6], [18, 17.3]]}}}, {"id": "Road/Major, ramp or traffic circle/1", "type": "line", "source": "esri", "source-layer": "Road", "filter": ["all", ["==", "_symbol", 4], ["!in", "Viz", 3]], "minzoom": 9, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#E3E5E2", "line-width": {"base": 1.2, "stops": [[9, 1.5], [14, 7.3], [16, 10.3], [18, 18]]}}}, {"id": "Road/Major/1", "type": "line", "source": "esri", "source-layer": "Road", "filter": ["all", ["==", "_symbol", 3], ["!in", "Viz", 3]], "minzoom": 9, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#E3E5E2", "line-width": {"base": 1.0, "stops": [[9, 1.5], [14, 7.3], [16, 10.3], [18, 18]]}}}, {"id": "Road/Freeway Motorway, ramp or traffic circle/1", "type": "line", "source": "esri", "source-layer": "Road", "filter": ["all", ["==", "_symbol", 2], ["!in", "Viz", 3]], "minzoom": 7, "layout": {"line-join": "round", "line-cap": "round"}, "paint": {"line-color": "#E3E5E2", "line-width": {"base": 1.0, "stops": [[9, 0.3], [14, 8.3], [16, 12.3], [18, 26]]}}}, {"id": "Road/Highway/1", "type": "line", "source": "esri", "source-layer": "Road", "filter": ["all", ["==", "_symbol", 1], ["!in", "Viz", 3]], "minzoom": 8, "layout": {"line-join": "round"}, "paint": {"line-color": "#E3E5E2", "line-width": {"base": 1.2, "stops": [[8, 0.3], [14, 8.3], [16, 12.3], [18, 26]]}}}, {"id": "Road/Freeway Motorway/1", "type": "line", "source": "esri", "source-layer": "Road", "filter": ["all", ["==", "_symbol", 0], ["!in", "Viz", 3]], "minzoom": 7, "layout": {"line-join": "round"}, "paint": {"line-color": "#E3E5E2", "line-width": {"base": 1.2, "stops": [[5, 0.3], [14, 8.3], [16, 12.3], [18, 26]]}}}, {"id": "Trail or path/0", "type": "line", "source": "esri", "source-layer": "Trail or path", "minzoom": 15, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#FFFFFF", "line-dasharray": [3, 1.5], "line-width": {"base": 1.2, "stops": [[14, 1.3], [16, 2], [18, 2.3]]}}}, {"id": "Road/Pedestrian/0", "type": "line", "source": "esri", "source-layer": "Road", "filter": ["all", ["==", "_symbol", 9], ["!in", "Viz", 3]], "minzoom": 15, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#FFFFFF", "line-dasharray": [3, 1.5], "line-width": {"base": 1.2, "stops": [[14, 1.3], [16, 2], [18, 2.3]]}}}, {"id": "Road/4WD/0", "type": "line", "source": "esri", "source-layer": "Road", "filter": ["all", ["==", "_symbol", 10], ["!in", "Viz", 3]], "minzoom": 13, "layout": {"line-join": "round"}, "paint": {"line-color": "#FFFFFF", "line-width": {"base": 1.2, "stops": [[11, 0.75], [14, 1.3], [18, 6.3]]}}}, {"id": "Road/Service/0", "type": "line", "source": "esri", "source-layer": "Road", "filter": ["all", ["==", "_symbol", 8], ["!in", "Viz", 3]], "minzoom": 13, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#FFFFFF", "line-width": {"base": 1.2, "stops": [[11, 0.75], [14, 1.3], [18, 6.3]]}}}, {"id": "Road/Local/0", "type": "line", "source": "esri", "source-layer": "Road", "filter": ["all", ["==", "_symbol", 7], ["!in", "Viz", 3]], "minzoom": 12, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": {"stops": [[12, "#FAFAFA"], [13, "#ffffff"]]}, "line-width": {"base": 1.4, "stops": [[11, 1.1], [14, 2], [16, 4], [18, 15.3]]}}}, {"id": "Road/Minor, ramp or traffic circle/0", "type": "line", "source": "esri", "source-layer": "Road", "filter": ["all", ["==", "_symbol", 6], ["!in", "Viz", 3]], "minzoom": 11, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#FFFFFF", "line-width": {"base": 1.2, "stops": [[11, 0.75], [14, 2], [16, 7.65], [18, 15.3]]}}}, {"id": "Road/Minor/0", "type": "line", "source": "esri", "source-layer": "Road", "filter": ["all", ["==", "_symbol", 5], ["!in", "Viz", 3]], "minzoom": 11, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#FFFFFF", "line-width": {"base": 1.2, "stops": [[11, 1.3], [14, 3.65], [16, 7.65], [18, 15.3]]}}}, {"id": "Road/Major, ramp or traffic circle/0", "type": "line", "source": "esri", "source-layer": "Road", "filter": ["all", ["==", "_symbol", 4], ["!in", "Viz", 3]], "minzoom": 9, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#ffffff", "line-width": {"base": 1.2, "stops": [[9, 0.75], [14, 5.3], [16, 8.3], [18, 16]]}}}, {"id": "Road/Major/0", "type": "line", "source": "esri", "source-layer": "Road", "filter": ["all", ["==", "_symbol", 3], ["!in", "Viz", 3]], "minzoom": 9, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#FFFFFF", "line-width": {"base": 1.2, "stops": [[9, 0.75], [14, 5.3], [16, 8.3], [18, 16]]}}}, {"id": "Road/Freeway Motorway, ramp or traffic circle/0", "type": "line", "source": "esri", "source-layer": "Road", "filter": ["all", ["==", "_symbol", 2], ["!in", "Viz", 3]], "minzoom": 7, "layout": {"line-join": "round", "line-cap": "round"}, "paint": {"line-color": "#ffffff", "line-width": {"base": 1.2, "stops": [[9, 0.3], [14, 6.3], [16, 10.3], [18, 24]]}}}, {"id": "Road/Highway/0", "type": "line", "source": "esri", "source-layer": "Road", "filter": ["all", ["==", "_symbol", 1], ["!in", "Viz", 3]], "minzoom": 8, "layout": {"line-join": "round"}, "paint": {"line-color": "#ffffff", "line-width": {"base": 1.2, "stops": [[8, 0.3], [14, 6.3], [16, 10.3], [18, 24]]}}}, {"id": "Road/Freeway Motorway/0", "type": "line", "source": "esri", "source-layer": "Road", "filter": ["all", ["==", "_symbol", 0], ["!in", "Viz", 3]], "minzoom": 6, "layout": {"line-join": "round"}, "paint": {"line-color": {"stops": [[6, "#FAFAFA"], [7, "#ffffff"]]}, "line-width": {"base": 1.2, "stops": [[5, 0.3], [14, 6.3], [16, 10.3], [18, 24]]}}}, {"id": "Road tunnel/4WD/1", "type": "line", "source": "esri", "source-layer": "Road tunnel", "filter": ["all", ["==", "_symbol", 10], ["!in", "Viz", 3]], "minzoom": 13, "layout": {"line-join": "round"}, "paint": {"line-color": "#E3E5E2", "line-opacity": 0.5, "line-dasharray": [2.0, 1.0], "line-width": {"base": 1.2, "stops": [[11, 1.5], [14, 3.3], [18, 8.3]]}}}, {"id": "Road tunnel/Service/1", "type": "line", "source": "esri", "source-layer": "Road tunnel", "filter": ["all", ["==", "_symbol", 8], ["!in", "Viz", 3]], "minzoom": 13, "layout": {"line-join": "round"}, "paint": {"line-color": "#E3E5E2", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[11, 1.5], [14, 3.3], [18, 8.3]]}}}, {"id": "Road tunnel/Local/1", "type": "line", "source": "esri", "source-layer": "Road tunnel", "filter": ["all", ["==", "_symbol", 7], ["!in", "Viz", 3]], "minzoom": 12, "layout": {"line-join": "round"}, "paint": {"line-color": "#E3E5E2", "line-opacity": 0.5, "line-width": {"base": 1.4, "stops": [[11, 1.5], [14, 4], [16, 6], [18, 17.3]]}}}, {"id": "Road tunnel/Pedestrian/1", "type": "line", "source": "esri", "source-layer": "Road tunnel", "filter": ["all", ["==", "_symbol", 9], ["!in", "Viz", 3]], "minzoom": 15, "layout": {"line-join": "round"}, "paint": {"line-color": "#E3E5E2", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[14, 1.5], [16, 3.3], [18, 4]]}}}, {"id": "Road tunnel/Minor, ramp or traffic circle/1", "type": "line", "source": "esri", "source-layer": "Road tunnel", "filter": ["all", ["==", "_symbol", 6], ["!in", "Viz", 3]], "minzoom": 11, "layout": {"line-join": "round"}, "paint": {"line-color": "#E3E5E2", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[11, 1], [14, 4], [16, 9.65], [18, 17.3]]}}}, {"id": "Road tunnel/Minor/1", "type": "line", "source": "esri", "source-layer": "Road tunnel", "filter": ["all", ["==", "_symbol", 5], ["!in", "Viz", 3]], "minzoom": 11, "layout": {"line-join": "round"}, "paint": {"line-color": "#E3E5E2", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[11, 2.6], [14, 5.65], [16, 9.65], [18, 17.3]]}}}, {"id": "Road tunnel/Major, ramp or traffic circle/1", "type": "line", "source": "esri", "source-layer": "Road tunnel", "filter": ["all", ["==", "_symbol", 4], ["!in", "Viz", 3]], "minzoom": 9, "layout": {"line-join": "round"}, "paint": {"line-color": "#E3E5E2", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[9, 1.5], [14, 7.3], [16, 10.3], [18, 18]]}}}, {"id": "Road tunnel/Major/1", "type": "line", "source": "esri", "source-layer": "Road tunnel", "filter": ["all", ["==", "_symbol", 3], ["!in", "Viz", 3]], "minzoom": 9, "layout": {"line-join": "round"}, "paint": {"line-color": "#E3E5E2", "line-opacity": 0.5, "line-width": {"base": 1.0, "stops": [[9, 1.5], [14, 7.3], [16, 10.3], [18, 18]]}}}, {"id": "Road tunnel/Freeway Motorway, ramp or traffic circle/1", "type": "line", "source": "esri", "source-layer": "Road tunnel", "filter": ["all", ["==", "_symbol", 2], ["!in", "Viz", 3]], "minzoom": 7, "layout": {"line-join": "round"}, "paint": {"line-color": "#E3E5E2", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[9, 0.3], [14, 8.3], [16, 14.3], [18, 28]]}}}, {"id": "Road tunnel/Highway/1", "type": "line", "source": "esri", "source-layer": "Road tunnel", "filter": ["all", ["==", "_symbol", 1], ["!in", "Viz", 3]], "minzoom": 8, "layout": {"line-join": "round"}, "paint": {"line-color": "#E3E5E2", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[8, 0.3], [14, 8.3], [16, 14.3], [18, 28]]}}}, {"id": "Road tunnel/Freeway Motorway/1", "type": "line", "source": "esri", "source-layer": "Road tunnel", "filter": ["all", ["==", "_symbol", 0], ["!in", "Viz", 3]], "minzoom": 7, "layout": {"line-join": "round"}, "paint": {"line-color": "#E3E5E2", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[5, 0.3], [14, 8.3], [16, 14.3], [18, 28]]}}}, {"id": "Road tunnel/Pedestrian/0", "type": "line", "source": "esri", "source-layer": "Road tunnel", "filter": ["all", ["==", "_symbol", 9], ["!in", "Viz", 3]], "minzoom": 15, "layout": {"line-join": "round"}, "paint": {"line-color": "#FFFFFF", "line-opacity": 0.5, "line-dasharray": [3, 1.5], "line-width": {"base": 1.2, "stops": [[14, 1.3], [16, 2], [18, 2.3]]}}}, {"id": "Road tunnel/4WD/0", "type": "line", "source": "esri", "source-layer": "Road tunnel", "filter": ["all", ["==", "_symbol", 10], ["!in", "Viz", 3]], "minzoom": 13, "layout": {"line-join": "round"}, "paint": {"line-color": "#FFFFFF", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[11, 0.75], [14, 1.3], [18, 6.3]]}}}, {"id": "Road tunnel/Service/0", "type": "line", "source": "esri", "source-layer": "Road tunnel", "filter": ["all", ["==", "_symbol", 8], ["!in", "Viz", 3]], "minzoom": 13, "layout": {"line-join": "round"}, "paint": {"line-color": "#FFFFFF", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[11, 0.75], [14, 1.3], [18, 6.3]]}}}, {"id": "Road tunnel/Local/0", "type": "line", "source": "esri", "source-layer": "Road tunnel", "filter": ["all", ["==", "_symbol", 7], ["!in", "Viz", 3]], "minzoom": 12, "layout": {"line-join": "round"}, "paint": {"line-color": {"stops": [[12, "#FAFAFA"], [13, "#ffffff"]]}, "line-opacity": 0.5, "line-width": {"base": 1.4, "stops": [[11, 1.1], [14, 2], [16, 4], [18, 15.3]]}}}, {"id": "Road tunnel/Minor, ramp or traffic circle/0", "type": "line", "source": "esri", "source-layer": "Road tunnel", "filter": ["all", ["==", "_symbol", 6], ["!in", "Viz", 3]], "minzoom": 11, "layout": {"line-join": "round"}, "paint": {"line-color": "#FFFFFF", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[11, 0.75], [14, 2], [16, 7.65], [18, 15.3]]}}}, {"id": "Road tunnel/Minor/0", "type": "line", "source": "esri", "source-layer": "Road tunnel", "filter": ["all", ["==", "_symbol", 5], ["!in", "Viz", 3]], "minzoom": 11, "layout": {"line-join": "round"}, "paint": {"line-color": "#FFFFFF", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[11, 1.3], [14, 3.65], [16, 7.65], [18, 15.3]]}}}, {"id": "Road tunnel/Major, ramp or traffic circle/0", "type": "line", "source": "esri", "source-layer": "Road tunnel", "filter": ["all", ["==", "_symbol", 4], ["!in", "Viz", 3]], "minzoom": 9, "layout": {"line-join": "round"}, "paint": {"line-color": "#ffffff", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[9, 0.75], [14, 5.3], [16, 8.3], [18, 16]]}}}, {"id": "Road tunnel/Major/0", "type": "line", "source": "esri", "source-layer": "Road tunnel", "filter": ["all", ["==", "_symbol", 3], ["!in", "Viz", 3]], "minzoom": 9, "layout": {"line-join": "round"}, "paint": {"line-color": "#ffffff", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[9, 0.75], [14, 5.3], [16, 8.3], [18, 16]]}}}, {"id": "Road tunnel/Freeway Motorway, ramp or traffic circle/0", "type": "line", "source": "esri", "source-layer": "Road tunnel", "filter": ["all", ["==", "_symbol", 2], ["!in", "Viz", 3]], "minzoom": 7, "layout": {"line-join": "round"}, "paint": {"line-color": "#ffffff", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[9, 0.3], [14, 6.3], [16, 12.3], [18, 26]]}}}, {"id": "Road tunnel/Highway/0", "type": "line", "source": "esri", "source-layer": "Road tunnel", "filter": ["all", ["==", "_symbol", 1], ["!in", "Viz", 3]], "minzoom": 8, "layout": {"line-join": "round"}, "paint": {"line-color": "#ffffff", "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[8, 0.3], [14, 6.3], [16, 12.3], [18, 26]]}}}, {"id": "Road tunnel/Freeway Motorway/0", "type": "line", "source": "esri", "source-layer": "Road tunnel", "filter": ["all", ["==", "_symbol", 0], ["!in", "Viz", 3]], "minzoom": 6, "layout": {"line-join": "round"}, "paint": {"line-color": {"stops": [[6, "#FAFAFA"], [7, "#ffffff"]]}, "line-opacity": 0.5, "line-width": {"base": 1.2, "stops": [[5, 0.3], [14, 6.3], [16, 12.3], [18, 26]]}}}, {"id": "Special area of interest/Gutter", "type": "fill", "source": "esri", "source-layer": "Special area of interest", "filter": ["==", "_symbol", 9], "minzoom": 14, "layout": {}, "paint": {"fill-color": "#f2f2f1", "fill-outline-color": "#efefef"}}, {"id": "Special area of interest/Curb", "type": "fill", "source": "esri", "source-layer": "Special area of interest", "filter": ["==", "_symbol", 3], "minzoom": 14, "layout": {}, "paint": {"fill-color": "#f2f2f1", "fill-outline-color": "#ebebeb"}}, {"id": "Boundary line/Disputed admin2/1", "type": "line", "source": "esri", "source-layer": "Boundary line", "filter": ["all", ["==", "_symbol", 8], ["!in", "Viz", 3]], "minzoom": 9, "layout": {"line-join": "round"}, "paint": {"line-color": "#dddedb", "line-opacity": 0.95, "line-width": {"base": 1.0, "stops": [[4, 0.65], [14, 7], [17, 7]]}}}, {"id": "Boundary line/Disputed admin2/0", "type": "line", "source": "esri", "source-layer": "Boundary line", "filter": ["all", ["==", "_symbol", 8], ["!in", "Viz", 3]], "minzoom": 9, "layout": {"line-join": "round"}, "paint": {"line-color": {"stops": [[1, "#FAFAFA"], [3, "#ffffff"]]}, "line-width": {"base": 1.2, "stops": [[1, 0.65], [14, 1.3], [17, 2.65]]}, "line-dasharray": [7.0, 5.0]}}, {"id": "Boundary line/Disputed admin1/1", "type": "line", "source": "esri", "source-layer": "Boundary line", "minzoom": 4, "filter": ["all", ["==", "_symbol", 7], ["!in", "Viz", 3]], "layout": {"line-join": "round"}, "paint": {"line-color": "#dddedb", "line-opacity": 0.95, "line-width": {"base": 1.0, "stops": [[4, 0.65], [14, 7]]}}}, {"id": "Boundary line/Disputed admin0/1", "type": "line", "source": "esri", "source-layer": "Boundary line", "filter": ["all", ["==", "_symbol", 6], ["!in", "Viz", 3], ["!in", "DisputeID", 8, 16, 90, 96, 0]], "minzoom": 1, "layout": {"line-join": "round"}, "paint": {"line-color": "#dddedb", "line-opacity": 0.95, "line-width": {"base": 1.0, "stops": [[1, 0.65], [14, 9.3]]}}}, {"id": "Boundary line/Disputed admin1/0", "type": "line", "source": "esri", "source-layer": "Boundary line", "minzoom": 4, "filter": ["all", ["==", "_symbol", 7], ["!in", "Viz", 3]], "layout": {"line-join": "round"}, "paint": {"line-color": {"stops": [[1, "#FAFAFA"], [3, "#ffffff"]]}, "line-width": {"base": 1.2, "stops": [[1, 0.65], [14, 1.3], [17, 2.65]]}, "line-dasharray": [7.0, 5.0]}}, {"id": "Boundary line/Disputed admin0/0", "type": "line", "source": "esri", "source-layer": "Boundary line", "filter": ["all", ["==", "_symbol", 6], ["!in", "Viz", 3], ["!in", "DisputeID", 8, 16, 90, 96, 0]], "minzoom": 1, "layout": {"line-join": "round"}, "paint": {"line-color": {"stops": [[1, "#FAFAFA"], [3, "#ffffff"]]}, "line-width": {"base": 1.2, "stops": [[1, 0.65], [14, 1.3], [17, 2.65]]}, "line-dasharray": [7.0, 5.0]}}, {"id": "Boundary line/Admin2/1", "type": "line", "source": "esri", "source-layer": "Boundary line", "filter": ["all", ["==", "_symbol", 2], ["!in", "Viz", 3]], "minzoom": 10, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#dfe0dd", "line-opacity": 0.6, "line-width": {"base": 1.2, "stops": [[8, 1.3], [14, 2.65]]}}}, {"id": "Boundary line/Admin1/1", "type": "line", "source": "esri", "source-layer": "Boundary line", "filter": ["all", ["==", "_symbol", 1], ["!in", "Viz", 3]], "minzoom": 4, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#dfe0dd", "line-width": {"base": 1.0, "stops": [[4, 0.65], [14, 7]]}}}, {"id": "Boundary line/Admin0/1", "type": "line", "source": "esri", "source-layer": "Boundary line", "filter": ["all", ["==", "_symbol", 0], ["!in", "Viz", 3]], "minzoom": 1, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#dddedb", "line-width": {"base": 1.0, "stops": [[1, 0.65], [14, 9.3]]}}}, {"id": "Boundary line/Admin5", "type": "line", "source": "esri", "source-layer": "Boundary line", "filter": ["all", ["==", "_symbol", 5], ["!in", "Viz", 3]], "minzoom": 16, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#b9b9b9", "line-width": 1, "line-dasharray": [5, 3]}}, {"id": "Boundary line/Admin4", "type": "line", "source": "esri", "source-layer": "Boundary line", "filter": ["all", ["==", "_symbol", 4], ["!in", "Viz", 3]], "minzoom": 16, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#b9b9b9", "line-width": 1, "line-dasharray": [5, 3]}}, {"id": "Boundary line/Admin3", "type": "line", "source": "esri", "source-layer": "Boundary line", "filter": ["all", ["==", "_symbol", 3], ["!in", "Viz", 3]], "minzoom": 16, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": "#b9b9b9", "line-width": 1, "line-dasharray": [5, 3]}}, {"id": "Boundary line/Admin2/0", "type": "line", "source": "esri", "source-layer": "Boundary line", "filter": ["all", ["==", "_symbol", 2], ["!in", "Viz", 3]], "minzoom": 9, "layout": {"line-join": "round"}, "paint": {"line-color": "#b9b9b9", "line-dasharray": [6, 4], "line-width": {"base": 1.2, "stops": [[8, 0.5], [14, 1]]}}}, {"id": "Boundary line/Admin1/0", "type": "line", "source": "esri", "source-layer": "Boundary line", "filter": ["all", ["==", "_symbol", 1], ["!in", "Viz", 3]], "minzoom": 7, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": {"stops": [[7, "#c8c8c8"], [12, "#b9b9b9"]]}, "line-dasharray": [7, 5.3], "line-width": {"base": 1.0, "stops": [[7, 0.3], [14, 1.3]]}}}, {"id": "Boundary line/Admin0/0", "type": "line", "source": "esri", "source-layer": "Boundary line", "filter": ["all", ["==", "_symbol", 0], ["!in", "Viz", 3]], "minzoom": 5, "layout": {"line-cap": "round", "line-join": "round"}, "paint": {"line-color": {"stops": [[5, "#cccccc"], [7, "#9C9C9C"]]}, "line-dasharray": [7, 5.3], "line-width": {"base": 1.2, "stops": [[5, 0.7], [14, 1.3]]}}}, {"id": "Water point/Sea or ocean", "type": "symbol", "source": "esri", "source-layer": "Water point", "filter": ["==", "_label_class", 0], "minzoom": 9, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Italic"], "text-size": {"stops": [[9, 8.5], [15, 15.5]]}, "text-anchor": "center", "text-letter-spacing": 0.3, "text-line-height": 1.6, "text-max-width": 4, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15}, "paint": {"text-color": "#888f91", "text-halo-blur": 1, "text-halo-color": "#efefef", "text-halo-width": 1}}, {"id": "Water point/Island", "type": "symbol", "source": "esri", "source-layer": "Water point", "filter": ["==", "_label_class", 7], "minzoom": 9, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Italic"], "text-size": {"stops": [[9, 8.5], [15, 10]]}, "text-anchor": "center", "text-letter-spacing": 0.1, "text-max-width": 4, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15}, "paint": {"text-color": "#808080", "text-halo-blur": 1, "text-halo-color": "#efefef", "text-halo-width": 1}}, {"id": "Water point/Dam or weir", "type": "symbol", "source": "esri", "source-layer": "Water point", "filter": ["==", "_label_class", 5], "minzoom": 9, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Regular"], "text-size": {"stops": [[9, 8.5], [15, 10]]}, "text-anchor": "center", "text-letter-spacing": 0.1, "text-max-width": 4, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 0.7, "text-halo-blur": 1}}, {"id": "Water point/Playa", "type": "symbol", "source": "esri", "source-layer": "Water point", "filter": ["==", "_label_class", 6], "minzoom": 9, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Italic"], "text-size": {"stops": [[9, 8.5], [15, 10]]}, "text-anchor": "center", "text-letter-spacing": 0.1, "text-max-width": 4, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 0.7, "text-halo-blur": 1}}, {"id": "Water point/Canal or ditch", "type": "symbol", "source": "esri", "source-layer": "Water point", "filter": ["==", "_label_class", 4], "minzoom": 9, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Italic"], "text-size": {"stops": [[9, 8.5], [15, 10]]}, "text-anchor": "center", "text-letter-spacing": 0.13, "text-max-width": 4, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15}, "paint": {"text-color": "#888f91", "text-halo-blur": 1, "text-halo-color": "#efefef", "text-halo-width": 1}}, {"id": "Water point/Stream or river", "type": "symbol", "source": "esri", "source-layer": "Water point", "filter": ["==", "_label_class", 3], "minzoom": 9, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Italic"], "text-size": {"stops": [[9, 8.5], [15, 10]]}, "text-anchor": "center", "text-letter-spacing": 0.1, "text-max-width": 4, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15}, "paint": {"text-color": "#888f91", "text-halo-blur": 1, "text-halo-color": "#efefef", "text-halo-width": 0.5}}, {"id": "Water point/Lake or reservoir", "type": "symbol", "source": "esri", "source-layer": "Water point", "filter": ["==", "_label_class", 2], "minzoom": 9, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Italic"], "text-size": {"stops": [[9, 8.5], [15, 10]]}, "text-anchor": "center", "text-letter-spacing": 0.1, "text-max-width": 4, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15}, "paint": {"text-color": "#888f91", "text-halo-blur": 1, "text-halo-color": "#efefef", "text-halo-width": 0.5}}, {"id": "Water point/Bay or inlet", "type": "symbol", "source": "esri", "source-layer": "Water point", "filter": ["==", "_label_class", 1], "minzoom": 9, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Italic"], "text-size": {"stops": [[9, 8.5], [15, 10]]}, "text-anchor": "center", "text-letter-spacing": 0.1, "text-max-width": 4, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15}, "paint": {"text-color": "#888f91", "text-halo-blur": 1, "text-halo-color": "#efefef", "text-halo-width": 1}}, {"id": "Water line/label/Default", "type": "symbol", "source": "esri", "source-layer": "Water line/label", "minzoom": 11, "layout": {"symbol-placement": "line", "symbol-avoid-edges": true, "text-font": ["Ubuntu Italic"], "text-size": 9, "text-letter-spacing": 0.07, "text-max-width": 6, "text-max-angle": 18, "text-field": "{_name_global}", "text-padding": 1, "text-offset": [0, -0.5], "symbol-spacing": 800}, "paint": {"text-color": "#A0A6A8", "text-halo-blur": 1, "text-halo-color": "#efefef", "text-halo-width": 0.5}}, {"id": "Marine park/label/Default", "type": "symbol", "source": "esri", "source-layer": "Marine park/label", "minzoom": 16, "layout": {"text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#888f91"}}, {"id": "Water area/label/Dam or weir", "type": "symbol", "source": "esri", "source-layer": "Water area/label", "filter": ["==", "_label_class", 8], "minzoom": 11, "layout": {"text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.08, "text-max-width": 4, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Water area/label/Playa", "type": "symbol", "source": "esri", "source-layer": "Water area/label", "filter": ["==", "_label_class", 9], "minzoom": 11, "layout": {"text-font": ["Ubuntu Italic"], "text-size": 9.5, "text-letter-spacing": 0.08, "text-max-width": 4, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Water area/label/Canal or ditch", "type": "symbol", "source": "esri", "source-layer": "Water area/label", "filter": ["==", "_label_class", 2], "minzoom": 11, "layout": {"symbol-placement": "line", "symbol-spacing": 1000, "text-font": ["Ubuntu Italic"], "text-size": 9.5, "text-letter-spacing": 0.13, "text-field": "{_name_global}", "text-padding": 15, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-max-width": 5}, "paint": {"text-color": "#888f91", "text-halo-blur": 1, "text-halo-color": "#efefef", "text-halo-width": 0.5}}, {"id": "Water area/label/Small river", "type": "symbol", "source": "esri", "source-layer": "Water area/label", "filter": ["==", "_label_class", 7], "minzoom": 11, "layout": {"symbol-placement": "line", "symbol-spacing": 1000, "text-font": ["Ubuntu Italic"], "text-size": 9.5, "text-letter-spacing": 0.13, "text-field": "{_name_global}", "text-padding": 15, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-max-width": 8}, "paint": {"text-color": "#888f91", "text-halo-blur": 1, "text-halo-color": "#efefef", "text-halo-width": 0.5}}, {"id": "Water area/label/Large river", "type": "symbol", "source": "esri", "source-layer": "Water area/label", "filter": ["==", "_label_class", 4], "minzoom": 11, "layout": {"symbol-placement": "line", "symbol-spacing": 1000, "text-font": ["Ubuntu Italic"], "text-size": 10, "text-letter-spacing": 0.13, "text-field": "{_name_global}", "text-padding": 15, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-max-width": 8}, "paint": {"text-color": "#888f91", "text-halo-blur": 1, "text-halo-color": "#efefef", "text-halo-width": 0.5}}, {"id": "Water area/label/Small lake or reservoir", "type": "symbol", "source": "esri", "source-layer": "Water area/label", "filter": ["==", "_label_class", 6], "minzoom": 11, "layout": {"text-font": ["Ubuntu Italic"], "text-size": 9.5, "text-letter-spacing": 0.13, "text-max-width": 4, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#888f91", "text-halo-blur": 1, "text-halo-color": "#efefef", "text-halo-width": 0.5}}, {"id": "Water area/label/Large lake or reservoir", "type": "symbol", "source": "esri", "source-layer": "Water area/label", "filter": ["==", "_label_class", 3], "minzoom": 11, "layout": {"text-font": ["Ubuntu Italic"], "text-size": 10, "text-letter-spacing": 0.13, "text-line-height": 1.15, "text-max-width": 4, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#888f91", "text-halo-blur": 1, "text-halo-color": "#efefef", "text-halo-width": 0.5}}, {"id": "Water area/label/Bay or inlet", "type": "symbol", "source": "esri", "source-layer": "Water area/label", "filter": ["==", "_label_class", 1], "minzoom": 11, "layout": {"text-font": ["Ubuntu Italic"], "text-size": 11, "text-letter-spacing": 0.13, "text-line-height": 1.15, "text-max-width": 4, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#888f91", "text-halo-blur": 1, "text-halo-color": "#efefef", "text-halo-width": 0.5}}, {"id": "Water area/label/Small island", "type": "symbol", "source": "esri", "source-layer": "Water area/label", "filter": ["==", "_label_class", 0], "minzoom": 11, "layout": {"text-size": 9.5, "text-letter-spacing": 0.1, "text-max-width": 4, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true, "text-font": ["Ubuntu Italic"]}, "paint": {"text-color": "#808080", "text-halo-blur": 1, "text-halo-color": "#efefef", "text-halo-width": 1}}, {"id": "Water area/label/Large island", "type": "symbol", "source": "esri", "source-layer": "Water area/label", "filter": ["==", "_label_class", 5], "minzoom": 11, "layout": {"text-size": 10, "text-letter-spacing": 0.13, "text-max-width": 4, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true, "text-font": ["Ubuntu Italic"]}, "paint": {"text-color": "#808080", "text-halo-blur": 1, "text-halo-color": "#efefef", "text-halo-width": 1}}, {"id": "Water area large scale/label/River", "type": "symbol", "source": "esri", "source-layer": "Water area large scale/label", "filter": ["==", "_label_class", 1], "minzoom": 7, "maxzoom": 11, "layout": {"symbol-placement": "line", "symbol-spacing": 1000, "text-font": ["Ubuntu Italic"], "text-size": 9, "text-letter-spacing": 0.1, "text-field": "{_name}", "text-padding": 15, "symbol-avoid-edges": true, "text-allow-overlap": false, "text-max-width": 4}, "paint": {"text-color": "#888f91", "text-halo-blur": 1, "text-halo-color": "#efefef", "text-halo-width": 0.5}}, {"id": "Water area large scale/label/Lake or lake intermittent", "type": "symbol", "source": "esri", "source-layer": "Water area large scale/label", "filter": ["==", "_label_class", 0], "minzoom": 7, "maxzoom": 11, "layout": {"text-font": ["Ubuntu Italic"], "text-size": 9.5, "text-letter-spacing": 0.1, "text-max-width": 4, "text-field": "{_name}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#888f91", "text-halo-blur": 1, "text-halo-color": "#efefef", "text-halo-width": 0.5}}, {"id": "Water area medium scale/label/Default", "type": "symbol", "source": "esri", "source-layer": "Water area medium scale/label", "minzoom": 5, "maxzoom": 7, "layout": {"text-max-width": 4, "text-field": "{_name}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true, "text-letter-spacing": 0.08, "text-font": ["Ubuntu Italic"], "text-size": 9}, "paint": {"text-color": "#888f91", "text-halo-blur": 1, "text-halo-color": "#efefef", "text-halo-width": 0.5}}, {"id": "Water area small scale/label/Default", "type": "symbol", "source": "esri", "source-layer": "Water area small scale/label", "minzoom": 1, "maxzoom": 5, "layout": {"text-font": ["Ubuntu Italic"], "text-size": 9, "text-letter-spacing": 0.08, "text-max-width": 4, "text-field": "{_name}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#888f91", "text-halo-blur": 1, "text-halo-color": "#efefef", "text-halo-width": 0.5}}, {"id": "Marine area/label/Default", "type": "symbol", "source": "esri", "source-layer": "Marine area/label", "minzoom": 11, "layout": {"text-font": ["Ubuntu Italic"], "text-size": 10, "text-letter-spacing": 0.13, "text-max-width": 4, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#888f91", "text-halo-blur": 1, "text-halo-color": "#efefef", "text-halo-width": 0.5}}, {"id": "Marine waterbody/label/small", "type": "symbol", "source": "esri", "source-layer": "Marine waterbody/label", "filter": ["==", "_label_class", 4], "minzoom": 4, "maxzoom": 10, "layout": {"text-font": ["Ubuntu Italic"], "text-letter-spacing": 0.12, "text-line-height": 1.2, "text-max-width": 4, "text-field": "{_name}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true, "text-size": {"stops": [[1, 9], [6, 11]]}}, "paint": {"text-color": "#888f91", "text-halo-blur": 1, "text-halo-color": "#e0e4e5", "text-halo-width": 0.5}}, {"id": "Marine waterbody/label/medium", "type": "symbol", "source": "esri", "source-layer": "Marine waterbody/label", "filter": ["==", "_label_class", 3], "minzoom": 4, "maxzoom": 10, "layout": {"text-font": ["Ubuntu Italic"], "text-letter-spacing": 0.15, "text-line-height": 1.2, "text-max-width": 4, "text-field": "{_name}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true, "text-size": {"stops": [[1, 9], [6, 11]]}}, "paint": {"text-color": "#888f91", "text-halo-blur": 1, "text-halo-color": "#e0e4e5", "text-halo-width": 0.5}}, {"id": "Marine waterbody/label/large", "type": "symbol", "source": "esri", "source-layer": "Marine waterbody/label", "filter": ["==", "_label_class", 2], "minzoom": 4, "maxzoom": 10, "layout": {"text-font": ["Ubuntu Italic"], "text-letter-spacing": 0.18, "text-line-height": 1.5, "text-max-width": 4, "text-field": "{_name}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true, "text-size": {"stops": [[1, 9], [6, 12]]}}, "paint": {"text-color": "#888f91", "text-halo-blur": 1, "text-halo-color": "#e0e4e5", "text-halo-width": 0.5}}, {"id": "Marine waterbody/label/x large", "type": "symbol", "source": "esri", "source-layer": "Marine waterbody/label", "filter": ["==", "_label_class", 1], "minzoom": 3, "maxzoom": 10, "layout": {"text-font": ["Ubuntu Italic"], "text-letter-spacing": 0.2, "text-line-height": 1.5, "text-max-width": 4, "text-field": "{_name}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true, "text-size": {"stops": [[1, 10], [6, 13]]}}, "paint": {"text-color": "#888f91", "text-halo-blur": 1, "text-halo-color": "#e0e4e5", "text-halo-width": 0.5}}, {"id": "Marine waterbody/label/2x large", "type": "symbol", "source": "esri", "source-layer": "Marine waterbody/label", "filter": ["==", "_label_class", 0], "minzoom": 2, "maxzoom": 10, "layout": {"text-font": ["Ubuntu Italic"], "text-letter-spacing": 0.3, "text-line-height": 1.6, "text-max-width": 4, "text-field": "{_name}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true, "text-size": {"stops": [[1, 11], [4, 14]]}}, "paint": {"text-color": "#888f91", "text-halo-blur": 1, "text-halo-color": "#e0e4e5", "text-halo-width": 0.5}}, {"id": "Ferry/label/Rail ferry", "type": "symbol", "source": "esri", "source-layer": "Ferry/label", "filter": ["all", ["==", "_label_class", 1], ["!in", "Viz", 3]], "minzoom": 16, "layout": {"symbol-placement": "line", "symbol-avoid-edges": true, "text-font": ["Ubuntu Regular"], "text-size": 8.5, "text-letter-spacing": 0.1, "text-max-width": 6, "text-field": "{_name_global}", "text-padding": 5, "text-offset": [0, -0.6], "symbol-spacing": 1000}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 1}}, {"id": "Railroad/label/Default", "type": "symbol", "source": "esri", "source-layer": "Railroad/label", "minzoom": 16, "layout": {"symbol-placement": "line", "symbol-avoid-edges": true, "text-font": ["Ubuntu Regular"], "text-size": 8.5, "text-letter-spacing": 0.1, "text-max-width": 6, "text-field": "{_name_global}", "text-padding": 5, "text-offset": [0, -0.6], "symbol-spacing": 1000}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 1}}, {"id": "Road tunnel/label/Pedestrian", "type": "symbol", "source": "esri", "source-layer": "Road tunnel/label", "filter": ["all", ["==", "_label_class", 6], ["!in", "Viz", 3]], "minzoom": 15, "layout": {"symbol-placement": "line", "symbol-avoid-edges": true, "symbol-spacing": 400, "text-font": ["Ubuntu Regular"], "text-size": 9.3, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-padding": 5}, "paint": {"text-color": "#666666", "text-halo-color": "#ffffff", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Road tunnel/label/Local, service, 4WD", "type": "symbol", "source": "esri", "source-layer": "Road tunnel/label", "filter": ["all", ["==", "_label_class", 5], ["!in", "Viz", 3]], "minzoom": 15, "layout": {"symbol-placement": "line", "symbol-avoid-edges": true, "symbol-spacing": 400, "text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.09, "text-max-width": 6, "text-field": "{_name_global}", "text-padding": 5}, "paint": {"text-color": "#666666", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Road tunnel/label/Minor", "type": "symbol", "source": "esri", "source-layer": "Road tunnel/label", "filter": ["all", ["==", "_label_class", 4], ["!in", "Viz", 3]], "minzoom": 14, "layout": {"symbol-placement": "line", "symbol-avoid-edges": true, "symbol-spacing": 400, "text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.09, "text-max-width": 6, "text-field": "{_name_global}", "text-padding": 5}, "paint": {"text-color": "#666666", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Road tunnel/label/Major, alt name", "type": "symbol", "source": "esri", "source-layer": "Road tunnel/label", "filter": ["all", ["==", "_label_class", 3], ["!in", "Viz", 3]], "minzoom": 14, "layout": {"symbol-placement": "line", "symbol-avoid-edges": true, "symbol-spacing": 400, "text-font": ["Ubuntu Regular"], "text-size": 10.5, "text-letter-spacing": 0.09, "text-max-width": 6, "text-field": "{_name}", "text-padding": 5}, "paint": {"text-color": "#666666", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Road tunnel/label/Major", "type": "symbol", "source": "esri", "source-layer": "Road tunnel/label", "filter": ["all", ["==", "_label_class", 2], ["!in", "Viz", 3]], "minzoom": 14, "layout": {"symbol-placement": "line", "symbol-avoid-edges": true, "symbol-spacing": 400, "text-font": ["Ubuntu Regular"], "text-size": 10.5, "text-letter-spacing": 0.09, "text-max-width": 6, "text-field": "{_name}", "text-padding": 5}, "paint": {"text-color": "#666666", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Road tunnel/label/Highway", "type": "symbol", "source": "esri", "source-layer": "Road tunnel/label", "filter": ["all", ["==", "_label_class", 7], ["!in", "Viz", 3]], "minzoom": 13, "layout": {"symbol-placement": "line", "symbol-avoid-edges": true, "symbol-spacing": 400, "text-font": ["Ubuntu Regular"], "text-size": 10.5, "text-letter-spacing": 0.09, "text-max-width": 6, "text-field": "{_name_global}", "text-padding": 5}, "paint": {"text-color": "#666666", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Road tunnel/label/Freeway Motorway, alt name", "type": "symbol", "source": "esri", "source-layer": "Road tunnel/label", "filter": ["all", ["==", "_label_class", 1], ["!in", "Viz", 3]], "minzoom": 13, "layout": {"symbol-placement": "line", "symbol-avoid-edges": true, "symbol-spacing": 400, "text-font": ["Ubuntu Regular"], "text-size": 10.5, "text-letter-spacing": 0.09, "text-max-width": 6, "text-field": "{_name_global}", "text-padding": 5}, "paint": {"text-color": "#666666", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Road tunnel/label/Freeway Motorway", "type": "symbol", "source": "esri", "source-layer": "Road tunnel/label", "filter": ["all", ["==", "_label_class", 0], ["!in", "Viz", 3]], "minzoom": 13, "layout": {"symbol-placement": "line", "symbol-avoid-edges": true, "symbol-spacing": 400, "text-font": ["Ubuntu Regular"], "text-size": 10.5, "text-letter-spacing": 0.09, "text-max-width": 6, "text-field": "{_name_global}", "text-padding": 5}, "paint": {"text-color": "#666666", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Building/label/Default", "type": "symbol", "source": "esri", "source-layer": "Building/label", "minzoom": 17, "layout": {"text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.08, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 0.7, "text-halo-blur": 1}}, {"id": "Trail or path/label/Default", "type": "symbol", "source": "esri", "source-layer": "Trail or path/label", "minzoom": 15, "layout": {"symbol-placement": "line", "symbol-avoid-edges": true, "symbol-spacing": 400, "text-font": ["Ubuntu Regular"], "text-size": 9.3, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-padding": 5}, "paint": {"text-color": "#666666", "text-halo-color": "#ffffff", "text-halo-width": 1}}, {"id": "Road/label/Pedestrian", "type": "symbol", "source": "esri", "source-layer": "Road/label", "filter": ["all", ["==", "_label_class", 6], ["!in", "Viz", 3]], "minzoom": 15, "layout": {"symbol-placement": "line", "symbol-avoid-edges": true, "symbol-spacing": 400, "text-font": ["Ubuntu Regular"], "text-size": 9.3, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-padding": 5}, "paint": {"text-color": "#666666", "text-halo-color": "#ffffff", "text-halo-width": 1}}, {"id": "Road/label/Local", "type": "symbol", "source": "esri", "source-layer": "Road/label", "filter": ["all", ["==", "_label_class", 5], ["!in", "Viz", 3]], "minzoom": 15, "layout": {"symbol-placement": "line", "symbol-avoid-edges": true, "symbol-spacing": 400, "text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.09, "text-max-width": 6, "text-field": "{_name_global}", "text-padding": 5}, "paint": {"text-color": "#666666", "text-halo-color": "#ffffff", "text-halo-width": 1}}, {"id": "Road/label/Minor", "type": "symbol", "source": "esri", "source-layer": "Road/label", "filter": ["all", ["==", "_label_class", 4], ["!in", "Viz", 3]], "minzoom": 14, "layout": {"symbol-placement": "line", "symbol-avoid-edges": true, "symbol-spacing": 400, "text-font": ["Ubuntu Regular"], "text-size": 10, "text-letter-spacing": 0.09, "text-max-width": 6, "text-field": "{_name_global}", "text-padding": 2}, "paint": {"text-color": "#666666", "text-halo-color": "#ffffff", "text-halo-width": 1}}, {"id": "Road/label/Major, alt name", "type": "symbol", "source": "esri", "source-layer": "Road/label", "filter": ["all", ["==", "_label_class", 3], ["!in", "Viz", 3]], "minzoom": 14, "layout": {"symbol-placement": "line", "symbol-avoid-edges": true, "symbol-spacing": 400, "text-font": ["Ubuntu Regular"], "text-size": 10.5, "text-letter-spacing": 0.09, "text-max-width": 6, "text-field": "{_name}", "text-padding": 2}, "paint": {"text-color": "#666666", "text-halo-color": "#ffffff", "text-halo-width": 1}}, {"id": "Road/label/Major", "type": "symbol", "source": "esri", "source-layer": "Road/label", "filter": ["all", ["==", "_label_class", 2], ["!in", "Viz", 3]], "minzoom": 14, "layout": {"symbol-placement": "line", "symbol-avoid-edges": true, "symbol-spacing": 400, "text-font": ["Ubuntu Regular"], "text-size": 10.5, "text-letter-spacing": 0.09, "text-max-width": 6, "text-field": "{_name_global}", "text-padding": 2}, "paint": {"text-color": "#666666", "text-halo-color": "#ffffff", "text-halo-width": 1}}, {"id": "Road/label/Highway", "type": "symbol", "source": "esri", "source-layer": "Road/label", "filter": ["all", ["==", "_label_class", 75], ["!in", "Viz", 3]], "minzoom": 13, "layout": {"symbol-placement": "line", "symbol-avoid-edges": true, "symbol-spacing": 400, "text-font": ["Ubuntu Regular"], "text-size": 10.5, "text-letter-spacing": 0.09, "text-max-width": 6, "text-field": "{_name_global}", "text-padding": 10}, "paint": {"text-color": "#666666", "text-halo-color": "#ffffff", "text-halo-width": 1}}, {"id": "Road/label/Freeway Motorway, alt name", "type": "symbol", "source": "esri", "source-layer": "Road/label", "filter": ["all", ["==", "_label_class", 1], ["!in", "Viz", 3]], "minzoom": 13, "layout": {"symbol-placement": "line", "symbol-avoid-edges": true, "symbol-spacing": 400, "text-font": ["Ubuntu Regular"], "text-size": 10.5, "text-letter-spacing": 0.09, "text-max-width": 6, "text-field": "{_name}", "text-padding": 2}, "paint": {"text-color": "#666666", "text-halo-color": "#ffffff", "text-halo-width": 1}}, {"id": "Road/label/Freeway Motorway", "type": "symbol", "source": "esri", "source-layer": "Road/label", "filter": ["all", ["==", "_label_class", 0], ["!in", "Viz", 3]], "minzoom": 13, "layout": {"symbol-placement": "line", "symbol-avoid-edges": true, "symbol-spacing": 400, "text-font": ["Ubuntu Regular"], "text-size": 10.5, "text-letter-spacing": 0.09, "text-max-width": 6, "text-field": "{_name_global}", "text-padding": 2}, "paint": {"text-color": "#666666", "text-halo-color": "#ffffff", "text-halo-width": 1}}, {"id": "Road/label/Rectangle white black (Alt)", "type": "symbol", "source": "esri", "source-layer": "Road/label", "filter": ["all", ["in", "_label_class", 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62, 64, 66, 68, 70, 72, 74], ["!in", "Viz", 3]], "minzoom": 14, "layout": {"symbol-placement": "line", "symbol-spacing": 800, "text-max-angle": 25, "symbol-avoid-edges": true, "text-font": ["Ubuntu Regular"], "text-size": 8.5, "text-max-width": 6, "text-field": "{_name}", "icon-image": "Road/Rectangle white black (Alt)/{_len}", "icon-rotation-alignment": "viewport", "text-rotation-alignment": "viewport", "text-offset": [0, 0.2], "text-padding": 30}, "paint": {"text-color": "#666666"}}, {"id": "Road/label/Rectangle white black", "type": "symbol", "source": "esri", "source-layer": "Road/label", "filter": ["all", ["in", "_label_class", 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 33, 35, 37, 39, 41, 43, 45, 47, 49, 51, 53, 55, 57, 59, 61, 63, 65, 67, 69, 71, 73], ["!in", "Viz", 3]], "minzoom": 14, "layout": {"symbol-placement": "line", "symbol-spacing": 800, "text-max-angle": 25, "symbol-avoid-edges": true, "text-font": ["Ubuntu Regular"], "text-size": 8.5, "text-max-width": 6, "text-field": "{_name}", "icon-image": "Road/Rectangle white black/{_len}", "icon-rotation-alignment": "viewport", "text-rotation-alignment": "viewport", "text-offset": [0, 0.2], "text-padding": 30}, "paint": {"text-color": "#666666"}}, {"id": "Cemetery/label/Default", "type": "symbol", "source": "esri", "source-layer": "Cemetery/label", "minzoom": 16, "layout": {"text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#939d8c", "text-halo-color": "#EBEDEB", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Freight/label/Default", "type": "symbol", "source": "esri", "source-layer": "Freight/label", "minzoom": 17, "layout": {"text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Water and wastewater/label/Default", "type": "symbol", "source": "esri", "source-layer": "Water and wastewater/label", "minzoom": 17, "layout": {"text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Port/label/Default", "type": "symbol", "source": "esri", "source-layer": "Port/label", "minzoom": 17, "layout": {"text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Industry/label/Default", "type": "symbol", "source": "esri", "source-layer": "Industry/label", "minzoom": 17, "layout": {"text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Government/label/Default", "type": "symbol", "source": "esri", "source-layer": "Government/label", "minzoom": 17, "layout": {"symbol-avoid-edges": false, "text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Finance/label/Default", "type": "symbol", "source": "esri", "source-layer": "Finance/label", "minzoom": 17, "layout": {"text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Emergency/label/Default", "type": "symbol", "source": "esri", "source-layer": "Emergency/label", "minzoom": 17, "layout": {"text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Indigenous/label/Default", "type": "symbol", "source": "esri", "source-layer": "Indigenous/label", "minzoom": 17, "layout": {"text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Military/label/Default", "type": "symbol", "source": "esri", "source-layer": "Military/label", "minzoom": 17, "layout": {"text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 25, "symbol-avoid-edges": true}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Transportation/label/Default", "type": "symbol", "source": "esri", "source-layer": "Transportation/label", "minzoom": 17, "layout": {"text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Pedestrian/label/Default", "type": "symbol", "source": "esri", "source-layer": "Pedestrian/label", "minzoom": 17, "layout": {"symbol-avoid-edges": false, "text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Beach/label/Default", "type": "symbol", "source": "esri", "source-layer": "Beach/label", "minzoom": 17, "layout": {"text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.08, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Golf course/label/Default", "type": "symbol", "source": "esri", "source-layer": "Golf course/label", "minzoom": 17, "layout": {"text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#939d8c", "text-halo-color": "#EBEDEB", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Zoo/label/Default", "type": "symbol", "source": "esri", "source-layer": "Zoo/label", "minzoom": 15, "layout": {"text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#939d8c", "text-halo-color": "#EBEDEB", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Retail/label/Default", "type": "symbol", "source": "esri", "source-layer": "Retail/label", "minzoom": 17, "layout": {"text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Landmark/label/Default", "type": "symbol", "source": "esri", "source-layer": "Landmark/label", "minzoom": 17, "layout": {"text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Openspace or forest/label/Default", "type": "symbol", "source": "esri", "source-layer": "Openspace or forest/label", "minzoom": 14, "layout": {"symbol-avoid-edges": false, "text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 25}, "paint": {"text-color": "#939d8c", "text-halo-color": "#EBEDEB", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Park or farming/label/Default", "type": "symbol", "source": "esri", "source-layer": "Park or farming/label", "minzoom": 14, "layout": {"symbol-avoid-edges": false, "text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 25}, "paint": {"text-color": "#939d8c", "text-halo-color": "#EBEDEB", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Point of interest/Park", "type": "symbol", "source": "esri", "source-layer": "Point of interest", "filter": ["==", "_label_class", 1], "minzoom": 14, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-anchor": "center", "text-letter-spacing": 0.08, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15}, "paint": {"text-color": "#939d8c", "text-halo-width": 1, "text-halo-color": "#EBEDEB", "text-halo-blur": 1}}, {"id": "Education/label/Default", "type": "symbol", "source": "esri", "source-layer": "Education/label", "minzoom": 17, "layout": {"text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Medical/label/Default", "type": "symbol", "source": "esri", "source-layer": "Medical/label", "minzoom": 17, "layout": {"text-font": ["Ubuntu Regular"], "text-size": 9.5, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Admin1 forest or park/label/Default", "type": "symbol", "source": "esri", "source-layer": "Admin1 forest or park/label", "minzoom": 9, "layout": {"symbol-avoid-edges": false, "text-font": ["Ubuntu Regular"], "text-size": {"stops": [[9, 8.5], [12, 9.5]]}, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 25}, "paint": {"text-color": "#939d8c", "text-halo-color": "#EBEDEB", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Admin0 forest or park/label/Default", "type": "symbol", "source": "esri", "source-layer": "Admin0 forest or park/label", "minzoom": 9, "layout": {"text-font": ["Ubuntu Regular"], "text-size": {"stops": [[9, 8.5], [12, 9.5]]}, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 25, "symbol-avoid-edges": true}, "paint": {"text-color": "#939d8c", "text-halo-color": "#EBEDEB", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Airport/label/Airport property", "type": "symbol", "source": "esri", "source-layer": "Airport/label", "minzoom": 9, "layout": {"text-font": ["Ubuntu Regular"], "text-size": {"stops": [[9, 8.5], [12, 9.5]]}, "text-letter-spacing": 0.05, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15, "symbol-avoid-edges": true}, "paint": {"text-color": "#808080", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Admin2 area/label/small", "type": "symbol", "source": "esri", "source-layer": "Admin2 area/label", "filter": ["==", "_label_class", 1], "minzoom": 9, "maxzoom": 11, "layout": {"text-letter-spacing": 0.2, "text-font": ["Ubuntu Regular"], "text-size": 9, "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-padding": 1, "symbol-avoid-edges": true, "text-transform": "uppercase"}, "paint": {"text-color": "#b1b2ad", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Admin2 area/label/large", "type": "symbol", "source": "esri", "source-layer": "Admin2 area/label", "filter": ["==", "_label_class", 0], "minzoom": 9, "maxzoom": 11, "layout": {"text-letter-spacing": 0.2, "text-font": ["Ubuntu Regular"], "text-size": 10, "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-padding": 1, "symbol-avoid-edges": true, "text-transform": "uppercase"}, "paint": {"text-color": "#b1b2ad", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Admin1 area/label/x small", "type": "symbol", "source": "esri", "source-layer": "Admin1 area/label", "filter": ["==", "_label_class", 5], "minzoom": 5, "maxzoom": 10, "layout": {"text-font": ["Ubuntu Regular"], "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-padding": 1, "symbol-avoid-edges": true, "text-transform": "uppercase", "text-size": {"stops": [[4, 9], [5, 9], [6, 9.5], [9, 10]]}, "text-letter-spacing": {"stops": [[4, 0.1], [8, 0.18]]}}, "paint": {"text-color": "#b4b4b4", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Admin1 area/label/small", "type": "symbol", "source": "esri", "source-layer": "Admin1 area/label", "filter": ["==", "_label_class", 4], "minzoom": 5, "maxzoom": 10, "layout": {"text-font": ["Ubuntu Regular"], "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-padding": 1, "symbol-avoid-edges": true, "text-transform": "uppercase", "text-size": {"stops": [[4, 9], [5, 9], [6, 9.5], [9, 11.5]]}, "text-letter-spacing": {"stops": [[4, 0.1], [8, 0.18]]}}, "paint": {"text-color": "#b4b4b4", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Admin1 area/label/medium", "type": "symbol", "source": "esri", "source-layer": "Admin1 area/label", "filter": ["==", "_label_class", 3], "minzoom": 5, "maxzoom": 10, "layout": {"text-font": ["Ubuntu Regular"], "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-padding": 1, "symbol-avoid-edges": true, "text-transform": "uppercase", "text-size": {"stops": [[4, 10], [5, 10], [6, 10.5], [9, 12]]}, "text-letter-spacing": {"stops": [[4, 0.1], [8, 0.18]]}}, "paint": {"text-color": "#b4b4b4", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Admin1 area/label/large", "type": "symbol", "source": "esri", "source-layer": "Admin1 area/label", "filter": ["==", "_label_class", 2], "minzoom": 5, "maxzoom": 10, "layout": {"text-font": ["Ubuntu Regular"], "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-padding": 1, "symbol-avoid-edges": true, "text-transform": "uppercase", "text-size": {"stops": [[4, 10], [5, 10.5], [6, 11], [9, 15]]}, "text-letter-spacing": {"stops": [[4, 0.1], [8, 0.2]]}}, "paint": {"text-color": "#b4b4b4", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Admin1 area/label/x large", "type": "symbol", "source": "esri", "source-layer": "Admin1 area/label", "filter": ["==", "_label_class", 1], "minzoom": 5, "maxzoom": 10, "layout": {"text-font": ["Ubuntu Regular"], "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-padding": 1, "symbol-avoid-edges": true, "text-transform": "uppercase", "text-size": {"stops": [[4, 10.5], [5, 11], [6, 11.5], [9, 17]]}, "text-letter-spacing": {"stops": [[4, 0.13], [8, 0.3]]}}, "paint": {"text-color": "#b4b4b4", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Admin1 area/label/2x large", "type": "symbol", "source": "esri", "source-layer": "Admin1 area/label", "filter": ["==", "_label_class", 0], "minzoom": 5, "maxzoom": 10, "layout": {"text-font": ["Ubuntu Regular"], "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-padding": 1, "symbol-avoid-edges": true, "text-transform": "uppercase", "text-size": {"stops": [[4, 11], [5, 11.5], [6, 12], [9, 17.5]]}, "text-letter-spacing": {"stops": [[4, 0.13], [8, 0.4]]}}, "paint": {"text-color": "#b4b4b4", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Point of interest/General", "type": "symbol", "source": "esri", "source-layer": "Point of interest", "filter": ["==", "_label_class", 0], "minzoom": 17, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Regular"], "text-size": 9, "text-anchor": "center", "text-letter-spacing": 0.08, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15}, "paint": {"text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#efefef", "text-halo-blur": 1}}, {"id": "Point of interest/Bus station", "type": "symbol", "source": "esri", "source-layer": "Point of interest", "filter": ["==", "_symbol", 2], "minzoom": 17, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Regular"], "text-size": 9, "text-letter-spacing": 0.04, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 5, "text-offset": [0, -0.9]}, "paint": {"text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#efefef", "text-halo-blur": 1}}, {"id": "Point of interest/Rail station", "type": "symbol", "source": "esri", "source-layer": "Point of interest", "filter": ["==", "_symbol", 3], "minzoom": 17, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Regular"], "text-size": 9, "text-letter-spacing": 0.04, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 5, "text-offset": [0, -0.9]}, "paint": {"text-color": "#808080", "text-halo-width": 1, "text-halo-color": "#efefef", "text-halo-blur": 1}}, {"id": "Neighborhood", "type": "symbol", "source": "esri", "source-layer": "Neighborhood", "minzoom": 15, "maxzoom": 17, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Light Regular"], "text-size": {"stops": [[10, 10], [16, 13]]}, "text-letter-spacing": 0.08, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 1}, "paint": {"text-color": "#353635", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City large scale/town small", "type": "symbol", "source": "esri", "source-layer": "City large scale", "filter": ["==", "_label_class", 5], "minzoom": 10, "maxzoom": 17, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Light Regular"], "text-size": {"stops": [[10, 10], [16, 13]]}, "text-letter-spacing": 0.08, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 15}, "paint": {"text-color": "#353635", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City large scale/town large", "type": "symbol", "source": "esri", "source-layer": "City large scale", "filter": ["==", "_label_class", 4], "minzoom": 10, "maxzoom": 17, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Light Regular"], "text-size": {"stops": [[10, 10], [16, 15]]}, "text-letter-spacing": 0.09, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 1}, "paint": {"text-halo-color": "#efefef", "text-color": "#353635", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City large scale/small", "type": "symbol", "source": "esri", "source-layer": "City large scale", "filter": ["==", "_label_class", 3], "minzoom": 10, "maxzoom": 17, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Light Regular"], "text-letter-spacing": 0.1, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 1, "text-size": {"stops": [[10, 11], [16, 16]]}}, "paint": {"text-halo-color": "#efefef", "text-color": "#353635", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City large scale/medium", "type": "symbol", "source": "esri", "source-layer": "City large scale", "filter": ["==", "_label_class", 2], "minzoom": 10, "maxzoom": 17, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Regular"], "text-letter-spacing": 0.1, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 1, "text-size": {"stops": [[10, 11], [16, 18.5]]}}, "paint": {"text-halo-color": "#efefef", "text-color": "#353635", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City large scale/large", "type": "symbol", "source": "esri", "source-layer": "City large scale", "filter": ["==", "_label_class", 1], "minzoom": 10, "maxzoom": 17, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Regular"], "text-letter-spacing": 0.1, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 1, "text-size": {"stops": [[10, 14], [16, 22]]}}, "paint": {"text-color": "#353635", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City large scale/x large", "type": "symbol", "source": "esri", "source-layer": "City large scale", "filter": ["==", "_label_class", 0], "minzoom": 10, "maxzoom": 17, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Regular"], "text-letter-spacing": 0.1, "text-max-width": 6, "text-field": "{_name_global}", "text-allow-overlap": false, "text-padding": 1, "text-size": {"stops": [[10, 15], [16, 25]]}}, "paint": {"text-color": "#353635", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City small scale/town small non capital", "type": "symbol", "source": "esri", "source-layer": "City small scale", "filter": ["==", "_symbol", 17], "minzoom": 2, "maxzoom": 10, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Light Regular"], "text-size": 10, "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-letter-spacing": 0.05, "text-padding": 1}, "paint": {"text-color": "#353635", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City small scale/town large non capital", "type": "symbol", "source": "esri", "source-layer": "City small scale", "filter": ["==", "_symbol", 15], "minzoom": 2, "maxzoom": 10, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Light Regular"], "text-size": 10, "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-letter-spacing": 0.05, "text-padding": 1}, "paint": {"text-color": "#353635", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City small scale/small non capital", "type": "symbol", "source": "esri", "source-layer": "City small scale", "filter": ["==", "_symbol", 12], "minzoom": 2, "maxzoom": 10, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Light Regular"], "text-size": 10, "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-letter-spacing": 0.05, "text-padding": 1}, "paint": {"text-color": "#353635", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City small scale/medium non capital", "type": "symbol", "source": "esri", "source-layer": "City small scale", "filter": ["==", "_symbol", 9], "minzoom": 2, "maxzoom": 10, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Light Regular"], "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-padding": 1, "text-letter-spacing": 0.05, "text-size": 10}, "paint": {"text-color": "#353635", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City small scale/other capital", "type": "symbol", "source": "esri", "source-layer": "City small scale", "filter": ["==", "_symbol", 18], "minzoom": 2, "maxzoom": 10, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Light Regular"], "text-size": 10, "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-letter-spacing": 0.05, "text-padding": 1}, "paint": {"text-color": "#353635", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City small scale/town large other capital", "type": "symbol", "source": "esri", "source-layer": "City small scale", "filter": ["==", "_symbol", 14], "minzoom": 2, "maxzoom": 10, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Light Regular"], "text-size": 10, "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-letter-spacing": 0.05, "text-padding": 1}, "paint": {"text-color": "#353635", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City small scale/small other capital", "type": "symbol", "source": "esri", "source-layer": "City small scale", "filter": ["==", "_symbol", 11], "minzoom": 2, "maxzoom": 10, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Light Regular"], "text-size": 10, "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-letter-spacing": 0.05, "text-padding": 1}, "paint": {"text-color": "#353635", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City small scale/medium other capital", "type": "symbol", "source": "esri", "source-layer": "City small scale", "filter": ["==", "_symbol", 8], "minzoom": 2, "maxzoom": 10, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Light Regular"], "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-letter-spacing": 0.05, "text-padding": 1, "text-size": 10}, "paint": {"text-color": "#353635", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Admin0 point/x small", "type": "symbol", "source": "esri", "source-layer": "Admin0 point", "filter": ["==", "_label_class", 5], "minzoom": 5, "maxzoom": 10, "layout": {"text-font": ["Ubuntu Bold"], "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-padding": 1, "symbol-avoid-edges": true, "text-letter-spacing": {"stops": [[5, 0.13], [8, 0.5]]}, "text-size": {"stops": [[5, 10], [10, 12.5]]}, "text-transform": "uppercase"}, "paint": {"text-color": "#aaafac", "text-halo-color": "#F7F7F7", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Admin0 point/small", "type": "symbol", "source": "esri", "source-layer": "Admin0 point", "filter": ["==", "_label_class", 4], "minzoom": 4, "maxzoom": 10, "layout": {"text-font": ["Ubuntu Bold"], "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-padding": 1, "symbol-avoid-edges": true, "text-letter-spacing": {"stops": [[4, 0.13], [8, 0.5]]}, "text-size": {"stops": [[4, 10], [10, 12.5]]}, "text-transform": "uppercase"}, "paint": {"text-color": "#aaafac", "text-halo-color": "#F7F7F7", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Admin0 point/medium", "type": "symbol", "source": "esri", "source-layer": "Admin0 point", "filter": ["==", "_label_class", 3], "minzoom": 2, "maxzoom": 10, "layout": {"text-font": ["Ubuntu Bold"], "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-padding": 1, "symbol-avoid-edges": true, "text-letter-spacing": {"stops": [[2, 0.13], [8, 0.5]]}, "text-size": {"stops": [[2, 8], [4, 10], [10, 16]]}, "text-transform": "uppercase"}, "paint": {"text-color": "#aaafac", "text-halo-color": "#F7F7F7", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Admin0 point/large", "type": "symbol", "source": "esri", "source-layer": "Admin0 point", "filter": ["==", "_label_class", 2], "minzoom": 2, "maxzoom": 10, "layout": {"text-font": ["Ubuntu Bold"], "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-padding": 1, "symbol-avoid-edges": true, "text-letter-spacing": {"stops": [[2, 0.13], [8, 0.5]]}, "text-size": {"stops": [[2, 9], [4, 10], [6, 16]]}, "text-transform": "uppercase"}, "paint": {"text-color": "#aaafac", "text-halo-color": "#F7F7F7", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Admin0 point/x large", "type": "symbol", "source": "esri", "source-layer": "Admin0 point", "filter": ["==", "_label_class", 1], "minzoom": 2, "maxzoom": 8, "layout": {"text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-padding": 1, "symbol-avoid-edges": true, "text-font": ["Ubuntu Bold"], "text-line-height": 1.5, "text-letter-spacing": {"stops": [[2, 0.15], [6, 0.5]]}, "text-size": {"stops": [[2, 9], [4, 10], [6, 16]]}, "text-transform": "uppercase"}, "paint": {"text-color": "#aaafac", "text-halo-color": "#F7F7F7", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City small scale/town small admin0 capital", "type": "symbol", "source": "esri", "source-layer": "City small scale", "filter": ["==", "_symbol", 16], "minzoom": 2, "maxzoom": 10, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Regular"], "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-letter-spacing": 0.05, "text-padding": 1, "text-size": {"stops": [[3, 10], [6, 10.5], [8, 13]]}}, "paint": {"text-color": "#353635", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City small scale/town large admin0 capital", "type": "symbol", "source": "esri", "source-layer": "City small scale", "filter": ["==", "_symbol", 13], "minzoom": 2, "maxzoom": 10, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Regular"], "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-letter-spacing": 0.05, "text-padding": 1, "text-size": {"stops": [[3, 10], [6, 10.5], [8, 13]]}}, "paint": {"text-color": "#353635", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City small scale/small admin0 capital", "type": "symbol", "source": "esri", "source-layer": "City small scale", "filter": ["==", "_symbol", 10], "minzoom": 2, "maxzoom": 10, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Regular"], "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-letter-spacing": 0.05, "text-padding": 1, "text-size": {"stops": [[3, 10], [6, 10.5], [8, 13]]}}, "paint": {"text-color": "#353635", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City small scale/medium admin0 capital", "type": "symbol", "source": "esri", "source-layer": "City small scale", "filter": ["==", "_symbol", 7], "minzoom": 2, "maxzoom": 10, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Regular"], "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-letter-spacing": 0.05, "text-padding": 1, "text-size": {"stops": [[3, 10], [6, 10.5], [8, 13]]}}, "paint": {"text-color": "#353635", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City small scale/large other capital", "type": "symbol", "source": "esri", "source-layer": "City small scale", "filter": ["==", "_symbol", 5], "minzoom": 2, "maxzoom": 10, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Regular"], "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-letter-spacing": 0.05, "text-padding": 1, "text-size": {"stops": [[3, 10], [6, 11], [8, 14]]}}, "paint": {"text-color": "#353635", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City small scale/x large admin2 capital", "type": "symbol", "source": "esri", "source-layer": "City small scale", "filter": ["==", "_symbol", 2], "minzoom": 2, "maxzoom": 10, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Regular"], "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-letter-spacing": 0.05, "text-padding": 1, "text-size": {"stops": [[3, 11], [6, 12], [8, 15]]}}, "paint": {"text-color": "#353635", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City small scale/large non capital", "type": "symbol", "source": "esri", "source-layer": "City small scale", "filter": ["==", "_symbol", 6], "minzoom": 2, "maxzoom": 10, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Regular"], "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-letter-spacing": 0.05, "text-padding": 1, "text-size": {"stops": [[3, 10], [6, 11], [8, 14]]}}, "paint": {"text-color": "#353635", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City small scale/large admin0 capital", "type": "symbol", "source": "esri", "source-layer": "City small scale", "filter": ["==", "_symbol", 4], "minzoom": 2, "maxzoom": 10, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Regular"], "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-letter-spacing": 0.05, "text-padding": 1, "text-size": {"stops": [[3, 10], [6, 11], [8, 14]]}}, "paint": {"text-color": "#353635", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City small scale/x large non capital", "type": "symbol", "source": "esri", "source-layer": "City small scale", "filter": ["==", "_symbol", 3], "minzoom": 2, "maxzoom": 10, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Regular"], "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-letter-spacing": 0.05, "text-padding": 1, "text-size": {"stops": [[3, 11], [6, 12], [8, 15]]}}, "paint": {"text-color": "#353635", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City small scale/x large admin1 capital", "type": "symbol", "source": "esri", "source-layer": "City small scale", "filter": ["==", "_symbol", 1], "minzoom": 2, "maxzoom": 10, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Regular"], "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-letter-spacing": 0.05, "text-padding": 1, "text-size": {"stops": [[3, 11], [6, 12], [8, 15]]}}, "paint": {"text-color": "#353635", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "City small scale/x large admin0 capital", "type": "symbol", "source": "esri", "source-layer": "City small scale", "filter": ["==", "_symbol", 0], "minzoom": 2, "maxzoom": 10, "layout": {"symbol-avoid-edges": true, "text-font": ["Ubuntu Regular"], "text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-letter-spacing": 0.05, "text-padding": 1, "text-size": {"stops": [[3, 11], [6, 12], [8, 15]]}}, "paint": {"text-color": "#353635", "text-halo-color": "#efefef", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Admin0 point/2x large", "type": "symbol", "source": "esri", "source-layer": "Admin0 point", "filter": ["==", "_label_class", 0], "minzoom": 2, "maxzoom": 6, "layout": {"text-max-width": 6, "text-field": "{_name}", "text-allow-overlap": false, "text-padding": 1, "symbol-avoid-edges": true, "text-font": ["Ubuntu Bold"], "text-line-height": 1.7, "text-letter-spacing": {"stops": [[2, 0.3], [5, 0.5]]}, "text-size": {"stops": [[2, 12], [4, 15.5], [5, 18]]}, "text-transform": "uppercase"}, "paint": {"text-color": "#aaafac", "text-halo-color": "#F7F7F7", "text-halo-width": 1, "text-halo-blur": 1}}, {"id": "Disputed label point/Island", "type": "symbol", "source": "esri", "source-layer": "Disputed label point", "filter": ["all", ["==", "_label_class", 1], ["in", "DisputeID", 0]], "minzoom": 6, "layout": {"icon-image": "Disputed label point", "icon-allow-overlap": true, "text-font": ["Ubuntu Italic"], "text-size": {"stops": [[6, 7], [15, 10]]}, "text-anchor": "center", "text-letter-spacing": 0.13, "text-max-width": 4, "text-field": "{_name}", "text-optional": true}, "paint": {"text-color": "#808080", "text-halo-blur": 1, "text-halo-color": "#efefef", "text-halo-width": 1}}, {"id": "Disputed label point/Waterbody", "type": "symbol", "source": "esri", "source-layer": "Disputed label point", "filter": ["all", ["==", "_label_class", 0], ["in", "DisputeID", 1006]], "minzoom": 2, "maxzoom": 10, "layout": {"icon-image": "Disputed label point", "icon-allow-overlap": true, "text-font": ["Ubuntu Italic"], "text-size": {"stops": [[2, 8], [6, 9.3]]}, "text-anchor": "center", "text-letter-spacing": 0.1, "text-max-width": 4, "text-field": "{_name}", "text-optional": true}, "paint": {"text-color": "#888f91", "text-halo-blur": 1, "text-halo-color": "#efefef", "text-halo-width": 0.5}}, {"id": "Disputed label point/Admin0", "type": "symbol", "source": "esri", "source-layer": "Disputed label point", "filter": ["all", ["==", "_label_class", 2], ["in", "DisputeID", 1021]], "minzoom": 2, "layout": {"icon-image": "Disputed label point", "icon-allow-overlap": true, "text-font": ["Ubuntu Bold"], "text-size": {"stops": [[2, 8], [4, 10], [10, 16]]}, "text-transform": "uppercase", "text-letter-spacing": {"stops": [[2, 0.13], [8, 0.5]]}, "text-anchor": "center", "text-max-width": 6, "text-field": "{_name}", "text-optional": true}, "paint": {"text-color": "#aaafac", "text-halo-color": "#F7F7F7", "text-halo-width": 1, "text-halo-blur": 1}}]}
+{
+  "version": 8,
+  "sprite": "https://cdn.arcgis.com/sharing/rest/content/items/8a2cba3b0ebf4140b7c0dc5ee149549a/resources/styles/../sprites/sprite",
+  "glyphs": "https://basemaps.arcgis.com/arcgis/rest/services/World_Basemap_v2/VectorTileServer/resources/fonts/{fontstack}/{range}.pbf",
+  "sources": {
+    "esri": {
+      "type": "vector",
+      "url": "https://basemaps.arcgis.com/arcgis/rest/services/World_Basemap_v2/VectorTileServer"
+    }
+  },
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": {
+        "background-color": "#cfd3d4"
+      }
+    },
+    {
+      "id": "Land",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Land",
+      "minzoom": 0,
+      "layout": {},
+      "paint": {
+        "fill-color": {
+          "stops": [
+            [
+              0,
+              "#f4f4f4"
+            ],
+            [
+              7,
+              "#efefef"
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Urban area",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Urban area",
+      "minzoom": 5,
+      "maxzoom": 15,
+      "layout": {},
+      "paint": {
+        "fill-color": {
+          "stops": [
+            [
+              5,
+              "#e5e8e7"
+            ],
+            [
+              10,
+              "#ECEDEC"
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Openspace or forest",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Openspace or forest",
+      "minzoom": 12,
+      "layout": {},
+      "paint": {
+        "fill-color": {
+          "stops": [
+            [
+              6,
+              "#ECEEEA"
+            ],
+            [
+              11,
+              "#e4e8e4"
+            ]
+          ]
+        },
+        "fill-outline-color": "#E7EAE6"
+      }
+    },
+    {
+      "id": "Admin0 forest or park",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Admin0 forest or park",
+      "minzoom": 7,
+      "layout": {},
+      "paint": {
+        "fill-color": {
+          "stops": [
+            [
+              6,
+              "#ECEEEA"
+            ],
+            [
+              11,
+              "#e4e8e4"
+            ]
+          ]
+        },
+        "fill-outline-color": "#E7EAE6"
+      }
+    },
+    {
+      "id": "Admin1 forest or park",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Admin1 forest or park",
+      "minzoom": 8,
+      "layout": {},
+      "paint": {
+        "fill-color": {
+          "stops": [
+            [
+              6,
+              "#ECEEEA"
+            ],
+            [
+              11,
+              "#e4e8e4"
+            ]
+          ]
+        },
+        "fill-outline-color": "#E7EAE6"
+      }
+    },
+    {
+      "id": "Zoo",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Zoo",
+      "minzoom": 12,
+      "layout": {},
+      "paint": {
+        "fill-color": "#e4e8e4"
+      }
+    },
+    {
+      "id": "Airport/Airport property",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Airport",
+      "filter": [
+        "==",
+        "_symbol",
+        1
+      ],
+      "minzoom": 9,
+      "layout": {},
+      "paint": {
+        "fill-color": {
+          "stops": [
+            [
+              11,
+              "#edede9"
+            ],
+            [
+              15,
+              "#efefef"
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Airport/Airport runway",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Airport",
+      "filter": [
+        "==",
+        "_symbol",
+        0
+      ],
+      "minzoom": 11,
+      "layout": {},
+      "paint": {
+        "fill-color": "#e1e2dd"
+      }
+    },
+    {
+      "id": "Pedestrian",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Pedestrian",
+      "minzoom": 14,
+      "layout": {},
+      "paint": {
+        "fill-color": "#f2f2f1"
+      }
+    },
+    {
+      "id": "Park or farming",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Park or farming",
+      "minzoom": 12,
+      "layout": {},
+      "paint": {
+        "fill-color": "#e4e8e4"
+      }
+    },
+    {
+      "id": "Beach",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Beach",
+      "minzoom": 13,
+      "layout": {},
+      "paint": {
+        "fill-pattern": "Special area of interest/Sand"
+      }
+    },
+    {
+      "id": "Special area of interest/Garden path",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Special area of interest",
+      "filter": [
+        "==",
+        "_symbol",
+        12
+      ],
+      "minzoom": 14,
+      "layout": {
+        "visibility": "none"
+      },
+      "paint": {
+        "fill-color": "#f7f7f7",
+        "fill-outline-color": "#EBE8E8"
+      }
+    },
+    {
+      "id": "Special area of interest/Parking",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Special area of interest",
+      "filter": [
+        "==",
+        "_symbol",
+        15
+      ],
+      "minzoom": 14,
+      "layout": {},
+      "paint": {
+        "fill-color": "#f2f2f1"
+      }
+    },
+    {
+      "id": "Special area of interest/Green openspace",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Special area of interest",
+      "filter": [
+        "==",
+        "_symbol",
+        11
+      ],
+      "minzoom": 14,
+      "layout": {},
+      "paint": {
+        "fill-color": "#e5eae5"
+      }
+    },
+    {
+      "id": "Special area of interest/Grass",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Special area of interest",
+      "filter": [
+        "==",
+        "_symbol",
+        8
+      ],
+      "minzoom": 14,
+      "layout": {},
+      "paint": {
+        "fill-color": "#e6eae6"
+      }
+    },
+    {
+      "id": "Special area of interest/Baseball field or other grounds",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Special area of interest",
+      "filter": [
+        "==",
+        "_symbol",
+        1
+      ],
+      "minzoom": 14,
+      "layout": {},
+      "paint": {
+        "fill-color": "#E2E5E2"
+      }
+    },
+    {
+      "id": "Special area of interest/Groundcover",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Special area of interest",
+      "filter": [
+        "==",
+        "_symbol",
+        13
+      ],
+      "minzoom": 14,
+      "layout": {},
+      "paint": {
+        "fill-pattern": "Special area of interest/Groundcover",
+        "fill-opacity": 0.5
+      }
+    },
+    {
+      "id": "Special area of interest/Field or court exterior",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Special area of interest",
+      "filter": [
+        "==",
+        "_symbol",
+        5
+      ],
+      "minzoom": 14,
+      "layout": {},
+      "paint": {
+        "fill-color": "#ECEEEC"
+      }
+    },
+    {
+      "id": "Special area of interest/Football field or court",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Special area of interest",
+      "filter": [
+        "==",
+        "_symbol",
+        4
+      ],
+      "minzoom": 14,
+      "layout": {},
+      "paint": {
+        "fill-color": "#E2E5E2",
+        "fill-outline-color": "#efefef"
+      }
+    },
+    {
+      "id": "Special area of interest/Hardcourt",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Special area of interest",
+      "filter": [
+        "==",
+        "_symbol",
+        10
+      ],
+      "minzoom": 14,
+      "layout": {},
+      "paint": {
+        "fill-color": "#d3d3d3",
+        "fill-outline-color": "#efefef"
+      }
+    },
+    {
+      "id": "Special area of interest/Mulch or dirt",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Special area of interest",
+      "filter": [
+        "==",
+        "_symbol",
+        14
+      ],
+      "minzoom": 14,
+      "layout": {},
+      "paint": {
+        "fill-color": "#eaeaea"
+      }
+    },
+    {
+      "id": "Special area of interest/Athletic track",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Special area of interest",
+      "filter": [
+        "==",
+        "_symbol",
+        0
+      ],
+      "minzoom": 14,
+      "layout": {},
+      "paint": {
+        "fill-color": "#e2e2e2",
+        "fill-outline-color": "#f2f2f2"
+      }
+    },
+    {
+      "id": "Special area of interest/Sand",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Special area of interest",
+      "filter": [
+        "==",
+        "_symbol",
+        6
+      ],
+      "minzoom": 14,
+      "layout": {},
+      "paint": {
+        "fill-pattern": "Special area of interest/Sand"
+      }
+    },
+    {
+      "id": "Special area of interest/Rock or gravel",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Special area of interest",
+      "filter": [
+        "==",
+        "_symbol",
+        16
+      ],
+      "minzoom": 14,
+      "layout": {},
+      "paint": {
+        "fill-pattern": "Special area of interest/Rock or gravel"
+      }
+    },
+    {
+      "id": "Special area of interest/Water",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Special area of interest",
+      "filter": [
+        "==",
+        "_symbol",
+        7
+      ],
+      "minzoom": 15,
+      "layout": {},
+      "paint": {
+        "fill-color": "#cfd3d4"
+      }
+    },
+    {
+      "id": "Water line small scale",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Water line small scale",
+      "minzoom": 1,
+      "maxzoom": 5,
+      "layout": {
+        "line-join": "round",
+        "visibility": "none"
+      },
+      "paint": {
+        "line-color": "#d6dadb",
+        "line-width": 0.5
+      }
+    },
+    {
+      "id": "Water line medium scale",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Water line medium scale",
+      "minzoom": 6,
+      "maxzoom": 7,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#d6dadb",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              5,
+              0.5
+            ],
+            [
+              7,
+              0.7
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Water line large scale",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Water line large scale",
+      "minzoom": 7,
+      "maxzoom": 11,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#cfd3d4",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              7,
+              0.7
+            ],
+            [
+              11,
+              0.8
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Water line/Waterfall",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Water line",
+      "filter": [
+        "==",
+        "_symbol",
+        5
+      ],
+      "minzoom": 11,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#cfd3d4",
+        "line-width": 0.8,
+        "line-dasharray": [
+          5,
+          5
+        ]
+      }
+    },
+    {
+      "id": "Water line/Dam or weir",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Water line",
+      "filter": [
+        "==",
+        "_symbol",
+        2
+      ],
+      "minzoom": 11,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#c3c3c3",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              0.7
+            ],
+            [
+              14,
+              0.7
+            ],
+            [
+              17,
+              2
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Water line/Levee/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Water line",
+      "filter": [
+        "==",
+        "_symbol",
+        3
+      ],
+      "minzoom": 11,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#cfd3d4",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              0.7
+            ],
+            [
+              14,
+              0.7
+            ],
+            [
+              17,
+              2
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Water line/Levee/0",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water line",
+      "filter": [
+        "==",
+        "_symbol",
+        3
+      ],
+      "minzoom": 13,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-avoid-edges": true,
+        "icon-image": "Water line/Levee/0",
+        "symbol-spacing": 15,
+        "icon-rotation-alignment": "map",
+        "icon-allow-overlap": true,
+        "icon-padding": 1
+      },
+      "paint": {}
+    },
+    {
+      "id": "Water line/Canal or ditch",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Water line",
+      "filter": [
+        "==",
+        "_symbol",
+        1
+      ],
+      "minzoom": 11,
+      "layout": {
+        "line-cap": "round"
+      },
+      "paint": {
+        "line-color": "#cfd3d4",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              0.8
+            ],
+            [
+              14,
+              0.8
+            ],
+            [
+              17,
+              2
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Water line/Stream or river intermittent",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Water line",
+      "filter": [
+        "==",
+        "_symbol",
+        4
+      ],
+      "minzoom": 11,
+      "layout": {},
+      "paint": {
+        "line-color": "#cfd3d4",
+        "line-dasharray": [
+          7,
+          3
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              0.8
+            ],
+            [
+              14,
+              0.8
+            ],
+            [
+              17,
+              2
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Water line/Stream or river",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Water line",
+      "filter": [
+        "==",
+        "_symbol",
+        0
+      ],
+      "minzoom": 11,
+      "layout": {
+        "line-cap": "round"
+      },
+      "paint": {
+        "line-color": "#cfd3d4",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              0.8
+            ],
+            [
+              14,
+              0.8
+            ],
+            [
+              17,
+              2
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Marine area",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Marine area",
+      "minzoom": 4,
+      "layout": {},
+      "paint": {
+        "fill-color": "#cfd3d4"
+      }
+    },
+    {
+      "id": "Water area small scale",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Water area small scale",
+      "minzoom": 1,
+      "maxzoom": 5,
+      "layout": {},
+      "paint": {
+        "fill-color": "#cfd3d4"
+      }
+    },
+    {
+      "id": "Water area medium scale/Lake intermittent",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Water area medium scale",
+      "filter": [
+        "==",
+        "_symbol",
+        1
+      ],
+      "minzoom": 5,
+      "maxzoom": 7,
+      "layout": {},
+      "paint": {
+        "fill-pattern": "Water area/Lake or river intermittent"
+      }
+    },
+    {
+      "id": "Water area medium scale/Lake or river",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Water area medium scale",
+      "filter": [
+        "==",
+        "_symbol",
+        0
+      ],
+      "minzoom": 5,
+      "maxzoom": 7,
+      "layout": {},
+      "paint": {
+        "fill-color": "#cfd3d4"
+      }
+    },
+    {
+      "id": "Water area large scale/Lake intermittent",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Water area large scale",
+      "filter": [
+        "==",
+        "_symbol",
+        1
+      ],
+      "minzoom": 7,
+      "maxzoom": 11,
+      "layout": {},
+      "paint": {
+        "fill-pattern": "Water area/Lake or river intermittent"
+      }
+    },
+    {
+      "id": "Water area large scale/Lake or river",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Water area large scale",
+      "filter": [
+        "==",
+        "_symbol",
+        0
+      ],
+      "minzoom": 7,
+      "maxzoom": 11,
+      "layout": {},
+      "paint": {
+        "fill-color": "#cfd3d4"
+      }
+    },
+    {
+      "id": "Water area/Lake, river or bay",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Water area",
+      "filter": [
+        "==",
+        "_symbol",
+        7
+      ],
+      "minzoom": 11,
+      "layout": {},
+      "paint": {
+        "fill-color": "#cfd3d4"
+      }
+    },
+    {
+      "id": "Water area/Lake or river intermittent",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Water area",
+      "filter": [
+        "==",
+        "_symbol",
+        6
+      ],
+      "minzoom": 11,
+      "layout": {},
+      "paint": {
+        "fill-pattern": "Water area/Lake or river intermittent"
+      }
+    },
+    {
+      "id": "Water area/Inundated area",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Water area",
+      "filter": [
+        "==",
+        "_symbol",
+        4
+      ],
+      "minzoom": 11,
+      "layout": {},
+      "paint": {
+        "fill-pattern": "Water area/Inundated area"
+      }
+    },
+    {
+      "id": "Water area/Swamp or marsh",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Water area",
+      "filter": [
+        "==",
+        "_symbol",
+        3
+      ],
+      "minzoom": 11,
+      "layout": {},
+      "paint": {
+        "fill-pattern": "Water area/Swamp or marsh"
+      }
+    },
+    {
+      "id": "Water area/Playa",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Water area",
+      "filter": [
+        "==",
+        "_symbol",
+        1
+      ],
+      "minzoom": 11,
+      "layout": {},
+      "paint": {
+        "fill-pattern": "Water area/Playa"
+      }
+    },
+    {
+      "id": "Water area/Dam or weir",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Water area",
+      "filter": [
+        "==",
+        "_symbol",
+        5
+      ],
+      "minzoom": 11,
+      "layout": {},
+      "paint": {
+        "fill-color": "#DFE1E2",
+        "fill-outline-color": "#efefef"
+      }
+    },
+    {
+      "id": "Special area of interest/Bike, walk or pedestrian",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Special area of interest",
+      "filter": [
+        "==",
+        "_symbol",
+        2
+      ],
+      "minzoom": 14,
+      "layout": {},
+      "paint": {
+        "fill-color": "#f2f2f1"
+      }
+    },
+    {
+      "id": "Railroad/2",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Railroad",
+      "minzoom": 12,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#EFEFEF",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              1.5
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              17,
+              3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Railroad/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Railroad",
+      "minzoom": 12,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#dcddda",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              0.5
+            ],
+            [
+              14,
+              1
+            ],
+            [
+              17,
+              1.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Ferry/Rail ferry/2",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Ferry",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          1
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 12,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#EFEFEF",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              1.5
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              17,
+              3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Ferry/Rail ferry/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Ferry",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          1
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 12,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#dcddda",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              0.5
+            ],
+            [
+              14,
+              1
+            ],
+            [
+              17,
+              1.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Special area of interest line/Dock or pier",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Special area of interest line",
+      "filter": [
+        "==",
+        "_symbol",
+        0
+      ],
+      "minzoom": 15,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#efefef",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              0.7
+            ],
+            [
+              17,
+              1.2
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Special area of interest line/Sports field",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Special area of interest line",
+      "filter": [
+        "==",
+        "_symbol",
+        6
+      ],
+      "minzoom": 15,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#efefef",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              0.7
+            ],
+            [
+              17,
+              1.2
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Building/Shadow",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Building",
+      "minzoom": 16,
+      "layout": {},
+      "paint": {
+        "fill-color": "#dcddde",
+        "fill-translate": {
+          "stops": [
+            [
+              15,
+              [
+                0,
+                0
+              ]
+            ],
+            [
+              18,
+              [
+                2,
+                2
+              ]
+            ]
+          ]
+        },
+        "fill-translate-anchor": "viewport"
+      }
+    },
+    {
+      "id": "Building",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Building",
+      "minzoom": 15,
+      "layout": {},
+      "paint": {
+        "fill-color": "#DFE1E2",
+        "fill-outline-color": "#efefef"
+      }
+    },
+    {
+      "id": "Special area of interest line/Parking lot",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Special area of interest line",
+      "filter": [
+        "==",
+        "_symbol",
+        5
+      ],
+      "minzoom": 15,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#FFFFFF",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              0.7
+            ],
+            [
+              17,
+              1.2
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Trail or path/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Trail or path",
+      "minzoom": 15,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#E3E5E2",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              14,
+              1.5
+            ],
+            [
+              16,
+              3.3
+            ],
+            [
+              18,
+              4
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road/4WD/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          10
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 13,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#E3E5E2",
+        "line-dasharray": [
+          2,
+          1
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              1.5
+            ],
+            [
+              14,
+              3.3
+            ],
+            [
+              18,
+              8.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road/Service/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          8
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 13,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#E3E5E2",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              1.5
+            ],
+            [
+              14,
+              3.3
+            ],
+            [
+              18,
+              8.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road/Local/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          7
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 12,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#E3E5E2",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              11,
+              1.5
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              16,
+              6
+            ],
+            [
+              18,
+              17.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road/Pedestrian/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          9
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 15,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#E3E5E2",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              14,
+              1.5
+            ],
+            [
+              16,
+              3.3
+            ],
+            [
+              18,
+              4
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road/Minor, ramp or traffic circle/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          6
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 11,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#E3E5E2",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              1
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              16,
+              9.6
+            ],
+            [
+              18,
+              17.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road/Minor/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          5
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 11,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#E3E5E2",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              2.6
+            ],
+            [
+              14,
+              5.6
+            ],
+            [
+              16,
+              9.6
+            ],
+            [
+              18,
+              17.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road/Major, ramp or traffic circle/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          4
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 9,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#E3E5E2",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              9,
+              1.5
+            ],
+            [
+              14,
+              7.3
+            ],
+            [
+              16,
+              10.3
+            ],
+            [
+              18,
+              18
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road/Major/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          3
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 9,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#E3E5E2",
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              9,
+              1.5
+            ],
+            [
+              14,
+              7.3
+            ],
+            [
+              16,
+              10.3
+            ],
+            [
+              18,
+              18
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road/Freeway Motorway, ramp or traffic circle/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          2
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 7,
+      "layout": {
+        "line-join": "round",
+        "line-cap": "round"
+      },
+      "paint": {
+        "line-color": "#E3E5E2",
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              9,
+              0.3
+            ],
+            [
+              14,
+              8.3
+            ],
+            [
+              16,
+              12.3
+            ],
+            [
+              18,
+              26
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road/Highway/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          1
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 8,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#E3E5E2",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              8,
+              0.3
+            ],
+            [
+              14,
+              8.3
+            ],
+            [
+              16,
+              12.3
+            ],
+            [
+              18,
+              26
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road/Freeway Motorway/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          0
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 7,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#E3E5E2",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              5,
+              0.3
+            ],
+            [
+              14,
+              8.3
+            ],
+            [
+              16,
+              12.3
+            ],
+            [
+              18,
+              26
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Trail or path/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Trail or path",
+      "minzoom": 15,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#FFFFFF",
+        "line-dasharray": [
+          3,
+          1.5
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              14,
+              1.3
+            ],
+            [
+              16,
+              2
+            ],
+            [
+              18,
+              2.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road/Pedestrian/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          9
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 15,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#FFFFFF",
+        "line-dasharray": [
+          3,
+          1.5
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              14,
+              1.3
+            ],
+            [
+              16,
+              2
+            ],
+            [
+              18,
+              2.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road/4WD/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          10
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 13,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#FFFFFF",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              0.75
+            ],
+            [
+              14,
+              1.3
+            ],
+            [
+              18,
+              6.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road/Service/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          8
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 13,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#FFFFFF",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              0.75
+            ],
+            [
+              14,
+              1.3
+            ],
+            [
+              18,
+              6.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road/Local/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          7
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 12,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": {
+          "stops": [
+            [
+              12,
+              "#FAFAFA"
+            ],
+            [
+              13,
+              "#ffffff"
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              11,
+              1.1
+            ],
+            [
+              14,
+              2
+            ],
+            [
+              16,
+              4
+            ],
+            [
+              18,
+              15.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road/Minor, ramp or traffic circle/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          6
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 11,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#FFFFFF",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              0.75
+            ],
+            [
+              14,
+              2
+            ],
+            [
+              16,
+              7.65
+            ],
+            [
+              18,
+              15.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road/Minor/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          5
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 11,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#FFFFFF",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              1.3
+            ],
+            [
+              14,
+              3.65
+            ],
+            [
+              16,
+              7.65
+            ],
+            [
+              18,
+              15.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road/Major, ramp or traffic circle/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          4
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 9,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#ffffff",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              9,
+              0.75
+            ],
+            [
+              14,
+              5.3
+            ],
+            [
+              16,
+              8.3
+            ],
+            [
+              18,
+              16
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road/Major/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          3
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 9,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#FFFFFF",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              9,
+              0.75
+            ],
+            [
+              14,
+              5.3
+            ],
+            [
+              16,
+              8.3
+            ],
+            [
+              18,
+              16
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road/Freeway Motorway, ramp or traffic circle/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          2
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 7,
+      "layout": {
+        "line-join": "round",
+        "line-cap": "round"
+      },
+      "paint": {
+        "line-color": "#ffffff",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              9,
+              0.3
+            ],
+            [
+              14,
+              6.3
+            ],
+            [
+              16,
+              10.3
+            ],
+            [
+              18,
+              24
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road/Highway/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          1
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 8,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#ffffff",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              8,
+              0.3
+            ],
+            [
+              14,
+              6.3
+            ],
+            [
+              16,
+              10.3
+            ],
+            [
+              18,
+              24
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road/Freeway Motorway/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          0
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 6,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": {
+          "stops": [
+            [
+              6,
+              "#FAFAFA"
+            ],
+            [
+              7,
+              "#ffffff"
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              5,
+              0.3
+            ],
+            [
+              14,
+              6.3
+            ],
+            [
+              16,
+              10.3
+            ],
+            [
+              18,
+              24
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road tunnel/4WD/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road tunnel",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          10
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 13,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#E3E5E2",
+        "line-opacity": 0.5,
+        "line-dasharray": [
+          2,
+          1
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              1.5
+            ],
+            [
+              14,
+              3.3
+            ],
+            [
+              18,
+              8.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road tunnel/Service/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road tunnel",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          8
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 13,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#E3E5E2",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              1.5
+            ],
+            [
+              14,
+              3.3
+            ],
+            [
+              18,
+              8.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road tunnel/Local/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road tunnel",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          7
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 12,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#E3E5E2",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              11,
+              1.5
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              16,
+              6
+            ],
+            [
+              18,
+              17.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road tunnel/Pedestrian/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road tunnel",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          9
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 15,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#E3E5E2",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              14,
+              1.5
+            ],
+            [
+              16,
+              3.3
+            ],
+            [
+              18,
+              4
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road tunnel/Minor, ramp or traffic circle/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road tunnel",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          6
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 11,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#E3E5E2",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              1
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              16,
+              9.65
+            ],
+            [
+              18,
+              17.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road tunnel/Minor/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road tunnel",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          5
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 11,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#E3E5E2",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              2.6
+            ],
+            [
+              14,
+              5.65
+            ],
+            [
+              16,
+              9.65
+            ],
+            [
+              18,
+              17.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road tunnel/Major, ramp or traffic circle/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road tunnel",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          4
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 9,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#E3E5E2",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              9,
+              1.5
+            ],
+            [
+              14,
+              7.3
+            ],
+            [
+              16,
+              10.3
+            ],
+            [
+              18,
+              18
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road tunnel/Major/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road tunnel",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          3
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 9,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#E3E5E2",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              9,
+              1.5
+            ],
+            [
+              14,
+              7.3
+            ],
+            [
+              16,
+              10.3
+            ],
+            [
+              18,
+              18
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road tunnel/Freeway Motorway, ramp or traffic circle/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road tunnel",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          2
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 7,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#E3E5E2",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              9,
+              0.3
+            ],
+            [
+              14,
+              8.3
+            ],
+            [
+              16,
+              14.3
+            ],
+            [
+              18,
+              28
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road tunnel/Highway/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road tunnel",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          1
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 8,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#E3E5E2",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              8,
+              0.3
+            ],
+            [
+              14,
+              8.3
+            ],
+            [
+              16,
+              14.3
+            ],
+            [
+              18,
+              28
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road tunnel/Freeway Motorway/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road tunnel",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          0
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 7,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#E3E5E2",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              5,
+              0.3
+            ],
+            [
+              14,
+              8.3
+            ],
+            [
+              16,
+              14.3
+            ],
+            [
+              18,
+              28
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road tunnel/Pedestrian/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road tunnel",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          9
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 15,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#FFFFFF",
+        "line-opacity": 0.5,
+        "line-dasharray": [
+          3,
+          1.5
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              14,
+              1.3
+            ],
+            [
+              16,
+              2
+            ],
+            [
+              18,
+              2.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road tunnel/4WD/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road tunnel",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          10
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 13,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#FFFFFF",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              0.75
+            ],
+            [
+              14,
+              1.3
+            ],
+            [
+              18,
+              6.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road tunnel/Service/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road tunnel",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          8
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 13,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#FFFFFF",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              0.75
+            ],
+            [
+              14,
+              1.3
+            ],
+            [
+              18,
+              6.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road tunnel/Local/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road tunnel",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          7
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 12,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": {
+          "stops": [
+            [
+              12,
+              "#FAFAFA"
+            ],
+            [
+              13,
+              "#ffffff"
+            ]
+          ]
+        },
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              11,
+              1.1
+            ],
+            [
+              14,
+              2
+            ],
+            [
+              16,
+              4
+            ],
+            [
+              18,
+              15.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road tunnel/Minor, ramp or traffic circle/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road tunnel",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          6
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 11,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#FFFFFF",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              0.75
+            ],
+            [
+              14,
+              2
+            ],
+            [
+              16,
+              7.65
+            ],
+            [
+              18,
+              15.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road tunnel/Minor/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road tunnel",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          5
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 11,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#FFFFFF",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              11,
+              1.3
+            ],
+            [
+              14,
+              3.65
+            ],
+            [
+              16,
+              7.65
+            ],
+            [
+              18,
+              15.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road tunnel/Major, ramp or traffic circle/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road tunnel",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          4
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 9,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#ffffff",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              9,
+              0.75
+            ],
+            [
+              14,
+              5.3
+            ],
+            [
+              16,
+              8.3
+            ],
+            [
+              18,
+              16
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road tunnel/Major/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road tunnel",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          3
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 9,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#ffffff",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              9,
+              0.75
+            ],
+            [
+              14,
+              5.3
+            ],
+            [
+              16,
+              8.3
+            ],
+            [
+              18,
+              16
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road tunnel/Freeway Motorway, ramp or traffic circle/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road tunnel",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          2
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 7,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#ffffff",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              9,
+              0.3
+            ],
+            [
+              14,
+              6.3
+            ],
+            [
+              16,
+              12.3
+            ],
+            [
+              18,
+              26
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road tunnel/Highway/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road tunnel",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          1
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 8,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#ffffff",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              8,
+              0.3
+            ],
+            [
+              14,
+              6.3
+            ],
+            [
+              16,
+              12.3
+            ],
+            [
+              18,
+              26
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Road tunnel/Freeway Motorway/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Road tunnel",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          0
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 6,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": {
+          "stops": [
+            [
+              6,
+              "#FAFAFA"
+            ],
+            [
+              7,
+              "#ffffff"
+            ]
+          ]
+        },
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              5,
+              0.3
+            ],
+            [
+              14,
+              6.3
+            ],
+            [
+              16,
+              12.3
+            ],
+            [
+              18,
+              26
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Special area of interest/Gutter",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Special area of interest",
+      "filter": [
+        "==",
+        "_symbol",
+        9
+      ],
+      "minzoom": 14,
+      "layout": {},
+      "paint": {
+        "fill-color": "#f2f2f1",
+        "fill-outline-color": "#efefef"
+      }
+    },
+    {
+      "id": "Special area of interest/Curb",
+      "type": "fill",
+      "source": "esri",
+      "source-layer": "Special area of interest",
+      "filter": [
+        "==",
+        "_symbol",
+        3
+      ],
+      "minzoom": 14,
+      "layout": {},
+      "paint": {
+        "fill-color": "#f2f2f1",
+        "fill-outline-color": "#ebebeb"
+      }
+    },
+    {
+      "id": "Boundary line/Disputed admin2/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Boundary line",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          8
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 9,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#dddedb",
+        "line-opacity": 0.95,
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              4,
+              0.65
+            ],
+            [
+              14,
+              7
+            ],
+            [
+              17,
+              7
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Boundary line/Disputed admin2/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Boundary line",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          8
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 9,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": {
+          "stops": [
+            [
+              1,
+              "#FAFAFA"
+            ],
+            [
+              3,
+              "#ffffff"
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              1,
+              0.65
+            ],
+            [
+              14,
+              1.3
+            ],
+            [
+              17,
+              2.65
+            ]
+          ]
+        },
+        "line-dasharray": [
+          7,
+          5
+        ]
+      }
+    },
+    {
+      "id": "Boundary line/Disputed admin1/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Boundary line",
+      "minzoom": 4,
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          7
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#dddedb",
+        "line-opacity": 0.95,
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              4,
+              0.65
+            ],
+            [
+              14,
+              7
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Boundary line/Disputed admin0/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Boundary line",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          6
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ],
+        [
+          "!in",
+          "DisputeID",
+          8,
+          16,
+          90,
+          96,
+          0
+        ]
+      ],
+      "minzoom": 1,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#dddedb",
+        "line-opacity": 0.95,
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              1,
+              0.65
+            ],
+            [
+              14,
+              9.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Boundary line/Disputed admin1/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Boundary line",
+      "minzoom": 4,
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          7
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": {
+          "stops": [
+            [
+              1,
+              "#FAFAFA"
+            ],
+            [
+              3,
+              "#ffffff"
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              1,
+              0.65
+            ],
+            [
+              14,
+              1.3
+            ],
+            [
+              17,
+              2.65
+            ]
+          ]
+        },
+        "line-dasharray": [
+          7,
+          5
+        ]
+      }
+    },
+    {
+      "id": "Boundary line/Disputed admin0/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Boundary line",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          6
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ],
+        [
+          "!in",
+          "DisputeID",
+          8,
+          16,
+          90,
+          96,
+          0
+        ]
+      ],
+      "minzoom": 1,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": {
+          "stops": [
+            [
+              1,
+              "#FAFAFA"
+            ],
+            [
+              3,
+              "#ffffff"
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              1,
+              0.65
+            ],
+            [
+              14,
+              1.3
+            ],
+            [
+              17,
+              2.65
+            ]
+          ]
+        },
+        "line-dasharray": [
+          7,
+          5
+        ]
+      }
+    },
+    {
+      "id": "Boundary line/Admin2/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Boundary line",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          2
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 10,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#dfe0dd",
+        "line-opacity": 0.6,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              8,
+              1.3
+            ],
+            [
+              14,
+              2.65
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Boundary line/Admin1/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Boundary line",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          1
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 4,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#dfe0dd",
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              4,
+              0.65
+            ],
+            [
+              14,
+              7
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Boundary line/Admin0/1",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Boundary line",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          0
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 1,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#dddedb",
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              1,
+              0.65
+            ],
+            [
+              14,
+              9.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Boundary line/Admin5",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Boundary line",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          5
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 16,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#b9b9b9",
+        "line-width": 1,
+        "line-dasharray": [
+          5,
+          3
+        ]
+      }
+    },
+    {
+      "id": "Boundary line/Admin4",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Boundary line",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          4
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 16,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#b9b9b9",
+        "line-width": 1,
+        "line-dasharray": [
+          5,
+          3
+        ]
+      }
+    },
+    {
+      "id": "Boundary line/Admin3",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Boundary line",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          3
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 16,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#b9b9b9",
+        "line-width": 1,
+        "line-dasharray": [
+          5,
+          3
+        ]
+      }
+    },
+    {
+      "id": "Boundary line/Admin2/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Boundary line",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          2
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 9,
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#b9b9b9",
+        "line-dasharray": [
+          6,
+          4
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              8,
+              0.5
+            ],
+            [
+              14,
+              1
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Boundary line/Admin1/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Boundary line",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          1
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 7,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": {
+          "stops": [
+            [
+              7,
+              "#c8c8c8"
+            ],
+            [
+              12,
+              "#b9b9b9"
+            ]
+          ]
+        },
+        "line-dasharray": [
+          7,
+          5.3
+        ],
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              7,
+              0.3
+            ],
+            [
+              14,
+              1.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Boundary line/Admin0/0",
+      "type": "line",
+      "source": "esri",
+      "source-layer": "Boundary line",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_symbol",
+          0
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 5,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": {
+          "stops": [
+            [
+              5,
+              "#cccccc"
+            ],
+            [
+              7,
+              "#9C9C9C"
+            ]
+          ]
+        },
+        "line-dasharray": [
+          7,
+          5.3
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              5,
+              0.7
+            ],
+            [
+              14,
+              1.3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Water point/Sea or ocean",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water point",
+      "filter": [
+        "==",
+        "_label_class",
+        0
+      ],
+      "minzoom": 9,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              9,
+              8.5
+            ],
+            [
+              15,
+              15.5
+            ]
+          ]
+        },
+        "text-anchor": "center",
+        "text-letter-spacing": 0.3,
+        "text-line-height": 1.6,
+        "text-max-width": 4,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15
+      },
+      "paint": {
+        "text-color": "#888f91",
+        "text-halo-blur": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "Water point/Island",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water point",
+      "filter": [
+        "==",
+        "_label_class",
+        7
+      ],
+      "minzoom": 9,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              9,
+              8.5
+            ],
+            [
+              15,
+              10
+            ]
+          ]
+        },
+        "text-anchor": "center",
+        "text-letter-spacing": 0.1,
+        "text-max-width": 4,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-blur": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "Water point/Dam or weir",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water point",
+      "filter": [
+        "==",
+        "_label_class",
+        5
+      ],
+      "minzoom": 9,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              9,
+              8.5
+            ],
+            [
+              15,
+              10
+            ]
+          ]
+        },
+        "text-anchor": "center",
+        "text-letter-spacing": 0.1,
+        "text-max-width": 4,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 0.7,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Water point/Playa",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water point",
+      "filter": [
+        "==",
+        "_label_class",
+        6
+      ],
+      "minzoom": 9,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              9,
+              8.5
+            ],
+            [
+              15,
+              10
+            ]
+          ]
+        },
+        "text-anchor": "center",
+        "text-letter-spacing": 0.1,
+        "text-max-width": 4,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 0.7,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Water point/Canal or ditch",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water point",
+      "filter": [
+        "==",
+        "_label_class",
+        4
+      ],
+      "minzoom": 9,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              9,
+              8.5
+            ],
+            [
+              15,
+              10
+            ]
+          ]
+        },
+        "text-anchor": "center",
+        "text-letter-spacing": 0.13,
+        "text-max-width": 4,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15
+      },
+      "paint": {
+        "text-color": "#888f91",
+        "text-halo-blur": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "Water point/Stream or river",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water point",
+      "filter": [
+        "==",
+        "_label_class",
+        3
+      ],
+      "minzoom": 9,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              9,
+              8.5
+            ],
+            [
+              15,
+              10
+            ]
+          ]
+        },
+        "text-anchor": "center",
+        "text-letter-spacing": 0.1,
+        "text-max-width": 4,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15
+      },
+      "paint": {
+        "text-color": "#888f91",
+        "text-halo-blur": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-width": 0.5
+      }
+    },
+    {
+      "id": "Water point/Lake or reservoir",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water point",
+      "filter": [
+        "==",
+        "_label_class",
+        2
+      ],
+      "minzoom": 9,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              9,
+              8.5
+            ],
+            [
+              15,
+              10
+            ]
+          ]
+        },
+        "text-anchor": "center",
+        "text-letter-spacing": 0.1,
+        "text-max-width": 4,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15
+      },
+      "paint": {
+        "text-color": "#888f91",
+        "text-halo-blur": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-width": 0.5
+      }
+    },
+    {
+      "id": "Water point/Bay or inlet",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water point",
+      "filter": [
+        "==",
+        "_label_class",
+        1
+      ],
+      "minzoom": 9,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              9,
+              8.5
+            ],
+            [
+              15,
+              10
+            ]
+          ]
+        },
+        "text-anchor": "center",
+        "text-letter-spacing": 0.1,
+        "text-max-width": 4,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15
+      },
+      "paint": {
+        "text-color": "#888f91",
+        "text-halo-blur": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "Water line/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water line/label",
+      "minzoom": 11,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-size": 9,
+        "text-letter-spacing": 0.07,
+        "text-max-width": 6,
+        "text-max-angle": 18,
+        "text-field": "{_name_global}",
+        "text-padding": 1,
+        "text-offset": [
+          0,
+          -0.5
+        ],
+        "symbol-spacing": 800
+      },
+      "paint": {
+        "text-color": "#A0A6A8",
+        "text-halo-blur": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-width": 0.5
+      }
+    },
+    {
+      "id": "Marine park/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Marine park/label",
+      "minzoom": 16,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#888f91"
+      }
+    },
+    {
+      "id": "Water area/label/Dam or weir",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water area/label",
+      "filter": [
+        "==",
+        "_label_class",
+        8
+      ],
+      "minzoom": 11,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.08,
+        "text-max-width": 4,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Water area/label/Playa",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water area/label",
+      "filter": [
+        "==",
+        "_label_class",
+        9
+      ],
+      "minzoom": 11,
+      "layout": {
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.08,
+        "text-max-width": 4,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Water area/label/Canal or ditch",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water area/label",
+      "filter": [
+        "==",
+        "_label_class",
+        2
+      ],
+      "minzoom": 11,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-spacing": 1000,
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.13,
+        "text-field": "{_name_global}",
+        "text-padding": 15,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-max-width": 5
+      },
+      "paint": {
+        "text-color": "#888f91",
+        "text-halo-blur": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-width": 0.5
+      }
+    },
+    {
+      "id": "Water area/label/Small river",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water area/label",
+      "filter": [
+        "==",
+        "_label_class",
+        7
+      ],
+      "minzoom": 11,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-spacing": 1000,
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.13,
+        "text-field": "{_name_global}",
+        "text-padding": 15,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-max-width": 8
+      },
+      "paint": {
+        "text-color": "#888f91",
+        "text-halo-blur": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-width": 0.5
+      }
+    },
+    {
+      "id": "Water area/label/Large river",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water area/label",
+      "filter": [
+        "==",
+        "_label_class",
+        4
+      ],
+      "minzoom": 11,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-spacing": 1000,
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-size": 10,
+        "text-letter-spacing": 0.13,
+        "text-field": "{_name_global}",
+        "text-padding": 15,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-max-width": 8
+      },
+      "paint": {
+        "text-color": "#888f91",
+        "text-halo-blur": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-width": 0.5
+      }
+    },
+    {
+      "id": "Water area/label/Small lake or reservoir",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water area/label",
+      "filter": [
+        "==",
+        "_label_class",
+        6
+      ],
+      "minzoom": 11,
+      "layout": {
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.13,
+        "text-max-width": 4,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#888f91",
+        "text-halo-blur": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-width": 0.5
+      }
+    },
+    {
+      "id": "Water area/label/Large lake or reservoir",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water area/label",
+      "filter": [
+        "==",
+        "_label_class",
+        3
+      ],
+      "minzoom": 11,
+      "layout": {
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-size": 10,
+        "text-letter-spacing": 0.13,
+        "text-line-height": 1.15,
+        "text-max-width": 4,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#888f91",
+        "text-halo-blur": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-width": 0.5
+      }
+    },
+    {
+      "id": "Water area/label/Bay or inlet",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water area/label",
+      "filter": [
+        "==",
+        "_label_class",
+        1
+      ],
+      "minzoom": 11,
+      "layout": {
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-size": 11,
+        "text-letter-spacing": 0.13,
+        "text-line-height": 1.15,
+        "text-max-width": 4,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#888f91",
+        "text-halo-blur": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-width": 0.5
+      }
+    },
+    {
+      "id": "Water area/label/Small island",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water area/label",
+      "filter": [
+        "==",
+        "_label_class",
+        0
+      ],
+      "minzoom": 11,
+      "layout": {
+        "text-size": 9.5,
+        "text-letter-spacing": 0.1,
+        "text-max-width": 4,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Italic"
+        ]
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-blur": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "Water area/label/Large island",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water area/label",
+      "filter": [
+        "==",
+        "_label_class",
+        5
+      ],
+      "minzoom": 11,
+      "layout": {
+        "text-size": 10,
+        "text-letter-spacing": 0.13,
+        "text-max-width": 4,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Italic"
+        ]
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-blur": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "Water area large scale/label/River",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water area large scale/label",
+      "filter": [
+        "==",
+        "_label_class",
+        1
+      ],
+      "minzoom": 7,
+      "maxzoom": 11,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-spacing": 1000,
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-size": 9,
+        "text-letter-spacing": 0.1,
+        "text-field": "{_name}",
+        "text-padding": 15,
+        "symbol-avoid-edges": true,
+        "text-allow-overlap": false,
+        "text-max-width": 4
+      },
+      "paint": {
+        "text-color": "#888f91",
+        "text-halo-blur": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-width": 0.5
+      }
+    },
+    {
+      "id": "Water area large scale/label/Lake or lake intermittent",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water area large scale/label",
+      "filter": [
+        "==",
+        "_label_class",
+        0
+      ],
+      "minzoom": 7,
+      "maxzoom": 11,
+      "layout": {
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.1,
+        "text-max-width": 4,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#888f91",
+        "text-halo-blur": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-width": 0.5
+      }
+    },
+    {
+      "id": "Water area medium scale/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water area medium scale/label",
+      "minzoom": 5,
+      "maxzoom": 7,
+      "layout": {
+        "text-max-width": 4,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true,
+        "text-letter-spacing": 0.08,
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-size": 9
+      },
+      "paint": {
+        "text-color": "#888f91",
+        "text-halo-blur": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-width": 0.5
+      }
+    },
+    {
+      "id": "Water area small scale/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water area small scale/label",
+      "minzoom": 1,
+      "maxzoom": 5,
+      "layout": {
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-size": 9,
+        "text-letter-spacing": 0.08,
+        "text-max-width": 4,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#888f91",
+        "text-halo-blur": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-width": 0.5
+      }
+    },
+    {
+      "id": "Marine area/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Marine area/label",
+      "minzoom": 11,
+      "layout": {
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-size": 10,
+        "text-letter-spacing": 0.13,
+        "text-max-width": 4,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#888f91",
+        "text-halo-blur": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-width": 0.5
+      }
+    },
+    {
+      "id": "Marine waterbody/label/small",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Marine waterbody/label",
+      "filter": [
+        "==",
+        "_label_class",
+        4
+      ],
+      "minzoom": 4,
+      "maxzoom": 10,
+      "layout": {
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-letter-spacing": 0.12,
+        "text-line-height": 1.2,
+        "text-max-width": 4,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true,
+        "text-size": {
+          "stops": [
+            [
+              1,
+              9
+            ],
+            [
+              6,
+              11
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#888f91",
+        "text-halo-blur": 1,
+        "text-halo-color": "#e0e4e5",
+        "text-halo-width": 0.5
+      }
+    },
+    {
+      "id": "Marine waterbody/label/medium",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Marine waterbody/label",
+      "filter": [
+        "==",
+        "_label_class",
+        3
+      ],
+      "minzoom": 4,
+      "maxzoom": 10,
+      "layout": {
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-letter-spacing": 0.15,
+        "text-line-height": 1.2,
+        "text-max-width": 4,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true,
+        "text-size": {
+          "stops": [
+            [
+              1,
+              9
+            ],
+            [
+              6,
+              11
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#888f91",
+        "text-halo-blur": 1,
+        "text-halo-color": "#e0e4e5",
+        "text-halo-width": 0.5
+      }
+    },
+    {
+      "id": "Marine waterbody/label/large",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Marine waterbody/label",
+      "filter": [
+        "==",
+        "_label_class",
+        2
+      ],
+      "minzoom": 4,
+      "maxzoom": 10,
+      "layout": {
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-letter-spacing": 0.18,
+        "text-line-height": 1.5,
+        "text-max-width": 4,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true,
+        "text-size": {
+          "stops": [
+            [
+              1,
+              9
+            ],
+            [
+              6,
+              12
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#888f91",
+        "text-halo-blur": 1,
+        "text-halo-color": "#e0e4e5",
+        "text-halo-width": 0.5
+      }
+    },
+    {
+      "id": "Marine waterbody/label/x large",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Marine waterbody/label",
+      "filter": [
+        "==",
+        "_label_class",
+        1
+      ],
+      "minzoom": 3,
+      "maxzoom": 10,
+      "layout": {
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-letter-spacing": 0.2,
+        "text-line-height": 1.5,
+        "text-max-width": 4,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true,
+        "text-size": {
+          "stops": [
+            [
+              1,
+              10
+            ],
+            [
+              6,
+              13
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#888f91",
+        "text-halo-blur": 1,
+        "text-halo-color": "#e0e4e5",
+        "text-halo-width": 0.5
+      }
+    },
+    {
+      "id": "Marine waterbody/label/2x large",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Marine waterbody/label",
+      "filter": [
+        "==",
+        "_label_class",
+        0
+      ],
+      "minzoom": 2,
+      "maxzoom": 10,
+      "layout": {
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-letter-spacing": 0.3,
+        "text-line-height": 1.6,
+        "text-max-width": 4,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true,
+        "text-size": {
+          "stops": [
+            [
+              1,
+              11
+            ],
+            [
+              4,
+              14
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#888f91",
+        "text-halo-blur": 1,
+        "text-halo-color": "#e0e4e5",
+        "text-halo-width": 0.5
+      }
+    },
+    {
+      "id": "Ferry/label/Rail ferry",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Ferry/label",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          1
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 16,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 8.5,
+        "text-letter-spacing": 0.1,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-padding": 5,
+        "text-offset": [
+          0,
+          -0.6
+        ],
+        "symbol-spacing": 1000
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "Railroad/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Railroad/label",
+      "minzoom": 16,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 8.5,
+        "text-letter-spacing": 0.1,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-padding": 5,
+        "text-offset": [
+          0,
+          -0.6
+        ],
+        "symbol-spacing": 1000
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "Road tunnel/label/Pedestrian",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Road tunnel/label",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          6
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 15,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-avoid-edges": true,
+        "symbol-spacing": 400,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.3,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-padding": 5
+      },
+      "paint": {
+        "text-color": "#666666",
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Road tunnel/label/Local, service, 4WD",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Road tunnel/label",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          5
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 15,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-avoid-edges": true,
+        "symbol-spacing": 400,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.09,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-padding": 5
+      },
+      "paint": {
+        "text-color": "#666666",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Road tunnel/label/Minor",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Road tunnel/label",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          4
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 14,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-avoid-edges": true,
+        "symbol-spacing": 400,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.09,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-padding": 5
+      },
+      "paint": {
+        "text-color": "#666666",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Road tunnel/label/Major, alt name",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Road tunnel/label",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          3
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 14,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-avoid-edges": true,
+        "symbol-spacing": 400,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 10.5,
+        "text-letter-spacing": 0.09,
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-padding": 5
+      },
+      "paint": {
+        "text-color": "#666666",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Road tunnel/label/Major",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Road tunnel/label",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          2
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 14,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-avoid-edges": true,
+        "symbol-spacing": 400,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 10.5,
+        "text-letter-spacing": 0.09,
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-padding": 5
+      },
+      "paint": {
+        "text-color": "#666666",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Road tunnel/label/Highway",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Road tunnel/label",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          7
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 13,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-avoid-edges": true,
+        "symbol-spacing": 400,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 10.5,
+        "text-letter-spacing": 0.09,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-padding": 5
+      },
+      "paint": {
+        "text-color": "#666666",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Road tunnel/label/Freeway Motorway, alt name",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Road tunnel/label",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          1
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 13,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-avoid-edges": true,
+        "symbol-spacing": 400,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 10.5,
+        "text-letter-spacing": 0.09,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-padding": 5
+      },
+      "paint": {
+        "text-color": "#666666",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Road tunnel/label/Freeway Motorway",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Road tunnel/label",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          0
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 13,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-avoid-edges": true,
+        "symbol-spacing": 400,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 10.5,
+        "text-letter-spacing": 0.09,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-padding": 5
+      },
+      "paint": {
+        "text-color": "#666666",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Building/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Building/label",
+      "minzoom": 17,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.08,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 0.7,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Trail or path/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Trail or path/label",
+      "minzoom": 15,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-avoid-edges": true,
+        "symbol-spacing": 400,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.3,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-padding": 5
+      },
+      "paint": {
+        "text-color": "#666666",
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "Road/label/Pedestrian",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Road/label",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          6
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 15,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-avoid-edges": true,
+        "symbol-spacing": 400,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.3,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-padding": 5
+      },
+      "paint": {
+        "text-color": "#666666",
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "Road/label/Local",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Road/label",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          5
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 15,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-avoid-edges": true,
+        "symbol-spacing": 400,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.09,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-padding": 5
+      },
+      "paint": {
+        "text-color": "#666666",
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "Road/label/Minor",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Road/label",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          4
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 14,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-avoid-edges": true,
+        "symbol-spacing": 400,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 10,
+        "text-letter-spacing": 0.09,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-padding": 2
+      },
+      "paint": {
+        "text-color": "#666666",
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "Road/label/Major, alt name",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Road/label",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          3
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 14,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-avoid-edges": true,
+        "symbol-spacing": 400,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 10.5,
+        "text-letter-spacing": 0.09,
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-padding": 2
+      },
+      "paint": {
+        "text-color": "#666666",
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "Road/label/Major",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Road/label",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          2
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 14,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-avoid-edges": true,
+        "symbol-spacing": 400,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 10.5,
+        "text-letter-spacing": 0.09,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-padding": 2
+      },
+      "paint": {
+        "text-color": "#666666",
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "Road/label/Highway",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Road/label",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          75
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 13,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-avoid-edges": true,
+        "symbol-spacing": 400,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 10.5,
+        "text-letter-spacing": 0.09,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-padding": 10
+      },
+      "paint": {
+        "text-color": "#666666",
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "Road/label/Freeway Motorway, alt name",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Road/label",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          1
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 13,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-avoid-edges": true,
+        "symbol-spacing": 400,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 10.5,
+        "text-letter-spacing": 0.09,
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-padding": 2
+      },
+      "paint": {
+        "text-color": "#666666",
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "Road/label/Freeway Motorway",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Road/label",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          0
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 13,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-avoid-edges": true,
+        "symbol-spacing": 400,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 10.5,
+        "text-letter-spacing": 0.09,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-padding": 2
+      },
+      "paint": {
+        "text-color": "#666666",
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "Road/label/Rectangle white black (Alt)",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Road/label",
+      "filter": [
+        "all",
+        [
+          "in",
+          "_label_class",
+          8,
+          10,
+          12,
+          14,
+          16,
+          18,
+          20,
+          22,
+          24,
+          26,
+          28,
+          30,
+          32,
+          34,
+          36,
+          38,
+          40,
+          42,
+          44,
+          46,
+          48,
+          50,
+          52,
+          54,
+          56,
+          58,
+          60,
+          62,
+          64,
+          66,
+          68,
+          70,
+          72,
+          74
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 14,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-spacing": 800,
+        "text-max-angle": 25,
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 8.5,
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "icon-image": "Road/Rectangle white black (Alt)/{_len}",
+        "icon-rotation-alignment": "viewport",
+        "text-rotation-alignment": "viewport",
+        "text-offset": [
+          0,
+          0.2
+        ],
+        "text-padding": 30
+      },
+      "paint": {
+        "text-color": "#666666"
+      }
+    },
+    {
+      "id": "Road/label/Rectangle white black",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Road/label",
+      "filter": [
+        "all",
+        [
+          "in",
+          "_label_class",
+          7,
+          9,
+          11,
+          13,
+          15,
+          17,
+          19,
+          21,
+          23,
+          25,
+          27,
+          29,
+          31,
+          33,
+          35,
+          37,
+          39,
+          41,
+          43,
+          45,
+          47,
+          49,
+          51,
+          53,
+          55,
+          57,
+          59,
+          61,
+          63,
+          65,
+          67,
+          69,
+          71,
+          73
+        ],
+        [
+          "!in",
+          "Viz",
+          3
+        ]
+      ],
+      "minzoom": 14,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-spacing": 800,
+        "text-max-angle": 25,
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 8.5,
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "icon-image": "Road/Rectangle white black/{_len}",
+        "icon-rotation-alignment": "viewport",
+        "text-rotation-alignment": "viewport",
+        "text-offset": [
+          0,
+          0.2
+        ],
+        "text-padding": 30
+      },
+      "paint": {
+        "text-color": "#666666"
+      }
+    },
+    {
+      "id": "Cemetery/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Cemetery/label",
+      "minzoom": 16,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#939d8c",
+        "text-halo-color": "#EBEDEB",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Freight/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Freight/label",
+      "minzoom": 17,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Water and wastewater/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Water and wastewater/label",
+      "minzoom": 17,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Port/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Port/label",
+      "minzoom": 17,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Industry/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Industry/label",
+      "minzoom": 17,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Government/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Government/label",
+      "minzoom": 17,
+      "layout": {
+        "symbol-avoid-edges": false,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Finance/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Finance/label",
+      "minzoom": 17,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Emergency/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Emergency/label",
+      "minzoom": 17,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Indigenous/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Indigenous/label",
+      "minzoom": 17,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Military/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Military/label",
+      "minzoom": 17,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 25,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Transportation/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Transportation/label",
+      "minzoom": 17,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Pedestrian/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Pedestrian/label",
+      "minzoom": 17,
+      "layout": {
+        "symbol-avoid-edges": false,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Beach/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Beach/label",
+      "minzoom": 17,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.08,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Golf course/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Golf course/label",
+      "minzoom": 17,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#939d8c",
+        "text-halo-color": "#EBEDEB",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Zoo/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Zoo/label",
+      "minzoom": 15,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#939d8c",
+        "text-halo-color": "#EBEDEB",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Retail/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Retail/label",
+      "minzoom": 17,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Landmark/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Landmark/label",
+      "minzoom": 17,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Openspace or forest/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Openspace or forest/label",
+      "minzoom": 14,
+      "layout": {
+        "symbol-avoid-edges": false,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 25
+      },
+      "paint": {
+        "text-color": "#939d8c",
+        "text-halo-color": "#EBEDEB",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Park or farming/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Park or farming/label",
+      "minzoom": 14,
+      "layout": {
+        "symbol-avoid-edges": false,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 25
+      },
+      "paint": {
+        "text-color": "#939d8c",
+        "text-halo-color": "#EBEDEB",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Point of interest/Park",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Point of interest",
+      "filter": [
+        "==",
+        "_label_class",
+        1
+      ],
+      "minzoom": 14,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-anchor": "center",
+        "text-letter-spacing": 0.08,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15
+      },
+      "paint": {
+        "text-color": "#939d8c",
+        "text-halo-width": 1,
+        "text-halo-color": "#EBEDEB",
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Education/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Education/label",
+      "minzoom": 17,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Medical/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Medical/label",
+      "minzoom": 17,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9.5,
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Admin1 forest or park/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Admin1 forest or park/label",
+      "minzoom": 9,
+      "layout": {
+        "symbol-avoid-edges": false,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              9,
+              8.5
+            ],
+            [
+              12,
+              9.5
+            ]
+          ]
+        },
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 25
+      },
+      "paint": {
+        "text-color": "#939d8c",
+        "text-halo-color": "#EBEDEB",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Admin0 forest or park/label/Default",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Admin0 forest or park/label",
+      "minzoom": 9,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              9,
+              8.5
+            ],
+            [
+              12,
+              9.5
+            ]
+          ]
+        },
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 25,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#939d8c",
+        "text-halo-color": "#EBEDEB",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Airport/label/Airport property",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Airport/label",
+      "minzoom": 9,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              9,
+              8.5
+            ],
+            [
+              12,
+              9.5
+            ]
+          ]
+        },
+        "text-letter-spacing": 0.05,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15,
+        "symbol-avoid-edges": true
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Admin2 area/label/small",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Admin2 area/label",
+      "filter": [
+        "==",
+        "_label_class",
+        1
+      ],
+      "minzoom": 9,
+      "maxzoom": 11,
+      "layout": {
+        "text-letter-spacing": 0.2,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9,
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "symbol-avoid-edges": true,
+        "text-transform": "uppercase"
+      },
+      "paint": {
+        "text-color": "#b1b2ad",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Admin2 area/label/large",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Admin2 area/label",
+      "filter": [
+        "==",
+        "_label_class",
+        0
+      ],
+      "minzoom": 9,
+      "maxzoom": 11,
+      "layout": {
+        "text-letter-spacing": 0.2,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 10,
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "symbol-avoid-edges": true,
+        "text-transform": "uppercase"
+      },
+      "paint": {
+        "text-color": "#b1b2ad",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Admin1 area/label/x small",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Admin1 area/label",
+      "filter": [
+        "==",
+        "_label_class",
+        5
+      ],
+      "minzoom": 5,
+      "maxzoom": 10,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "symbol-avoid-edges": true,
+        "text-transform": "uppercase",
+        "text-size": {
+          "stops": [
+            [
+              4,
+              9
+            ],
+            [
+              5,
+              9
+            ],
+            [
+              6,
+              9.5
+            ],
+            [
+              9,
+              10
+            ]
+          ]
+        },
+        "text-letter-spacing": {
+          "stops": [
+            [
+              4,
+              0.1
+            ],
+            [
+              8,
+              0.18
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#b4b4b4",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Admin1 area/label/small",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Admin1 area/label",
+      "filter": [
+        "==",
+        "_label_class",
+        4
+      ],
+      "minzoom": 5,
+      "maxzoom": 10,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "symbol-avoid-edges": true,
+        "text-transform": "uppercase",
+        "text-size": {
+          "stops": [
+            [
+              4,
+              9
+            ],
+            [
+              5,
+              9
+            ],
+            [
+              6,
+              9.5
+            ],
+            [
+              9,
+              11.5
+            ]
+          ]
+        },
+        "text-letter-spacing": {
+          "stops": [
+            [
+              4,
+              0.1
+            ],
+            [
+              8,
+              0.18
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#b4b4b4",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Admin1 area/label/medium",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Admin1 area/label",
+      "filter": [
+        "==",
+        "_label_class",
+        3
+      ],
+      "minzoom": 5,
+      "maxzoom": 10,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "symbol-avoid-edges": true,
+        "text-transform": "uppercase",
+        "text-size": {
+          "stops": [
+            [
+              4,
+              10
+            ],
+            [
+              5,
+              10
+            ],
+            [
+              6,
+              10.5
+            ],
+            [
+              9,
+              12
+            ]
+          ]
+        },
+        "text-letter-spacing": {
+          "stops": [
+            [
+              4,
+              0.1
+            ],
+            [
+              8,
+              0.18
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#b4b4b4",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Admin1 area/label/large",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Admin1 area/label",
+      "filter": [
+        "==",
+        "_label_class",
+        2
+      ],
+      "minzoom": 5,
+      "maxzoom": 10,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "symbol-avoid-edges": true,
+        "text-transform": "uppercase",
+        "text-size": {
+          "stops": [
+            [
+              4,
+              10
+            ],
+            [
+              5,
+              10.5
+            ],
+            [
+              6,
+              11
+            ],
+            [
+              9,
+              15
+            ]
+          ]
+        },
+        "text-letter-spacing": {
+          "stops": [
+            [
+              4,
+              0.1
+            ],
+            [
+              8,
+              0.2
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#b4b4b4",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Admin1 area/label/x large",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Admin1 area/label",
+      "filter": [
+        "==",
+        "_label_class",
+        1
+      ],
+      "minzoom": 5,
+      "maxzoom": 10,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "symbol-avoid-edges": true,
+        "text-transform": "uppercase",
+        "text-size": {
+          "stops": [
+            [
+              4,
+              10.5
+            ],
+            [
+              5,
+              11
+            ],
+            [
+              6,
+              11.5
+            ],
+            [
+              9,
+              17
+            ]
+          ]
+        },
+        "text-letter-spacing": {
+          "stops": [
+            [
+              4,
+              0.13
+            ],
+            [
+              8,
+              0.3
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#b4b4b4",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Admin1 area/label/2x large",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Admin1 area/label",
+      "filter": [
+        "==",
+        "_label_class",
+        0
+      ],
+      "minzoom": 5,
+      "maxzoom": 10,
+      "layout": {
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "symbol-avoid-edges": true,
+        "text-transform": "uppercase",
+        "text-size": {
+          "stops": [
+            [
+              4,
+              11
+            ],
+            [
+              5,
+              11.5
+            ],
+            [
+              6,
+              12
+            ],
+            [
+              9,
+              17.5
+            ]
+          ]
+        },
+        "text-letter-spacing": {
+          "stops": [
+            [
+              4,
+              0.13
+            ],
+            [
+              8,
+              0.4
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#b4b4b4",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Point of interest/General",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Point of interest",
+      "filter": [
+        "==",
+        "_label_class",
+        0
+      ],
+      "minzoom": 17,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9,
+        "text-anchor": "center",
+        "text-letter-spacing": 0.08,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Point of interest/Bus station",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Point of interest",
+      "filter": [
+        "==",
+        "_symbol",
+        2
+      ],
+      "minzoom": 17,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9,
+        "text-letter-spacing": 0.04,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 5,
+        "text-offset": [
+          0,
+          -0.9
+        ]
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Point of interest/Rail station",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Point of interest",
+      "filter": [
+        "==",
+        "_symbol",
+        3
+      ],
+      "minzoom": 17,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-size": 9,
+        "text-letter-spacing": 0.04,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 5,
+        "text-offset": [
+          0,
+          -0.9
+        ]
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-width": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Neighborhood",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Neighborhood",
+      "minzoom": 15,
+      "maxzoom": 17,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Light Regular"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              10,
+              10
+            ],
+            [
+              16,
+              13
+            ]
+          ]
+        },
+        "text-letter-spacing": 0.08,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 1
+      },
+      "paint": {
+        "text-color": "#353635",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City large scale/town small",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City large scale",
+      "filter": [
+        "==",
+        "_label_class",
+        5
+      ],
+      "minzoom": 10,
+      "maxzoom": 17,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Light Regular"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              10,
+              10
+            ],
+            [
+              16,
+              13
+            ]
+          ]
+        },
+        "text-letter-spacing": 0.08,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 15
+      },
+      "paint": {
+        "text-color": "#353635",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City large scale/town large",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City large scale",
+      "filter": [
+        "==",
+        "_label_class",
+        4
+      ],
+      "minzoom": 10,
+      "maxzoom": 17,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Light Regular"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              10,
+              10
+            ],
+            [
+              16,
+              15
+            ]
+          ]
+        },
+        "text-letter-spacing": 0.09,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 1
+      },
+      "paint": {
+        "text-halo-color": "#efefef",
+        "text-color": "#353635",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City large scale/small",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City large scale",
+      "filter": [
+        "==",
+        "_label_class",
+        3
+      ],
+      "minzoom": 10,
+      "maxzoom": 17,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Light Regular"
+        ],
+        "text-letter-spacing": 0.1,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-size": {
+          "stops": [
+            [
+              10,
+              11
+            ],
+            [
+              16,
+              16
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-halo-color": "#efefef",
+        "text-color": "#353635",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City large scale/medium",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City large scale",
+      "filter": [
+        "==",
+        "_label_class",
+        2
+      ],
+      "minzoom": 10,
+      "maxzoom": 17,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-letter-spacing": 0.1,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-size": {
+          "stops": [
+            [
+              10,
+              11
+            ],
+            [
+              16,
+              18.5
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-halo-color": "#efefef",
+        "text-color": "#353635",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City large scale/large",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City large scale",
+      "filter": [
+        "==",
+        "_label_class",
+        1
+      ],
+      "minzoom": 10,
+      "maxzoom": 17,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-letter-spacing": 0.1,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-size": {
+          "stops": [
+            [
+              10,
+              14
+            ],
+            [
+              16,
+              22
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#353635",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City large scale/x large",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City large scale",
+      "filter": [
+        "==",
+        "_label_class",
+        0
+      ],
+      "minzoom": 10,
+      "maxzoom": 17,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-letter-spacing": 0.1,
+        "text-max-width": 6,
+        "text-field": "{_name_global}",
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-size": {
+          "stops": [
+            [
+              10,
+              15
+            ],
+            [
+              16,
+              25
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#353635",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City small scale/town small non capital",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City small scale",
+      "filter": [
+        "==",
+        "_symbol",
+        17
+      ],
+      "minzoom": 2,
+      "maxzoom": 10,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Light Regular"
+        ],
+        "text-size": 10,
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-letter-spacing": 0.05,
+        "text-padding": 1
+      },
+      "paint": {
+        "text-color": "#353635",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City small scale/town large non capital",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City small scale",
+      "filter": [
+        "==",
+        "_symbol",
+        15
+      ],
+      "minzoom": 2,
+      "maxzoom": 10,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Light Regular"
+        ],
+        "text-size": 10,
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-letter-spacing": 0.05,
+        "text-padding": 1
+      },
+      "paint": {
+        "text-color": "#353635",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City small scale/small non capital",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City small scale",
+      "filter": [
+        "==",
+        "_symbol",
+        12
+      ],
+      "minzoom": 2,
+      "maxzoom": 10,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Light Regular"
+        ],
+        "text-size": 10,
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-letter-spacing": 0.05,
+        "text-padding": 1
+      },
+      "paint": {
+        "text-color": "#353635",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City small scale/medium non capital",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City small scale",
+      "filter": [
+        "==",
+        "_symbol",
+        9
+      ],
+      "minzoom": 2,
+      "maxzoom": 10,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Light Regular"
+        ],
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "text-letter-spacing": 0.05,
+        "text-size": 10
+      },
+      "paint": {
+        "text-color": "#353635",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City small scale/other capital",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City small scale",
+      "filter": [
+        "==",
+        "_symbol",
+        18
+      ],
+      "minzoom": 2,
+      "maxzoom": 10,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Light Regular"
+        ],
+        "text-size": 10,
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-letter-spacing": 0.05,
+        "text-padding": 1
+      },
+      "paint": {
+        "text-color": "#353635",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City small scale/town large other capital",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City small scale",
+      "filter": [
+        "==",
+        "_symbol",
+        14
+      ],
+      "minzoom": 2,
+      "maxzoom": 10,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Light Regular"
+        ],
+        "text-size": 10,
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-letter-spacing": 0.05,
+        "text-padding": 1
+      },
+      "paint": {
+        "text-color": "#353635",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City small scale/small other capital",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City small scale",
+      "filter": [
+        "==",
+        "_symbol",
+        11
+      ],
+      "minzoom": 2,
+      "maxzoom": 10,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Light Regular"
+        ],
+        "text-size": 10,
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-letter-spacing": 0.05,
+        "text-padding": 1
+      },
+      "paint": {
+        "text-color": "#353635",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City small scale/medium other capital",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City small scale",
+      "filter": [
+        "==",
+        "_symbol",
+        8
+      ],
+      "minzoom": 2,
+      "maxzoom": 10,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Light Regular"
+        ],
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-letter-spacing": 0.05,
+        "text-padding": 1,
+        "text-size": 10
+      },
+      "paint": {
+        "text-color": "#353635",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Admin0 point/x small",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Admin0 point",
+      "filter": [
+        "==",
+        "_label_class",
+        5
+      ],
+      "minzoom": 5,
+      "maxzoom": 10,
+      "layout": {
+        "text-font": [
+          "Ubuntu Bold"
+        ],
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "symbol-avoid-edges": true,
+        "text-letter-spacing": {
+          "stops": [
+            [
+              5,
+              0.13
+            ],
+            [
+              8,
+              0.5
+            ]
+          ]
+        },
+        "text-size": {
+          "stops": [
+            [
+              5,
+              10
+            ],
+            [
+              10,
+              12.5
+            ]
+          ]
+        },
+        "text-transform": "uppercase"
+      },
+      "paint": {
+        "text-color": "#aaafac",
+        "text-halo-color": "#F7F7F7",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Admin0 point/small",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Admin0 point",
+      "filter": [
+        "==",
+        "_label_class",
+        4
+      ],
+      "minzoom": 4,
+      "maxzoom": 10,
+      "layout": {
+        "text-font": [
+          "Ubuntu Bold"
+        ],
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "symbol-avoid-edges": true,
+        "text-letter-spacing": {
+          "stops": [
+            [
+              4,
+              0.13
+            ],
+            [
+              8,
+              0.5
+            ]
+          ]
+        },
+        "text-size": {
+          "stops": [
+            [
+              4,
+              10
+            ],
+            [
+              10,
+              12.5
+            ]
+          ]
+        },
+        "text-transform": "uppercase"
+      },
+      "paint": {
+        "text-color": "#aaafac",
+        "text-halo-color": "#F7F7F7",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Admin0 point/medium",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Admin0 point",
+      "filter": [
+        "==",
+        "_label_class",
+        3
+      ],
+      "minzoom": 2,
+      "maxzoom": 10,
+      "layout": {
+        "text-font": [
+          "Ubuntu Bold"
+        ],
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "symbol-avoid-edges": true,
+        "text-letter-spacing": {
+          "stops": [
+            [
+              2,
+              0.13
+            ],
+            [
+              8,
+              0.5
+            ]
+          ]
+        },
+        "text-size": {
+          "stops": [
+            [
+              2,
+              8
+            ],
+            [
+              4,
+              10
+            ],
+            [
+              10,
+              16
+            ]
+          ]
+        },
+        "text-transform": "uppercase"
+      },
+      "paint": {
+        "text-color": "#aaafac",
+        "text-halo-color": "#F7F7F7",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Admin0 point/large",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Admin0 point",
+      "filter": [
+        "==",
+        "_label_class",
+        2
+      ],
+      "minzoom": 2,
+      "maxzoom": 10,
+      "layout": {
+        "text-font": [
+          "Ubuntu Bold"
+        ],
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "symbol-avoid-edges": true,
+        "text-letter-spacing": {
+          "stops": [
+            [
+              2,
+              0.13
+            ],
+            [
+              8,
+              0.5
+            ]
+          ]
+        },
+        "text-size": {
+          "stops": [
+            [
+              2,
+              9
+            ],
+            [
+              4,
+              10
+            ],
+            [
+              6,
+              16
+            ]
+          ]
+        },
+        "text-transform": "uppercase"
+      },
+      "paint": {
+        "text-color": "#aaafac",
+        "text-halo-color": "#F7F7F7",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Admin0 point/x large",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Admin0 point",
+      "filter": [
+        "==",
+        "_label_class",
+        1
+      ],
+      "minzoom": 2,
+      "maxzoom": 8,
+      "layout": {
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Bold"
+        ],
+        "text-line-height": 1.5,
+        "text-letter-spacing": {
+          "stops": [
+            [
+              2,
+              0.15
+            ],
+            [
+              6,
+              0.5
+            ]
+          ]
+        },
+        "text-size": {
+          "stops": [
+            [
+              2,
+              9
+            ],
+            [
+              4,
+              10
+            ],
+            [
+              6,
+              16
+            ]
+          ]
+        },
+        "text-transform": "uppercase"
+      },
+      "paint": {
+        "text-color": "#aaafac",
+        "text-halo-color": "#F7F7F7",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City small scale/town small admin0 capital",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City small scale",
+      "filter": [
+        "==",
+        "_symbol",
+        16
+      ],
+      "minzoom": 2,
+      "maxzoom": 10,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-letter-spacing": 0.05,
+        "text-padding": 1,
+        "text-size": {
+          "stops": [
+            [
+              3,
+              10
+            ],
+            [
+              6,
+              10.5
+            ],
+            [
+              8,
+              13
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#353635",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City small scale/town large admin0 capital",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City small scale",
+      "filter": [
+        "==",
+        "_symbol",
+        13
+      ],
+      "minzoom": 2,
+      "maxzoom": 10,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-letter-spacing": 0.05,
+        "text-padding": 1,
+        "text-size": {
+          "stops": [
+            [
+              3,
+              10
+            ],
+            [
+              6,
+              10.5
+            ],
+            [
+              8,
+              13
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#353635",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City small scale/small admin0 capital",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City small scale",
+      "filter": [
+        "==",
+        "_symbol",
+        10
+      ],
+      "minzoom": 2,
+      "maxzoom": 10,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-letter-spacing": 0.05,
+        "text-padding": 1,
+        "text-size": {
+          "stops": [
+            [
+              3,
+              10
+            ],
+            [
+              6,
+              10.5
+            ],
+            [
+              8,
+              13
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#353635",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City small scale/medium admin0 capital",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City small scale",
+      "filter": [
+        "==",
+        "_symbol",
+        7
+      ],
+      "minzoom": 2,
+      "maxzoom": 10,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-letter-spacing": 0.05,
+        "text-padding": 1,
+        "text-size": {
+          "stops": [
+            [
+              3,
+              10
+            ],
+            [
+              6,
+              10.5
+            ],
+            [
+              8,
+              13
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#353635",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City small scale/large other capital",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City small scale",
+      "filter": [
+        "==",
+        "_symbol",
+        5
+      ],
+      "minzoom": 2,
+      "maxzoom": 10,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-letter-spacing": 0.05,
+        "text-padding": 1,
+        "text-size": {
+          "stops": [
+            [
+              3,
+              10
+            ],
+            [
+              6,
+              11
+            ],
+            [
+              8,
+              14
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#353635",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City small scale/x large admin2 capital",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City small scale",
+      "filter": [
+        "==",
+        "_symbol",
+        2
+      ],
+      "minzoom": 2,
+      "maxzoom": 10,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-letter-spacing": 0.05,
+        "text-padding": 1,
+        "text-size": {
+          "stops": [
+            [
+              3,
+              11
+            ],
+            [
+              6,
+              12
+            ],
+            [
+              8,
+              15
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#353635",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City small scale/large non capital",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City small scale",
+      "filter": [
+        "==",
+        "_symbol",
+        6
+      ],
+      "minzoom": 2,
+      "maxzoom": 10,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-letter-spacing": 0.05,
+        "text-padding": 1,
+        "text-size": {
+          "stops": [
+            [
+              3,
+              10
+            ],
+            [
+              6,
+              11
+            ],
+            [
+              8,
+              14
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#353635",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City small scale/large admin0 capital",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City small scale",
+      "filter": [
+        "==",
+        "_symbol",
+        4
+      ],
+      "minzoom": 2,
+      "maxzoom": 10,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-letter-spacing": 0.05,
+        "text-padding": 1,
+        "text-size": {
+          "stops": [
+            [
+              3,
+              10
+            ],
+            [
+              6,
+              11
+            ],
+            [
+              8,
+              14
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#353635",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City small scale/x large non capital",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City small scale",
+      "filter": [
+        "==",
+        "_symbol",
+        3
+      ],
+      "minzoom": 2,
+      "maxzoom": 10,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-letter-spacing": 0.05,
+        "text-padding": 1,
+        "text-size": {
+          "stops": [
+            [
+              3,
+              11
+            ],
+            [
+              6,
+              12
+            ],
+            [
+              8,
+              15
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#353635",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City small scale/x large admin1 capital",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City small scale",
+      "filter": [
+        "==",
+        "_symbol",
+        1
+      ],
+      "minzoom": 2,
+      "maxzoom": 10,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-letter-spacing": 0.05,
+        "text-padding": 1,
+        "text-size": {
+          "stops": [
+            [
+              3,
+              11
+            ],
+            [
+              6,
+              12
+            ],
+            [
+              8,
+              15
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#353635",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "City small scale/x large admin0 capital",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "City small scale",
+      "filter": [
+        "==",
+        "_symbol",
+        0
+      ],
+      "minzoom": 2,
+      "maxzoom": 10,
+      "layout": {
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Regular"
+        ],
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-letter-spacing": 0.05,
+        "text-padding": 1,
+        "text-size": {
+          "stops": [
+            [
+              3,
+              11
+            ],
+            [
+              6,
+              12
+            ],
+            [
+              8,
+              15
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "#353635",
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Admin0 point/2x large",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Admin0 point",
+      "filter": [
+        "==",
+        "_label_class",
+        0
+      ],
+      "minzoom": 2,
+      "maxzoom": 6,
+      "layout": {
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-allow-overlap": false,
+        "text-padding": 1,
+        "symbol-avoid-edges": true,
+        "text-font": [
+          "Ubuntu Bold"
+        ],
+        "text-line-height": 1.7,
+        "text-letter-spacing": {
+          "stops": [
+            [
+              2,
+              0.3
+            ],
+            [
+              5,
+              0.5
+            ]
+          ]
+        },
+        "text-size": {
+          "stops": [
+            [
+              2,
+              12
+            ],
+            [
+              4,
+              15.5
+            ],
+            [
+              5,
+              18
+            ]
+          ]
+        },
+        "text-transform": "uppercase"
+      },
+      "paint": {
+        "text-color": "#aaafac",
+        "text-halo-color": "#F7F7F7",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "Disputed label point/Island",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Disputed label point",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          1
+        ],
+        [
+          "in",
+          "DisputeID",
+          0
+        ]
+      ],
+      "minzoom": 6,
+      "layout": {
+        "icon-image": "Disputed label point",
+        "icon-allow-overlap": true,
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              6,
+              7
+            ],
+            [
+              15,
+              10
+            ]
+          ]
+        },
+        "text-anchor": "center",
+        "text-letter-spacing": 0.13,
+        "text-max-width": 4,
+        "text-field": "{_name}",
+        "text-optional": true
+      },
+      "paint": {
+        "text-color": "#808080",
+        "text-halo-blur": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "Disputed label point/Waterbody",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Disputed label point",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          0
+        ],
+        [
+          "in",
+          "DisputeID",
+          1006
+        ]
+      ],
+      "minzoom": 2,
+      "maxzoom": 10,
+      "layout": {
+        "icon-image": "Disputed label point",
+        "icon-allow-overlap": true,
+        "text-font": [
+          "Ubuntu Italic"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              2,
+              8
+            ],
+            [
+              6,
+              9.3
+            ]
+          ]
+        },
+        "text-anchor": "center",
+        "text-letter-spacing": 0.1,
+        "text-max-width": 4,
+        "text-field": "{_name}",
+        "text-optional": true
+      },
+      "paint": {
+        "text-color": "#888f91",
+        "text-halo-blur": 1,
+        "text-halo-color": "#efefef",
+        "text-halo-width": 0.5
+      }
+    },
+    {
+      "id": "Disputed label point/Admin0",
+      "type": "symbol",
+      "source": "esri",
+      "source-layer": "Disputed label point",
+      "filter": [
+        "all",
+        [
+          "==",
+          "_label_class",
+          2
+        ],
+        [
+          "in",
+          "DisputeID",
+          1021
+        ]
+      ],
+      "minzoom": 2,
+      "layout": {
+        "icon-image": "Disputed label point",
+        "icon-allow-overlap": true,
+        "text-font": [
+          "Ubuntu Bold"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              2,
+              8
+            ],
+            [
+              4,
+              10
+            ],
+            [
+              10,
+              16
+            ]
+          ]
+        },
+        "text-transform": "uppercase",
+        "text-letter-spacing": {
+          "stops": [
+            [
+              2,
+              0.13
+            ],
+            [
+              8,
+              0.5
+            ]
+          ]
+        },
+        "text-anchor": "center",
+        "text-max-width": 6,
+        "text-field": "{_name}",
+        "text-optional": true
+      },
+      "paint": {
+        "text-color": "#aaafac",
+        "text-halo-color": "#F7F7F7",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    }
+  ]
+}

--- a/scripts/geo/fetch-esri-style.sh
+++ b/scripts/geo/fetch-esri-style.sh
@@ -41,8 +41,8 @@ METADATA_FILE="$DIR_LIB_GEO/metadata.json"
 STYLE_URL="http://www.arcgis.com/sharing/rest/content/items/$STYLE_ID/resources/styles/root.json"
 
 # fetch style root
-curl -s "$STYLE_URL" > "$STYLE_FILE"
+curl -s "$STYLE_URL" | jq . > "$STYLE_FILE"
 
 # fetch style metadata
 METADATA_URL=$(jq -r ".sources.esri.url" "$STYLE_FILE")
-curl -s "$METADATA_URL" > "$METADATA_FILE"
+curl -s "$METADATA_URL" | jq . > "$METADATA_FILE"

--- a/tests/jest/unit/geo/GeoStyle.spec.js
+++ b/tests/jest/unit/geo/GeoStyle.spec.js
@@ -1,31 +1,51 @@
 import { validate } from '@mapbox/mapbox-gl-style-spec';
 
-import rootStyleDark from '@/lib/geo/theme/dark/root.json';
-import metadataDark from '@/lib/geo/theme/dark/metadata.json';
-import rootStyleLight from '@/lib/geo/theme/light/root.json';
-import metadataLight from '@/lib/geo/theme/light/metadata.json';
 import GeoStyle from '@/lib/geo/GeoStyle';
 
-test('GeoStyle#get [dark]', () => {
-  const mapStyle = new GeoStyle(rootStyleDark, metadataDark);
+test('GeoStyle#get [aerial dark]', () => {
+  const options = { aerial: true, dark: true };
 
-  const { style } = mapStyle;
+  const style = GeoStyle.get(options);
   const errors = validate(style);
   expect(errors).toHaveLength(0);
 
-  const styleCopy = mapStyle.get();
+  const styleCopy = GeoStyle.get(options);
   expect(styleCopy).not.toBe(style);
   expect(styleCopy).toEqual(style);
 });
 
-test('GeoStyle#get [light]', () => {
-  const mapStyle = new GeoStyle(rootStyleLight, metadataLight);
+test('GeoStyle#get [aerial light]', () => {
+  const options = { aerial: true, dark: false };
 
-  const { style } = mapStyle;
+  const style = GeoStyle.get(options);
   const errors = validate(style);
   expect(errors).toHaveLength(0);
 
-  const styleCopy = mapStyle.get();
+  const styleCopy = GeoStyle.get(options);
+  expect(styleCopy).not.toBe(style);
+  expect(styleCopy).toEqual(style);
+});
+
+test('GeoStyle#get [map dark]', () => {
+  const options = { aerial: false, dark: true };
+
+  const style = GeoStyle.get(options);
+  const errors = validate(style);
+  expect(errors).toHaveLength(0);
+
+  const styleCopy = GeoStyle.get(options);
+  expect(styleCopy).not.toBe(style);
+  expect(styleCopy).toEqual(style);
+});
+
+test('GeoStyle#get [map light]', () => {
+  const options = { aerial: false, dark: false };
+
+  const style = GeoStyle.get(options);
+  const errors = validate(style);
+  expect(errors).toHaveLength(0);
+
+  const styleCopy = GeoStyle.get(options);
   expect(styleCopy).not.toBe(style);
   expect(styleCopy).toEqual(style);
 });

--- a/tests/unitSetup.js
+++ b/tests/unitSetup.js
@@ -3,4 +3,8 @@ import Blob from 'node-blob';
 
 global.Blob = Blob;
 global.URL.createObjectURL = jest.fn();
-global.window = {};
+global.window = {
+  location: {
+    origin: 'https://localhost:8081',
+  },
+};

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -18,8 +18,8 @@
       </FcButton>
       <FcButton
         type="fab-text"
-        @click="toggleSatellite">
-        {{ satellite ? 'Map' : 'Aerial' }}
+        @click="aerial = !aerial">
+        {{ aerial ? 'Map' : 'Aerial' }}
       </FcButton>
     </div>
     <FcPaneMapPopup
@@ -42,12 +42,9 @@ import mapboxgl from 'mapbox-gl/dist/mapbox-gl';
 import Vue from 'vue';
 import { mapMutations, mapState } from 'vuex';
 
-import { Enum } from '@/lib/ClassUtils';
-import { CentrelineType } from '@/lib/Constants';
+import { CentrelineType, MapZoom } from '@/lib/Constants';
 import { debounce } from '@/lib/FunctionUtils';
 import { getGeometryMidpoint } from '@/lib/geo/GeometryUtils';
-import rootStyleLight from '@/lib/geo/theme/light/root.json';
-import metadataLight from '@/lib/geo/theme/light/metadata.json';
 import GeoStyle from '@/lib/geo/GeoStyle';
 import FcPaneMapPopup from '@/web/components/FcPaneMapPopup.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
@@ -57,240 +54,6 @@ const BOUNDS_TORONTO = new mapboxgl.LngLatBounds(
   new mapboxgl.LngLat(-79.639264937, 43.580995995),
   new mapboxgl.LngLat(-79.115243191, 43.855457183),
 );
-
-class MapZoom extends Enum {
-  get maxzoomSource() {
-    return this.maxzoomLayer - 1;
-  }
-}
-MapZoom.init({
-  LEVEL_3: {
-    minzoom: 10,
-    maxzoomLayer: 14,
-  },
-  LEVEL_2: {
-    minzoom: 14,
-    maxzoomLayer: 17,
-  },
-  LEVEL_1: {
-    minzoom: 17,
-    maxzoomLayer: 20,
-  },
-});
-MapZoom.MIN = MapZoom.LEVEL_3.minzoom;
-MapZoom.MAX = MapZoom.LEVEL_1.maxzoomSource;
-
-function interactionAttr(base, hovered, selected) {
-  return [
-    'case',
-    ['boolean', ['feature-state', 'selected'], false], selected,
-    ['boolean', ['feature-state', 'hover'], false], hovered,
-    base,
-  ];
-}
-
-const PAINT_OPACITY = interactionAttr(0.45, 0.6, 0.6);
-const PAINT_COLOR_CENTRELINE = interactionAttr(
-  '#dcdee0',
-  '#e5a000',
-  '#00a91c',
-);
-const PAINT_COLOR_COUNTS = interactionAttr(
-  '#00bde3',
-  '#e5a000',
-  '#00a91c',
-);
-const PAINT_WIDTH_MIDBLOCKS = interactionAttr(3, 5, 5);
-const PAINT_RADIUS_INTERSECTIONS = interactionAttr(8, 10, 10);
-const PAINT_RADIUS_COUNTS = interactionAttr(10, 12, 12);
-
-function addTippecanoeSource(style, id, minLevel, maxLevel, crossfade = 0) {
-  /* eslint-disable-next-line no-param-reassign */
-  style.sources[id] = {
-    type: 'vector',
-    tiles: [`https://flashcrow-etladmin.intra.dev-toronto.ca/tiles/${id}/{z}/{x}/{y}.pbf`],
-    minzoom: minLevel.minzoom,
-    maxzoom: maxLevel.maxzoomSource + crossfade,
-  };
-}
-
-function addDynamicTileSource(style, id, minLevel, maxLevel) {
-  const { origin } = window.location;
-  /* eslint-disable-next-line no-param-reassign */
-  style.sources[id] = {
-    type: 'vector',
-    tiles: [`${origin}/api/dynamicTiles/${id}/{z}/{x}/{y}.pbf`],
-    minzoom: minLevel.minzoom,
-    maxzoom: maxLevel.maxzoomSource,
-  };
-}
-
-function addLayer(style, id, type, options) {
-  const source = style.sources[id];
-  style.layers.push({
-    id,
-    source: id,
-    'source-layer': id,
-    type,
-    minzoom: source.minzoom,
-    maxzoom: source.maxzoom + 1,
-    ...options,
-  });
-}
-
-function injectSourcesAndLayers(rawStyle) {
-  const STYLE = { ...rawStyle };
-
-  STYLE.glyphs = 'https://flashcrow-etladmin.intra.dev-toronto.ca/glyphs/{fontstack}/{range}.pbf';
-
-  addTippecanoeSource(STYLE, 'collisionsLevel3', MapZoom.LEVEL_3, MapZoom.LEVEL_3, 2);
-  addTippecanoeSource(STYLE, 'collisionsLevel2', MapZoom.LEVEL_2, MapZoom.LEVEL_2);
-  addDynamicTileSource(STYLE, 'collisionsLevel1', MapZoom.LEVEL_1, MapZoom.LEVEL_1);
-  addDynamicTileSource(STYLE, 'counts', MapZoom.LEVEL_2, MapZoom.LEVEL_1);
-  addTippecanoeSource(STYLE, 'intersections', MapZoom.LEVEL_3, MapZoom.LEVEL_1);
-  addTippecanoeSource(STYLE, 'midblocks', MapZoom.LEVEL_3, MapZoom.LEVEL_1);
-  addTippecanoeSource(STYLE, 'schoolsLevel2', MapZoom.LEVEL_2, MapZoom.LEVEL_2);
-  addDynamicTileSource(STYLE, 'schoolsLevel1', MapZoom.LEVEL_1, MapZoom.LEVEL_1);
-
-  addLayer(STYLE, 'midblocks', 'line', {
-    paint: {
-      'line-color': PAINT_COLOR_CENTRELINE,
-      'line-width': PAINT_WIDTH_MIDBLOCKS,
-      'line-opacity': PAINT_OPACITY,
-    },
-  });
-  addLayer(STYLE, 'intersections', 'circle', {
-    paint: {
-      'circle-color': PAINT_COLOR_CENTRELINE,
-      'circle-radius': PAINT_RADIUS_INTERSECTIONS,
-      'circle-opacity': PAINT_OPACITY,
-    },
-  });
-  addLayer(STYLE, 'counts', 'circle', {
-    paint: {
-      'circle-color': PAINT_COLOR_COUNTS,
-      'circle-radius': PAINT_RADIUS_COUNTS,
-      'circle-opacity': PAINT_OPACITY,
-    },
-  });
-  addLayer(STYLE, 'collisionsLevel3', 'heatmap', {
-    paint: {
-      'heatmap-color': [
-        'interpolate',
-        ['linear'],
-        ['heatmap-density'],
-        0, 'rgba(244, 227, 219, 0)',
-        0.5, '#f39268',
-        1, '#d63e04',
-      ],
-      'heatmap-intensity': [
-        'interpolate',
-        ['linear'],
-        ['zoom'],
-        STYLE.sources.collisionsLevel3.minzoom, 1,
-        STYLE.sources.collisionsLevel3.maxzoom, 3,
-      ],
-      'heatmap-opacity': [
-        'interpolate',
-        ['linear'],
-        ['zoom'],
-        STYLE.sources.collisionsLevel3.maxzoom, 0.8,
-        STYLE.sources.collisionsLevel3.maxzoom + 1, 0,
-      ],
-      'heatmap-radius': [
-        'interpolate',
-        ['linear'],
-        ['zoom'],
-        STYLE.sources.collisionsLevel3.minzoom, 5,
-        STYLE.sources.collisionsLevel3.maxzoom, 10,
-      ],
-      'heatmap-weight': ['get', 'heatmap_weight'],
-    },
-  });
-  addLayer(STYLE, 'collisionsLevel2', 'circle', {
-    layout: {
-      'circle-sort-key': ['get', 'injury'],
-    },
-    paint: {
-      'circle-color': [
-        'case',
-        ['>=', ['get', 'injury'], 3], '#b51d09',
-        '#d63e04',
-      ],
-      'circle-opacity': [
-        'interpolate',
-        ['linear'],
-        ['zoom'],
-        STYLE.sources.collisionsLevel2.minzoom, 0.2,
-        STYLE.sources.collisionsLevel2.minzoom + 1, [
-          'case',
-          ['>=', ['get', 'injury'], 3], 0.8,
-          0.6,
-        ],
-      ],
-      'circle-radius': [
-        'case',
-        ['>=', ['get', 'injury'], 3], 10,
-        5,
-      ],
-    },
-  });
-  addLayer(STYLE, 'collisionsLevel1', 'circle', {
-    layout: {
-      'circle-sort-key': ['get', 'injury'],
-    },
-    paint: {
-      'circle-color': [
-        'case',
-        ['>=', ['get', 'injury'], 3], '#b51d09',
-        '#d63e04',
-      ],
-      'circle-opacity': [
-        'case',
-        ['>=', ['get', 'injury'], 3], 0.8,
-        0.6,
-      ],
-      'circle-radius': [
-        'case',
-        ['>=', ['get', 'injury'], 3], 10,
-        5,
-      ],
-    },
-  });
-  addLayer(STYLE, 'schoolsLevel2', 'symbol', {
-    layout: {
-      'text-field': [
-        'match',
-        ['get', 'schoolType'],
-        'U', '\uf19d',
-        'C', '\uf19d',
-        '\uf549',
-      ],
-      'text-font': ['literal', ['Font Awesome 5 Free']],
-      'text-size': 16,
-    },
-    paint: {
-      'text-color': '#00a91c',
-    },
-  });
-  addLayer(STYLE, 'schoolsLevel1', 'symbol', {
-    layout: {
-      'text-field': [
-        'match',
-        ['get', 'schoolType'],
-        'U', '\uf19d',
-        'C', '\uf19d',
-        '\uf549',
-      ],
-      'text-font': ['literal', ['Font Awesome 5 Free']],
-      'text-size': 20,
-    },
-    paint: {
-      'text-color': '#00a91c',
-    },
-  });
-  return STYLE;
-}
 
 function getFeatureKey(feature) {
   if (feature === null) {
@@ -319,7 +82,7 @@ export default {
     return {
       coordinates: null,
       loading: false,
-      satellite: false,
+      aerial: false,
       // keeps track of which feature we are currently hovering over
       hoveredFeature: null,
       // used to add slight debounce delay (250ms) to hovered popup
@@ -335,6 +98,15 @@ export default {
     featureKeySelected() {
       return getFeatureKey(this.selectedFeature);
     },
+    mapStyle() {
+      const { aerial } = this;
+      const { dark } = this.$vuetify.theme;
+      const options = {
+        aerial,
+        dark,
+      };
+      return GeoStyle.get(options);
+    },
     ...mapState(['drawerOpen', 'location']),
   },
   created() {
@@ -342,29 +114,6 @@ export default {
   },
   mounted() {
     const bounds = BOUNDS_TORONTO;
-    const mapStyle = new GeoStyle(rootStyleLight, metadataLight).get();
-    this.mapStyle = injectSourcesAndLayers(mapStyle);
-    this.satelliteStyle = injectSourcesAndLayers({
-      version: 8,
-      sources: {
-        'gcc-ortho-webm': {
-          type: 'raster',
-          tiles: [
-            'https://gis.toronto.ca/arcgis/rest/services/primary/cot_ortho_webm/MapServer/tile/{z}/{y}/{x}',
-          ],
-          tileSize: 256,
-        },
-      },
-      layers: [
-        {
-          id: 'gcc-ortho-webm',
-          type: 'raster',
-          source: 'gcc-ortho-webm',
-          minzoom: MapZoom.LEVEL_3.minzoom,
-          maxzoom: MapZoom.LEVEL_1.maxzoomLayer,
-        },
-      ],
-    });
 
     // marker
     this.selectedMarker = new mapboxgl.Marker()
@@ -437,6 +186,12 @@ export default {
     hoveredFeature: debounce(function watchHoveredFeature() {
       this.featureKeyHoveredPopup = this.featureKeyHovered;
     }, 250),
+    mapStyle: {
+      handler() {
+        this.map.setStyle(this.mapStyle);
+      },
+      immediate: true,
+    },
     location(location, oldLocation) {
       this.updateSelectedMarker();
       if (this.location === null) {
@@ -690,14 +445,6 @@ export default {
       const z = Math.round(zoom);
       const url = `https://www.google.com/maps/@${lat},${lng},${z}z`;
       window.open(url, '_blank');
-    },
-    toggleSatellite() {
-      this.satellite = !this.satellite;
-      if (this.satellite) {
-        this.map.setStyle(this.satelliteStyle, { diff: false });
-      } else {
-        this.map.setStyle(this.mapStyle, { diff: false });
-      }
     },
     updateCoordinates() {
       const { lat, lng } = this.map.getCenter();

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -186,11 +186,8 @@ export default {
     hoveredFeature: debounce(function watchHoveredFeature() {
       this.featureKeyHoveredPopup = this.featureKeyHovered;
     }, 250),
-    mapStyle: {
-      handler() {
-        this.map.setStyle(this.mapStyle);
-      },
-      immediate: true,
+    mapStyle() {
+      this.map.setStyle(this.mapStyle);
     },
     location(location, oldLocation) {
       this.updateSelectedMarker();

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -46,8 +46,8 @@ import { Enum } from '@/lib/ClassUtils';
 import { CentrelineType } from '@/lib/Constants';
 import { debounce } from '@/lib/FunctionUtils';
 import { getGeometryMidpoint } from '@/lib/geo/GeometryUtils';
-import rootStyleDark from '@/lib/geo/theme/dark/root.json';
-import metadataDark from '@/lib/geo/theme/dark/metadata.json';
+import rootStyleLight from '@/lib/geo/theme/light/root.json';
+import metadataLight from '@/lib/geo/theme/light/metadata.json';
 import GeoStyle from '@/lib/geo/GeoStyle';
 import FcPaneMapPopup from '@/web/components/FcPaneMapPopup.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
@@ -342,7 +342,7 @@ export default {
   },
   mounted() {
     const bounds = BOUNDS_TORONTO;
-    const mapStyle = new GeoStyle(rootStyleDark, metadataDark).get();
+    const mapStyle = new GeoStyle(rootStyleLight, metadataLight).get();
     this.mapStyle = injectSourcesAndLayers(mapStyle);
     this.satelliteStyle = injectSourcesAndLayers({
       version: 8,


### PR DESCRIPTION
This PR closes #362 by separating text label layers from our basemap styles, moving them to top, switching to Roboto, increasing font size and halo width, and showing them in both map and aerial modes:

![image](https://user-images.githubusercontent.com/151605/77332727-c752c100-6cf8-11ea-9495-85f00cfd630b.png)
