### PR TITLE
RBAC: scope configuration, dynamic matching, stub admin UI

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -4,14 +4,25 @@ import TimeFormatters from '@/lib/time/TimeFormatters';
 /**
  * Authentication scopes.  Used to restrict access to certain REST API endpoints,
  * frontend routes, and features.
+ *
+ * @param {string} description - human-readable description of the permissions granted
+ * under this scope
  */
 class AuthScope extends Enum {}
-AuthScope.init([
-  'ADMIN',
-  'STUDY_REQUESTS',
-  'STUDY_REQUESTS_ADMIN',
-  'STUDY_REQUESTS_EDIT',
-]);
+AuthScope.init({
+  ADMIN: {
+    description: 'Admin MOVE',
+  },
+  STUDY_REQUESTS: {
+    description: 'View Study Requests',
+  },
+  STUDY_REQUESTS_ADMIN: {
+    description: 'Admin Study Requests',
+  },
+  STUDY_REQUESTS_EDIT: {
+    description: 'Create and Edit Study Requests',
+  },
+});
 
 /**
  * Four cardinal directions.  Our legacy FLOW system stores Turning Movement Count

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -199,8 +199,7 @@ async function getStudyRequest(id) {
 
 // TODO: filtering
 async function getStudyRequests() {
-  const options = {};
-  let studyRequests = await apiClient.fetch('/requests/study', options);
+  let studyRequests = await apiClient.fetch('/requests/study');
 
   const studyRequestsSchema = Joi.array().items(StudyRequest.read);
   studyRequests = await studyRequestsSchema.validateAsync(studyRequests);

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -197,11 +197,9 @@ async function getStudyRequest(id) {
   };
 }
 
-async function getUserStudyRequests(isSupervisor) {
+// TODO: filtering
+async function getStudyRequests() {
   const options = {};
-  if (isSupervisor) {
-    options.data = { isSupervisor };
-  }
   let studyRequests = await apiClient.fetch('/requests/study', options);
 
   const studyRequestsSchema = Joi.array().items(StudyRequest.read);
@@ -259,14 +257,11 @@ async function postStudyRequestComment(csrf, studyRequest, comment) {
   return StudyRequestComment.read.validateAsync(persistedComment);
 }
 
-async function putStudyRequests(csrf, isSupervisor, studyRequests) {
+async function putStudyRequests(csrf, studyRequests) {
   const promisesStudyRequests = studyRequests.map((studyRequest) => {
     const data = {
       ...studyRequest,
     };
-    if (isSupervisor) {
-      data.isSupervisor = isSupervisor;
-    }
     const url = `/requests/study/${data.id}`;
     const options = {
       method: 'PUT',
@@ -313,7 +308,7 @@ const WebApi = {
   getPoiByCentrelineSummary,
   getStudiesByCentrelinePending,
   getStudyRequest,
-  getUserStudyRequests,
+  getStudyRequests,
   getUsersByIds,
   postStudyRequest,
   postStudyRequestComment,
@@ -335,7 +330,7 @@ export {
   getPoiByCentrelineSummary,
   getStudiesByCentrelinePending,
   getStudyRequest,
-  getUserStudyRequests,
+  getStudyRequests,
   getUsersByIds,
   postStudyRequest,
   postStudyRequestComment,

--- a/lib/auth/ScopeMatcher.js
+++ b/lib/auth/ScopeMatcher.js
@@ -1,11 +1,11 @@
-function hasAuthScope(user, authScope) {
+function hasAuthScope(user, scope) {
   if (user === null) {
     return false;
   }
-  if (Array.isArray(authScope)) {
-    return authScope.some(subAuthScope => hasAuthScope(user, subAuthScope));
+  if (Array.isArray(scope)) {
+    return scope.some(authScope => user.scope.includes(authScope));
   }
-  return user.scope.includes(authScope);
+  return user.scope.includes(scope);
 }
 
 const ScopeMatcher = {

--- a/lib/auth/ScopeMatcher.js
+++ b/lib/auth/ScopeMatcher.js
@@ -1,0 +1,18 @@
+function hasAuthScope(user, authScope) {
+  if (user === null) {
+    return false;
+  }
+  if (Array.isArray(authScope)) {
+    return authScope.some(subAuthScope => hasAuthScope(user, subAuthScope));
+  }
+  return user.scope.includes(authScope);
+}
+
+const ScopeMatcher = {
+  hasAuthScope,
+};
+
+export {
+  ScopeMatcher as default,
+  hasAuthScope,
+};

--- a/lib/controller/StudyController.js
+++ b/lib/controller/StudyController.js
@@ -1,8 +1,8 @@
 import Joi from '@/lib/model/Joi';
 
+import { AuthScope, CentrelineType } from '@/lib/Constants';
 import StudyDAO from '@/lib/db/StudyDAO';
 import Study from '@/lib/model/Study';
-import { CentrelineType } from '@/lib/Constants';
 
 /**
  * Routes related to metadata for studies submitted via MOVE.  Note that this is different from
@@ -26,6 +26,9 @@ StudyController.push({
   method: 'GET',
   path: '/studies/byCentreline/pending',
   options: {
+    auth: {
+      scope: [AuthScope.STUDY_REQUESTS.name],
+    },
     response: {
       schema: Joi.array().items(Study.read),
     },

--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -1,7 +1,7 @@
 import Boom from '@hapi/boom';
 import Joi from '@/lib/model/Joi';
 
-import { StudyRequestStatus } from '@/lib/Constants';
+import { AuthScope, StudyRequestStatus } from '@/lib/Constants';
 import StudyRequestDAO from '@/lib/db/StudyRequestDAO';
 import StudyRequestCommentDAO from '@/lib/db/StudyRequestCommentDAO';
 import EmailStudyRequestConfirmation from '@/lib/email/EmailStudyRequestConfirmation';
@@ -35,6 +35,9 @@ StudyRequestController.push({
   method: 'POST',
   path: '/requests/study',
   options: {
+    auth: {
+      scope: [AuthScope.STUDY_REQUESTS_EDIT.name],
+    },
     response: {
       schema: StudyRequest.read,
     },
@@ -70,6 +73,9 @@ StudyRequestController.push({
   method: 'GET',
   path: '/requests/study/{id}',
   options: {
+    auth: {
+      scope: [AuthScope.STUDY_REQUESTS.name],
+    },
     response: {
       schema: StudyRequest.read,
     },
@@ -95,31 +101,22 @@ StudyRequestController.push({
  * yet others can view all submitted requests.
  *
  * @memberof StudyRequestController
- * @name getUserStudyRequests
+ * @name getStudyRequests
  * @type {Hapi.ServerRoute}
  */
 StudyRequestController.push({
   method: 'GET',
   path: '/requests/study',
   options: {
+    auth: {
+      scope: [AuthScope.STUDY_REQUESTS.name],
+    },
     response: {
       schema: Joi.array().items(StudyRequest.read),
     },
-    validate: {
-      query: {
-        // TODO: remove when we have RBAC
-        isSupervisor: Joi.boolean().default(false),
-      },
-    },
   },
-  handler: async (request) => {
-    const { isSupervisor } = request.query;
-    if (isSupervisor) {
-      return StudyRequestDAO.all();
-    }
-    const user = request.auth.credentials;
-    return StudyRequestDAO.byUser(user);
-  },
+  // TODO: filtering
+  handler: async () => StudyRequestDAO.all(),
 });
 
 /**
@@ -139,6 +136,9 @@ StudyRequestController.push({
   method: 'PUT',
   path: '/requests/study/{id}',
   options: {
+    auth: {
+      scope: [AuthScope.STUDY_REQUESTS_EDIT.name],
+    },
     response: {
       schema: StudyRequest.read,
     },
@@ -146,16 +146,13 @@ StudyRequestController.push({
       params: {
         id: Joi.number().integer().positive().required(),
       },
-      payload: StudyRequest.update.append({
-        // TODO: remove when we have RBAC
-        isSupervisor: Joi.boolean().default(false),
-      }),
+      payload: StudyRequest.update,
     },
   },
   handler: async (request) => {
     const user = request.auth.credentials;
     const { id } = request.params;
-    const { isSupervisor, ...studyRequestNew } = request.payload;
+    const studyRequestNew = request.payload;
 
     const studyRequestOld = await StudyRequestDAO.byId(id);
     if (studyRequestOld === null) {
@@ -182,6 +179,8 @@ StudyRequestController.push({
       return Boom.badRequest('cannot change last edit timestamp for study request');
     }
 
+    const isSupervisor = false;
+    // TODO: actual check
     if (studyRequestOld.userId !== user.id && !isSupervisor) {
       return Boom.forbidden('not authorized to change study request owned by another user');
     }
@@ -212,6 +211,9 @@ StudyRequestController.push({
   method: 'POST',
   path: '/requests/study/{studyRequestId}/comments',
   options: {
+    auth: {
+      scope: [AuthScope.STUDY_REQUESTS.name],
+    },
     response: {
       schema: StudyRequestComment.read,
     },
@@ -247,6 +249,9 @@ StudyRequestController.push({
   method: 'GET',
   path: '/requests/study/{studyRequestId}/comments',
   options: {
+    auth: {
+      scope: [AuthScope.STUDY_REQUESTS.name],
+    },
     response: {
       schema: Joi.array().items(StudyRequestComment.read),
     },
@@ -281,6 +286,9 @@ StudyRequestController.push({
   method: 'PUT',
   path: '/requests/study/{studyRequestId}/comments/{commentId}',
   options: {
+    auth: {
+      scope: [AuthScope.STUDY_REQUESTS.name],
+    },
     response: {
       schema: StudyRequestComment.read,
     },
@@ -340,6 +348,9 @@ StudyRequestController.push({
   method: 'DELETE',
   path: '/requests/study/{studyRequestId}/comments/{commentId}',
   options: {
+    auth: {
+      scope: [AuthScope.STUDY_REQUESTS.name],
+    },
     response: {
       schema: SuccessResponse,
     },

--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -1,12 +1,13 @@
 import Boom from '@hapi/boom';
-import Joi from '@/lib/model/Joi';
 
 import { AuthScope, StudyRequestStatus } from '@/lib/Constants';
+import { hasAuthScope } from '@/lib/auth/ScopeMatcher';
 import StudyRequestDAO from '@/lib/db/StudyRequestDAO';
 import StudyRequestCommentDAO from '@/lib/db/StudyRequestCommentDAO';
 import EmailStudyRequestConfirmation from '@/lib/email/EmailStudyRequestConfirmation';
 import Mailer from '@/lib/email/Mailer';
 import LogTag from '@/lib/log/LogTag';
+import Joi from '@/lib/model/Joi';
 import StudyRequest from '@/lib/model/StudyRequest';
 import StudyRequestComment from '@/lib/model/StudyRequestComment';
 import SuccessResponse from '@/lib/model/SuccessResponse';
@@ -179,16 +180,17 @@ StudyRequestController.push({
       return Boom.badRequest('cannot change last edit timestamp for study request');
     }
 
-    const isSupervisor = false;
-    // TODO: actual check
-    if (studyRequestOld.userId !== user.id && !isSupervisor) {
-      return Boom.forbidden('not authorized to change study request owned by another user');
-    }
-    if (studyRequestNew.assignedTo !== studyRequestOld.assignedTo && !isSupervisor) {
-      return Boom.forbidden('not authorized to change assignment for study request');
-    }
-    if (studyRequestNew.status !== studyRequestOld.status && !isSupervisor) {
-      return Boom.forbidden('not authorized to change status for study request');
+    if (!hasAuthScope(user, AuthScope.STUDY_REQUESTS_ADMIN)) {
+      if (studyRequestOld.userId !== user.id) {
+        return Boom.forbidden('not authorized to change study request owned by another user');
+      }
+      if (studyRequestNew.assignedTo !== studyRequestOld.assignedTo) {
+        return Boom.forbidden('not authorized to change assignment for study request');
+      }
+      // TODO: the requester *can* change the status to CANCELLED!
+      if (studyRequestNew.status !== studyRequestOld.status) {
+        return Boom.forbidden('not authorized to change status for study request');
+      }
     }
 
     return StudyRequestDAO.update(studyRequestNew, user);

--- a/lib/controller/UserController.js
+++ b/lib/controller/UserController.js
@@ -1,3 +1,6 @@
+import Boom from '@hapi/boom';
+
+import { AuthScope } from '@/lib/Constants';
 import UserDAO from '@/lib/db/UserDAO';
 import Joi from '@/lib/model/Joi';
 import User from '@/lib/model/User';
@@ -8,6 +11,24 @@ import User from '@/lib/model/User';
  * @type {Array<Hapi.ServerRoute>}
  */
 const UserController = [];
