### PR TITLE
AADT volume layer frontend integration

### DIFF
--- a/lib/geo/GeoStyle.js
+++ b/lib/geo/GeoStyle.js
@@ -1,4 +1,4 @@
-import { MapZoom } from '@/lib/Constants';
+import { MapZoom, RoadSegmentType } from '@/lib/Constants';
 import rootStyleDark from '@/lib/geo/theme/dark/root.json';
 import metadataDark from '@/lib/geo/theme/dark/metadata.json';
 import rootStyleLight from '@/lib/geo/theme/light/root.json';
@@ -237,23 +237,24 @@ injectSources(STYLE_BASE_AERIAL);
 
 // MOVE FEATURE LAYERS
 
-function interactionAttr(base, hovered, selected) {
+const COLOR_CENTRELINE_GREY = '#757575';
+const COLOR_COLLISION_HEATMAP_ZERO = 'rgba(244, 227, 219, 0)';
+const COLOR_COLLISION_HEATMAP_HALF = '#f39268';
+const COLOR_COLLISION_FILL = '#ef4848';
+const COLOR_COLLISION_STROKE = '#773333';
+const COLOR_VOLUME_GREEN = '#26de81';
+const COLOR_VOLUME_YELLOW = '#fed330';
+const COLOR_VOLUME_RED = '#fc5c65';
+
+function aadtScale(green, red) {
   return [
-    'case',
-    ['boolean', ['feature-state', 'selected'], false], selected,
-    ['boolean', ['feature-state', 'hover'], false], hovered,
-    base,
+    'step',
+    ['get', 'aadt'],
+    COLOR_VOLUME_GREEN,
+    green, COLOR_VOLUME_YELLOW,
+    red, COLOR_VOLUME_RED,
   ];
 }
-
-const PAINT_OPACITY = interactionAttr(0.45, 0.6, 0.6);
-const PAINT_COLOR_CENTRELINE = interactionAttr(
-  '#dcdee0',
-  '#e5a000',
-  '#00a91c',
-);
-const PAINT_WIDTH_MIDBLOCKS = interactionAttr(3, 5, 5);
-const PAINT_RADIUS_INTERSECTIONS = interactionAttr(8, 10, 10);
 
 function getLayer(style, id, type, options) {
   const source = style.sources[id];
@@ -289,21 +290,49 @@ class GeoStyle {
     return LAYERS_NON_SYMBOL_MAP_LIGHT;
   }
 
-  static getCentrelineLayers(options, baseStyle) {
-    // TODO: switch paint on volume
+  static getCentrelineLayers({ layers: { volume } }, baseStyle) {
+    const lineColor = volume ? [
+      'case',
+      ['==', ['get', 'aadt'], null], COLOR_CENTRELINE_GREY,
+      [
+        'match',
+        ['get', 'featureCode'],
+        [
+          RoadSegmentType.LOCAL.featureCode,
+          RoadSegmentType.OTHER.featureCode,
+          RoadSegmentType.OTHER_RAMP.featureCode,
+          RoadSegmentType.LANEWAY.featureCode,
+        ], aadtScale(1250, 2500),
+        [
+          RoadSegmentType.COLLECTOR.featureCode,
+          RoadSegmentType.COLLECTOR_RAMP.featureCode,
+        ], aadtScale(5000, 10000),
+        [
+          RoadSegmentType.MINOR_ARTERIAL.featureCode,
+          RoadSegmentType.MINOR_ARTERIAL_RAMP.featureCode,
+        ], aadtScale(10000, 20000),
+        [
+          RoadSegmentType.MAJOR_ARTERIAL.featureCode,
+          RoadSegmentType.MAJOR_ARTERIAL_RAMP.featureCode,
+        ], aadtScale(20000, 40000),
+        [
+          RoadSegmentType.EXPRESSWAY.featureCode,
+          RoadSegmentType.EXPRESSWAY_RAMP.featureCode,
+        ], aadtScale(40000, 80000),
+        COLOR_CENTRELINE_GREY,
+      ],
+    ] : COLOR_CENTRELINE_GREY;
     return [
       getLayer(baseStyle, 'midblocks', 'line', {
         paint: {
-          'line-color': PAINT_COLOR_CENTRELINE,
-          'line-width': PAINT_WIDTH_MIDBLOCKS,
-          'line-opacity': PAINT_OPACITY,
+          'line-color': lineColor,
+          'line-width': 5,
         },
       }),
       getLayer(baseStyle, 'intersections', 'circle', {
         paint: {
-          'circle-color': PAINT_COLOR_CENTRELINE,
-          'circle-radius': PAINT_RADIUS_INTERSECTIONS,
-          'circle-opacity': PAINT_OPACITY,
+          'circle-color': COLOR_CENTRELINE_GREY,
+          'circle-radius': 10,
         },
       }),
     ];
@@ -355,9 +384,9 @@ class GeoStyle {
             'interpolate',
             ['linear'],
             ['heatmap-density'],
-            0, 'rgba(244, 227, 219, 0)',
-            0.5, '#f39268',
-            1, '#ef4848',
+            0, COLOR_COLLISION_HEATMAP_ZERO,
+            0.5, COLOR_COLLISION_HEATMAP_HALF,
+            1, COLOR_COLLISION_FILL,
           ],
           'heatmap-intensity': [
             'interpolate',
@@ -394,7 +423,7 @@ class GeoStyle {
           visibility,
         },
         paint: {
-          'circle-color': '#EF4848',
+          'circle-color': COLOR_COLLISION_FILL,
           'circle-opacity': [
             'interpolate',
             ['linear'],
@@ -407,7 +436,7 @@ class GeoStyle {
             ['>=', ['get', 'injury'], 3], 4.5,
             6.5,
           ],
-          'circle-stroke-color': '#773333',
+          'circle-stroke-color': COLOR_COLLISION_STROKE,
           'circle-stroke-opacity': [
             'interpolate',
             ['linear'],
@@ -433,13 +462,13 @@ class GeoStyle {
           visibility,
         },
         paint: {
-          'circle-color': '#EF4848',
+          'circle-color': COLOR_COLLISION_FILL,
           'circle-radius': [
             'case',
             ['>=', ['get', 'injury'], 3], 4.5,
             6.5,
           ],
-          'circle-stroke-color': '#773333',
+          'circle-stroke-color': COLOR_COLLISION_STROKE,
           'circle-stroke-width': [
             'case',
             ['>=', ['get', 'injury'], 3], 3,

--- a/lib/geo/GeoStyle.js
+++ b/lib/geo/GeoStyle.js
@@ -237,7 +237,7 @@ injectSources(STYLE_BASE_AERIAL);
 
 // MOVE FEATURE LAYERS
 
-const COLOR_CENTRELINE_GREY = '#757575';
+const COLOR_CENTRELINE_GREY = '#acacac';
 const COLOR_COLLISION_HEATMAP_ZERO = 'rgba(244, 227, 219, 0)';
 const COLOR_COLLISION_HEATMAP_HALF = '#f39268';
 const COLOR_COLLISION_FILL = '#ef4848';
@@ -246,13 +246,59 @@ const COLOR_VOLUME_GREEN = '#26de81';
 const COLOR_VOLUME_YELLOW = '#fed330';
 const COLOR_VOLUME_RED = '#fc5c65';
 
-function aadtScale(green, red) {
+function interactionAttr(base, hovered, selected) {
+  return [
+    'case',
+    ['boolean', ['feature-state', 'selected'], false], selected,
+    ['boolean', ['feature-state', 'hover'], false], hovered,
+    base,
+  ];
+}
+
+function aadtScaleLineColor(green, red) {
   return [
     'step',
     ['get', 'aadt'],
     COLOR_VOLUME_GREEN,
     green, COLOR_VOLUME_YELLOW,
     red, COLOR_VOLUME_RED,
+  ];
+}
+
+function aadtScaledFeature(volume, defaultValue, aadtScale) {
+  if (!volume) {
+    return defaultValue;
+  }
+  return [
+    'case',
+    ['==', ['get', 'aadt'], null], defaultValue,
+    [
+      'match',
+      ['get', 'featureCode'],
+      [
+        RoadSegmentType.LOCAL.featureCode,
+        RoadSegmentType.OTHER.featureCode,
+        RoadSegmentType.OTHER_RAMP.featureCode,
+        RoadSegmentType.LANEWAY.featureCode,
+      ], aadtScale(1500, 2500),
+      [
+        RoadSegmentType.COLLECTOR.featureCode,
+        RoadSegmentType.COLLECTOR_RAMP.featureCode,
+      ], aadtScale(6000, 10000),
+      [
+        RoadSegmentType.MINOR_ARTERIAL.featureCode,
+        RoadSegmentType.MINOR_ARTERIAL_RAMP.featureCode,
+      ], aadtScale(12000, 20000),
+      [
+        RoadSegmentType.MAJOR_ARTERIAL.featureCode,
+        RoadSegmentType.MAJOR_ARTERIAL_RAMP.featureCode,
+      ], aadtScale(24000, 40000),
+      [
+        RoadSegmentType.EXPRESSWAY.featureCode,
+        RoadSegmentType.EXPRESSWAY_RAMP.featureCode,
+      ], aadtScale(48000, 80000),
+      defaultValue,
+    ],
   ];
 }
 
@@ -291,48 +337,49 @@ class GeoStyle {
   }
 
   static getCentrelineLayers({ layers: { volume } }, baseStyle) {
-    const lineColor = volume ? [
-      'case',
-      ['==', ['get', 'aadt'], null], COLOR_CENTRELINE_GREY,
-      [
-        'match',
-        ['get', 'featureCode'],
-        [
-          RoadSegmentType.LOCAL.featureCode,
-          RoadSegmentType.OTHER.featureCode,
-          RoadSegmentType.OTHER_RAMP.featureCode,
-          RoadSegmentType.LANEWAY.featureCode,
-        ], aadtScale(1250, 2500),
-        [
-          RoadSegmentType.COLLECTOR.featureCode,
-          RoadSegmentType.COLLECTOR_RAMP.featureCode,
-        ], aadtScale(5000, 10000),
-        [
-          RoadSegmentType.MINOR_ARTERIAL.featureCode,
-          RoadSegmentType.MINOR_ARTERIAL_RAMP.featureCode,
-        ], aadtScale(10000, 20000),
-        [
-          RoadSegmentType.MAJOR_ARTERIAL.featureCode,
-          RoadSegmentType.MAJOR_ARTERIAL_RAMP.featureCode,
-        ], aadtScale(20000, 40000),
-        [
-          RoadSegmentType.EXPRESSWAY.featureCode,
-          RoadSegmentType.EXPRESSWAY_RAMP.featureCode,
-        ], aadtScale(40000, 80000),
-        COLOR_CENTRELINE_GREY,
-      ],
-    ] : COLOR_CENTRELINE_GREY;
+    const lineColor = aadtScaledFeature(volume, COLOR_CENTRELINE_GREY, aadtScaleLineColor);
     return [
       getLayer(baseStyle, 'midblocks', 'line', {
+        layout: {
+          'line-sort-key': ['get', 'aadt'],
+        },
         paint: {
           'line-color': lineColor,
-          'line-width': 5,
+          'line-opacity': [
+            'interpolate',
+            ['linear'],
+            ['zoom'],
+            MapZoom.LEVEL_3.minzoom, 0.5,
+            MapZoom.LEVEL_2.minzoom, 1,
+          ],
+          'line-width': [
+            'interpolate',
+            ['linear'],
+            ['zoom'],
+            MapZoom.LEVEL_3.minzoom, 2,
+            MapZoom.LEVEL_2.minzoom, 4,
+          ],
         },
       }),
+      {
+        id: 'midblocksCasing',
+        source: 'midblocks',
+        'source-layer': 'midblocks',
+        type: 'line',
+        minzoom: MapZoom.LEVEL_2.minzoom,
+        maxzoom: MapZoom.LEVEL_1.maxzoomSource + 1,
+        paint: {
+          'line-color': interactionAttr('#ffffff', '#757575', '#757575'),
+          'line-gap-width': 4,
+          'line-width': 1,
+        },
+      },
       getLayer(baseStyle, 'intersections', 'circle', {
         paint: {
           'circle-color': COLOR_CENTRELINE_GREY,
-          'circle-radius': 10,
+          'circle-stroke-color': interactionAttr('#ffffff', '#757575', '#757575'),
+          'circle-stroke-width': 1,
+          'circle-radius': 5,
         },
       }),
     ];

--- a/lib/geo/GeoStyle.js
+++ b/lib/geo/GeoStyle.js
@@ -113,7 +113,7 @@ function normalizeAndSeparateLayers(style) {
     paint['text-color'] = '#272727';
     paint['text-halo-blur'] = 0;
     paint['text-halo-color'] = '#ffffff';
-    paint['text-halo-width'] = 1;
+    paint['text-halo-width'] = 2;
   });
 
   /*

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -63,6 +63,10 @@ function getFeatureKey(feature) {
     return null;
   }
   const { layer: { id: layerId }, id } = feature;
+  if (layerId === 'counts' || layerId === 'intersections' || layerId === 'midblocks') {
+    const { centrelineType, centrelineId } = feature.properties;
+    return `c:${centrelineType}:${centrelineId}`;
+  }
   return `${layerId}:${id}`;
 }
 

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -24,6 +24,16 @@
         {{ aerial ? 'Map' : 'Aerial' }}
       </FcButton>
     </div>
+    <div
+      v-if="location !== null"
+      class="pane-map-navigate">
+      <FcButton
+        class="px-0 py-1"
+        type="fab-text"
+        @click="easeToLocation(location, null)">
+        <v-icon class="display-1">mdi-crosshairs-gps</v-icon>
+      </FcButton>
+    </div>
     <FcPaneMapPopup
       v-if="hoveredFeature
         && featureKeyHovered !== featureKeySelected
@@ -524,8 +534,18 @@ export default {
   & > .pane-map-mode {
     bottom: 35px;
     position: absolute;
-    right: 54px;
+    right: 58px;
     z-index: var(--z-index-controls);
+  }
+  & > .pane-map-navigate {
+    bottom: 102px;
+    position: absolute;
+    right: 20px;
+    z-index: var(--z-index-controls);
+    & > .fc-button {
+      min-width: 30px;
+      width: 30px;
+    }
   }
   .fc-pane-map-marker {
     background-image: url('/icons/map/pin.png');
@@ -537,7 +557,7 @@ export default {
     & > .mapboxgl-ctrl-group {
       bottom: 25px;
       position: absolute;
-      right: 6px;
+      right: 10px;
     }
     & > .mapboxgl-ctrl-scale {
       border-color: #272727;
@@ -547,17 +567,17 @@ export default {
       height: 17px;
       line-height: 0.875rem;
       position: absolute;
-      right: 170px;
+      right: 174px;
     }
     & > .mapboxgl-ctrl-attrib {
       bottom: 10px;
       color: #272727;
       font-size: 0.75rem;
       line-height: 0.875rem;
-      padding: 2px 5px;
+      padding: 2px;
       position: absolute;
-      right: 5px;
-      width: 170px;
+      right: 19px;
+      width: 160px;
       & a {
         color: #272727;
       }

--- a/web/components/FcPaneMapPopup.vue
+++ b/web/components/FcPaneMapPopup.vue
@@ -155,6 +155,16 @@ function getCentrelineDescription(feature, { location }) {
     description.push(locationFeatureType.description);
   }
 
+  const { centrelineType } = feature.properties;
+  if (centrelineType === CentrelineType.SEGMENT) {
+    let { aadt } = feature.properties;
+    if (aadt !== null) {
+      aadt = Math.round(aadt);
+      aadt = `AADT (est. 2018): ${aadt}`;
+      description.push(aadt);
+    }
+  }
+
   return description;
 }
 


### PR DESCRIPTION
This PR closes #364 , closes #365 , and closes #367 .  It also fixes a known issue where hovering on the midblock under a selected midblock station would show two popups, one right underneath the other one.