### PR TITLE
Navigational fixes

### DIFF
--- a/lib/db/StudyDAO.js
+++ b/lib/db/StudyDAO.js
@@ -41,7 +41,8 @@ SELECT
   WHERE sr."centrelineId" = $(centrelineId)
   AND sr."centrelineType" = $(centrelineType)
   AND sr."status" != 'COMPLETED'
-  AND NOT sr."closed"`;
+  AND NOT sr."closed"
+  ORDER BY s."createdAt" DESC`;
     return db.manyOrNone(sql, { centrelineId, centrelineType });
   }
 

--- a/web/App.vue
+++ b/web/App.vue
@@ -1,5 +1,10 @@
 <template>
   <v-app id="fc_app">
+    <component
+      v-if="hasAlert"
+      v-model="hasAlert"
+      :is="'FcDialogAlert' + alert"
+      v-bind="alertData" />
     <v-snackbar
       v-if="hasToast"
       v-model="hasToast"
@@ -56,6 +61,8 @@ import { mapMutations, mapState } from 'vuex';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import '@/web/css/main.scss';
 
+import FcDialogAlertStudyRequestUrgent from
+  '@/web/components/dialogs/FcDialogAlertStudyRequestUrgent.vue';
 import FcDashboardNavBrand from '@/web/components/nav/FcDashboardNavBrand.vue';
 import FcDashboardNavItem from '@/web/components/nav/FcDashboardNavItem.vue';
 import FcDashboardNavUser from '@/web/components/nav/FcDashboardNavUser.vue';