+
+/**
+ * Get all users.
+ *
+ * @memberof UserController
+ * @name getUsers
+ * @type {Hapi.ServerRoute}
+ */
+UserController.push({
+  method: 'GET',
+  path: '/users',
+  options: {
+    response: {
+      schema: Joi.array().items(User.read),
+    },
+  },
+  handler: async () => UserDAO.all(),
+});
 
 /**
  * Get user names and emails for the given user IDs.
@@ -40,6 +61,57 @@ UserController.push({
     const { id: ids } = request.query;
     const users = await UserDAO.byIds(ids);
     return Array.from(users);
+  },
+});
+
+/**
+ * Update the given user.
+ *
+ * Changing the `sub` field is forbidden, and making any other changes requires
+ * `ADMIN` access for now.  We may change that in the future if we implement user
+ * profiles.
+ *
+ * @memberof UserController
+ * @name putUser
+ * @type {Hapi.ServerRoute}
+ */
+UserController.push({
+  method: 'PUT',
+  path: '/users/{id}',
+  options: {
+    auth: {
+      scope: [AuthScope.ADMIN.name],
+    },
+    response: {
+      schema: User.read,
+    },
+    validate: {
+      params: {
+        id: Joi.number().integer().positive().required(),
+      },
+      payload: User.read,
+    },
+  },
+  handler: async (request) => {
+    const { id } = request.params;
+    const userNew = request.payload;
+
+    const userOld = await UserDAO.byId(id);
+    if (userOld === null) {
+      return Boom.notFound(`no user found with ID ${id}`);
+    }
+
+    if (userNew.id !== userOld.id) {
+      return Boom.badRequest('cannot change ID for user');
+    }
+    if (!userNew.createdAt.equals(userOld.createdAt)) {
+      return Boom.badRequest('cannot change creation timestamp for user');
+    }
+    if (userNew.sub !== userOld.sub) {
+      return Boom.badRequest('cannot change subject identifier for user');
+    }
+
+    return UserDAO.update(userNew);
   },
 });
 

