### PR TITLE
Switching time frames on dynamic collision tiles

### DIFF
--- a/lib/controller/DynamicTileController.js
+++ b/lib/controller/DynamicTileController.js
@@ -26,7 +26,10 @@ DynamicTileController.push({
     validate: {
       params: {
         layerName: Joi.string().valid(
-          'collisionsLevel1',
+          'collisionsLevel1:1',
+          'collisionsLevel1:3',
+          'collisionsLevel1:5',
+          'collisionsLevel1:10',
           'counts',
           'hospitalsLevel1',
           'schoolsLevel1',

--- a/lib/db/DynamicTileDAO.js
+++ b/lib/db/DynamicTileDAO.js
@@ -36,7 +36,8 @@ class DynamicTileDAO {
     };
   }
 
-  static async getCollisionsFeatures(tileInfo) {
+  static async getCollisionsFeatures(tileInfo, datesFrom) {
+    const datesFromYear = `${datesFrom} year`;
     const sql = `
 WITH event_injury AS (
   SELECT i.collision_id, MAX(CONCAT('0', i.injury)::int) AS injury
@@ -45,7 +46,7 @@ WITH event_injury AS (
   WHERE ST_Intersects(
     ST_Transform(e.geom, 3857),
     ST_MakeEnvelope($(xmin), $(ymin), $(xmax), $(ymax), 3857)
-  ) AND e.accdate >= now() - interval '1 year'
+  ) AND e.accdate >= now() - interval $(datesFromYear)
   GROUP BY i.collision_id
 ),
 collisions AS (
@@ -76,7 +77,10 @@ centreline_id AS "centrelineId",
 centreline_type AS "centrelineType",
 injury
 FROM collisions`;
-    return db.manyOrNone(sql, tileInfo);
+    return db.manyOrNone(sql, {
+      ...tileInfo,
+      datesFromYear,
+    });
   }
 
   static async getCountsFeatures(tileInfo) {
@@ -179,8 +183,10 @@ FROM schools`;
 
   static async getTileFeatures(layerName, z, x, y) {
     const tileInfo = DynamicTileDAO.getTileInfo(z, x, y);
-    if (layerName === 'collisionsLevel1') {
-      return DynamicTileDAO.getCollisionsFeatures(tileInfo);
+    if (layerName.startsWith('collisionsLevel1')) {
+      const [, datesFromStr] = layerName.split(':');
+      const datesFrom = parseInt(datesFromStr, 10);
+      return DynamicTileDAO.getCollisionsFeatures(tileInfo, datesFrom);
     }
     if (layerName === 'counts') {
       return DynamicTileDAO.getCountsFeatures(tileInfo);

--- a/lib/geo/GeoStyle.js
+++ b/lib/geo/GeoStyle.js
@@ -176,7 +176,10 @@ function injectSources(style) {
   // SOURCES
   addTippecanoeSource(style, 'collisionsLevel3', MapZoom.LEVEL_3, MapZoom.LEVEL_3, 2);
   addTippecanoeSource(style, 'collisionsLevel2', MapZoom.LEVEL_2, MapZoom.LEVEL_2);
-  addDynamicTileSource(style, 'collisionsLevel1', MapZoom.LEVEL_1, MapZoom.LEVEL_1);
+  addDynamicTileSource(style, 'collisionsLevel1:1', MapZoom.LEVEL_1, MapZoom.LEVEL_1);
+  addDynamicTileSource(style, 'collisionsLevel1:3', MapZoom.LEVEL_1, MapZoom.LEVEL_1);
+  addDynamicTileSource(style, 'collisionsLevel1:5', MapZoom.LEVEL_1, MapZoom.LEVEL_1);
+  addDynamicTileSource(style, 'collisionsLevel1:10', MapZoom.LEVEL_1, MapZoom.LEVEL_1);
   addDynamicTileSource(style, 'counts', MapZoom.LEVEL_2, MapZoom.LEVEL_1);
   addTippecanoeSource(style, 'hospitalsLevel2', MapZoom.LEVEL_2, MapZoom.LEVEL_2);
   addDynamicTileSource(style, 'hospitalsLevel1', MapZoom.LEVEL_1, MapZoom.LEVEL_1);
@@ -327,10 +330,19 @@ class GeoStyle {
     ];
   }
 
-  static getCollisionsLayers({ layers: { collisions } }, baseStyle) {
+  static getCollisionsLayers({ datesFrom, layers: { collisions } }, baseStyle) {
+    const sourceLevel3 = 'collisionsLevel3';
+    const sourceLevel2 = 'collisionsLevel2';
+    const sourceLevel1 = `collisionsLevel1:${datesFrom}`;
     const visibility = collisions ? 'visible' : 'none';
     return [
-      getLayer(baseStyle, 'collisionsLevel3', 'heatmap', {
+      {
+        id: 'collisionsLevel3',
+        source: sourceLevel3,
+        'source-layer': sourceLevel3,
+        type: 'heatmap',
+        minzoom: MapZoom.LEVEL_3.minzoom,
+        maxzoom: MapZoom.LEVEL_3.maxzoomSource + 1,
         layout: {
           visibility,
         },
@@ -366,8 +378,13 @@ class GeoStyle {
           ],
           'heatmap-weight': ['get', 'heatmap_weight'],
         },
-      }),
-      getLayer(baseStyle, 'collisionsLevel2', 'circle', {
+      }, {
+        id: 'collisionsLevel2',
+        source: sourceLevel2,
+        'source-layer': sourceLevel2,
+        type: 'circle',
+        minzoom: MapZoom.LEVEL_2.minzoom,
+        maxzoom: MapZoom.LEVEL_2.maxzoomSource + 1,
         layout: {
           'circle-sort-key': ['get', 'injury'],
           visibility,
@@ -395,8 +412,13 @@ class GeoStyle {
             5,
           ],
         },
-      }),
-      getLayer(baseStyle, 'collisionsLevel1', 'circle', {
+      }, {
+        id: 'collisionsLevel1',
+        source: sourceLevel1,
+        'source-layer': sourceLevel1,
+        type: 'circle',
+        minzoom: MapZoom.LEVEL_1.minzoom,
+        maxzoom: MapZoom.LEVEL_1.maxzoomSource + 1,
         layout: {
           'circle-sort-key': ['get', 'injury'],
           visibility,
@@ -418,7 +440,7 @@ class GeoStyle {
             5,
           ],
         },
-      }),
+      },
     ];
   }
 


### PR DESCRIPTION
This PR makes further progress on #363 - at this point, we've almost completed that issue, but we're still waiting on Airflow jobs to make final changes.

We use a "multiple sources, one layer" strategy: we define sources with IDs `collisionsLevel1:${datesFrom}`, and use `datesFrom` within `DynamicTileDAO.getCollisionsFeatures` to modify the SQL query.  In `GeoStyle`, we then load the appropriate source by switching `source` and `source-layer` according to the current value of `datesFrom`.