### PR TITLE
Improved location search: web integration

### DIFF
--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -115,40 +115,14 @@ async function getLocationByFeature(feature) {
   return locationsMap.get(key);
 }
 
-async function getLocationByKeyString(keyString) {
-  const options = {
-    data: { keyString },
-  };
-  return apiClient.fetch('/cotgeocoder/findAddressCandidates', options);
-}
-
 async function getLocationSuggestions(query) {
-  if (query.startsWith('pxo:') || query.startsWith('px:')) {
-    let pxStr = null;
-    let signalType = null;
-    if (query.startsWith('px:')) {
-      pxStr = query.split('px:')[1].trim();
-      signalType = 1;
-    } else {
-      pxStr = query.split('pxo:')[1].trim();
-      signalType = 2;
-    }
-    const px = parseInt(pxStr, 10);
-    if (Number.isNaN(px)) {
-      return [];
-    }
-    const pxOptions = {
-      data: { px, signalType },
-    };
-    return apiClient.fetch('/px/suggest', pxOptions);
-  }
   if (query.length < 3) {
     return [];
   }
   const options = {
-    data: { q: query },
+    data: { limit: 10, q: query },
   };
-  return apiClient.fetch('/cotgeocoder/suggest', options);
+  return apiClient.fetch('/location/suggest', options);
 }
 
 async function getPoiByCentrelineSummary(feature) {
@@ -334,7 +308,6 @@ const WebApi = {
   getCountsByCentrelineSummary,
   getLocationByFeature,
   getLocationsByFeature,
-  getLocationByKeyString,
   getLocationSuggestions,
   getPoiByCentrelineSummary,
   getStudiesByCentrelinePending,
@@ -356,7 +329,6 @@ export {
   getCountsByCentrelineSummary,
   getLocationByFeature,
   getLocationsByFeature,
-  getLocationByKeyString,
   getLocationSuggestions,
   getPoiByCentrelineSummary,
   getStudiesByCentrelinePending,

--- a/lib/controller/LocationController.js
+++ b/lib/controller/LocationController.js
@@ -1,5 +1,3 @@
-import Boom from '@hapi/boom';
-import rp from 'request-promise-native';
 import Joi from '@/lib/model/Joi';
 
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
@@ -14,65 +12,29 @@ const LocationController = [];
 
 /**
  * @memberof LocationController
- * @name getCotGeocoderSuggestions
+ * @name getLocationSuggestions
  * @type {Hapi.ServerRoute}
  */
 LocationController.push({
   method: 'GET',
-  path: '/cotgeocoder/suggest',
+  path: '/location/suggest',
   options: {
     auth: { mode: 'try' },
+    validate: {
+      query: {
+        q: Joi.string().min(3).required(),
+        limit: Joi
+          .number()
+          .integer()
+          .positive()
+          .max(100)
+          .required(),
+      },
+    },
   },
   handler: async (request) => {
-    const searchString = request.query.q;
-    const uri = 'https://map.toronto.ca/cotgeocoder/rest/geocoder/suggest';
-    const qs = { searchString, f: 'json' };
-    const response = await rp({
-      json: true,
-      uri,
-      qs,
-      rejectUnauthorized: false,
-    });
-    if (response.result && response.result.rows) {
-      return response.result.rows;
-    }
-    return [];
-  },
-});
-
-/**
- * @memberof LocationController
- * @name getCotGeocoderAddressCandidates
- * @type {Hapi.ServerRoute}
- */
-LocationController.push({
-  method: 'GET',
-  path: '/cotgeocoder/findAddressCandidates',
-  options: {
-    auth: { mode: 'try' },
-  },
-  handler: async (request) => {
-    const { keyString } = request.query;
-    const uri = 'https://map.toronto.ca/cotgeocoder/rest/geocoder/findAddressCandidates';
-    const qs = { keyString, f: 'json' };
-    const response = await rp({
-      json: true,
-      uri,
-      qs,
-      rejectUnauthorized: false,
-    });
-    if (!response.result || !response.result.rows) {
-      return Boom.notFound('invalid response from geocoder API');
-    }
-    if (response.result.rows.length === 0) {
-      return Boom.notFound(`could not locate key string: ${keyString}`);
-    }
-    const { INT_GEO_ID: centrelineId } = response.result.rows[0];
-    const feature = CentrelineDAO.byIdAndType(centrelineId, CentrelineType.INTERSECTION);
-    if (feature === null) {
-      return Boom.notFound(`could not locate intersection with ID: ${centrelineId}`);
-    }
-    return feature;
+    const { limit, q } = request.query;
+    return CentrelineDAO.intersectionSuggestions(q, limit);
   },
 });
 

--- a/lib/db/CentrelineDAO.js
+++ b/lib/db/CentrelineDAO.js
@@ -125,6 +125,77 @@ SELECT DISTINCT ON (int_id)
     return rows.map(intersectionToFeature);
   }
 
+  static async intersectionSuggestions(query, limit) {
+    const sqlExact = `
+WITH candidates AS (
+  SELECT
+    int_id,
+    ts_rank_cd(
+      to_tsvector('english', intersec5),
+      (plainto_tsquery($(query))::text || ':*')::tsquery,
+      2 | 4
+    ) AS f_rank_cd,
+    CASE
+      WHEN position(lower($(query)) IN lower(intersec5)) != 0 THEN 1
+      ELSE 0
+    END AS f_substring_match,
+    elevatio9 AS f_feature_code
+  FROM location_search.centreline_intersection
+  WHERE to_tsvector('english', intersec5) @@ (plainto_tsquery($(query))::text || ':*')::tsquery
+)
+SELECT
+  ci.int_id,
+  ci.intersec5,
+  ci.elevatio9,
+  ST_AsGeoJSON(ci.geom)::json AS geom,
+  f_rank_cd * 20 + f_substring_match * 0.5 - abs(501245 - f_feature_code) / 100.0 AS score
+FROM candidates JOIN gis.centreline_intersection ci USING (int_id)
+ORDER BY score DESC, intersec5 ASC
+LIMIT $(limit);`;
+    const rowsExact = await db.manyOrNone(sqlExact, { limit, query });
+    const intersectionsExact = rowsExact.map(({ score, ...intersection }) => ({
+      score,
+      ...intersectionToFeature(intersection),
+    }));
+
+    const limitApprox = limit - intersectionsExact.length;
+    if (limitApprox <= 0) {
+      return intersectionsExact;
+    }
+
+    const sqlApprox = `
+SET pg_trgm.word_similarity_threshold = 0.3;
+WITH candidates AS (
+  SELECT
+    int_id,
+    word_similarity(
+      replace(replace(plainto_tsquery($(query))::text, '''', ''), ' &', ''),
+      intersec5
+    ) AS f_word_similarity,
+    elevatio9 AS f_feature_code
+  FROM location_search.centreline_intersection
+  WHERE replace(replace(plainto_tsquery($(query))::text, '''', ''), ' &', '') <% intersec5
+)
+SELECT
+  ci.int_id,
+  ci.intersec5,
+  ci.elevatio9,
+  ST_AsGeoJSON(ci.geom)::json AS geom,
+  f_word_similarity * 2 - abs(501245 - f_feature_code) / 100.0 AS score
+FROM candidates JOIN gis.centreline_intersection ci USING (int_id)
+ORDER BY score DESC, intersec5 ASC
+LIMIT $(limitApprox);`;
+    const rowsApprox = await db.manyOrNone(sqlApprox, {
+      limitApprox,
+      query,
+    });
+    const intersectionsApprox = rowsApprox.map(({ score, ...intersection }) => ({
+      score,
+      ...intersectionToFeature(intersection),
+    }));
+    return intersectionsExact.concat(intersectionsApprox);
+  }
+
   // COMBINED METHODS
 
   static async byIdAndType(centrelineId, centrelineType) {

--- a/lib/db/CentrelineDAO.js
+++ b/lib/db/CentrelineDAO.js
@@ -125,7 +125,46 @@ SELECT DISTINCT ON (int_id)
     return rows.map(intersectionToFeature);
   }
 
+  /**
+   * Suggests intersections matching a textual prefix query.  The set of suggestions may include
+   * both exact matches (e.g. 'Danforth' for 'Danf') and approximate matches (e.g. 'Danforth'
+   * for 'Damf').  Exact matches take priority.
+   *
+   * Each type of match uses a linear combination of features for ranking: we extract a series of
+   * numeric features from each candidate intersection, multiply each feature by a predetermined
+   * weight, and add the results.  In our case, the weights have been chosen such that each
+   * feature lies roughly within the unit interval.
+   *
+   * To speed up these queries, we limit the candidate set using PostgreSQL's `@@` and `<%`
+   * operators in conjunction with appropriate indexes.
+   *
+   * @param {string} query - query to suggest intersections for
+   * @param {number} limit - number of results to return
+   * @returns {Array<Object>} - array of suggestions for the given query, containing at
+   * most `limit` results
+   */
   static async intersectionSuggestions(query, limit) {
+    /*
+     * For exact matches, we use `tsvector` and `tsquery` full-text support together with
+     * these features:
+     *
+     * - `f_rank_cd`: number of matched terms in the intersection name, normalized by
+     *   intersection name length to avoid biasing towards long expressway ramp names;
+     * - `f_substring_match`: whether the intersection name contains the original query
+     *   as a substring, as a workaround for word stemming applied by `plainto_tsquery`;
+     * - `f_feature_code`: the type of intersection, either 501100 (expressway),
+     *   501200 (major), or 501300 (minor).
+     *
+     * For `f_rank_cd`, `2 | 4` is a bitmask that controls normalization of term count.
+     *
+     * For `f_feature_code`, we make the assumption that major intersections are slightly
+     * more relevant than minor intersections, as they often help users in landmarking.
+     * Both are typically much more useful than expressway intersections.  The expression
+     *
+     *     -abs(501245 - f_feature_code) / 100.0
+     *
+     * is chosen here to rank in this order.
+     */
     const sqlExact = `
 WITH candidates AS (
   SELECT
@@ -153,16 +192,38 @@ FROM candidates JOIN gis.centreline_intersection ci USING (int_id)
 ORDER BY score DESC, intersec5 ASC
 LIMIT $(limit);`;
     const rowsExact = await db.manyOrNone(sqlExact, { limit, query });
+    /*
+     * Although we don't currently surface the score anywhere in the frontend, we preserve
+     * them in the results in case they prove helpful eventually.
+     */
     const intersectionsExact = rowsExact.map(({ score, ...intersection }) => ({
       score,
       ...intersectionToFeature(intersection),
     }));
 
+    /*
+     * If we have enough results, stop; otherwise, continue to approximate matching and
+     * fill out the result list.
+     */
     const limitApprox = limit - intersectionsExact.length;
     if (limitApprox <= 0) {
       return intersectionsExact;
     }
 
+    /*
+     * For approximate matches, we use `pg_trgm` trigram support together with these features:
+     *
+     * - `f_word_similarity`: computes trigram similarity between query terms and tokens in
+     *   intersection names;
+     * - `f_feature_code`: same as for exact matches.
+     *
+     * The lower `pg_trgm.word_similarity_threshold` is chosen to balance precision and recall;
+     * PostgreSQL defaults this parameter to 0.6.
+     *
+     * This expression normalizes the query, removing stopwords and punctuation:
+     *
+     *     replace(replace(plainto_tsquery($(query))::text, '''', ''), ' &', '')
+     */
     const sqlApprox = `
 SET pg_trgm.word_similarity_threshold = 0.3;
 WITH candidates AS (

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -131,7 +131,7 @@ export default {
       aerial: false,
       coordinates: null,
       // used to add slight debounce delay (250ms) to hovered popup
-      featureKeyHoveredPopup: false,
+      featureKeyHoveredPopup: null,
       // keeps track of which feature we are currently hovering over
       hoveredFeature: null,
       loading: false,
@@ -239,19 +239,22 @@ export default {
         new mapboxgl.NavigationControl({ showCompass: false }),
         'bottom-right',
       );
+
+      this.updateLocationMarker();
       this.easeToLocation(this.location, null);
+
+      this.map.on('dataloading', () => {
+        this.loading = true;
+      });
+      this.map.on('data', this.onMapData.bind(this));
+      this.map.on('idle', () => {
+        this.loading = false;
+      });
       this.map.on('load', () => {
         this.map.on('move', this.onMapMove.bind(this));
         this.map.on('click', this.onMapClick.bind(this));
         this.map.on('mousemove', this.onMapMousemove.bind(this));
       });
-      this.map.on('dataloading', () => {
-        this.loading = true;
-      });
-      this.map.on('idle', () => {
-        this.loading = false;
-      });
-      this.updateLocationMarker();
     });
   },
   beforeDestroy() {
@@ -286,9 +289,6 @@ export default {
         this.setSelectedFeature(feature);
       } else {
         this.easeToLocation(location, oldLocation);
-        this.map.once('idle', () => {
-          this.updateSelectedFeature();
-        });
       }
     },
     $route() {
@@ -354,9 +354,6 @@ export default {
         return;
       }
       this.easeToLocation(this.location, null);
-      this.map.once('idle', () => {
-        this.updateSelectedFeature();
-      });
     },
     getFeatureForLayerAndProperty(layer, key, value) {
       const features = this.map.queryRenderedFeatures({
@@ -466,6 +463,31 @@ export default {
       });
       this.setSelectedFeature(feature);
     },
+    onMapData(e) {
+      if (this.location === null || this.map.isMoving() || !e.tile) {
+        return;
+      }
+      const { centrelineType } = this.location;
+      if ((centrelineType === CentrelineType.SEGMENT && e.sourceId !== 'midblocks')
+        || (centrelineType === CentrelineType.INTERSECTION && e.sourceId === 'intersections')) {
+        return;
+      }
+      const { lat, lng } = this.location;
+      const {
+        latRange: [latMin, latMax],
+        lngRange: [lngMin, lngMax],
+      } = e.target.transform;
+      if (lat < latMin || lat > latMax || lng < lngMin || lng > lngMax) {
+        return;
+      }
+      const feature = this.getFeatureForLocation(this.location);
+      if (feature === null) {
+        this.clearSelectedFeature();
+      } else {
+        console.log('selected', feature);
+        this.setSelectedFeature(feature);
+      }
+    },
     onMapMousemove(e) {
       const feature = this.getFeatureForPoint(e.point);
       this.setHoveredFeature(feature);
@@ -495,14 +517,6 @@ export default {
         this.locationMarker
           .setLngLat([lng, lat])
           .addTo(this.map);
-      }
-    },
-    updateSelectedFeature() {
-      const feature = this.getFeatureForLocation(this.location);
-      if (feature === null) {
-        this.clearSelectedFeature();
-      } else {
-        this.setSelectedFeature(feature);
       }
     },
     ...mapMutations(['setDrawerOpen', 'setLegendOptions', 'setLocation']),

--- a/web/components/inputs/FcSearchBarLocation.vue
+++ b/web/components/inputs/FcSearchBarLocation.vue
@@ -4,11 +4,10 @@
       v-if="$route.name !== 'viewReportsAtLocation'"
       v-model="internalLocation"
       append-icon="mdi-magnify"
-      autofocus
       class="fc-search-bar-location elevation-2"
       dense
-      hide-no-data
       hide-details
+      hide-no-data
       :items="items"
       item-text="description"
       label="Search"
@@ -80,13 +79,30 @@ export default {
     ...mapState(['location']),
   },
   watch: {
+    location: {
+      handler() {
+        if (this.location !== null) {
+          this.query = this.location.description;
+        }
+      },
+      immediate: true,
+    },
     query: debounce(async function processQuery() {
-      if (this.query === null) {
-        return;
+      if (this.location !== null) {
+        if (this.query === null) {
+          this.query = this.location.description;
+          return;
+        }
+        if (this.query === this.location.description) {
+          this.items = [this.location];
+          return;
+        }
       }
-      this.loading = true;
-      this.items = await getLocationSuggestions(this.query);
-      this.loading = false;
+      if (this.query !== null) {
+        this.loading = true;
+        this.items = await getLocationSuggestions(this.query);
+        this.loading = false;
+      }
     }, 250),
   },
   methods: {

--- a/web/components/inputs/FcSearchBarLocation.vue
+++ b/web/components/inputs/FcSearchBarLocation.vue
@@ -78,10 +78,27 @@ export default {
     },
     ...mapState(['location']),
   },
+  /*
+   * To understand the following watchers, imagine a state machine:
+   *
+   * 1. selected location...
+   *   a. empty query
+   *   b. query that matches location
+   *   c. query that doesn't match location
+   * 2. no selected location...
+   *   a. empty query
+   *   b. non-empty query
+   *
+   * Transitions between these are explained below.
+   */
   watch: {
     location: {
       handler() {
         if (this.location !== null) {
+          /*
+           * 1c -> 1b: the user just selected a location, either via the autocomplete
+           * dropdown or via map interaction.  We need to update the search bar to match.
+           */
           this.query = this.location.description;
         }
       },
@@ -90,19 +107,45 @@ export default {
     query: debounce(async function processQuery() {
       if (this.location !== null) {
         if (this.query === null) {
+          /*
+           * 1a -> 1b: a new search bar instance was just loaded, and we already have a
+           * selected location.  We need to update the search bar to match.
+           *
+           * While setting a value in its own watcher is unusual, we can avoid infinite
+           * recursion by moving through the state machine.
+           */
           this.query = this.location.description;
           return;
         }
         if (this.query === this.location.description) {
+          /*
+           * 1b: `<v-autocomplete>` gets confused if the list of items doesn't contain
+           * the `v-model` value, so we make a special items list with the selected
+           * location to un-confuse it.
+           */
           this.items = [this.location];
           return;
         }
+        /*
+         * 1c: we already have a selected location, but the user is currently typing
+         * a new query...
+         */
       }
       if (this.query !== null) {
+        /*
+         * 1c / 2b: the user is currently typing a query.  We need to fetch suggested
+         * locations for that query.
+         *
+         * Once the user selects a suggested location, `location` is updated, triggering
+         * the location watcher to move us into 1b.
+         */
         this.loading = true;
         this.items = await getLocationSuggestions(this.query);
         this.loading = false;
       }
+      /*
+       * 2a: there is no selected location, and no query to search for.  Do nothing.
+       */
     }, 250),
   },
   methods: {

--- a/web/components/inputs/FcSearchBarLocation.vue
+++ b/web/components/inputs/FcSearchBarLocation.vue
@@ -2,19 +2,19 @@
   <div class="fc-search-bar-location-wrapper">
     <v-autocomplete
       v-if="$route.name !== 'viewReportsAtLocation'"
-      v-model="keystring"
+      v-model="internalLocation"
       append-icon="mdi-magnify"
       autofocus
-      cache-items
       class="fc-search-bar-location elevation-2"
       dense
       hide-no-data
       hide-details
       :items="items"
-      item-text="ADDRESS"
-      item-value="KEYSTRING"
+      item-text="description"
       label="Search"
       :loading="loading"
+      no-filter
+      return-object
       :search-input.sync="query"
       solo>
       <template v-slot:item="{ attrs, item, on, parent }">
@@ -52,7 +52,7 @@
 import { mapMutations, mapState } from 'vuex';
 
 import { debounce } from '@/lib/FunctionUtils';
-import { getLocationByKeyString, getLocationSuggestions } from '@/lib/api/WebApi';
+import { getLocationSuggestions } from '@/lib/api/WebApi';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 
 export default {
@@ -62,8 +62,8 @@ export default {
   },
   data() {
     return {
-      keystring: null,
       items: [],
+      key: null,
       loading: false,
       query: null,
     };
@@ -73,8 +73,8 @@ export default {
       get() {
         return this.location;
       },
-      set(location) {
-        this.setLocation(location);
+      set(internalLocation) {
+        this.setLocation(internalLocation);
       },
     },
     ...mapState(['location']),
@@ -82,22 +82,12 @@ export default {
   watch: {
     query: debounce(async function processQuery() {
       if (this.query === null) {
-        this.internalLocation = null;
         return;
       }
       this.loading = true;
       this.items = await getLocationSuggestions(this.query);
       this.loading = false;
     }, 250),
-    async keystring() {
-      if (this.keystring === null) {
-        this.internalLocation = null;
-        return;
-      }
-      this.loading = true;
-      this.internalLocation = await getLocationByKeyString(this.keystring);
-      this.loading = false;
-    },
   },
   methods: {
     ...mapMutations(['setLocation']),


### PR DESCRIPTION
# Issue Addressed
This PR closes #391 in combination with PR #392 .

# Description
We implement a simple intersection search engine designed to supplement GCC services using `tsvector` / `tsquery` for exact matches and `pg_trgm` trigram similarity for near-matches.  This can be extended later to include midblocks, signals, and other transportation / civic landmarks (e.g. schools, crosswalks, etc.)

We then use this to help improve location bar handling - #391 identified an issue where, due to the multiple instances of `FcSearchBarLocation`, the user's search query was getting lost when navigating between different parts of the site.

Finally, we speed up the loading of popups upon selecting a search result, by listening for Mapbox GL's `data` event and loading the popup as soon as the relevant tile has been loaded.  (Previously we waited for `idle`, which is only fired once *all* animations, data / tile loads, and renders have completed.)

# Tests
Manual testing in frontend: searched for many different intersections in various parts of the city, and of varying size.  Also included small typos in some search terms, since that's the whole point of fuzzy matching!