### PR TITLE
RBAC user scopes: migration, creation, DAO updates

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -2,6 +2,18 @@ import { Enum } from '@/lib/ClassUtils';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 
 /**
+ * Authentication scopes.  Used to restrict access to certain REST API endpoints,
+ * frontend routes, and features.
+ */
+class AuthScope extends Enum {}
+AuthScope.init([
+  'ADMIN',
+  'STUDY_REQUESTS',
+  'STUDY_REQUESTS_ADMIN',
+  'STUDY_REQUESTS_EDIT',
+]);
+
+/**
  * Four cardinal directions.  Our legacy FLOW system stores Turning Movement Count
  * data according to these directions.  Additionally, since Toronto's streets operate
  * on a grid system, it is often useful to know cardinal directions of travel.
@@ -745,6 +757,7 @@ TurningMovement.init({
 const TZ_TORONTO = 'America/Toronto';
 
 const Constants = {
+  AuthScope,
   CardinalDirection,
   centrelineKey,
   CentrelineType,
@@ -776,6 +789,7 @@ const Constants = {
 };
 export {
   Constants as default,
+  AuthScope,
   CardinalDirection,
   centrelineKey,
   CentrelineType,

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -3,6 +3,7 @@ import {
   POI_RADIUS,
 } from '@/lib/Constants';
 import BackendClient from '@/lib/api/BackendClient';
+import AuthState from '@/lib/model/AuthState';
 import Category from '@/lib/model/Category';
 import Count from '@/lib/model/Count';
 import Joi from '@/lib/model/Joi';
@@ -24,6 +25,11 @@ async function deleteStudyRequestComment(csrf, studyRequest, comment) {
   };
   const result = await apiClient.fetch(url, options);
   return SuccessResponse.validateAsync(result);
+}
+
+async function getAuth() {
+  const auth = await apiClient.fetch('/auth');
+  return AuthState.read.validateAsync(auth);
 }
 
 async function getCollisionPopupDetails(id) {
@@ -228,6 +234,16 @@ async function getUserStudyRequests(isSupervisor) {
   };
 }
 
+async function postStudyRequest(csrf, studyRequest) {
+  const options = {
+    method: 'POST',
+    csrf,
+    data: studyRequest,
+  };
+  const persistedStudyRequest = await apiClient.fetch('/requests/study', options);
+  return StudyRequest.read.validateAsync(persistedStudyRequest);
+}
+
 async function postStudyRequestComment(csrf, studyRequest, comment) {
   const { id: studyRequestId } = studyRequest;
   const url = `/requests/study/${studyRequestId}/comments`;
@@ -286,6 +302,7 @@ async function putStudyRequestComment(csrf, studyRequest, comment) {
 
 const WebApi = {
   deleteStudyRequestComment,
+  getAuth,
   getCollisionPopupDetails,
   getCollisionsByCentrelineSummary,
   getCountsByCentreline,
@@ -298,6 +315,7 @@ const WebApi = {
   getStudyRequest,
   getUserStudyRequests,
   getUsersByIds,
+  postStudyRequest,
   postStudyRequestComment,
   putStudyRequests,
   putStudyRequestComment,
@@ -306,6 +324,7 @@ const WebApi = {
 export {
   WebApi as default,
   deleteStudyRequestComment,
+  getAuth,
   getCollisionPopupDetails,
   getCollisionsByCentrelineSummary,
   getCountsByCentreline,
@@ -318,6 +337,7 @@ export {
   getStudyRequest,
   getUserStudyRequests,
   getUsersByIds,
+  postStudyRequest,
   postStudyRequestComment,
   putStudyRequests,
   putStudyRequestComment,

--- a/lib/controller/AuthController.js
+++ b/lib/controller/AuthController.js
@@ -101,7 +101,7 @@ AuthController.push({
  * Gets the current authentication status.
  *
  * @memberof AuthController
- * @name get
+ * @name getAuth
  */
 AuthController.push({
   method: 'GET',

--- a/lib/controller/AuthController.js
+++ b/lib/controller/AuthController.js
@@ -2,10 +2,13 @@ import Boom from '@hapi/boom';
 import { v4 as uuidv4 } from 'uuid';
 import Joi from '@/lib/model/Joi';
 
+import { AuthScope } from '@/lib/Constants';
 import OpenIdClient from '@/lib/auth/OpenIdClient';
 import config from '@/lib/config/MoveConfig';
 import UserDAO from '@/lib/db/UserDAO';
 import LogTag from '@/lib/log/LogTag';
+import AuthState from '@/lib/model/AuthState';
+import User from '@/lib/model/User';
 import { generateUser } from '@/lib/test/random/UserGenerator';
 
 async function login(request, { email, sub, uniqueName }) {
@@ -13,6 +16,7 @@ async function login(request, { email, sub, uniqueName }) {
   if (user === null) {
     user = {
       email,
+      scope: [AuthScope.STUDY_REQUESTS],
       sub,
       uniqueName,
     };
@@ -104,6 +108,9 @@ AuthController.push({
   path: '/auth',
   options: {
     auth: { mode: 'try' },
+    response: {
+      schema: AuthState.read,
+    },
   },
   handler: async (request, h) => {
     const csrf = request.server.plugins.crumb.generate(request, h);
@@ -153,6 +160,9 @@ AuthController.push({
   path: '/auth/test-login',
   options: {
     auth: false,
+    response: {
+      schema: User.read,
+    },
   },
   handler: async (request) => {
     if (config.ENV !== 'test') {

--- a/lib/db/UserDAO.js
+++ b/lib/db/UserDAO.js
@@ -1,5 +1,19 @@
 import db from '@/lib/db/db';
+import Joi from '@/lib/model/Joi';
+import User from '@/lib/model/User';
 import DateTime from '@/lib/time/DateTime';
+
+async function normalizeUser(user) {
+  if (user === null) {
+    return null;
+  }
+  return User.read.validateAsync(user);
+}
+
+async function normalizeUsers(users) {
+  const usersSchema = Joi.array().items(User.read);
+  return usersSchema.validateAsync(users);
+}
 
 /**
  * Data access layer for users.
@@ -7,7 +21,8 @@ import DateTime from '@/lib/time/DateTime';
 class UserDAO {
   static async byId(id) {
     const sql = 'SELECT * FROM "users" WHERE "id" = $(id)';
-    return db.oneOrNone(sql, { id });
+    const user = await db.oneOrNone(sql, { id });
+    return normalizeUser(user);
   }
 
   /**
@@ -22,44 +37,57 @@ class UserDAO {
       return new Map();
     }
     const sql = 'SELECT * FROM "users" WHERE "id" IN ($(uniqueIds:csv))';
-    const rows = await db.manyOrNone(sql, { uniqueIds });
-    return new Map(rows.map(user => [user.id, user]));
+    const users = await db.manyOrNone(sql, { uniqueIds });
+    const usersNormalized = await normalizeUsers(users);
+    return new Map(usersNormalized.map(user => [user.id, user]));
   }
 
   static async bySub(sub) {
     const sql = 'SELECT * FROM "users" WHERE "sub" = $(sub)';
-    return db.oneOrNone(sql, { sub });
+    const user = await db.oneOrNone(sql, { sub });
+    return normalizeUser(user);
   }
 
   static async byEmail(email) {
     const sql = 'SELECT * FROM "users" WHERE "email" = $(email)';
-    return db.oneOrNone(sql, { email });
+    const user = await db.oneOrNone(sql, { email });
+    return normalizeUser(user);
   }
 
   static async create(user) {
     const sql = `
-INSERT INTO "users" ("createdAt", "email", "sub", "uniqueName")
-VALUES ($(createdAt), $(email), $(sub), $(uniqueName))
-RETURNING "id"`;
-    const createdAt = DateTime.local();
-    const { id } = await db.one(sql, {
-      createdAt,
-      ...user,
-    });
-    return {
-      id,
-      createdAt,
+INSERT INTO "users" (
+  "createdAt",
+  "email",
+  "scope",
+  "sub",
+  "uniqueName"
+) VALUES (
+  $(createdAt),
+  $(email),
+  $(scope),
+  $(sub),
+  $(uniqueName)
+) RETURNING "id"`;
+    const persistedUser = {
+      createdAt: DateTime.local(),
       ...user,
     };
+    const { id } = await db.one(sql, persistedUser);
+    persistedUser.id = id;
+    return normalizeUser(persistedUser);
   }
 
   static async update(user) {
     const sql = `
 UPDATE "users"
-  SET "email" = $(email), "uniqueName" = $(uniqueName)
+  SET
+    "email" = $(email),
+    "scope" = $(scope),
+    "uniqueName" = $(uniqueName)
   WHERE "id" = $(id)`;
-    const rowsUpdated = await db.result(sql, user, r => r.rowCount);
-    return rowsUpdated === 1;
+    await db.query(sql, user);
+    return normalizeUser(user);
   }
 
   static async delete({ id }) {

--- a/lib/model/AuthState.js
+++ b/lib/model/AuthState.js
@@ -1,0 +1,10 @@
+import Joi from '@/lib/model/Joi';
+import User from '@/lib/model/User';
+
+export default {
+  read: Joi.object().keys({
+    csrf: Joi.string().required(),
+    loggedIn: Joi.boolean().required(),
+    user: User.read.allow(null).required(),
+  }),
+};

--- a/lib/model/User.js
+++ b/lib/model/User.js
@@ -1,3 +1,4 @@
+import { AuthScope } from '@/lib/Constants';
 import Joi from '@/lib/model/Joi';
 
 export default {
@@ -5,6 +6,9 @@ export default {
     id: Joi.number().integer().positive().required(),
     createdAt: Joi.dateTime().required(),
     email: Joi.string().email({ tlds: false }).required(),
+    scope: Joi.array().items(
+      Joi.enum().ofType(AuthScope),
+    ).required(),
     sub: Joi.string().required(),
     uniqueName: Joi.string().required(),
   }),

--- a/lib/test/random/UserGenerator.js
+++ b/lib/test/random/UserGenerator.js
@@ -1,4 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
+
+import { AuthScope } from '@/lib/Constants';
 import Random from '@/lib/Random';
 
 const FIRST_NAMES = [
@@ -9,6 +11,7 @@ const FIRST_NAMES = [
   'Jie',
   'Janis',
   'Jale',
+  'Jurgen',
 ];
 
 const LAST_NAMES = [
@@ -20,6 +23,7 @@ const LAST_NAMES = [
   'Devan',
   'Dagher',
   'Dimitriou',
+  'Diaghilev',
 ];
 
 function generateName() {
@@ -46,12 +50,15 @@ function generateEmail({ first, last, suffix }) {
 }
 
 function generateUser() {
+  // TODO: allow configuration of scopes
+  const scope = [AuthScope.STUDY_REQUESTS];
   const sub = uuidv4();
   const name = generateName();
   const email = generateEmail(name);
   const uniqueName = generateUniqueName(name);
   return {
     email,
+    scope,
     sub,
     uniqueName,
   };

--- a/scripts/db/schema-10.down.sql
+++ b/scripts/db/schema-10.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE "users" DROP COLUMN "scope";
+
+UPDATE "APP_META"."DB_UPDATE" SET "currentVersion" = 9;
+COMMIT;

--- a/scripts/db/schema-10.up.sql
+++ b/scripts/db/schema-10.up.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE "users" ADD COLUMN "scope" VARCHAR[];
+UPDATE "users" SET "scope" = '{"STUDY_REQUESTS"}';
+ALTER TABLE "users" ALTER COLUMN "scope" SET NOT NULL;
+
+UPDATE "APP_META"."DB_UPDATE" SET "currentVersion" = 10;
+COMMIT;

--- a/tests/jest/db/DAO.spec.js
+++ b/tests/jest/db/DAO.spec.js
@@ -2,6 +2,7 @@
 import path from 'path';
 
 import {
+  AuthScope,
   CardinalDirection,
   centrelineKey,
   CentrelineType,
@@ -676,6 +677,10 @@ test('UserDAO', async () => {
   const email = generateEmail(name);
   const uniqueName = generateUniqueName(name);
   Object.assign(persistedUser1, { email, uniqueName });
+  await expect(UserDAO.update(persistedUser1)).resolves.toEqual(persistedUser1);
+  Object.assign(persistedUser1, {
+    scope: [AuthScope.STUDY_REQUESTS, AuthScope.STUDY_REQUESTS_EDIT],
+  });
   await expect(UserDAO.update(persistedUser1)).resolves.toEqual(persistedUser1);
   await expect(UserDAO.bySub(transientUser1.sub)).resolves.toEqual(persistedUser1);
 

--- a/tests/jest/db/DAO.spec.js
+++ b/tests/jest/db/DAO.spec.js
@@ -676,7 +676,7 @@ test('UserDAO', async () => {
   const email = generateEmail(name);
   const uniqueName = generateUniqueName(name);
   Object.assign(persistedUser1, { email, uniqueName });
-  await expect(UserDAO.update(persistedUser1)).resolves.toEqual(true);
+  await expect(UserDAO.update(persistedUser1)).resolves.toEqual(persistedUser1);
   await expect(UserDAO.bySub(transientUser1.sub)).resolves.toEqual(persistedUser1);
 
   let users = await UserDAO.byIds([]);

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -1,7 +1,11 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 
-import { apiFetch } from '@/lib/api/BackendClient';
+import {
+  getAuth,
+  postStudyRequest,
+  putStudyRequests,
+} from '@/lib/api/WebApi';
 import { getLocationFeatureType } from '@/lib/geo/CentrelineUtils';
 import {
   REQUEST_STUDY_SUBMITTED,
@@ -98,13 +102,8 @@ export default new Vuex.Store({
   },
   actions: {
     // AUTH / HELPERS STATE
-    async webInit({ commit }) {
-      const response = await apiFetch('/web/init');
-      commit('webInit', response);
-      return response;
-    },
     async checkAuth({ commit }) {
-      const auth = await apiFetch('/auth');
+      const auth = await getAuth('/auth');
       commit('setAuth', auth);
       return auth;
     },
@@ -122,18 +121,11 @@ export default new Vuex.Store({
         commit('setToast', toast);
       }
 
-      const data = studyRequest;
-      if (update && isSupervisor) {
-        data.isSupervisor = true;
+      const { csrf } = state.auth;
+      if (update) {
+        return putStudyRequests(csrf, isSupervisor, [studyRequest]);
       }
-      const method = update ? 'PUT' : 'POST';
-      const url = update ? `/requests/study/${id}` : '/requests/study';
-      const options = {
-        method,
-        csrf: state.auth.csrf,
-        data,
-      };
-      return apiFetch(url, options);
+      return postStudyRequest(csrf, studyRequest);
     },
   },
 });


### PR DESCRIPTION
# Issue Addressed
This PR makes further progress on #394 - still several steps to go!

# Description
This implements the database layer for user authentication scopes, and beefs up testing / validation a tiny bit around this at the same time.

# Tests
`npm run test:test-db` passes.  I haven't checked that `GET /api/auth` works still; that will be tested in subsequent PRs alongside other REST API / frontend-facing changes.