--- a/lib/db/UserDAO.js
+++ b/lib/db/UserDAO.js
@@ -42,6 +42,12 @@ class UserDAO {
     return new Map(usersNormalized.map(user => [user.id, user]));
   }
 
+  static async all() {
+    const sql = 'SELECT * FROM "users" ORDER BY "id" ASC';
+    const users = await db.manyOrNone(sql);
+    return normalizeUsers(users);
+  }
+
   static async bySub(sub) {
     const sql = 'SELECT * FROM "users" WHERE "sub" = $(sub)';
     const user = await db.oneOrNone(sql, { sub });

--- a/tests/jest/db/DAO.spec.js
+++ b/tests/jest/db/DAO.spec.js
@@ -672,6 +672,7 @@ test('UserDAO', async () => {
   await expect(UserDAO.bySub(transientUser1.sub)).resolves.toEqual(persistedUser1);
   await expect(UserDAO.bySub(transientUser2.sub)).resolves.toBeNull();
   await expect(UserDAO.byEmail(transientUser1.email)).resolves.toEqual(persistedUser1);
+  await expect(UserDAO.all()).resolves.toContainEqual(persistedUser1);
 
   const name = generateName();
   const email = generateEmail(name);
@@ -696,7 +697,9 @@ test('UserDAO', async () => {
   expect(users.size).toBe(2);
   expect(users.get(persistedUser1.id)).toEqual(persistedUser1);
   expect(users.get(persistedUser2.id)).toEqual(persistedUser2);
+  await expect(UserDAO.all()).resolves.toContainEqual(persistedUser2);
 
   await expect(UserDAO.delete(persistedUser1)).resolves.toEqual(true);
   await expect(UserDAO.bySub(transientUser1.sub)).resolves.toBeNull();
+  await expect(UserDAO.all()).resolves.not.toContainEqual(persistedUser1);
 });

--- a/web/App.vue
+++ b/web/App.vue
@@ -1,10 +1,10 @@
 <template>
   <v-app id="fc_app">
     <component
-      v-if="hasAlert"
-      v-model="hasAlert"
-      :is="'FcDialogAlert' + alert"
-      v-bind="alertData" />
+      v-if="hasDialog"
+      v-model="hasDialog"
+      :is="'FcDialog' + dialog"
+      v-bind="dialogData" />
     <v-snackbar
       v-if="hasToast"
       v-model="hasToast"
@@ -63,6 +63,8 @@ import '@/web/css/main.scss';
 
 import FcDialogAlertStudyRequestUrgent from
   '@/web/components/dialogs/FcDialogAlertStudyRequestUrgent.vue';
+import FcDialogConfirmUnauthorized from
+  '@/web/components/dialogs/FcDialogConfirmUnauthorized.vue';
 import FcDashboardNavBrand from '@/web/components/nav/FcDashboardNavBrand.vue';
 import FcDashboardNavItem from '@/web/components/nav/FcDashboardNavItem.vue';
 import FcDashboardNavUser from '@/web/components/nav/FcDashboardNavUser.vue';
@@ -74,15 +76,16 @@ export default {
     FcDashboardNavItem,
     FcDashboardNavUser,
     FcDialogAlertStudyRequestUrgent,
+    FcDialogConfirmUnauthorized,
   },
   computed: {
-    hasAlert: {
+    hasDialog: {
       get() {
-        return this.alert !== null;
+        return this.dialog !== null;
       },
-      set(hasAlert) {
-        if (!hasAlert) {
-          this.clearAlert();
+      set(hasDialog) {
+        if (!hasDialog) {
+          this.clearDialog();
         }
       },
     },
@@ -98,14 +101,14 @@ export default {
     },
     ...mapState([
       'auth',
-      'alert',
-      'alertData',
+      'dialog',
+      'dialogData',
       'location',
       'toast',
     ]),
   },
   methods: {
-    ...mapMutations(['clearAlert', 'clearToast']),
+    ...mapMutations(['clearDialog', 'clearToast']),
   },
 };
 </script>

--- a/web/components/FcDrawerRequestStudy.vue
+++ b/web/components/FcDrawerRequestStudy.vue
@@ -223,9 +223,6 @@ export default {
     isCreate() {
       return this.$route.name === 'requestStudyNew';
     },
-    isSupervisor() {
-      return Object.prototype.hasOwnProperty.call(this.$route.query, 'isSupervisor');
-    },
     itemsStudyType() {
       const itemsStudyType = StudyType.enumValues.map((studyType) => {
         const { label: text } = studyType;
@@ -245,14 +242,10 @@ export default {
         return null;
       }
       const { id } = this.studyRequest;
-      const route = {
+      return {
         name: 'requestStudyView',
         params: { id },
       };
-      if (this.isSupervisor) {
-        route.query = { isSupervisor: true };
-      }
-      return route;
     },
     subtitle() {
       if (this.location === null) {
@@ -338,8 +331,8 @@ export default {
       }
     },
     onFinish() {
-      const { isSupervisor, studyRequest } = this;
-      this.saveStudyRequest({ isSupervisor, studyRequest });
+      const { studyRequest } = this;
+      this.saveStudyRequest(studyRequest);
       this.leaveConfirmed = true;
       this.$router.push(this.routeFinish);
     },

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -176,6 +176,7 @@ import {
   mapState,
 } from 'vuex';
 
+import { AuthScope } from '@/lib/Constants';
 import {
   getCollisionsByCentrelineSummary,
   getCountsByCentrelineSummary,
@@ -190,11 +191,15 @@ import FcDataTableStudies from '@/web/components/FcDataTableStudies.vue';
 import FcDialogStudyFilters from '@/web/components/dialogs/FcDialogStudyFilters.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcSearchBarLocation from '@/web/components/inputs/FcSearchBarLocation.vue';
+import FcMixinAuthScope from '@/web/mixins/FcMixinAuthScope';
 import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
 
 export default {
   name: 'FcDrawerViewData',
-  mixins: [FcMixinRouteAsync],
+  mixins: [
+    FcMixinAuthScope,
+    FcMixinRouteAsync,
+  ],
   components: {
     FcButton,
     FcDataTableStudies,
@@ -355,7 +360,7 @@ export default {
         getLocationByFeature({ centrelineId, centrelineType }),
         getPoiByCentrelineSummary({ centrelineId, centrelineType }),
       ];
-      if (this.auth.loggedIn) {
+      if (this.hasAuthScope(AuthScope.STUDY_REQUESTS)) {
         tasks.push(getStudiesByCentrelinePending({ centrelineId, centrelineType }));
       }
       const [

--- a/web/components/FcDrawerViewRequest.vue
+++ b/web/components/FcDrawerViewRequest.vue
@@ -16,7 +16,11 @@
         </span>
       </h1>
       <FcButton
-        v-if="!loading && (auth.user.id === studyRequest.userId || isSupervisor)"
+        v-if="!loading
+          && (
+            auth.user.id === studyRequest.userId
+            || hasAuthScope(AuthScope.STUDY_REQUESTS_ADMIN)
+          )"
         type="secondary"
         @click="actionEdit">
         <v-icon color="primary" left>mdi-pencil</v-icon> Edit
@@ -70,11 +74,15 @@ import FcCommentsStudyRequest from '@/web/components/FcCommentsStudyRequest.vue'
 import FcSummaryStudy from '@/web/components/FcSummaryStudy.vue';
 import FcSummaryStudyRequest from '@/web/components/FcSummaryStudyRequest.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
+import FcMixinAuthScope from '@/web/mixins/FcMixinAuthScope';
 import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
 
 export default {
   name: 'FcDrawerViewRequest',
-  mixins: [FcMixinRouteAsync],
+  mixins: [
+    FcMixinAuthScope,
+    FcMixinRouteAsync,
+  ],
   components: {
     FcButton,
     FcCommentsStudyRequest,

--- a/web/components/FcDrawerViewRequest.vue
+++ b/web/components/FcDrawerViewRequest.vue
@@ -89,9 +89,6 @@ export default {
     };
   },
   computed: {
-    isSupervisor() {
-      return Object.prototype.hasOwnProperty.call(this.$route.query, 'isSupervisor');
-    },
     labelNavigateBack() {
       const { backViewRequest: { name } } = this;
       if (name === 'viewDataAtLocation') {
@@ -118,17 +115,10 @@ export default {
         name: 'requestStudyEdit',
         params: { id },
       };
-      if (this.isSupervisor) {
-        route.query = { isSupervisor: true };
-      }
       this.$router.push(route);
     },
     actionNavigateBack() {
-      const { backViewRequest } = this;
-      const route = { ...backViewRequest };
-      if (this.isSupervisor) {
-        route.query = { isSupervisor: true };
-      }
+      const { backViewRequest: route } = this;
       this.$router.push(route);
     },
     async loadAsyncForRoute(to) {

--- a/web/components/FcDrawerViewRequest.vue
+++ b/web/components/FcDrawerViewRequest.vue
@@ -16,11 +16,8 @@
         </span>
       </h1>
       <FcButton
-        v-if="!loading
-          && (
-            auth.user.id === studyRequest.userId
-            || hasAuthScope(AuthScope.STUDY_REQUESTS_ADMIN)
-          )"
+        v-if="canEdit"
+        :disabled="loading"
         type="secondary"
         @click="actionEdit">
         <v-icon color="primary" left>mdi-pencil</v-icon> Edit
@@ -67,9 +64,8 @@
 <script>
 import { mapMutations, mapState } from 'vuex';
 
-import {
-  getStudyRequest,
-} from '@/lib/api/WebApi';
+import { AuthScope } from '@/lib/Constants';
+import { getStudyRequest } from '@/lib/api/WebApi';
 import FcCommentsStudyRequest from '@/web/components/FcCommentsStudyRequest.vue';
 import FcSummaryStudy from '@/web/components/FcSummaryStudy.vue';
 import FcSummaryStudyRequest from '@/web/components/FcSummaryStudyRequest.vue';
@@ -97,6 +93,15 @@ export default {
     };
   },
   computed: {
+    canEdit() {
+      if (this.hasAuthScope(AuthScope.STUDY_REQUESTS_ADMIN)) {
+        return true;
+      }
+      if (this.studyRequest !== null && this.hasAuthScope(AuthScope.STUDY_REQUESTS_EDIT)) {
+        return this.auth.user.id === this.studyRequest.userId;
+      }
+      return false;
+    },
     labelNavigateBack() {
       const { backViewRequest: { name } } = this;
       if (name === 'viewDataAtLocation') {

--- a/web/components/admin/FcAdminMetrics.vue
+++ b/web/components/admin/FcAdminMetrics.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="fc-admin-metrics">
+    <h2 class="display-2">TODO: coming soon</h2>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'FcAdminMetrics',
+};
+</script>

--- a/web/components/admin/FcAdminPermissions.vue
+++ b/web/components/admin/FcAdminPermissions.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="fc-admin-permissions">
+    <h2 class="display-2">TODO: coming soon</h2>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'FcAdminPermissions',
+};
+</script>

--- a/web/components/dialogs/FcDialogConfirmUnauthorized.vue
+++ b/web/components/dialogs/FcDialogConfirmUnauthorized.vue
@@ -1,0 +1,68 @@
+<template>
+  <FcDialogConfirm
+    v-model="internalValue"
+    textOk="Request Access"
+    title="Access Unauthorized"
+    @action-ok="actionRequestAccess">
+    <div class="body-1">
+      <p>
+        This feature requires additional permissions to access.
+      </p>
+      <div
+        v-for="{ authScope, granted } in scopeDetails"
+        :key="authScope.name"
+        :class="granted ? 'success--text' : 'error--text'">
+        <v-icon
+          :color="granted ? 'success' : 'error'"
+          left>
+          {{granted ? 'mdi-check-circle' : 'mdi-close-octagon'}}
+        </v-icon>
+        <span>{{authScope.description}}</span>
+      </div>
+    </div>
+  </FcDialogConfirm>
+</template>
+
+<script>
+import { mapGetters } from 'vuex';
+
+import FcDialogConfirm from '@/web/components/dialogs/FcDialogConfirm.vue';
+import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+
+export default {
+  name: 'FcDialogConfirmUnauthorized',
+  mixins: [FcMixinVModelProxy(Boolean)],
+  components: {
+    FcDialogConfirm,
+  },
+  props: {
+    scope: Array,
+  },
+  computed: {
+    scopeDetails() {
+      const { scope, userScope } = this;
+      return scope.map((authScope) => {
+        const granted = userScope.includes(authScope);
+        return {
+          authScope,
+          granted,
+        };
+      });
+    },
+    ...mapGetters(['username', 'userScope']),
+  },
+  methods: {
+    actionRequestAccess() {
+      const { scopeDetails, username } = this;
+      const authScopesMissing = scopeDetails
+        .filter(({ granted }) => !granted)
+        .map(({ authScope }) => authScope.name)
+        .join(', ');
+      const subject = `Requesting access for ${username}: ${authScopesMissing}`;
+      const subjectEncoded = window.encodeURIComponent(subject);
+      const url = `mailto:move-team@toronto.ca?subject=${subjectEncoded}`;
+      window.open(url, '_blank');
+    },
+  },
+};
+</script>

--- a/web/components/nav/FcDashboardNavUser.vue
+++ b/web/components/nav/FcDashboardNavUser.vue
@@ -33,6 +33,15 @@
         </v-tooltip>
       </template>
       <v-list>
+        <template
+          v-if="hasAuthScope(AuthScope.ADMIN)">
+          <v-list-item
+            link
+            :to="{ name: 'admin' }">
+            <v-list-item-title>Admin Console</v-list-item-title>
+          </v-list-item>
+          <v-divider></v-divider>
+        </template>
         <v-list-item
           @click="actionSignOut()">
           <v-list-item-title>Sign out</v-list-item-title>
@@ -61,10 +70,14 @@ import Vue from 'vue';
 import { mapGetters, mapState } from 'vuex';
 
 import FcButton from '@/web/components/inputs/FcButton.vue';
+import FcMixinAuthScope from '@/web/mixins/FcMixinAuthScope';
 import { saveLoginState } from '@/web/store/LoginState';
 
 export default {
   name: 'FcDashboardNavUser',
+  mixins: [
+    FcMixinAuthScope,
+  ],
   components: {
     FcButton,
   },

--- a/web/mixins/FcMixinAuthScope.js
+++ b/web/mixins/FcMixinAuthScope.js
@@ -1,0 +1,55 @@
+import { mapState } from 'vuex';
+
+import { AuthScope } from '@/lib/Constants';
+import { hasAuthScope } from '@/lib/auth/ScopeMatcher';
+
+/**
+ * Vue mixin that allows you to include dynamic auth scope checks in your templates.
+ *
+ * @name FcMixinAuthScope
+ * @example
+ * <template>
+ *   <FcButton type="primary">
+ *     <v-icon left>mdi-binoculars</v-icon>
+ *     Watch Safely from Afar
+ *   </FcButton>
+ *   <FcButton
+ *     v-if="hasAuthScope(AuthScope.ADMIN)"
+ *     color="error"
+ *     type="secondary">
+ *     <v-icon left>mdi-rocket</v-icon>
+ *     Launch!
+ *   </FcButton>
+ * </template>
+ *
+ * <script>
+ * import FcButton from '@/web/components/inputs/FcButton.vue';
+ * import FcMixinAuthScope from '@/web/mixins/FcMixinAuthScope';
+ *
+ * export default {
+ *   name: 'FcControlRocket',
+ *   mixins: [
+ *     FcMixinAuthScope,
+ *   ],
+ *   components: {
+ *     FcButton,
+ *   },
+ * };
+ * </script>
+ */
+export default {
+  data() {
+    return {
+      AuthScope,
+    };
+  },
+  computed: {
+    ...mapState(['auth']),
+  },
+  methods: {
+    hasAuthScope(authScope) {
+      const { user } = this.auth;
+      return hasAuthScope(user, authScope);
+    },
+  },
+};

--- a/web/router.js
+++ b/web/router.js
@@ -24,19 +24,11 @@ const router = new Router({
       children: [{
         path: '',
         name: 'admin',
-        meta: {
-          auth: {
-            scope: [AuthScope.ADMIN],
-          },
-        },
         redirect: { name: 'adminPermissions' },
       }, {
         path: '/admin/metrics',
         name: 'adminMetrics',
         meta: {
-          auth: {
-            scope: [AuthScope.ADMIN],
-          },
           title: 'Admin Console: Metrics',
         },
         component: () => import(/* webpackChunkName: "admin" */ '@/web/components/admin/FcAdminMetrics.vue'),
@@ -44,9 +36,6 @@ const router = new Router({
         path: '/admin/permissions',
         name: 'adminPermissions',
         meta: {
-          auth: {
-            scope: [AuthScope.ADMIN],
-          },
           title: 'Admin Console: Permissions',
         },
         component: () => import(/* webpackChunkName: "admin" */ '@/web/components/admin/FcAdminPermissions.vue'),

--- a/web/router.js
+++ b/web/router.js
@@ -14,12 +14,7 @@ const router = new Router({
       path: '/requests/track',
       name: 'requestsTrack',
       meta: {
-        title({ query: { isSupervisor = null } }) {
-          if (isSupervisor) {
-            return 'Manage Requests';
-          }
-          return 'Track Requests';
-        },
+        title: 'Track Requests',
       },
       component: () => import(/* webpackChunkName: "home" */ '@/web/views/FcRequestsTrack.vue'),
       beforeEnter(to, from, next) {

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -26,11 +26,12 @@ export default new Vuex.Store({
     auth: {
       csrf: '',
       loggedIn: false,
+      user: null,
     },
     now: DateTime.local(),
     // TOP-LEVEL UI
-    alert: null,
-    alertData: {},
+    dialog: null,
+    dialogData: {},
     drawerOpen: false,
     toast: null,
     // NAVIGATION
@@ -59,6 +60,13 @@ export default new Vuex.Store({
       }
       return uniqueName.slice(i + 1);
     },
+    userScope(state) {
+      if (!state.auth.loggedIn) {
+        return [];
+      }
+      const { scope } = state.auth.user;
+      return scope;
+    },
     // LOCATION
     locationFeatureType(state) {
       const { location } = state;
@@ -71,16 +79,16 @@ export default new Vuex.Store({
       Vue.set(state, 'auth', auth);
     },
     // TOP-LEVEL UI
-    clearAlert(state) {
-      Vue.set(state, 'alert', null);
-      Vue.set(state, 'alertData', {});
+    clearDialog(state) {
+      Vue.set(state, 'dialog', null);
+      Vue.set(state, 'dialogData', {});
     },
     clearToast(state) {
       Vue.set(state, 'toast', null);
     },
-    setAlert(state, { alert, alertData = {} }) {
-      Vue.set(state, 'alert', alert);
-      Vue.set(state, 'alertData', alertData);
+    setDialog(state, { dialog, dialogData = {} }) {
+      Vue.set(state, 'dialog', dialog);
+      Vue.set(state, 'dialogData', dialogData);
     },
     setDrawerOpen(state, drawerOpen) {
       Vue.set(state, 'drawerOpen', drawerOpen);
@@ -112,9 +120,9 @@ export default new Vuex.Store({
       const { id, urgent } = studyRequest;
       const update = id !== undefined;
       if (urgent) {
-        commit('setAlert', {
-          alert: 'StudyRequestUrgent',
-          alertData: { update },
+        commit('setDialog', {
+          dialog: 'StudyRequestUrgent',
+          dialogData: { update },
         });
       } else {
         const toast = update ? REQUEST_STUDY_UPDATED : REQUEST_STUDY_SUBMITTED;

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -108,7 +108,7 @@ export default new Vuex.Store({
       return auth;
     },
     // STUDY REQUESTS
-    async saveStudyRequest({ state, commit }, { isSupervisor, studyRequest }) {
+    async saveStudyRequest({ state, commit }, studyRequest) {
       const { id, urgent } = studyRequest;
       const update = id !== undefined;
       if (urgent) {
@@ -123,7 +123,7 @@ export default new Vuex.Store({
 
       const { csrf } = state.auth;
       if (update) {
-        return putStudyRequests(csrf, isSupervisor, [studyRequest]);
+        return putStudyRequests(csrf, [studyRequest]);
       }
       return postStudyRequest(csrf, studyRequest);
     },

--- a/web/views/FcAdmin.vue
+++ b/web/views/FcAdmin.vue
@@ -1,0 +1,46 @@
+<template>
+  <section class="fc-admin d-flex flex-column fill-height">
+    <header class="flex-grow-0 flex-shrink-0">
+      <v-tabs>
+        <v-tab :to="{ name: 'adminPermissions' }">
+          Permissions
+        </v-tab>
+        <v-tab :to="{ name: 'adminMetrics' }">
+          Metrics
+        </v-tab>
+      </v-tabs>
+      <v-divider></v-divider>
+      <div class="px-5">
+        <h1 class="display-3 mt-5">{{title}}</h1>
+      </div>
+    </header>
+    <section class="flex-grow-1 flex-shrink-1 overflow-y-auto px-5">
+      <router-view></router-view>
+    </section>
+  </section>
+</template>
+
+<script>
+export default {
+  name: 'FcAdmin',
+  computed: {
+    title() {
+      const { name } = this.$route;
+      if (name === 'adminMetrics') {
+        return 'MOVE Metrics';
+      }
+      if (name === 'adminPermissions') {
+        return 'MOVE Permissions';
+      }
+      return 'MOVE Admin Console';
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+.fc-admin {
+  max-height: 100vh;
+  width: 100%;
+}
+</style>

--- a/web/views/FcRequestsTrack.vue
+++ b/web/views/FcRequestsTrack.vue
@@ -214,7 +214,7 @@ import {
 } from '@/lib/Constants';
 import { formatDuration } from '@/lib/StringFormatters';
 import {
-  getUserStudyRequests,
+  getStudyRequests,
   putStudyRequests,
 } from '@/lib/api/WebApi';
 import TimeFormatters from '@/lib/time/TimeFormatters';
@@ -339,9 +339,6 @@ export default {
     closed() {
       return this.indexClosed === 1;
     },
-    isSupervisor() {
-      return Object.prototype.hasOwnProperty.call(this.$route.query, 'isSupervisor');
-    },
     items() {
       return this.itemsStudyRequests
         .filter(({ closed }) => closed === this.closed);
@@ -442,9 +439,6 @@ export default {
         name: 'requestStudyView',
         params: { id: item.id },
       };
-      if (this.isSupervisor) {
-        route.query = { isSupervisor: true };
-      }
       this.$router.push(route);
     },
     async loadAsyncForRoute() {
@@ -452,19 +446,18 @@ export default {
         studyRequests,
         studyRequestLocations,
         studyRequestUsers,
-      } = await getUserStudyRequests(this.isSupervisor);
+      } = await getStudyRequests();
 
       this.studyRequests = studyRequests;
       this.studyRequestLocations = studyRequestLocations;
       this.studyRequestUsers = studyRequestUsers;
     },
     async setStudyRequests(items, updates) {
-      const { isSupervisor } = this;
       const studyRequests = items.map((item) => {
         const studyRequest = this.studyRequests.find(({ id }) => id === item.id);
         return Object.assign(studyRequest, updates);
       });
-      return putStudyRequests(this.auth.csrf, isSupervisor, studyRequests);
+      return putStudyRequests(this.auth.csrf, studyRequests);
     },
     ...mapActions([
       'saveStudyRequest',

--- a/web/views/FcRequestsTrack.vue
+++ b/web/views/FcRequestsTrack.vue
@@ -34,7 +34,7 @@
             </FcButton>
             <template v-else>
               <template
-                v-if="isSupervisor">
+                v-if="hasAuthScope(AuthScope.STUDY_REQUESTS_ADMIN)">
                 <FcButton
                   class="mr-2"
                   type="secondary"
@@ -74,7 +74,6 @@
       <FcDataTable
         v-model="selectedItems"
         class="fc-data-table-requests"
-        :class="{ supervisor: isSupervisor }"
         :columns="columns"
         :items="items"
         :loading="loading || loadingRefresh"
@@ -150,7 +149,7 @@
               color="warning"
               title="Urgent">mdi-clipboard-alert</v-icon>
 
-            <template v-if="isSupervisor && !closed">
+            <template v-if="hasAuthScope(AuthScope.STUDY_REQUESTS_ADMIN) && !closed">
               <v-tooltip top>
                 <template v-slot:activator="{ on }">
                   <FcButton
@@ -220,6 +219,7 @@ import {
 import TimeFormatters from '@/lib/time/TimeFormatters';
 import FcDataTable from '@/web/components/FcDataTable.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
+import FcMixinAuthScope from '@/web/mixins/FcMixinAuthScope';
 import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
 
 function getItemFields(item) {
@@ -294,7 +294,10 @@ function getItemRows(item) {
 
 export default {
   name: 'FcRequestsTrack',
-  mixins: [FcMixinRouteAsync],
+  mixins: [
+    FcMixinAuthScope,
+    FcMixinRouteAsync,
+  ],
   components: {
     FcButton,
     FcDataTable,


### PR DESCRIPTION
# Issue Addressed
This PR makes significant further progress on #394 .

# Description
Several pieces coming together:

- added scopes to all backend REST API endpoints and frontend routes;
- added REST API endpoints and DAO methods to get all users, and to update a user object;
- added `@/lib/auth/ScopeMatcher` to perform dynamic checks;
- added '/admin` routes with stub UI implementation, including a second tab that will eventually be used for site-wide metrics;
- added `FcDialogConfirmUnauthorized`, which is used to notify the user when they attempt to access a feature to which they do not currently have access.

More on this last one: while outright hiding features can be better in some cases, there's always the possibility that we'll miss something, so it helps to have a user-facing way to remediate.

# Tests
- tested "Request Study" using the `esavage` user;
- modified permissions in the database to exercise authorized vs. unauthorized paths;
- tested stub admin UI manually;
- `npm run test:test-db` to test DAO changes.

This still requires more extensive REST API testing, as specified in #385 .