### PR TITLE
Track Requests: filters and shortcut chips

### DIFF
--- a/web/components/FcDataTableRequests.vue
+++ b/web/components/FcDataTableRequests.vue
@@ -14,14 +14,8 @@
     :sort-keys="sortKeys">
     <template v-slot:no-data>
       <div class="mt-8 pt-7 secondary--text">
-        <span v-if="itemsStudyRequests.length === 0">
-          You have not requested a study,<br>
-          please view the map <router-link :to="{name: 'viewData'}">here</router-link>
-        </span>
-        <span v-else>
-          No requests match the active filters,<br>
-          clear one or more filters to see requests
-        </span>
+        No requests match the active filters,<br>
+        clear one or more filters to see requests
       </div>
     </template>
     <template v-slot:header.data-table-select>

--- a/web/components/FcDataTableRequests.vue
+++ b/web/components/FcDataTableRequests.vue
@@ -14,8 +14,14 @@
     :sort-keys="sortKeys">
     <template v-slot:no-data>
       <div class="mt-8 pt-7 secondary--text">
-        No requests match the active filters,<br>
-        clear one or more filters to see requests
+        <span v-if="hasFilters">
+          No requests match the active filters,<br>
+          clear one or more filters to see requests
+        </span>
+        <span v-else>
+          No studies have been requested,<br>
+          please <router-link :to="{name: 'viewData'}">view the map</router-link>
+        </span>
       </div>
     </template>
     <template v-slot:header.data-table-select>
@@ -154,6 +160,7 @@ export default {
   },
   props: {
     columns: Array,
+    hasFilters: Boolean,
     items: Array,
     loading: {
       type: Boolean,

--- a/web/components/dialogs/FcDialogRequestFilters.vue
+++ b/web/components/dialogs/FcDialogRequestFilters.vue
@@ -1,0 +1,173 @@
+<template>
+  <v-dialog
+    v-model="internalValue"
+    max-width="336"
+    scrollable>
+    <v-card role="dialog">
+      <v-card-title>
+        <h1 class="headline">Filter</h1>
+      </v-card-title>
+      <v-card-text>
+        <h2 class="body-1 mt-4">Study Types</h2>
+        <v-checkbox
+          v-for="studyType in StudyType.enumValues"
+          :key="studyType.name"
+          v-model="internalStudyTypes"
+          class="mt-2"
+          hide-details
+          :label="studyType.label"
+          :value="studyType"></v-checkbox>
+
+        <h2 class="body-1 mt-4">Status</h2>
+        <v-checkbox
+          v-for="status in StudyRequestStatus.enumValues"
+          :key="status.name"
+          v-model="internalStatuses"
+          class="mt-2"
+          hide-details
+          :label="status.text"
+          :value="status"></v-checkbox>
+        <v-checkbox
+          v-model="internalClosed"
+          class="mt-2"
+          hide-details
+          label="Closed"></v-checkbox>
+
+        <h2 class="body-1 mt-4">Assigned To</h2>
+        <v-checkbox
+          v-model="internalAssignees"
+          class="mt-2"
+          hide-details
+          label="None"
+          :value="null"></v-checkbox>
+        <v-checkbox
+          v-for="assignee in StudyRequestAssignee.enumValues"
+          :key="assignee.name"
+          v-model="internalAssignees"
+          class="mt-2"
+          hide-details
+          :label="assignee.text"
+          :value="assignee"></v-checkbox>
+
+        <FcRadioGroup
+          v-model="internalCreatedAt"
+          class="mt-4"
+          hide-details
+          :items="[
+            { label: 'Less than 1 month ago', value: -1 },
+            { label: 'Less than 3 months ago', value: -3 },
+            { label: 'At least 3 months ago', value: 3 },
+            { label: 'All', value: 0 },
+          ]">
+          <template v-slot:legend>
+            <h2 class="body-1 secondary--text">Date Created</h2>
+          </template>
+        </FcRadioGroup>
+
+        <FcRadioGroup
+          v-model="internalLastEditedAt"
+          class="mt-4"
+          hide-details
+          :items="[
+            { label: 'Less than 1 month ago', value: -1 },
+            { label: 'Less than 3 months ago', value: -3 },
+            { label: 'At least 3 months ago', value: 3 },
+            { label: 'All', value: 0 },
+          ]">
+          <template v-slot:legend>
+            <h2 class="body-1 secondary--text">Last Updated</h2>
+          </template>
+        </FcRadioGroup>
+
+        <FcRadioGroup
+          v-model="internalUserOnly"
+          class="mt-4"
+          hide-details
+          :items="[
+            { label: 'All', value: false },
+            { label: 'User', value: true },
+          ]">
+          <template v-slot:legend>
+            <h2 class="body-1 secondary--text">Requester</h2>
+          </template>
+        </FcRadioGroup>
+      </v-card-text>
+      <v-divider></v-divider>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <FcButton
+          type="tertiary"
+          @click="internalValue = false">
+          Cancel
+        </FcButton>
+        <FcButton
+          type="tertiary"
+          @click="actionSave">
+          Save
+        </FcButton>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import {
+  StudyRequestAssignee,
+  StudyRequestStatus,
+  StudyType,
+} from '@/lib/Constants';
+import FcButton from '@/web/components/inputs/FcButton.vue';
+import FcRadioGroup from '@/web/components/inputs/FcRadioGroup.vue';
+import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+
+export default {
+  name: 'FcDialogRequestFilters',
+  mixins: [FcMixinVModelProxy(Boolean)],
+  components: {
+    FcButton,
+    FcRadioGroup,
+  },
+  props: {
+    assignees: Array,
+    closed: Boolean,
+    createdAt: Number,
+    lastEditedAt: Number,
+    statuses: Array,
+    studyTypes: Array,
+    userOnly: Boolean,
+  },
+  data() {
+    return {
+      internalAssignees: this.assignees,
+      internalClosed: this.closed,
+      internalCreatedAt: this.createdAt,
+      internalLastEditedAt: this.lastEditedAt,
+      internalStatuses: this.statuses,
+      internalStudyTypes: this.studyTypes,
+      internalUserOnly: this.userOnly,
+      StudyRequestAssignee,
+      StudyRequestStatus,
+      StudyType,
+    };
+  },
+  computed: {
+    internalFilters() {
+      return {
+        assignees: this.internalAssignees,
+        closed: this.internalClosed,
+        createdAt: this.internalCreatedAt,
+        lastEditedAt: this.internalLastEditedAt,
+        statuses: this.internalStatuses,
+        studyTypes: this.internalStudyTypes,
+        userOnly: this.internalUserOnly,
+      };
+    },
+  },
+  methods: {
+    actionSave() {
+      this.$emit('set-filters', this.internalFilters);
+      this.internalValue = false;
+    },
+  },
+};
+</script>