@@ -66,8 +73,19 @@ export default {
     FcDashboardNavBrand,
     FcDashboardNavItem,
     FcDashboardNavUser,
+    FcDialogAlertStudyRequestUrgent,
   },
   computed: {
+    hasAlert: {
+      get() {
+        return this.alert !== null;
+      },
+      set(hasAlert) {
+        if (!hasAlert) {
+          this.clearAlert();
+        }
+      },
+    },
     hasToast: {
       get() {
         return this.toast !== null;
@@ -80,12 +98,14 @@ export default {
     },
     ...mapState([
       'auth',
+      'alert',
+      'alertData',
       'location',
       'toast',
     ]),
   },
   methods: {
-    ...mapMutations(['clearToast']),
+    ...mapMutations(['clearAlert', 'clearToast']),
   },
 };
 </script>

--- a/web/components/FcDataTable.vue
+++ b/web/components/FcDataTable.vue
@@ -37,6 +37,8 @@
 </template>
 
 <script>
+import { Ripple } from 'vuetify/lib/directives';
+
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
 function compareKeys(ka, kb, kf) {
@@ -55,6 +57,9 @@ function compareKeys(ka, kb, kf) {
 export default {
   name: 'FcDataTable',
   mixins: [FcMixinVModelProxy(Array)],
+  directives: {
+    Ripple,
+  },
   props: {
     caption: {
       type: String,

--- a/web/components/FcDataTableStudies.vue
+++ b/web/components/FcDataTableStudies.vue
@@ -33,7 +33,7 @@
       <FcButton
         type="tertiary"
         @click="$emit('show-reports', item)">
-        <span>View Report</span>
+        <span>View Reports</span>
       </FcButton>
     </template>
   </FcDataTable>

--- a/web/components/FcDrawerRequestStudy.vue
+++ b/web/components/FcDrawerRequestStudy.vue
@@ -269,7 +269,7 @@ export default {
       });
     },
   },
-  validations: ValidationsStudyRequest.validations,
+  validations: ValidationsStudyRequest,
   methods: {
     actionAddStudy(studyType) {
       const item = makeStudy(studyType);

--- a/web/components/FcDrawerRequestStudy.vue
+++ b/web/components/FcDrawerRequestStudy.vue
@@ -91,6 +91,7 @@
           class="pr-5 mt-6 text-right">
           <div>
             <FcButton
+              class="mr-2"
               type="tertiary"
               @click="actionNavigateBack">
               Cancel

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -9,14 +9,14 @@
         indeterminate />
       <template v-else>
         <header class="px-5 pt-1 pb-5 shading">
-          <h1 class="display-4">{{location.description}}</h1>
-          <div class="label mt-2">
+          <h1 class="display-3">{{location.description}}</h1>
+          <div class="label mt-1">
             <span v-if="locationFeatureType !== null">
               {{locationFeatureType.description}} &#x2022;
             </span>
             <span>{{countSummaryHeaderText}}</span>
           </div>
-          <v-row class="mt-5">
+          <v-row class="mt-4">
             <v-col cols="2">
               <div class="label mb-1">KSI</div>
               <v-progress-circular
@@ -44,7 +44,7 @@
               </div>
             </v-col>
           </v-row>
-          <div class="mt-5">
+          <div class="mt-4">
             <div class="label mb-1">Nearby</div>
             <div>
               <div
@@ -136,7 +136,7 @@
           </header>
           <div
             v-if="countSummary.length === 0"
-            class="mt-8 pt-12 secondary--text text-center">
+            class="my-8 py-12 secondary--text text-center">
             There are no studies for this location,<br>
             please request a study if necessary
           </div>

--- a/web/components/FcDrawerViewReports.vue
+++ b/web/components/FcDrawerViewReports.vue
@@ -7,12 +7,12 @@
       <div>
         <div class="align-center d-flex flex-grow-0 flex-shrink-0 px-3 pt-2">
           <FcButton
-            aria-label="Back"
-            type="icon"
+            type="secondary"
             @click="actionNavigateBack">
-            <v-icon>mdi-chevron-left</v-icon>
+            <v-icon left>mdi-chevron-left</v-icon>
+            View Data
           </FcButton>
-          <h1 class="headline">{{studyType.label}}</h1>
+          <h1 class="headline ml-4">{{studyType.label}}</h1>
           <div
             class="ml-1 font-weight-regular headline secondary--text">
             <span>&#x2022; {{location.description}}</span>

--- a/web/components/FcDrawerViewReports.vue
+++ b/web/components/FcDrawerViewReports.vue
@@ -30,14 +30,29 @@
             </v-chip>
           </div>
           <v-spacer></v-spacer>
-          <v-overflow-btn
-            v-model="indexActiveCount"
-            class="fc-select-active-count flex-grow-0 mt-0"
-            dense
-            hide-details
-            :items="itemsCounts"
-            :label="labelActiveCount">
-          </v-overflow-btn>
+          <v-menu>
+            <template v-slot:activator="{ on, attrs }">
+              <FcButton
+                v-bind="attrs"
+                v-on="on"
+                class="flex-grow-0 mt-0"
+                type="secondary">
+                <v-icon color="primary" left>mdi-history</v-icon>
+                {{labelActiveCount}}
+                <v-icon>mdi-menu-down</v-icon>
+              </FcButton>
+            </template>
+            <v-list>
+              <v-list-item
+                v-for="{ text, value } in itemsCounts"
+                :key="value"
+                @click="indexActiveCount = value">
+                <v-list-item-title>
+                  {{text}}
+                </v-list-item-title>
+              </v-list-item>
+            </v-list>
+          </v-menu>
         </div>
 
         <v-tabs v-model="indexActiveReportType">
@@ -360,10 +375,6 @@ export default {
 <style lang="scss">
 .fc-drawer-view-reports {
   max-height: 50vh;
-
-  .fc-select-active-count {
-    width: 250px;
-  }
 
   .fc-report-wrapper {
     position: relative;

--- a/web/components/FcDrawerViewRequest.vue
+++ b/web/components/FcDrawerViewRequest.vue
@@ -5,7 +5,7 @@
         type="secondary"
         @click="actionNavigateBack">
         <v-icon left>mdi-chevron-left</v-icon>
-        Requests
+        {{labelNavigateBack}}
       </FcButton>
       <h1 class="flex-grow-1 headline text-center">
         <span>
@@ -83,6 +83,7 @@ export default {
   },
   data() {
     return {
+      prevRoute: null,
       studyRequest: null,
       studyRequestComments: [],
       studyRequestUsers: new Map(),
@@ -91,6 +92,24 @@ export default {
   computed: {
     isSupervisor() {
       return Object.prototype.hasOwnProperty.call(this.$route.query, 'isSupervisor');
+    },
+    labelNavigateBack() {
+      const { name } = this.prevRouteNormalized;
+      if (name === 'viewDataAtLocation') {
+        return 'View Data';
+      }
+      return 'Requests';
+    },
+    prevRouteNormalized() {
+      const { prevRoute } = this;
+      if (prevRoute === null) {
+        return { name: 'requestsTrack' };
+      }
+      const { name } = prevRoute;
+      if (name === 'viewDataAtLocation') {
+        return prevRoute;
+      }
+      return { name: 'requestsTrack' };
     },
     subtitle() {
       if (this.location === null) {
@@ -103,6 +122,12 @@ export default {
       return `Request #${id}`;
     },
     ...mapState(['auth', 'location']),
+  },
+  beforeRouteEnter(to, from, next) {
+    next((vm) => {
+      /* eslint-disable-next-line no-param-reassign */
+      vm.prevRoute = from;
+    });
   },
   methods: {
     actionEdit() {
@@ -117,7 +142,7 @@ export default {
       this.$router.push(route);
     },
     actionNavigateBack() {
-      const route = { name: 'requestsTrack' };
+      const route = this.prevRouteNormalized;
       if (this.isSupervisor) {
         route.query = { isSupervisor: true };
       }

--- a/web/components/FcDrawerViewRequest.vue
+++ b/web/components/FcDrawerViewRequest.vue
@@ -83,7 +83,6 @@ export default {
   },
   data() {
     return {
-      prevRoute: null,
       studyRequest: null,
       studyRequestComments: [],
       studyRequestUsers: new Map(),
@@ -94,22 +93,11 @@ export default {
       return Object.prototype.hasOwnProperty.call(this.$route.query, 'isSupervisor');
     },
     labelNavigateBack() {
-      const { name } = this.prevRouteNormalized;
+      const { backViewRequest: { name } } = this;
       if (name === 'viewDataAtLocation') {
         return 'View Data';
       }
       return 'Requests';
-    },
-    prevRouteNormalized() {
-      const { prevRoute } = this;
-      if (prevRoute === null) {
-        return { name: 'requestsTrack' };
-      }
-      const { name } = prevRoute;
-      if (name === 'viewDataAtLocation') {
-        return prevRoute;
-      }
-      return { name: 'requestsTrack' };
     },
     subtitle() {
       if (this.location === null) {
@@ -121,13 +109,7 @@ export default {
       const { id } = this.$route.params;
       return `Request #${id}`;
     },
-    ...mapState(['auth', 'location']),
-  },
-  beforeRouteEnter(to, from, next) {
-    next((vm) => {
-      /* eslint-disable-next-line no-param-reassign */
-      vm.prevRoute = from;
-    });
+    ...mapState(['auth', 'backViewRequest', 'location']),
   },
   methods: {
     actionEdit() {
@@ -142,7 +124,8 @@ export default {
       this.$router.push(route);
     },
     actionNavigateBack() {
-      const route = this.prevRouteNormalized;
+      const { backViewRequest } = this;
+      const route = { ...backViewRequest };
       if (this.isSupervisor) {
         route.query = { isSupervisor: true };
       }

--- a/web/components/FcDrawerViewRequest.vue
+++ b/web/components/FcDrawerViewRequest.vue
@@ -61,7 +61,7 @@
 </template>
 
 <script>
-import { mapActions, mapMutations, mapState } from 'vuex';
+import { mapMutations, mapState } from 'vuex';
 
 import {
   getStudyRequest,
@@ -167,7 +167,6 @@ export default {
     onDeleteComment(i) {
       this.studyRequestComments.splice(i, 1);
     },
-    ...mapActions(['setToast']),
     ...mapMutations(['setLocation']),
   },
 };

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -36,7 +36,7 @@
               aria-label="Recenter location"
               class="pa-0"
               type="fab-text"
-              @click="easeToLocation(location, null)"
+              @click="recenterLocation()"
               v-on="on">
               <v-icon class="display-1">mdi-crosshairs-gps</v-icon>
             </FcButton>
@@ -348,6 +348,15 @@ export default {
           zoom: MapZoom.LEVEL_3.minzoom,
         });
       }
+    },
+    recenterLocation() {
+      if (this.location === null) {
+        return;
+      }
+      this.easeToLocation(this.location, null);
+      this.map.once('idle', () => {
+        this.updateSelectedFeature();
+      });
     },
     getFeatureForLayerAndProperty(layer, key, value) {
       const features = this.map.queryRenderedFeatures({

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -28,7 +28,7 @@
       v-if="location !== null"
       class="pane-map-navigate">
       <FcButton
-        class="px-0 py-1"
+        class="pa-0"
         type="fab-text"
         @click="easeToLocation(location, null)">
         <v-icon class="display-1">mdi-crosshairs-gps</v-icon>
@@ -42,7 +42,9 @@
       :feature="hoveredFeature"
       :hovered="true" />
     <FcPaneMapPopup
-      v-if="!drawerOpen && selectedFeature"
+      v-if="selectedFeature
+        && !drawerOpen
+        && $route.name !== 'viewReportsAtLocation'"
       :key="'s:' + featureKeySelected"
       :feature="selectedFeature"
       :hovered="false" />
@@ -521,7 +523,7 @@ export default {
     width: 100%;
     z-index: var(--z-index-controls);
   }
-  & > .fc-search-bar-location {
+  & > .fc-search-bar-location-wrapper {
     left: 20px;
     top: 20px;
     position: absolute;
@@ -545,6 +547,7 @@ export default {
     right: 20px;
     z-index: var(--z-index-controls);
     & > .fc-button {
+      height: 32px;
       min-width: 30px;
       width: 30px;
     }
@@ -558,8 +561,17 @@ export default {
   .mapboxgl-ctrl-bottom-right {
     & > .mapboxgl-ctrl-group {
       bottom: 25px;
+      box-shadow:
+        0 3px 1px -2px rgba(0, 0, 0, 0.2),
+        0 2px 2px 0 rgba(0, 0, 0, 0.14),
+        0 1px 5px 0 rgba(0, 0, 0, 0.12);
       position: absolute;
       right: 10px;
+      & > button {
+        transition-duration: 0.28s;
+        transition-property: background-color;
+        transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+      }
     }
     & > .mapboxgl-ctrl-scale {
       border-color: #272727;

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -45,16 +45,12 @@
         </v-tooltip>
       </div>
       <FcPaneMapPopup
-        v-if="hoveredFeature
-          && featureKeyHovered !== featureKeySelected
-          && featureKeyHovered === featureKeyHoveredPopup"
+        v-if="showHoveredPopup"
         :key="'h:' + featureKeyHovered"
         :feature="hoveredFeature"
         :hovered="true" />
       <FcPaneMapPopup
-        v-if="selectedFeature
-          && !drawerOpen
-          && $route.name !== 'viewReportsAtLocation'"
+        v-if="showSelectedPopup"
         :key="'s:' + featureKeySelected"
         :feature="selectedFeature"
         :hovered="false" />
@@ -96,6 +92,19 @@ function getFeatureKey(feature) {
   return `${layerId}:${id}`;
 }
 
+function getFeatureKeyRoute($route) {
+  const {
+    params: {
+      centrelineId = null,
+      centrelineType = null,
+    },
+  } = $route;
+  if (centrelineType === null || centrelineId === null) {
+    return null;
+  }
+  return `c:${centrelineType}:${centrelineId}`;
+}
+
 export default {
   name: 'FcPaneMap',
   components: {
@@ -135,6 +144,9 @@ export default {
     featureKeyHovered() {
       return getFeatureKey(this.hoveredFeature);
     },
+    featureKeyRoute() {
+      return getFeatureKeyRoute(this.$route);
+    },
     featureKeySelected() {
       return getFeatureKey(this.selectedFeature);
     },
@@ -157,6 +169,24 @@ export default {
     },
     mapStyle() {
       return GeoStyle.get(this.mapOptions);
+    },
+    showHoveredPopup() {
+      if (this.hoveredFeature === null) {
+        return false;
+      }
+      return this.featureKeyHovered !== this.featureKeySelected
+        && this.featureKeyHovered === this.featureKeyHoveredPopup;
+    },
+    showSelectedPopup() {
+      if (this.selectedFeature === null) {
+        return false;
+      }
+      const { vertical = false } = this.$route.meta;
+      const featureMatchesRoute = this.featureKeySelected === this.featureKeyRoute;
+      if (vertical) {
+        return !featureMatchesRoute;
+      }
+      return !this.drawerOpen && !featureMatchesRoute;
     },
     ...mapState(['drawerOpen', 'legendOptions', 'location']),
   },

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -28,12 +28,21 @@
       <div
         v-if="location !== null"
         class="pane-map-navigate">
-        <FcButton
-          class="pa-0"
-          type="fab-text"
-          @click="easeToLocation(location, null)">
-          <v-icon class="display-1">mdi-crosshairs-gps</v-icon>
-        </FcButton>
+        <v-tooltip
+          left
+          :z-index="100">
+          <template v-slot:activator="{ on }">
+            <FcButton
+              aria-label="Recenter location"
+              class="pa-0"
+              type="fab-text"
+              @click="easeToLocation(location, null)"
+              v-on="on">
+              <v-icon class="display-1">mdi-crosshairs-gps</v-icon>
+            </FcButton>
+          </template>
+          <span>Recenter location</span>
+        </v-tooltip>
       </div>
       <FcPaneMapPopup
         v-if="hoveredFeature

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -2,52 +2,57 @@
   <div
     class="fill-height pane-map"
     @mouseleave="clearHoveredFeature">
-    <div class="pane-map-progress">
-      <v-progress-linear
-        :active="loading"
-        indeterminate />
-    </div>
-    <FcSearchBarLocation
-      v-if="!drawerOpen" />
-    <FcPaneMapLegend
-      v-model="internalLegendOptions" />
-    <div class="pane-map-mode">
-      <FcButton
-        class="mr-2"
-        type="fab-text"
-        @click="openGoogleMaps">
-        Street View
-      </FcButton>
-      <FcButton
-        type="fab-text"
-        @click="aerial = !aerial">
-        {{ aerial ? 'Map' : 'Aerial' }}
-      </FcButton>
-    </div>
+    <template v-if="!background">
+      <div class="pane-map-progress">
+        <v-progress-linear
+          :active="loading"
+          indeterminate />
+      </div>
+      <FcSearchBarLocation
+        v-if="!drawerOpen" />
+      <FcPaneMapLegend
+        v-model="internalLegendOptions" />
+      <div class="pane-map-mode">
+        <FcButton
+          class="mr-2"
+          type="fab-text"
+          @click="openGoogleMaps">
+          Street View
+        </FcButton>
+        <FcButton
+          type="fab-text"
+          @click="aerial = !aerial">
+          {{ aerial ? 'Map' : 'Aerial' }}
+        </FcButton>
+      </div>
+      <div
+        v-if="location !== null"
+        class="pane-map-navigate">
+        <FcButton
+          class="pa-0"
+          type="fab-text"
+          @click="easeToLocation(location, null)">
+          <v-icon class="display-1">mdi-crosshairs-gps</v-icon>
+        </FcButton>
+      </div>
+      <FcPaneMapPopup
+        v-if="hoveredFeature
+          && featureKeyHovered !== featureKeySelected
+          && featureKeyHovered === featureKeyHoveredPopup"
+        :key="'h:' + featureKeyHovered"
+        :feature="hoveredFeature"
+        :hovered="true" />
+      <FcPaneMapPopup
+        v-if="selectedFeature
+          && !drawerOpen
+          && $route.name !== 'viewReportsAtLocation'"
+        :key="'s:' + featureKeySelected"
+        :feature="selectedFeature"
+        :hovered="false" />
+    </template>
     <div
-      v-if="location !== null"
-      class="pane-map-navigate">
-      <FcButton
-        class="pa-0"
-        type="fab-text"
-        @click="easeToLocation(location, null)">
-        <v-icon class="display-1">mdi-crosshairs-gps</v-icon>
-      </FcButton>
-    </div>
-    <FcPaneMapPopup
-      v-if="hoveredFeature
-        && featureKeyHovered !== featureKeySelected
-        && featureKeyHovered === featureKeyHoveredPopup"
-      :key="'h:' + featureKeyHovered"
-      :feature="hoveredFeature"
-      :hovered="true" />
-    <FcPaneMapPopup
-      v-if="selectedFeature
-        && !drawerOpen
-        && $route.name !== 'viewReportsAtLocation'"
-      :key="'s:' + featureKeySelected"
-      :feature="selectedFeature"
-      :hovered="false" />
+      v-else
+      class="pane-map-background-overlay"></div>
   </div>
 </template>
 
@@ -97,6 +102,12 @@ export default {
         return self.map;
       },
     };
+  },
+  props: {
+    background: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     return {
@@ -596,6 +607,15 @@ export default {
         color: #272727;
       }
     }
+  }
+  & > .pane-map-background-overlay {
+    background-color: rgba(39, 39, 39, 0.4);
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    z-index: calc(var(--z-index-controls) - 1);
   }
 }
 </style>

--- a/web/components/FcPaneMapPopup.vue
+++ b/web/components/FcPaneMapPopup.vue
@@ -363,7 +363,9 @@ export default {
   },
   methods: {
     async actionViewData() {
-      this.setDrawerOpen(true);
+      if (this.$route.name === 'viewDataAtLocation') {
+        this.setDrawerOpen(true);
+      }
 
       // update location
       const { centrelineId, centrelineType } = this.feature.properties;

--- a/web/components/FcPaneMapPopup.vue
+++ b/web/components/FcPaneMapPopup.vue
@@ -362,17 +362,13 @@ export default {
     this.popup.remove();
   },
   methods: {
-    async actionViewData() {
+    actionViewData() {
       if (this.$route.name === 'viewDataAtLocation') {
         this.setDrawerOpen(true);
       }
 
-      // update location
-      const { centrelineId, centrelineType } = this.feature.properties;
-      const location = await getLocationByFeature({ centrelineId, centrelineType });
-      this.setLocation(location);
-
       // open the view data window
+      const { centrelineId, centrelineType } = this.feature.properties;
       this.$router.push({
         name: 'viewDataAtLocation',
         params: { centrelineId, centrelineType },

--- a/web/components/FcPaneMapPopup.vue
+++ b/web/components/FcPaneMapPopup.vue
@@ -159,7 +159,7 @@ function getCentrelineDescription(feature, { location }) {
   if (centrelineType === CentrelineType.SEGMENT) {
     let { aadt = null } = feature.properties;
     if (aadt !== null) {
-      aadt = Math.round(aadt);
+      aadt = 100 * Math.round(aadt / 100);
       aadt = `AADT (est. 2018): ${aadt}`;
       description.push(aadt);
     }

--- a/web/components/dialogs/FcDialogAlert.vue
+++ b/web/components/dialogs/FcDialogAlert.vue
@@ -1,0 +1,45 @@
+<template>
+  <v-dialog
+    v-model="internalValue"
+    max-width="560">
+    <v-card role="dialog">
+      <v-card-title>
+        <h1 class="display-1">{{title}}</h1>
+      </v-card-title>
+      <v-card-text>
+        <slot></slot>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <FcButton
+          type="tertiary"
+          @click="internalValue = false">
+          {{textOk}}
+        </FcButton>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import FcButton from '@/web/components/inputs/FcButton.vue';
+import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+
+export default {
+  name: 'FcDialogAlert',
+  mixins: [FcMixinVModelProxy(Boolean)],
+  components: {
+    FcButton,
+  },
+  props: {
+    textOk: {
+      type: String,
+      default: 'OK',
+    },
+    title: {
+      type: String,
+      default: 'Alert',
+    },
+  },
+};
+</script>

--- a/web/components/dialogs/FcDialogAlertStudyRequestUrgent.vue
+++ b/web/components/dialogs/FcDialogAlertStudyRequestUrgent.vue
@@ -1,0 +1,33 @@
+<template>
+  <FcDialogAlert
+    v-model="internalValue"
+    :title="title">
+    <span class="body-1">
+      You have requested an urgent study request,
+      please wait for an email from
+      <strong>trafficdata@toronto.ca</strong>
+      for further instructions.
+    </span>
+  </FcDialogAlert>
+</template>
+
+<script>
+import FcDialogAlert from '@/web/components/dialogs/FcDialogAlert.vue';
+import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+
+export default {
+  name: 'FcDialogAlertStudyRequestUrgent',
+  mixins: [FcMixinVModelProxy(Boolean)],
+  components: {
+    FcDialogAlert,
+  },
+  props: {
+    update: Boolean,
+  },
+  computed: {
+    title() {
+      return this.update ? 'Study request updated' : 'Study request sent';
+    },
+  },
+};
+</script>

--- a/web/components/dialogs/FcDialogConfirm.vue
+++ b/web/components/dialogs/FcDialogConfirm.vue
@@ -1,0 +1,60 @@
+<template>
+  <v-dialog
+    v-model="internalValue"
+    max-width="560">
+    <v-card role="dialog">
+      <v-card-title>
+        <h1 class="display-1">{{title}}</h1>
+      </v-card-title>
+      <v-card-text>
+        <slot></slot>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <FcButton
+          type="tertiary"
+          @click="internalValue = false">
+          {{textCancel}}
+        </FcButton>
+        <FcButton
+          type="tertiary"
+          @click="actionClickOk">
+          {{textOk}}
+        </FcButton>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import FcButton from '@/web/components/inputs/FcButton.vue';
+import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+
+export default {
+  name: 'FcDialogConfirm',
+  mixins: [FcMixinVModelProxy(Boolean)],
+  components: {
+    FcButton,
+  },
+  props: {
+    textCancel: {
+      type: String,
+      default: 'Cancel',
+    },
+    textOk: {
+      type: String,
+      default: 'OK',
+    },
+    title: {
+      type: String,
+      default: 'Confirm',
+    },
+  },
+  methods: {
+    actionClickOk() {
+      this.$emit('action-ok');
+      this.internalValue = false;
+    },
+  },
+};
+</script>

--- a/web/components/inputs/FcButton.vue
+++ b/web/components/inputs/FcButton.vue
@@ -30,6 +30,7 @@ const BUTTON_ATTRS = {
   },
   'fab-text': {
     class: 'elevation-2',
+    color: 'white',
   },
   icon: {
     icon: true,

--- a/web/components/inputs/FcButton.vue
+++ b/web/components/inputs/FcButton.vue
@@ -52,6 +52,7 @@ export default {
 <style lang="scss">
 button.fc-button.v-btn.secondary--text {
   background-color: white;
+  border-color: #e0e0e0;
   & > .v-btn__content {
     color: var(--v-default-base);
   }

--- a/web/components/inputs/FcSearchBarLocation.vue
+++ b/web/components/inputs/FcSearchBarLocation.vue
@@ -40,7 +40,7 @@
           type="fab-text"
           @click="$router.push({ name: 'viewData' })"
           v-on="on">
-          <v-icon>mdi-magnify</v-icon>
+          <v-icon class="unselected--text">mdi-magnify</v-icon>
         </FcButton>
       </template>
       <span>Search for new location</span>

--- a/web/components/inputs/FcSearchBarLocation.vue
+++ b/web/components/inputs/FcSearchBarLocation.vue
@@ -1,31 +1,40 @@
 <template>
-  <v-autocomplete
-    v-model="keystring"
-    append-icon="mdi-magnify"
-    cache-items
-    class="fc-search-bar-location elevation-2"
-    dense
-    hide-no-data
-    hide-details
-    :items="items"
-    item-text="ADDRESS"
-    item-value="KEYSTRING"
-    label="Search"
-    :loading="loading"
-    :search-input.sync="query"
-    solo>
-    <template v-slot:item="{ attrs, item, on, parent }">
-      <v-list-item
-        v-bind="attrs"
-        v-on="on">
-        <v-list-item-content>
-          <v-list-item-title>
-            <span>{{item[parent.itemText]}}</span>
-          </v-list-item-title>
-        </v-list-item-content>
-      </v-list-item>
-    </template>
-  </v-autocomplete>
+  <div class="fc-search-bar-location-wrapper">
+    <v-autocomplete
+      v-if="$route.name !== 'viewReportsAtLocation'"
+      v-model="keystring"
+      append-icon="mdi-magnify"
+      cache-items
+      class="fc-search-bar-location elevation-2"
+      dense
+      hide-no-data
+      hide-details
+      :items="items"
+      item-text="ADDRESS"
+      item-value="KEYSTRING"
+      label="Search"
+      :loading="loading"
+      :search-input.sync="query"
+      solo>
+      <template v-slot:item="{ attrs, item, on, parent }">
+        <v-list-item
+          v-bind="attrs"
+          v-on="on">
+          <v-list-item-content>
+            <v-list-item-title>
+              <span>{{item[parent.itemText]}}</span>
+            </v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+      </template>
+    </v-autocomplete>
+    <FcButton
+      v-else
+      class="fc-search-bar-open"
+      type="fab-text">
+      <v-icon>mdi-magnify</v-icon>
+    </FcButton>
+  </div>
 </template>
 
 <script>
@@ -33,9 +42,13 @@ import { mapMutations, mapState } from 'vuex';
 
 import { debounce } from '@/lib/FunctionUtils';
 import { getLocationByKeyString, getLocationSuggestions } from '@/lib/api/WebApi';
+import FcButton from '@/web/components/inputs/FcButton.vue';
 
 export default {
   name: 'FcSearchBarLocation',
+  components: {
+    FcButton,
+  },
   data() {
     return {
       keystring: null,
@@ -82,13 +95,20 @@ export default {
 </script>
 
 <style lang="scss">
-.fc-search-bar-location {
-  width: 392px;
-  &.v-select .v-input__append-inner .v-input__icon--append .v-icon {
-    margin-top: 0;
+.fc-search-bar-location-wrapper {
+  & > .fc-search-bar-location {
+    width: 392px;
+    &.v-select .v-input__append-inner .v-input__icon--append .v-icon {
+      margin-top: 0;
+    }
+    &.v-select.v-select--is-menu-active .v-input__icon--append .v-icon {
+      transform: none;
+    }
   }
-  &.v-select.v-select--is-menu-active .v-input__icon--append .v-icon {
-    transform: none;
+
+  & > button.fc-button.v-btn.fc-search-bar-open {
+    min-width: 36px;
+    width: 36px;
   }
 }
 </style>

--- a/web/components/inputs/FcSearchBarLocation.vue
+++ b/web/components/inputs/FcSearchBarLocation.vue
@@ -28,12 +28,22 @@
         </v-list-item>
       </template>
     </v-autocomplete>
-    <FcButton
+    <v-tooltip
       v-else
-      class="fc-search-bar-open"
-      type="fab-text">
-      <v-icon>mdi-magnify</v-icon>
-    </FcButton>
+      right
+      :z-index="100">
+      <template v-slot:activator="{ on }">
+        <FcButton
+          aria-label="Search for new location"
+          class="fc-search-bar-open"
+          type="fab-text"
+          @click="actionOpenSearch()"
+          v-on="on">
+          <v-icon>mdi-magnify</v-icon>
+        </FcButton>
+      </template>
+      <span>Search for new location</span>
+    </v-tooltip>
   </div>
 </template>
 
@@ -89,6 +99,9 @@ export default {
     },
   },
   methods: {
+    actionOpenSearch() {
+      // TODO: implement this
+    },
     ...mapMutations(['setLocation']),
   },
 };

--- a/web/components/inputs/FcSearchBarLocation.vue
+++ b/web/components/inputs/FcSearchBarLocation.vue
@@ -29,34 +29,22 @@
         </v-list-item>
       </template>
     </v-autocomplete>
-    <template v-else>
-      <FcDialogConfirm
-        v-model="showConfirmLeave"
-        textCancel="Stay on this page"
-        textOk="Leave"
-        title="Leave Reports"
-        @action-ok="actionLeave">
-        <span class="body-1">
-          Leaving this page will cause you to switch to another location.
-          Are you sure you want to leave?
-        </span>
-      </FcDialogConfirm>
-      <v-tooltip
-        right
-        :z-index="100">
-        <template v-slot:activator="{ on }">
-          <FcButton
-            aria-label="Search for new location"
-            class="fc-search-bar-open"
-            type="fab-text"
-            @click="showConfirmLeave = true"
-            v-on="on">
-            <v-icon>mdi-magnify</v-icon>
-          </FcButton>
-        </template>
-        <span>Search for new location</span>
-      </v-tooltip>
-    </template>
+    <v-tooltip
+      v-else
+      right
+      :z-index="100">
+      <template v-slot:activator="{ on }">
+        <FcButton
+          aria-label="Search for new location"
+          class="fc-search-bar-open"
+          type="fab-text"
+          @click="$router.push({ name: 'viewData' })"
+          v-on="on">
+          <v-icon>mdi-magnify</v-icon>
+        </FcButton>
+      </template>
+      <span>Search for new location</span>
+    </v-tooltip>
   </div>
 </template>
 
@@ -65,14 +53,12 @@ import { mapMutations, mapState } from 'vuex';
 
 import { debounce } from '@/lib/FunctionUtils';
 import { getLocationByKeyString, getLocationSuggestions } from '@/lib/api/WebApi';
-import FcDialogConfirm from '@/web/components/dialogs/FcDialogConfirm.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 
 export default {
   name: 'FcSearchBarLocation',
   components: {
     FcButton,
-    FcDialogConfirm,
   },
   data() {
     return {
@@ -80,7 +66,6 @@ export default {
       items: [],
       loading: false,
       query: null,
-      showConfirmLeave: false,
     };
   },
   computed: {
@@ -115,9 +100,6 @@ export default {
     },
   },
   methods: {
-    actionLeave() {
-      this.$router.push({ name: 'viewData' });
-    },
     ...mapMutations(['setLocation']),
   },
 };

--- a/web/components/inputs/FcSearchBarLocation.vue
+++ b/web/components/inputs/FcSearchBarLocation.vue
@@ -4,6 +4,7 @@
       v-if="$route.name !== 'viewReportsAtLocation'"
       v-model="keystring"
       append-icon="mdi-magnify"
+      autofocus
       cache-items
       class="fc-search-bar-location elevation-2"
       dense
@@ -28,22 +29,34 @@
         </v-list-item>
       </template>
     </v-autocomplete>
-    <v-tooltip
-      v-else
-      right
-      :z-index="100">
-      <template v-slot:activator="{ on }">
-        <FcButton
-          aria-label="Search for new location"
-          class="fc-search-bar-open"
-          type="fab-text"
-          @click="actionOpenSearch()"
-          v-on="on">
-          <v-icon>mdi-magnify</v-icon>
-        </FcButton>
-      </template>
-      <span>Search for new location</span>
-    </v-tooltip>
+    <template v-else>
+      <FcDialogConfirm
+        v-model="showConfirmLeave"
+        textCancel="Stay on this page"
+        textOk="Leave"
+        title="Leave Reports"
+        @action-ok="actionLeave">
+        <span class="body-1">
+          Leaving this page will cause you to switch to another location.
+          Are you sure you want to leave?
+        </span>
+      </FcDialogConfirm>
+      <v-tooltip
+        right
+        :z-index="100">
+        <template v-slot:activator="{ on }">
+          <FcButton
+            aria-label="Search for new location"
+            class="fc-search-bar-open"
+            type="fab-text"
+            @click="showConfirmLeave = true"
+            v-on="on">
+            <v-icon>mdi-magnify</v-icon>
+          </FcButton>
+        </template>
+        <span>Search for new location</span>
+      </v-tooltip>
+    </template>
   </div>
 </template>
 
@@ -52,12 +65,14 @@ import { mapMutations, mapState } from 'vuex';
 
 import { debounce } from '@/lib/FunctionUtils';
 import { getLocationByKeyString, getLocationSuggestions } from '@/lib/api/WebApi';
+import FcDialogConfirm from '@/web/components/dialogs/FcDialogConfirm.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 
 export default {
   name: 'FcSearchBarLocation',
   components: {
     FcButton,
+    FcDialogConfirm,
   },
   data() {
     return {
@@ -65,6 +80,7 @@ export default {
       items: [],
       loading: false,
       query: null,
+      showConfirmLeave: false,
     };
   },
   computed: {
@@ -99,8 +115,8 @@ export default {
     },
   },
   methods: {
-    actionOpenSearch() {
-      // TODO: implement this
+    actionLeave() {
+      this.$router.push({ name: 'viewData' });
     },
     ...mapMutations(['setLocation']),
   },

--- a/web/components/nav/FcDashboardNavUser.vue
+++ b/web/components/nav/FcDashboardNavUser.vue
@@ -61,6 +61,7 @@ import Vue from 'vue';
 import { mapGetters, mapState } from 'vuex';
 
 import FcButton from '@/web/components/inputs/FcButton.vue';
+import { saveLoginState } from '@/web/store/LoginState';
 
 export default {
   name: 'FcDashboardNavUser',
@@ -74,6 +75,7 @@ export default {
   methods: {
     actionSignIn() {
       Vue.nextTick(() => {
+        saveLoginState(this.$route);
         this.$refs.formSignIn.submit();
       });
     },

--- a/web/router.js
+++ b/web/router.js
@@ -2,10 +2,9 @@ import Vue from 'vue';
 import Router from 'vue-router';
 
 import store from '@/web/store';
+import { restoreLoginState, saveLoginState } from '@/web/store/LoginState';
 
 Vue.use(Router);
-
-const STORAGE_KEY_LOGIN_STATE = 'ca.toronto.move.loginState';
 
 const router = new Router({
   mode: 'history',
@@ -140,32 +139,6 @@ function routeMetaKey(to, key, defaultValue) {
     return defaultValue;
   }
   return routeWithKey.meta[key];
-}
-
-function restoreLoginState(next) {
-  const loginState = window.sessionStorage.getItem(STORAGE_KEY_LOGIN_STATE);
-  if (loginState === null) {
-    return false;
-  }
-  window.sessionStorage.removeItem(STORAGE_KEY_LOGIN_STATE);
-  try {
-    const { location, name, params } = JSON.parse(loginState);
-    store.commit('setLocation', location);
-    next({ name, params });
-    return true;
-  } catch (err) {
-    if (err instanceof SyntaxError) {
-      return false;
-    }
-    throw err;
-  }
-}
-
-function saveLoginState(to) {
-  const { location } = store.state;
-  const { name, params = {} } = to;
-  const loginState = JSON.stringify({ location, name, params });
-  window.sessionStorage.setItem(STORAGE_KEY_LOGIN_STATE, loginState);
 }
 
 router.beforeEach(async (to, from, next) => {

--- a/web/router.js
+++ b/web/router.js
@@ -207,7 +207,7 @@ router.onError((err) => {
   const { currentRoute } = router;
   const toast = onErrorShowToast(err, currentRoute);
   if (toast) {
-    store.dispatch('setToast', toast);
+    store.commit('setToast', toast);
   }
 });
 

--- a/web/router.js
+++ b/web/router.js
@@ -65,6 +65,7 @@ const router = new Router({
         meta: {
           auth: { mode: 'try' },
           title: 'View Reports',
+          vertical: true,
         },
         component: () => import(/* webpackChunkName: "home" */ '@/web/components/FcDrawerViewReports.vue'),
         beforeEnter(to, from, next) {

--- a/web/router.js
+++ b/web/router.js
@@ -22,6 +22,10 @@ const router = new Router({
         },
       },
       component: () => import(/* webpackChunkName: "home" */ '@/web/views/FcRequestsTrack.vue'),
+      beforeEnter(to, from, next) {
+        store.commit('setBackViewRequest', to);
+        next();
+      },
     },
     // DRAWER ROUTES
     {
@@ -56,6 +60,7 @@ const router = new Router({
         },
         component: () => import(/* webpackChunkName: "home" */ '@/web/components/FcDrawerViewData.vue'),
         beforeEnter(to, from, next) {
+          store.commit('setBackViewRequest', to);
           store.commit('setDrawerOpen', true);
           next();
         },

--- a/web/store/LoginState.js
+++ b/web/store/LoginState.js
@@ -1,0 +1,40 @@
+import store from '@/web/store';
+
+const STORAGE_KEY_LOGIN_STATE = 'ca.toronto.move.loginState';
+
+function restoreLoginState(next) {
+  const loginState = window.sessionStorage.getItem(STORAGE_KEY_LOGIN_STATE);
+  if (loginState === null) {
+    return false;
+  }
+  window.sessionStorage.removeItem(STORAGE_KEY_LOGIN_STATE);
+  try {
+    const { location, name, params } = JSON.parse(loginState);
+    store.commit('setLocation', location);
+    next({ name, params });
+    return true;
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+function saveLoginState(to) {
+  const { location } = store.state;
+  const { name, params = {} } = to;
+  const loginState = JSON.stringify({ location, name, params });
+  window.sessionStorage.setItem(STORAGE_KEY_LOGIN_STATE, loginState);
+}
+
+const LoginState = {
+  restoreLoginState,
+  saveLoginState,
+};
+
+export {
+  LoginState as default,
+  restoreLoginState,
+  saveLoginState,
+};

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -29,6 +29,8 @@ export default new Vuex.Store({
     alertData: {},
     drawerOpen: false,
     toast: null,
+    // NAVIGATION
+    backViewRequest: { name: 'requestsTrack' },
     // LOCATION
     location: null,
     legendOptions: {
@@ -81,6 +83,10 @@ export default new Vuex.Store({
     },
     setToast(state, toast) {
       Vue.set(state, 'toast', toast);
+    },
+    // NAVIGATION
+    setBackViewRequest(state, backViewRequest) {
+      Vue.set(state, 'backViewRequest', backViewRequest);
     },
     // LOCATION
     setLocation(state, location) {

--- a/web/views/FcLayoutDrawerMap.vue
+++ b/web/views/FcLayoutDrawerMap.vue
@@ -6,25 +6,34 @@
       horizontal: !vertical,
       vertical
     }">
-    <v-tooltip
-      v-if="hasDrawer"
-      :bottom="vertical && drawerOpen"
-      :right="!vertical"
-      :top="vertical && !drawerOpen"
-      :z-index="100">
-      <template v-slot:activator="{ on }">
-        <FcButton
-          :aria-label="labelDrawerToggle"
-          class="pane-drawer-toggle"
-          type="icon"
-          @click="setDrawerOpen(!drawerOpen)"
-          v-on="on">
-          <v-icon>{{iconDrawerToggle}}</v-icon>
-        </FcButton>
-      </template>
-      <span>{{labelDrawerToggle}}</span>
-    </v-tooltip>
-
+    <template v-if="hasDrawer">
+      <FcButton
+        v-if="vertical"
+        class="pane-drawer-toggle mb-2"
+        type="fab-text"
+        @click="setDrawerOpen(!drawerOpen)">
+        <v-icon
+          color="primary"
+          left>{{iconDrawerToggle}}</v-icon>
+        {{labelDrawerToggle}}
+      </FcButton>
+      <v-tooltip
+        v-else
+        right
+        :z-index="100">
+        <template v-slot:activator="{ on }">
+          <FcButton
+            :aria-label="labelDrawerToggle"
+            class="pane-drawer-toggle"
+            type="icon"
+            @click="setDrawerOpen(!drawerOpen)"
+            v-on="on">
+            <v-icon>{{iconDrawerToggle}}</v-icon>
+          </FcButton>
+        </template>
+        <span>{{labelDrawerToggle}}</span>
+      </v-tooltip>
+    </template>
     <div
       class="fc-pane-wrapper d-flex fill-height"
       :class="{
@@ -39,12 +48,13 @@
         <router-view></router-view>
       </div>
       <div
-        v-show="showMap"
-        class="flex-grow-1 flex-shrink-0"
+        class="fc-map flex-shrink-0"
         :class="{
+          'flex-grow-1': !mapBackground,
           'order-1': vertical,
         }">
-        <FcPaneMap />
+        <FcPaneMap
+          :background="mapBackground" />
       </div>
     </div>
   </div>
@@ -69,24 +79,24 @@ export default {
     iconDrawerToggle() {
       const { drawerOpen, vertical } = this;
       if (vertical) {
-        return drawerOpen ? 'mdi-menu-down' : 'mdi-menu-up';
+        return drawerOpen ? 'mdi-arrow-collapse' : 'mdi-arrow-expand';
       }
       return drawerOpen ? 'mdi-menu-left' : 'mdi-menu-right';
     },
     labelDrawerToggle() {
       const { drawerOpen, vertical } = this;
       if (vertical) {
-        return drawerOpen ? 'Shrink bottom panel' : 'Expand bottom panel';
+        return drawerOpen ? 'Collapse page' : 'Expand page';
       }
       return drawerOpen ? 'Collapse side panel' : 'Expand side panel';
+    },
+    mapBackground() {
+      const { drawerOpen, vertical } = this;
+      return drawerOpen && vertical;
     },
     showDrawer() {
       const { drawerOpen, hasDrawer, vertical } = this;
       return (hasDrawer && drawerOpen) || vertical;
-    },
-    showMap() {
-      const { drawerOpen, vertical } = this;
-      return !drawerOpen || !vertical;
     },
     vertical() {
       return this.$route.name === 'viewReportsAtLocation';
@@ -104,73 +114,75 @@ export default {
   position: relative;
   width: 100%;
 
-  & .fc-drawer {
-    box-shadow:
-      0 2px 4px rgba(0, 0, 0, 0.2),
-      0 1px 10px rgba(0, 0, 0, 0.12),
-      0 4px 5px rgba(0, 0, 0, 0.14);
-  }
-
   & > .fc-pane-wrapper > div {
     flex-basis: 0;
   }
 
   & > .pane-drawer-toggle {
-    background-color: var(--white);
-    color: var(--ink);
     cursor: pointer;
     position: absolute;
     z-index: var(--z-index-controls);
+  }
 
-    &:hover {
-      background-color: var(--v-shading-base);
+  &.vertical {
+    & > .pane-drawer-toggle {
+      bottom: 50%;
+      left: calc(50% - 80px);
+      width: 160px;
+    }
+    & > .fc-pane-wrapper > div {
+      height: 50%;
+      &.fc-drawer {
+        border-top: 1px solid rgba(0, 0, 0, 0.12);
+      }
     }
   }
 
   &.horizontal {
     & > .pane-drawer-toggle {
+      background-color: var(--white);
       border-radius: 0 var(--space-s) var(--space-s) 0;
+
+      /* modified version of .elevation-1 */
+      box-shadow:
+        0 2px 1px -1px rgba(0, 0, 0, 0.2),
+        0 1px 1px 0 rgba(0, 0, 0, 0.14),
+        2px 1px 3px 0 rgba(0, 0, 0, 0.12);
+      color: var(--ink);
       height: 38px;
       top: 20px;
       width: 16px;
+
+      &:hover {
+        background-color: var(--v-shading-base);
+      }
     }
     & > .fc-pane-wrapper > div {
       width: 50%;
     }
   }
 
-  &.vertical {
-    & > .pane-drawer-toggle {
-      border-bottom: 1px solid rgba(0, 0, 0, 0.12);
-      border-radius: var(--space-s) var(--space-s) 0 0;
-      bottom: 50%;
-      height: 16px;
-      left: calc(50% - 19px);
-      width: 38px;
-      & i {
-        margin-top: -6px;
-      }
-    }
-    & > .fc-pane-wrapper > div {
-      height: 50%;
-    }
-  }
-
   &.drawer-open {
-    &.horizontal > .pane-drawer-toggle {
-      border-left: 1px solid rgba(0, 0, 0, 0.12);
-      left: 50%;
+    &.horizontal {
+      & > .pane-drawer-toggle {
+        border-left: 1px solid rgba(0, 0, 0, 0.12);
+        left: 50%;
+      }
+      & > .fc-pane-wrapper > .fc-drawer {
+        border-right: 1px solid rgba(0, 0, 0, 0.12);
+      }
     }
     &.vertical {
       & > .pane-drawer-toggle {
-        border-left: 1px solid rgba(0, 0, 0, 0.12);
-        border-radius: 0 0 var(--space-s) var(--space-s);
-        border-right: 1px solid rgba(0, 0, 0, 0.12);
-        bottom: auto;
-        top: 0;
+        bottom: calc(100% - 60px);
+        left: calc(50% - 90px);
+        width: 180px;
       }
-      & > .fc-pane-wrapper > div {
-        height: 100%;
+      & > .fc-pane-wrapper > .fc-map {
+        height: 60px;
+      }
+      & > .fc-pane-wrapper > .fc-drawer {
+        height: calc(100% - 60px);
       }
     }
   }

--- a/web/views/FcLayoutDrawerMap.vue
+++ b/web/views/FcLayoutDrawerMap.vue
@@ -99,7 +99,8 @@ export default {
       return (hasDrawer && drawerOpen) || vertical;
     },
     vertical() {
-      return this.$route.name === 'viewReportsAtLocation';
+      const { vertical = false } = this.$route.meta;
+      return vertical;
     },
     ...mapState(['drawerOpen']),
   },

--- a/web/views/FcRequestsTrack.vue
+++ b/web/views/FcRequestsTrack.vue
@@ -456,7 +456,6 @@ export default {
     },
     ...mapActions([
       'saveStudyRequest',
-      'setToast',
     ]),
   },
 };

--- a/web/views/FcRequestsTrack.vue
+++ b/web/views/FcRequestsTrack.vue
@@ -151,25 +151,37 @@
               title="Urgent">mdi-clipboard-alert</v-icon>
 
             <template v-if="isSupervisor && !closed">
-              <FcButton
-                :aria-label="'Approve Request #' + item.id"
-                class="mr-2"
-                :color="item.status === StudyRequestStatus.ACCEPTED ? 'primary' : 'unselected'"
-                type="icon"
-                @click="actionApprove([item])">
-                <v-icon>mdi-thumb-up</v-icon>
-              </FcButton>
-              <FcButton
-                :aria-label="'Ask for Changes to Request #' + item.id"
-                class="mr-2"
-                :color="item.status === StudyRequestStatus.REJECTED ? 'error' : 'unselected'"
-                type="icon"
-                @click="actionReject([item])">
-                <v-icon>mdi-clipboard-arrow-left</v-icon>
-              </FcButton>
+              <v-tooltip top>
+                <template v-slot:activator="{ on }">
+                  <FcButton
+                    :aria-label="'Approve Request #' + item.id"
+                    class="mr-2"
+                    :color="item.status === StudyRequestStatus.ACCEPTED ? 'primary' : 'unselected'"
+                    type="icon"
+                    @click="actionApprove([item])"
+                    v-on="on">
+                    <v-icon>mdi-thumb-up</v-icon>
+                  </FcButton>
+                </template>
+                <span>Approve Request #{{item.id}}</span>
+              </v-tooltip>
+              <v-tooltip top>
+                <template v-slot:activator="{ on }">
+                  <FcButton
+                    :aria-label="'Ask for Changes to Request #' + item.id"
+                    class="mr-2"
+                    :color="item.status === StudyRequestStatus.REJECTED ? 'error' : 'unselected'"
+                    type="icon"
+                    @click="actionReject([item])"
+                    v-on="on">
+                    <v-icon>mdi-clipboard-arrow-left</v-icon>
+                  </FcButton>
+                </template>
+                <span>Ask for Changes to Request #{{item.id}}</span>
+              </v-tooltip>
             </template>
 
-            <v-tooltip left>
+            <v-tooltip top>
               <template v-slot:activator="{ on }">
                 <FcButton
                   :aria-label="'View Request #' + item.id"

--- a/web/views/FcRequestsTrack.vue
+++ b/web/views/FcRequestsTrack.vue
@@ -169,12 +169,18 @@
               </FcButton>
             </template>
 
-            <FcButton
-              :aria-label="'View Request #' + item.id"
-              type="icon"
-              @click="actionShowRequest(item)">
-              <v-icon>mdi-file-eye</v-icon>
-            </FcButton>
+            <v-tooltip left>
+              <template v-slot:activator="{ on }">
+                <FcButton
+                  :aria-label="'View Request #' + item.id"
+                  type="icon"
+                  @click="actionShowRequest(item)"
+                  v-on="on">
+                  <v-icon>mdi-file-eye</v-icon>
+                </FcButton>
+              </template>
+              <span>View Request #{{item.id}}</span>
+            </v-tooltip>
           </div>
         </template>
       </FcDataTable>

--- a/web/views/FcRequestsTrack.vue
+++ b/web/views/FcRequestsTrack.vue
@@ -7,11 +7,11 @@
       </v-tabs>
       <v-divider></v-divider>
       <div class="px-5">
-        <h1 class="display-4 mt-5">
-          <span v-if="closed">Closed Requests</span>
-          <span v-else>Open Requests</span>
+        <h1 class="display-3 mt-5">
+          <span v-if="closed">My Closed Requests</span>
+          <span v-else>My Requests</span>
         </h1>
-        <div class="align-center d-flex mt-8 mb-2">
+        <div class="align-center d-flex mt-6 mb-2">
           <FcButton
             v-if="selectedItems.length === 0"
             class="mr-2"


### PR DESCRIPTION
# Issue Addressed
This PR closes #386 by improving cross-flow navigation throughout MOVE.

# Description
It introduces confirm dialogs for leaving various flows, alerts for a more heavyweight flow completion notification than the snackbar, seamless manual login, smart back button for View Request, and a bunch of minor navigational tweaks around the map.

# Tests
Manually ran through flows, clicked a lot of buttons, used browser Back button a bunch. 