### PR TITLE
Finish up RBAC admin UI

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -546,6 +546,9 @@ const SortKeys = {
     STATUS: r => r.status.ordinal,
     URGENT: r => (r.urgent ? 1 : 0),
   },
+  Users: {
+    UNIQUE_NAME: u => u.uniqueName,
+  },
 };
 
 

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -136,6 +136,12 @@ async function getStudiesByCentrelinePending(feature) {
   return studiesSchema.validateAsync(studies);
 }
 
+async function getUsers() {
+  const users = await apiClient.fetch('/users');
+  const usersSchema = Joi.array().items(User.read);
+  return usersSchema.validateAsync(users);
+}
+
 async function getUsersByIds(ids) {
   const idsArray = Array.from(ids);
   if (idsArray.length === 0) {
@@ -244,13 +250,10 @@ async function postStudyRequest(csrf, studyRequest) {
 async function postStudyRequestComment(csrf, studyRequest, comment) {
   const { id: studyRequestId } = studyRequest;
   const url = `/requests/study/${studyRequestId}/comments`;
-  const data = {
-    ...comment,
-  };
   const options = {
     method: 'POST',
     csrf,
-    data,
+    data: comment,
   };
   const persistedComment = await apiClient.fetch(url, options);
   return StudyRequestComment.read.validateAsync(persistedComment);
@@ -258,14 +261,12 @@ async function postStudyRequestComment(csrf, studyRequest, comment) {
 
 async function putStudyRequests(csrf, studyRequests) {
   const promisesStudyRequests = studyRequests.map((studyRequest) => {
-    const data = {
-      ...studyRequest,
-    };
-    const url = `/requests/study/${data.id}`;
+    const { id: studyRequestId } = studyRequest;
+    const url = `/requests/study/${studyRequestId}`;
     const options = {
       method: 'PUT',
       csrf,
-      data,
+      data: studyRequest,
     };
     return apiClient.fetch(url, options);
   });
@@ -281,17 +282,27 @@ async function putStudyRequestComment(csrf, studyRequest, comment) {
   const { id: commentId } = comment;
   const { id: studyRequestId } = studyRequest;
   const url = `/requests/study/${studyRequestId}/comments/${commentId}`;
-  const data = {
-    ...comment,
-  };
   const options = {
     method: 'PUT',
     csrf,
-    data,
+    data: comment,
   };
 
   const persistedComment = await apiClient.fetch(url, options);
   return StudyRequestComment.read.validateAsync(persistedComment);
+}
+
+async function putUser(csrf, user) {
+  const { id: userId } = user;
+  const url = `/users/${userId}`;
+  const options = {
+    method: 'PUT',
+    csrf,
+    data: user,
+  };
+
+  const persistedUser = await apiClient.fetch(url, options);
+  return User.read.validateAsync(persistedUser);
 }
 
 const WebApi = {
@@ -308,11 +319,13 @@ const WebApi = {
   getStudiesByCentrelinePending,
   getStudyRequest,
   getStudyRequests,
+  getUsers,
   getUsersByIds,
   postStudyRequest,
   postStudyRequestComment,
   putStudyRequests,
   putStudyRequestComment,
+  putUser,
 };
 
 export {
@@ -330,9 +343,11 @@ export {
   getStudiesByCentrelinePending,
   getStudyRequest,
   getStudyRequests,
+  getUsers,
   getUsersByIds,
   postStudyRequest,
   postStudyRequestComment,
   putStudyRequests,
   putStudyRequestComment,
+  putUser,
 };

--- a/web/components/admin/FcAdminPermissions.vue
+++ b/web/components/admin/FcAdminPermissions.vue
@@ -1,11 +1,102 @@
 <template>
   <div class="fc-admin-permissions">
-    <h2 class="display-2">TODO: coming soon</h2>
+    <FcDataTable
+      class="fc-data-table-users"
+      :columns="columns"
+      :items="users"
+      :loading="loading"
+      must-sort
+      sort-by="UNIQUE_NAME"
+      :sort-desc="false"
+      :sort-keys="sortKeys">
+      <template v-slot:item.UNIQUE_NAME="{ item }">
+        <span>{{item.uniqueName}}</span>
+      </template>
+      <template
+        v-for="{ authScope, itemSlot } of authScopeSlots"
+        v-slot:[itemSlot]="{ item }">
+        <div
+          :key="'u:' + item.id + ':' + authScope.name"
+          class="d-flex">
+          <v-tooltip right>
+            <template v-slot:activator="{ on }">
+              <v-checkbox
+                v-model="item.scope"
+                class="mt-0 pt-0"
+                :disabled="loadingChangeUserScope"
+                hide-details
+                :value="authScope"
+                @change="actionChangeUserScope(item)"
+                v-on="on"></v-checkbox>
+            </template>
+            <span>
+              <span v-if="item.scope.includes(authScope)">
+                Deny {{authScope.name}}
+              </span>
+              <span v-else>
+                Grant {{authScope.name}}
+              </span>
+            </span>
+          </v-tooltip>
+        </div>
+      </template>
+    </FcDataTable>
   </div>
 </template>
 
 <script>
+import { mapState } from 'vuex';
+
+import { AuthScope, SortKeys } from '@/lib/Constants';
+import { getUsers, putUser } from '@/lib/api/WebApi';
+import FcDataTable from '@/web/components/FcDataTable.vue';
+import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
+
 export default {
   name: 'FcAdminPermissions',
+  mixins: [
+    FcMixinRouteAsync,
+  ],
+  components: {
+    FcDataTable,
+  },
+  data() {
+    const authScopeSlots = AuthScope.enumValues.map((authScope) => {
+      const { name } = authScope;
+      const itemSlot = `item.${name}`;
+      return { authScope, itemSlot };
+    });
+    const columns = [
+      {
+        value: 'UNIQUE_NAME',
+        text: 'User',
+      },
+      ...AuthScope.enumValues.map(({ name }) => ({
+        value: name,
+        text: name,
+      })),
+    ];
+    return {
+      authScopeSlots,
+      columns,
+      loadingChangeUserScope: false,
+      sortKeys: SortKeys.Users,
+      users: [],
+    };
+  },
+  computed: {
+    ...mapState(['auth']),
+  },
+  methods: {
+    async actionChangeUserScope(user) {
+      this.loadingChangeUserScope = true;
+      await putUser(this.auth.csrf, user);
+      this.loadingChangeUserScope = false;
+    },
+    async loadAsyncForRoute() {
+      const users = await getUsers();
+      this.users = users;
+    },
+  },
 };
 </script>


### PR DESCRIPTION
# Issue Addressed
This PR closes #394 🎉 

# Description
For now, this is just a quick-and-dirty `FcDataTable`: each row is a user, and we have columns with checkboxes to set different permission scopes.  This leans on the new REST API endpoints in `UserController`, which themselves use new functionality in `UserDAO`.

# Tests
Logged in several users in local development version.  Loaded up admin console as `esavage` (who has `ADMIN` scope).  Edited permissions.  Verified that:

- the permissions changes are reflected in database;
- the permissions changes are reflected in the UI, and persist across page refreshes;
- granting `STUDY_REQUESTS_EDIT` allows users to access Request Study.