--- a/web/views/FcRequestsTrack.vue
+++ b/web/views/FcRequestsTrack.vue
@@ -29,7 +29,10 @@
     <section class="flex-grow-1 flex-shrink-1 mt-6 mb-8 overflow-y-auto px-5">
       <v-card class="fc-requests-track-card">
         <v-card-title class="align-center d-flex py-2">
-          <v-simple-checkbox class="mr-6"></v-simple-checkbox>
+          <v-simple-checkbox
+            v-model="selectAll"
+            class="mr-6"
+            :indeterminate="selectAll === null"></v-simple-checkbox>
 
           <FcButton
             v-if="selectedItems.length === 0"
@@ -87,6 +90,7 @@
           <FcDataTableRequests
             v-model="selectedItems"
             :columns="columns"
+            :has-filters="filterChips.length > 0"
             :items="items"
             :loading="loading"
             :loading-items="loadingSaveStudyRequest"
@@ -489,6 +493,25 @@ export default {
           studyRequest,
         };
       });
+    },
+    selectAll: {
+      get() {
+        const k = this.selectedItems.length;
+        if (k === 0) {
+          return false;
+        }
+        if (k === this.items.length) {
+          return true;
+        }
+        return null;
+      },
+      set(selectAll) {
+        if (selectAll) {
+          this.selectedItems = this.items;
+        } else {
+          this.selectedItems = [];
+        }
+      },
     },
     ...mapState(['auth']),
   },

--- a/web/views/FcRequestsTrack.vue
+++ b/web/views/FcRequestsTrack.vue
@@ -66,6 +66,19 @@
               left>mdi-filter-variant</v-icon>
             Filter
           </FcButton>
+          <div
+            v-if="filterChips.length > 0"
+            class="ml-5">
+            <v-chip
+              v-for="(filterChip, i) in filterChips"
+              :key="i"
+              class="mr-2 primary--text"
+              color="light-blue lighten-5"
+              @click="removeFilter(filterChip)">
+              <v-icon left>mdi-check</v-icon>
+              {{filterChip.text}}
+            </v-chip>
+          </div>
         </v-card-title>
 
         <v-divider></v-divider>
@@ -355,17 +368,17 @@ export default {
         filterChips.push(filterChip);
       }
       assignees.forEach((assignee) => {
-        const { text } = assignee;
+        const text = assignee === null ? 'None' : assignee.text;
         const filterChip = { filter: 'assignees', text, value: assignee };
         filterChips.push(filterChip);
       });
       if (createdAt !== 0) {
-        const text = timeAgoFilterText(createdAt);
+        const text = timeAgoFilterText('Created', createdAt);
         const filterChip = { filter: 'createdAt', text, value: createdAt };
         filterChips.push(filterChip);
       }
       if (lastEditedAt !== 0) {
-        const text = timeAgoFilterText(lastEditedAt);
+        const text = timeAgoFilterText('Updated', lastEditedAt);
         const filterChip = { filter: 'lastEditedAt', text, value: lastEditedAt };
         filterChips.push(filterChip);
       }
@@ -473,6 +486,23 @@ export default {
       this.studyRequests = studyRequests;
       this.studyRequestLocations = studyRequestLocations;
       this.studyRequestUsers = studyRequestUsers;
+    },
+    removeFilter({ filter, value }) {
+      if (filter === 'closed') {
+        this.filters.closed = false;
+      } else if (filter === 'createdAt') {
+        this.filters.createdAt = 0;
+      } else if (filter === 'lastEditedAt') {
+        this.filters.lastEditedAt = 0;
+      } else if (filter === 'userOnly') {
+        this.filters.userOnly = false;
+      } else {
+        const values = this.filters[filter];
+        const i = values.indexOf(value);
+        if (i !== -1) {
+          values.splice(i, 1);
+        }
+      }
     },
     setFilters(filters) {
       this.filters = filters;


### PR DESCRIPTION
# Issue Addressed
This PR closes #408 .

# Description
We add a filters dialog to Track Requests, wire up the chips to shortcut to commonly-used sets of filters, and implement filtering end-to-end.

# Tests
Tested in the frontend quickly.  This will probably need more rigorous testing as we get closer to production, since there's a lot of branching logic here.
