### PR TITLE
Track Requests: fulfillment status bar

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -506,11 +506,11 @@ const SearchKeys = {
       return rLower.indexOf(qLower) !== -1;
     },
     REQUESTER: (q, r) => {
-      if (!r.requestedBy || !r.requestedBy.uniqueName) {
+      if (r.requestedBy === null) {
         return q === '';
       }
       const qLower = q.toLowerCase();
-      const rLower = r.requestedBy.uniqueName.toLowerCase();
+      const rLower = r.requestedBy.toLowerCase();
       return rLower.indexOf(qLower) !== -1;
     },
     STUDY_TYPE: (q, r) => {
@@ -545,7 +545,7 @@ const SortKeys = {
       r => (r.studyRequest.lastEditedAt === null
         ? r.studyRequest.createdAt.valueOf() : r.studyRequest.lastEditedAt.valueOf()),
     LOCATION: r => r.location.description,
-    REQUESTER: r => r.requestedBy.uniqueName,
+    REQUESTER: r => r.requestedBy,
     STATUS: r => r.studyRequest.status.ordinal,
     STUDY_TYPE: r => r.studyRequest.studyType.label,
     URGENT: r => (r.studyRequest.urgent ? 1 : 0),

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -691,6 +691,7 @@ class StudyRequestStatus extends Enum {
 StudyRequestStatus.init({
   REQUESTED: {
     color: 'statusRequested',
+    detailsIndex: 0,
     text: 'Requested',
     get transitionsTo() {
       return [
@@ -702,6 +703,7 @@ StudyRequestStatus.init({
   },
   CHANGES_NEEDED: {
     color: 'statusChangesNeeded',
+    detailsIndex: 1,
     text: 'Changes Needed',
     get transitionsTo() {
       return [
@@ -713,6 +715,7 @@ StudyRequestStatus.init({
   },
   CANCELLED: {
     color: 'statusCancelled',
+    detailsIndex: 1,
     text: 'Cancelled',
     get transitionsTo() {
       return [
@@ -722,6 +725,7 @@ StudyRequestStatus.init({
   },
   ASSIGNED: {
     color: 'statusAssigned',
+    detailsIndex: 2,
     text: 'Assigned',
     get transitionsTo() {
       return [
@@ -732,6 +736,7 @@ StudyRequestStatus.init({
   },
   REJECTED: {
     color: 'statusRejected',
+    detailsIndex: 3,
     text: 'Rejected',
     get transitionsTo() {
       return [];
@@ -739,6 +744,7 @@ StudyRequestStatus.init({
   },
   COMPLETED: {
     color: 'statusCompleted',
+    detailsIndex: 4,
     text: 'Completed',
     get transitionsTo() {
       return [];

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -691,7 +691,9 @@ class StudyRequestStatus extends Enum {
 StudyRequestStatus.init({
   REQUESTED: {
     color: 'statusRequested',
+    dataViewable: false,
     detailsIndex: 0,
+    editable: true,
     text: 'Requested',
     get transitionsTo() {
       return [
@@ -703,7 +705,9 @@ StudyRequestStatus.init({
   },
   CHANGES_NEEDED: {
     color: 'statusChangesNeeded',
+    dataViewable: false,
     detailsIndex: 1,
+    editable: true,
     text: 'Changes Needed',
     get transitionsTo() {
       return [
@@ -715,7 +719,9 @@ StudyRequestStatus.init({
   },
   CANCELLED: {
     color: 'statusCancelled',
+    dataViewable: false,
     detailsIndex: 1,
+    editable: false,
     text: 'Cancelled',
     get transitionsTo() {
       return [
@@ -725,7 +731,9 @@ StudyRequestStatus.init({
   },
   ASSIGNED: {
     color: 'statusAssigned',
+    dataViewable: false,
     detailsIndex: 2,
+    editable: false,
     text: 'Assigned',
     get transitionsTo() {
       return [
@@ -736,7 +744,9 @@ StudyRequestStatus.init({
   },
   REJECTED: {
     color: 'statusRejected',
+    dataViewable: false,
     detailsIndex: 3,
+    editable: false,
     text: 'Rejected',
     get transitionsTo() {
       return [];
@@ -744,7 +754,9 @@ StudyRequestStatus.init({
   },
   COMPLETED: {
     color: 'statusCompleted',
+    dataViewable: true,
     detailsIndex: 4,
+    editable: false,
     text: 'Completed',
     get transitionsTo() {
       return [];

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -8,6 +8,7 @@ import Category from '@/lib/model/Category';
 import Count from '@/lib/model/Count';
 import Joi from '@/lib/model/Joi';
 import StudyRequest from '@/lib/model/StudyRequest';
+import StudyRequestChange from '@/lib/model/StudyRequestChange';
 import StudyRequestComment from '@/lib/model/StudyRequestComment';
 import SuccessResponse from '@/lib/model/SuccessResponse';
 import User from '@/lib/model/User';
@@ -144,14 +145,19 @@ async function getUsersByIds(ids) {
 async function getStudyRequest(id) {
   let [
     studyRequest,
+    studyRequestChanges,
     studyRequestComments,
   ] = await Promise.all([
     apiClient.fetch(`/requests/study/${id}`),
+    apiClient.fetch(`/requests/study/${id}/changes`),
     apiClient.fetch(`/requests/study/${id}/comments`),
   ]);
 
   const studyRequestSchema = StudyRequest.read;
   studyRequest = await studyRequestSchema.validateAsync(studyRequest);
+
+  const studyRequestChangesSchema = Joi.array().items(StudyRequestChange.read);
+  studyRequestChanges = await studyRequestChangesSchema.validateAsync(studyRequestChanges);
 
   const studyRequestCommentsSchema = Joi.array().items(StudyRequestComment.read);
   studyRequestComments = await studyRequestCommentsSchema.validateAsync(studyRequestComments);
@@ -177,6 +183,7 @@ async function getStudyRequest(id) {
 
   return {
     studyRequest,
+    studyRequestChanges,
     studyRequestComments,
     studyRequestLocation,
     studyRequestUsers,
@@ -265,8 +272,12 @@ async function putStudyRequest(csrf, studyRequest) {
     csrf,
     data: studyRequest,
   };
-  const studyRequestUpdated = await apiClient.fetch(url, options);
-  return StudyRequest.read.validateAsync(studyRequestUpdated);
+  const response = await apiClient.fetch(url, options);
+  const responseSchema = Joi.object().keys({
+    studyRequest: StudyRequest.read,
+    studyRequestChange: StudyRequestChange.read.allow(null),
+  });
+  return responseSchema.validateAsync(response);
 }
 
 async function putStudyRequestComment(csrf, studyRequest, comment) {

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -23,8 +23,12 @@ async function deleteStudyRequestComment(csrf, studyRequest, comment) {
     method: 'DELETE',
     csrf,
   };
-  const result = await apiClient.fetch(url, options);
-  return SuccessResponse.validateAsync(result);
+  const response = await apiClient.fetch(url, options);
+  const responseSchema = Joi.object().keys({
+    studyRequest: StudyRequest.read,
+    studyRequestComment: SuccessResponse,
+  });
+  return responseSchema.validateAsync(response);
 }
 
 async function getAuth() {
@@ -260,8 +264,12 @@ async function postStudyRequestComment(csrf, studyRequest, comment) {
     csrf,
     data: comment,
   };
-  const persistedComment = await apiClient.fetch(url, options);
-  return StudyRequestComment.read.validateAsync(persistedComment);
+  const response = await apiClient.fetch(url, options);
+  const responseSchema = Joi.object().keys({
+    studyRequest: StudyRequest.read,
+    studyRequestComment: StudyRequestComment.read,
+  });
+  return responseSchema.validateAsync(response);
 }
 
 async function putStudyRequest(csrf, studyRequest) {
@@ -290,8 +298,12 @@ async function putStudyRequestComment(csrf, studyRequest, comment) {
     data: comment,
   };
 
-  const persistedComment = await apiClient.fetch(url, options);
-  return StudyRequestComment.read.validateAsync(persistedComment);
+  const response = await apiClient.fetch(url, options);
+  const responseSchema = Joi.object().keys({
+    studyRequest: StudyRequest.read,
+    studyRequestComment: StudyRequestComment.read,
+  });
+  return responseSchema.validateAsync(response);
 }
 
 async function putUser(csrf, user) {

--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -240,6 +240,12 @@ StudyRequestController.push({
 
     const tasks = [StudyRequestDAO.update(studyRequestNew, user)];
     if (studyRequestNew.status !== studyRequestOld.status) {
+      /*
+       * At one point, we had planned to log all changes in `study_request_changes`.
+       * This was abandoned in favour of the current "status changes only" approach,
+       * which allows us to quickly determine the last time the status was changed
+       * to a particular code.
+       */
       tasks.push(StudyRequestChangeDAO.create(studyRequestNew, user));
     }
     const [studyRequest, studyRequestChange = null] = await Promise.all(tasks);

--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -176,7 +176,10 @@ StudyRequestController.push({
       scope: [AuthScope.STUDY_REQUESTS_EDIT.name],
     },
     response: {
-      schema: StudyRequest.read,
+      schema: {
+        studyRequest: StudyRequest.read,
+        studyRequestChange: StudyRequestChange.read.allow(null),
+      },
     },
     validate: {
       params: {
@@ -235,11 +238,12 @@ StudyRequestController.push({
       }
     }
 
+    const tasks = [StudyRequestDAO.update(studyRequestNew, user)];
     if (studyRequestNew.status !== studyRequestOld.status) {
-      await StudyRequestChangeDAO.create(studyRequestNew, user);
+      tasks.push(StudyRequestChangeDAO.create(studyRequestNew, user));
     }
-
-    return StudyRequestDAO.update(studyRequestNew, user);
+    const [studyRequest, studyRequestChange = null] = await Promise.all(tasks);
+    return { studyRequest, studyRequestChange };
   },
 });
 

--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -302,7 +302,10 @@ StudyRequestController.push({
       scope: [AuthScope.STUDY_REQUESTS.name],
     },
     response: {
-      schema: StudyRequestComment.read,
+      schema: {
+        studyRequest: StudyRequest.read,
+        studyRequestComment: StudyRequestComment.read,
+      },
     },
     validate: {
       params: {
@@ -318,7 +321,16 @@ StudyRequestController.push({
     if (studyRequest === null) {
       return Boom.notFound(`no study request found with ID ${studyRequestId}`);
     }
-    return StudyRequestCommentDAO.create(request.payload, studyRequest, user);
+
+    // update last edited timestamp
+    const [studyRequestUpdated, studyRequestComment] = await Promise.all([
+      StudyRequestDAO.update(studyRequest, user),
+      StudyRequestCommentDAO.create(request.payload, studyRequest, user),
+    ]);
+    return {
+      studyRequest: studyRequestUpdated,
+      studyRequestComment,
+    };
   },
 });
 
@@ -374,7 +386,10 @@ StudyRequestController.push({
       scope: [AuthScope.STUDY_REQUESTS.name],
     },
     response: {
-      schema: StudyRequestComment.read,
+      schema: {
+        studyRequest: StudyRequest.read,
+        studyRequestComment: StudyRequestComment.read,
+      },
     },
     validate: {
       params: {
@@ -417,7 +432,15 @@ StudyRequestController.push({
       return Boom.forbidden('cannot update comment owned by another user');
     }
 
-    return StudyRequestCommentDAO.update(commentNew);
+    // update last edited timestamp
+    const [studyRequestUpdated, studyRequestComment] = await Promise.all([
+      StudyRequestDAO.update(studyRequest, user),
+      StudyRequestCommentDAO.update(commentNew),
+    ]);
+    return {
+      studyRequest: studyRequestUpdated,
+      studyRequestComment,
+    };
   },
 });
 
@@ -436,7 +459,10 @@ StudyRequestController.push({
       scope: [AuthScope.STUDY_REQUESTS.name],
     },
     response: {
-      schema: SuccessResponse,
+      schema: {
+        studyRequest: StudyRequest.read,
+        studyRequestComment: SuccessResponse,
+      },
     },
     validate: {
       params: {
@@ -463,11 +489,17 @@ StudyRequestController.push({
     if (comment.userId !== user.id) {
       return Boom.forbidden('cannot delete comment owned by another user');
     }
-    const success = await StudyRequestCommentDAO.delete(comment);
+    const [studyRequestUpdated, success] = await Promise.all([
+      StudyRequestDAO.update(studyRequest, user),
+      StudyRequestCommentDAO.delete(comment),
+    ]);
     if (!success) {
       return Boom.notFound(`could not delete comment with ID ${commentId}`);
     }
-    return { success };
+    return {
+      studyRequest: studyRequestUpdated,
+      studyRequestComment: { success },
+    };
   },
 });
 

--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -7,12 +7,14 @@ import {
 } from '@/lib/Constants';
 import { hasAuthScope } from '@/lib/auth/ScopeMatcher';
 import StudyRequestDAO from '@/lib/db/StudyRequestDAO';
+import StudyRequestChangeDAO from '@/lib/db/StudyRequestChangeDAO';
 import StudyRequestCommentDAO from '@/lib/db/StudyRequestCommentDAO';
 import EmailStudyRequestConfirmation from '@/lib/email/EmailStudyRequestConfirmation';
 import Mailer from '@/lib/email/Mailer';
 import LogTag from '@/lib/log/LogTag';
 import Joi from '@/lib/model/Joi';
 import StudyRequest from '@/lib/model/StudyRequest';
+import StudyRequestChange from '@/lib/model/StudyRequestChange';
 import StudyRequestComment from '@/lib/model/StudyRequestComment';
 import SuccessResponse from '@/lib/model/SuccessResponse';
 
@@ -233,7 +235,46 @@ StudyRequestController.push({
       }
     }
 
+    if (studyRequestNew.status !== studyRequestOld.status) {
+      await StudyRequestChangeDAO.create(studyRequestNew, user);
+    }
+
     return StudyRequestDAO.update(studyRequestNew, user);
+  },
+});
+
+// STUDY REQUEST CHANGES
+
+/**
+ * Get status changes for the given study request.
+ *
+ * @memberof StudyRequestController
+ * @name getStudyRequestChanges
+ * @type {Hapi.ServerRoute}
+ */
+StudyRequestController.push({
+  method: 'GET',
+  path: '/requests/study/{studyRequestId}/changes',
+  options: {
+    auth: {
+      scope: [AuthScope.STUDY_REQUESTS.name],
+    },
+    response: {
+      schema: Joi.array().items(StudyRequestChange.read),
+    },
+    validate: {
+      params: {
+        studyRequestId: Joi.number().integer().positive().required(),
+      },
+    },
+  },
+  handler: async (request) => {
+    const { studyRequestId } = request.params;
+    const studyRequest = await StudyRequestDAO.byId(studyRequestId);
+    if (studyRequest === null) {
+      return Boom.notFound(`no study request found with ID ${studyRequestId}`);
+    }
+    return StudyRequestChangeDAO.byStudyRequest(studyRequest);
   },
 });
 
@@ -267,16 +308,13 @@ StudyRequestController.push({
     },
   },
   handler: async (request) => {
-    const { id: userId } = request.auth.credentials;
+    const user = request.auth.credentials;
     const { studyRequestId } = request.params;
     const studyRequest = await StudyRequestDAO.byId(studyRequestId);
     if (studyRequest === null) {
       return Boom.notFound(`no study request found with ID ${studyRequestId}`);
     }
-    return StudyRequestCommentDAO.create(studyRequest, {
-      userId,
-      ...request.payload,
-    });
+    return StudyRequestCommentDAO.create(request.payload, studyRequest, user);
   },
 });
 

--- a/lib/db/StudyRequestChangeDAO.js
+++ b/lib/db/StudyRequestChangeDAO.js
@@ -1,0 +1,95 @@
+import db from '@/lib/db/db';
+import Joi from '@/lib/model/Joi';
+import StudyRequestChange from '@/lib/model/StudyRequestChange';
+import DateTime from '@/lib/time/DateTime';
+
+/**
+ * Data Access Object for status changes made to study requests submitted
+ * via MOVE.
+ *
+ * These changes are logged automatically by MOVE as users submit actions that
+ * change the status of study requests.
+ */
+class StudyRequestChangeDAO {
+  /**
+   * @param {Object} studyRequest - study request that was changed
+   * @param {Object} user - user who made this change
+   * @returns {Object} change object, as persisted to database
+   */
+  static async create(studyRequest, user) {
+    const sql = `
+INSERT INTO "study_request_changes" (
+  "createdAt",
+  "userId",
+  "studyRequestId",
+  "status"
+) VALUES (
+  $(createdAt),
+  $(userId),
+  $(studyRequestId),
+  $(status)
+) RETURNING "id"`;
+    const { id: studyRequestId, status } = studyRequest;
+    const { id: userId } = user;
+    const persistedChange = {
+      createdAt: DateTime.local(),
+      userId,
+      studyRequestId,
+      status,
+    };
+    const { id } = await db.one(sql, persistedChange);
+    persistedChange.id = id;
+    return StudyRequestChange.read.validateAsync(persistedChange);
+  }
+
+  /**
+   * Fetch the change with the given ID.
+   *
+   * @param {number} id - ID to fetch change for
+   * @returns {Object} change object, or null if no such change exists
+   */
+  static async byId(id) {
+    const sql = 'SELECT * FROM "study_request_changes" WHERE "id" = $(id)';
+    const change = await db.oneOrNone(sql, { id });
+    if (change === null) {
+      return null;
+    }
+    return StudyRequestChange.read.validateAsync(change);
+  }
+
+  /**
+   * Fetch all changes for the given study request.
+   *
+   * @param {Object} studyRequest - study request to fetch changes for
+   * @returns {Object} changes object, or null if no such change exists
+   */
+  static async byStudyRequest(studyRequest) {
+    const sql = `
+SELECT * FROM "study_request_changes"
+WHERE "studyRequestId" = $(studyRequestId)
+ORDER BY "createdAt" DESC`;
+    const { id: studyRequestId } = studyRequest;
+    const changes = await db.manyOrNone(sql, { studyRequestId });
+    const studyRequestChangesSchema = Joi.array().items(StudyRequestChange.read);
+    return studyRequestChangesSchema.validateAsync(changes);
+  }
+
+  /**
+   * Delete all changes for the given study request.  This is intended for use
+   * by `StudyRequestDAO.delete`.
+   *
+   * @see {StudyRequestDAO}
+   * @param {Object} studyRequest - study request to delete changes for
+   * @returns {boolean} whether any rows were deleted
+   */
+  static async deleteByStudyRequest(studyRequest) {
+    const sql = `
+DELETE FROM "study_request_changes"
+WHERE "studyRequestId" = $(studyRequestId)`;
+    const { id: studyRequestId } = studyRequest;
+    const rowsDeleted = await db.result(sql, { studyRequestId }, r => r.rowCount);
+    return rowsDeleted > 0;
+  }
+}
+
+export default StudyRequestChangeDAO;

--- a/lib/db/StudyRequestCommentDAO.js
+++ b/lib/db/StudyRequestCommentDAO.js
@@ -10,11 +10,12 @@ class StudyRequestCommentDAO {
   /**
    * Create a row for the given comment in database.
    *
-   * @param {Object} studyRequest - study request to attach this comment to
    * @param {Object} comment - comment information, as submitted by frontend
+   * @param {Object} studyRequest - study request to attach this comment to
+   * @param {Object} user - user submitting this comment
    * @returns {Object} comment object, as persisted to database
    */
-  static async create(studyRequest, comment) {
+  static async create(comment, studyRequest, user) {
     const sql = `
 INSERT INTO "study_request_comments" (
   "createdAt",
@@ -27,19 +28,16 @@ INSERT INTO "study_request_comments" (
   $(studyRequestId),
   $(comment)
 ) RETURNING "id"`;
-    const createdAt = DateTime.local();
     const { id: studyRequestId } = studyRequest;
-    const { id } = await db.one(sql, {
-      createdAt,
-      studyRequestId,
-      ...comment,
-    });
+    const { id: userId } = user;
     const persistedComment = {
-      id,
-      createdAt,
+      createdAt: DateTime.local(),
+      userId,
       studyRequestId,
       ...comment,
     };
+    const { id } = await db.one(sql, persistedComment);
+    persistedComment.id = id;
     return StudyRequestComment.read.validateAsync(persistedComment);
   }
 
@@ -108,15 +106,14 @@ WHERE "id" = $(id)`;
    * by `StudyRequestDAO.delete`.
    *
    * @see {StudyRequestDAO}
-   * @param {Object} studyRequest - comment to delete
-   * @param {number} studyRequest.id - ID of study request to delete comments for, used to
-   * identify it
+   * @param {Object} studyRequest - study request to delete comments for
    * @returns {boolean} whether any rows were deleted
    */
-  static async deleteByStudyRequest({ id: studyRequestId }) {
+  static async deleteByStudyRequest(studyRequest) {
     const sql = `
 DELETE FROM "study_request_comments"
 WHERE "studyRequestId" = $(studyRequestId)`;
+    const { id: studyRequestId } = studyRequest;
     const rowsDeleted = await db.result(sql, { studyRequestId }, r => r.rowCount);
     return rowsDeleted > 0;
   }

--- a/lib/db/StudyRequestDAO.js
+++ b/lib/db/StudyRequestDAO.js
@@ -1,5 +1,6 @@
 import { StudyRequestStatus } from '@/lib/Constants';
 import db from '@/lib/db/db';
+import StudyRequestChangeDAO from '@/lib/db/StudyRequestChangeDAO';
 import StudyRequestCommentDAO from '@/lib/db/StudyRequestCommentDAO';
 import Joi from '@/lib/model/Joi';
 import StudyRequest from '@/lib/model/StudyRequest';
@@ -236,6 +237,7 @@ UPDATE "study_requests" SET
    * @returns {boolean} whether any rows were deleted
    */
   static async delete(studyRequest) {
+    await StudyRequestChangeDAO.deleteByStudyRequest(studyRequest);
     await StudyRequestCommentDAO.deleteByStudyRequest(studyRequest);
 
     const sql = 'DELETE FROM "study_requests" WHERE "id" = $(id)';

--- a/lib/model/StudyRequestChange.js
+++ b/lib/model/StudyRequestChange.js
@@ -1,0 +1,22 @@
+import { StudyRequestStatus } from '@/lib/Constants';
+import Joi from '@/lib/model/Joi';
+import Model from '@/lib/model/orm/Model';
+import ModelField from '@/lib/model/orm/ModelField';
+
+const PERSISTED_COLUMNS = {
+  id: Joi.number().integer().positive(),
+  createdAt: Joi.dateTime(),
+  userId: Joi.number().integer().positive(),
+  studyRequestId: Joi.number().integer().positive(),
+};
+
+const TRANSIENT_COLUMNS = {
+  status: Joi.enum().ofType(StudyRequestStatus),
+};
+
+const StudyRequestChange = new Model([
+  ...ModelField.persisted(PERSISTED_COLUMNS),
+  ...ModelField.transient(TRANSIENT_COLUMNS),
+]);
+
+export default StudyRequestChange;

--- a/lib/model/StudyRequestComment.js
+++ b/lib/model/StudyRequestComment.js
@@ -1,4 +1,6 @@
 import Joi from '@/lib/model/Joi';
+import Model from '@/lib/model/orm/Model';
+import ModelField from '@/lib/model/orm/ModelField';
 
 const PERSISTED_COLUMNS = {
   id: Joi.number().integer().positive().required(),
@@ -7,18 +9,13 @@ const PERSISTED_COLUMNS = {
   studyRequestId: Joi.number().integer().positive().required(),
 };
 
-const COLUMNS = {
+const TRANSIENT_COLUMNS = {
   comment: Joi.string().required(),
 };
 
-export default {
-  read: Joi.object().keys({
-    ...PERSISTED_COLUMNS,
-    ...COLUMNS,
-  }),
-  update: Joi.object().keys({
-    ...PERSISTED_COLUMNS,
-    ...COLUMNS,
-  }),
-  create: Joi.object().keys(COLUMNS),
-};
+const StudyRequestComment = new Model([
+  ...ModelField.persisted(PERSISTED_COLUMNS),
+  ...ModelField.transient(TRANSIENT_COLUMNS),
+]);
+
+export default StudyRequestComment;

--- a/scripts/db/schema-12.down.sql
+++ b/scripts/db/schema-12.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP TABLE "study_request_changes";
+
+UPDATE "APP_META"."DB_UPDATE" SET "currentVersion" = 11;
+COMMIT;

--- a/scripts/db/schema-12.up.sql
+++ b/scripts/db/schema-12.up.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+-- forward migration SQL goes here
+CREATE TABLE "study_request_changes" (
+  "id" BIGSERIAL PRIMARY KEY NOT NULL,
+  "createdAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  "userId" BIGINT NOT NULL REFERENCES "users" ("id"),
+  "studyRequestId" BIGINT NOT NULL REFERENCES "study_requests" ("id"),
+  "status" VARCHAR NOT NULL
+);
+CREATE INDEX "study_request_changes_studyRequestId_createdAt" ON "study_request_changes" ("studyRequestId", "createdAt");
+
+UPDATE "APP_META"."DB_UPDATE" SET "currentVersion" = 12;
+COMMIT;

--- a/tests/jest/unit/Constants.spec.js
+++ b/tests/jest/unit/Constants.spec.js
@@ -21,13 +21,6 @@ test('Constants.SearchKeys', () => {
     lng: 0,
     lat: 0,
   };
-  const requestedBy = {
-    id: 42,
-    createdAt: DateTime.local(),
-    sub: '0123456789',
-    email: 'Baz.Quux@toronto.ca',
-    uniqueName: 'ORG\\BazQuux',
-  };
 
   const REQUEST = {
     id: 42,
@@ -58,7 +51,7 @@ test('Constants.SearchKeys', () => {
   expect(SearchKeys.Requests.LOCATION('Bar St', REQUEST)).toBe(true);
 
   expect(SearchKeys.Requests.REQUESTER('', REQUEST)).toBe(true);
-  REQUEST.requestedBy = requestedBy;
+  REQUEST.requestedBy = 'ORG\\BazQuux';
   expect(SearchKeys.Requests.REQUESTER('BAZ', REQUEST)).toBe(true);
   expect(SearchKeys.Requests.REQUESTER('quux', REQUEST)).toBe(true);
 
@@ -152,7 +145,7 @@ test('Constants.SortKeys', () => {
   expect(SortKeys.Requests.LOCATION(REQUEST_STANDARD))
     .toEqual(REQUEST_STANDARD.location.description);
   expect(SortKeys.Requests.REQUESTER(REQUEST_STANDARD))
-    .toEqual(REQUEST_STANDARD.requestedBy.uniqueName);
+    .toEqual(REQUEST_STANDARD.requestedBy);
   expect(SortKeys.Requests.STATUS(REQUEST_STANDARD))
     .toEqual(REQUEST_STANDARD.studyRequest.status.ordinal);
   expect(SortKeys.Requests.STUDY_TYPE(REQUEST_STANDARD))

--- a/web/components/FcCommentsStudyRequest.vue
+++ b/web/components/FcCommentsStudyRequest.vue
@@ -92,15 +92,15 @@ export default {
       };
       this.commentText = '';
       this.loadingAddComment = true;
-      const persistedComment = await postStudyRequestComment(csrf, studyRequest, comment);
-      this.$emit('add-comment', persistedComment);
+      const response = await postStudyRequestComment(csrf, studyRequest, comment);
+      this.$emit('add-comment', response);
       this.loadingAddComment = false;
     },
     async actionDeleteComment(i) {
       const { auth: { csrf }, studyRequest, studyRequestComments } = this;
       const comment = studyRequestComments[i];
-      this.$emit('delete-comment', i);
-      await deleteStudyRequestComment(csrf, studyRequest, comment);
+      const response = await deleteStudyRequestComment(csrf, studyRequest, comment);
+      this.$emit('delete-comment', { i, ...response });
     },
   },
 };

--- a/web/components/FcDataTable.vue
+++ b/web/components/FcDataTable.vue
@@ -83,8 +83,10 @@ export default {
   computed: {
     headers() {
       return this.columns.map(({ value, ...options }) => {
+        const headerClass = `fc-data-table-header-${value}`;
         const sortable = Object.prototype.hasOwnProperty.call(this.sortKeys, value);
         return {
+          class: headerClass,
           sortable,
           value,
           ...options,

--- a/web/components/FcDataTableRequests.vue
+++ b/web/components/FcDataTableRequests.vue
@@ -27,19 +27,21 @@
     <template v-slot:header.data-table-select>
     </template>
     <template v-slot:item.ID="{ item }">
-      <span>{{item.studyRequest.id}}</span>
+      <span
+        class="text-truncate"
+        :title="item.studyRequest.id">
+        {{item.studyRequest.id}}
+      </span>
     </template>
     <template v-slot:item.LOCATION="{ item }">
-      <div class="text-truncate">
-        <span
-          v-if="item.location !== null"
-          :title="item.location.description">
+      <div class="text-wrap">
+        <span v-if="item.location !== null">
           {{item.location.description}}
         </span>
       </div>
     </template>
     <template v-slot:item.STUDY_TYPE="{ item }">
-      <div class="text-truncate">
+      <div class="text-wrap">
         {{item.studyRequest.studyType.label}}
       </div>
     </template>
@@ -47,8 +49,8 @@
       <div class="text-truncate">
         <span
           v-if="item.requestedBy !== null"
-          :title="item.requestedBy.uniqueName">
-          {{item.requestedBy.uniqueName}}
+          :title="item.requestedBy">
+          {{item.requestedBy}}
         </span>
       </div>
     </template>
@@ -65,8 +67,10 @@
         <template v-slot:activator="{ on }">
           <FcButton
             :loading="loadingItems.has(item.id)"
+            class="body-1 text-none"
+            small
             type="secondary"
-            width="140"
+            width="120"
             v-on="on">
             <span v-if="item.studyRequest.assignedTo === null">
               None
@@ -97,7 +101,7 @@
     </template>
     <template v-slot:item.STATUS="{ item }">
       <div class="align-center d-flex">
-        <v-icon :color="item.studyRequest.status.color">mdi-circle-medium</v-icon>
+        <v-icon :color="item.studyRequest.status.color" class="ml-n2">mdi-circle-medium</v-icon>
         <span>{{item.studyRequest.status.text}}</span>
       </div>
     </template>
@@ -184,3 +188,42 @@ export default {
   },
 };
 </script>
+
+<style lang="scss">
+.fc-data-table-requests {
+  & td:not(:first-child):not(:last-child),
+  & th:not(:first-child):not(:last-child) {
+    padding: 0 8px;
+  }
+  & th.fc-data-table-header-ID {
+    min-width: 70px;
+    width: 70px;
+  }
+  & th.fc-data-table-header-LOCATION {
+    min-width: 100px;
+  }
+  & th.fc-data-table-header-STUDY_TYPE {
+    min-width: 110px;
+  }
+  & th.fc-data-table-header-REQUESTER {
+    min-width: 100px;
+  }
+  & th.fc-data-table-header-CREATED_AT {
+    min-width: 120px;
+  }
+  & th.fc-data-table-header-ASSIGNED_TO {
+    min-width: 140px;
+    width: 140px;
+  }
+  & th.fc-data-table-header-DUE_DATE {
+    min-width: 125px;
+  }
+  & th.fc-data-table-header-LAST_EDITED_AT {
+    min-width: 120px;
+  }
+  & th.fc-data-table-header-ACTIONS {
+    min-width: 100px;
+    width: 100px;
+  }
+}
+</style>

--- a/web/components/FcDataTableRequests.vue
+++ b/web/components/FcDataTableRequests.vue
@@ -106,10 +106,7 @@
       </div>
     </template>
     <template v-slot:item.LAST_EDITED_AT="{ item }">
-      <span v-if="item.studyRequest.lastEditedAt === null">
-        {{item.studyRequest.createdAt | date}}
-      </span>
-      <span v-else>
+      <span v-if="item.studyRequest.lastEditedAt !== null">
         {{item.studyRequest.lastEditedAt | date}}
       </span>
     </template>

--- a/web/components/FcDrawerViewRequest.vue
+++ b/web/components/FcDrawerViewRequest.vue
@@ -141,7 +141,7 @@ export default {
     canReopen() {
       return this.canEdit
         && this.studyRequest !== null
-        && this.studyRequest.status === StudyRequestStatus.CANCELLED;
+        && this.closed;
     },
     canRequestChanges() {
       return this.hasAuthScope(AuthScope.STUDY_REQUESTS_ADMIN)
@@ -207,6 +207,7 @@ export default {
     },
     async actionCancel() {
       this.studyRequest.status = StudyRequestStatus.CANCELLED;
+      this.studyRequest.closed = true;
 
       this.loadingMoreActions = true;
       this.studyRequest = await this.saveStudyRequest(this.studyRequest);
@@ -245,6 +246,9 @@ export default {
       this.$router.push(route);
     },
     async actionReopen() {
+      if (this.studyRequest.status === StudyRequestStatus.CANCELLED) {
+        this.studyRequest.status = StudyRequestStatus.REQUESTED;
+      }
       this.studyRequest.closed = false;
 
       this.loadingMoreActions = true;

--- a/web/components/FcDrawerViewRequest.vue
+++ b/web/components/FcDrawerViewRequest.vue
@@ -267,10 +267,12 @@ export default {
       this.studyRequestUsers = studyRequestUsers;
       this.setLocation(studyRequestLocation);
     },
-    onAddComment(comment) {
-      this.studyRequestComments.unshift(comment);
+    onAddComment({ studyRequest, studyRequestComment }) {
+      this.studyRequest = studyRequest;
+      this.studyRequestComments.unshift(studyRequestComment);
     },
-    onDeleteComment(i) {
+    onDeleteComment({ studyRequest, i }) {
+      this.studyRequest = studyRequest;
       this.studyRequestComments.splice(i, 1);
     },
     async updateMoreActions() {

--- a/web/components/FcDrawerViewRequest.vue
+++ b/web/components/FcDrawerViewRequest.vue
@@ -16,14 +16,14 @@
         </span>
       </h1>
       <FcButton
-        v-if="studyRequest.status.dataViewable"
+        v-if="studyRequest !== null && studyRequest.status.dataViewable"
         :disabled="loading"
         type="secondary"
         @click="actionViewData">
         View Data
       </FcButton>
       <FcButton
-        v-else-if="canEdit && studyRequest.status.editable"
+        v-else-if="studyRequest !== null && canEdit && studyRequest.status.editable"
         :disabled="loading"
         type="secondary"
         @click="actionEdit">

--- a/web/components/FcDrawerViewRequest.vue
+++ b/web/components/FcDrawerViewRequest.vue
@@ -16,7 +16,14 @@
         </span>
       </h1>
       <FcButton
-        v-if="canEdit"
+        v-if="studyRequest.status.dataViewable"
+        :disabled="loading"
+        type="secondary"
+        @click="actionViewData">
+        View Data
+      </FcButton>
+      <FcButton
+        v-else-if="canEdit && studyRequest.status.editable"
         :disabled="loading"
         type="secondary"
         @click="actionEdit">
@@ -143,7 +150,7 @@ export default {
     canReopen() {
       return this.canEdit
         && this.studyRequest !== null
-        && this.closed;
+        && this.studyRequest.closed;
     },
     canRequestChanges() {
       return this.hasAuthScope(AuthScope.STUDY_REQUESTS_ADMIN)
@@ -248,6 +255,17 @@ export default {
     async actionRequestChanges() {
       this.studyRequest.status = StudyRequestStatus.CHANGES_NEEDED;
       await this.updateMoreActions();
+    },
+    actionViewData() {
+      if (this.location === null) {
+        return;
+      }
+      const { centrelineId, centrelineType } = this.location;
+      const route = {
+        name: 'viewDataAtLocation',
+        params: { centrelineId, centrelineType },
+      };
+      this.$router.push(route);
     },
     async loadAsyncForRoute(to) {
       const { id } = to.params;

--- a/web/components/FcStatusStudyRequest.vue
+++ b/web/components/FcStatusStudyRequest.vue
@@ -10,30 +10,49 @@
       :key="'circle_' + circle"
       class="status-circle"
       :class="'status-circle-' + circle"></div>
-    <v-row class="pt-2">
+    <v-row class="mx-0 pt-2">
       <v-col
-        v-for="({ date, status }, i) in details"
+        v-for="(detail, i) in details"
         :key="'details_' + i"
         :class="{
+          'pl-0': i !== 1,
+          'pl-2': i === 1,
+          'pr-0': i !== 3,
+          'pr-2': i === 3,
           'text-left': i === 0,
-          'text-center': i === 1,
-          'text-right': i === 2,
+          'text-center': 0 < i && i < 4,
+          'text-right': i === 4,
         }"
-        cols="4">
-        <div class="headline font-weight-regular">
-          {{status}}
-        </div>
-        <v-messages
-          class="mt-1"
-          :value="[date]"></v-messages>
+        :cols="i === 2 ? 4 : 2">
+        <template v-if="detail !== null">
+          <div class="headline font-weight-regular">
+            {{detail.status.text}}
+          </div>
+          <div class="mt-1 subtitle-2">
+            {{detail.createdAt | date}}
+          </div>
+        </template>
       </v-col>
     </v-row>
   </div>
 </template>
 
 <script>
+import { mapState } from 'vuex';
+
+import ArrayUtils from '@/lib/ArrayUtils';
 import { StudyRequestStatus } from '@/lib/Constants';
-import TimeFormatters from '@/lib/time/TimeFormatters';
+
+/**
+ * @param {DateTime} dt1 - date to compare against
+ * @param {DateTime} dt2 - date being compared
+ * @returns {boolean} whether the date `dt2` takes place on is after the date
+ * `dt1` takes place on
+ */
+function afterDateOf(dt1, dt2) {
+  const endOfDay1 = dt1.endOf('day');
+  return dt2.valueOf() > endOfDay1.valueOf();
+}
 
 export default {
   name: 'FcStatusStudyRequest',
@@ -43,27 +62,89 @@ export default {
   },
   computed: {
     circles() {
-      return [
-        'REQUESTED',
-        'center',
-        'right',
-      ];
+      const circles = this.milestones.map(({ status }) => status.name);
+      if (this.progress < 50) {
+        circles.push('center');
+      }
+      if (this.progress < 100) {
+        circles.push('right');
+      }
+      return circles;
     },
     details() {
-      const detailsRequested = {
-        date: TimeFormatters.formatDefault(this.studyRequest.createdAt),
-        status: StudyRequestStatus.REQUESTED.text,
-      };
+      const details = new Array(5).fill(null);
+      this.milestones.forEach((milestone) => {
+        const { detailsIndex } = milestone.status;
+        details[detailsIndex] = milestone;
+      });
+      return details;
+    },
+    milestones() {
+      const { createdAt, status } = this.studyRequest;
+      const milestones = [{
+        createdAt,
+        status: StudyRequestStatus.REQUESTED,
+      }];
 
-      // TODO: add to this
+      if (status === StudyRequestStatus.REQUESTED) {
+        return milestones;
+      }
+      if (status === StudyRequestStatus.CHANGES_NEEDED) {
+        const changesNeeded = this.statusChanges.get(StudyRequestStatus.CHANGES_NEEDED);
+        milestones.push(changesNeeded);
+        return milestones;
+      }
+      if (status === StudyRequestStatus.CANCELLED) {
+        const cancelled = this.statusChanges.get(StudyRequestStatus.CANCELLED);
+        milestones.push(cancelled);
+        return milestones;
+      }
 
-      return [detailsRequested];
+      const assigned = this.statusChanges.get(StudyRequestStatus.ASSIGNED);
+      milestones.push(assigned);
+
+      if (status === StudyRequestStatus.ASSIGNED) {
+        return milestones;
+      }
+      if (status === StudyRequestStatus.REJECTED) {
+        const rejected = this.statusChanges.get(StudyRequestStatus.REJECTED);
+        milestones.push(rejected);
+        return milestones;
+      }
+      // COMPLETED
+      const completed = this.statusChanges.get(StudyRequestStatus.COMPLETED);
+      milestones.push(completed);
+      return milestones;
     },
     progress() {
-      // TODO: implement this
-
-      return 25;
+      const { status } = this.studyRequest;
+      if (status === StudyRequestStatus.REQUESTED) {
+        const { createdAt } = this.studyRequest;
+        return afterDateOf(createdAt, this.now) ? 25 : 0;
+      }
+      if (status === StudyRequestStatus.CHANGES_NEEDED
+        || status === StudyRequestStatus.CANCELLED) {
+        return 25;
+      }
+      if (status === StudyRequestStatus.ASSIGNED) {
+        const { createdAt: assignedAt } = this.statusChanges.get(StudyRequestStatus.ASSIGNED);
+        return afterDateOf(assignedAt, this.now) ? 75 : 50;
+      }
+      if (status === StudyRequestStatus.REJECTED) {
+        return 75;
+      }
+      // COMPLETED
+      return 100;
     },
+    statusChanges() {
+      const changesByStatus = ArrayUtils.groupBy(
+        this.studyRequestChanges,
+        change => change.status.ordinal,
+      );
+      const mostRecentChangesByStatus = changesByStatus.map(g => [g[0].status, g[0]]);
+      return new Map(mostRecentChangesByStatus);
+    },
+    ...mapState(['now']),
   },
 };
 </script>
@@ -96,12 +177,42 @@ export default {
       left: 0;
     }
 
+    &.status-circle-CHANGES_NEEDED {
+      background-color: var(--v-statusChangesNeeded-base);
+      border: 2px solid #fff;
+      left: calc(25% - 4px);
+    }
+
+    &.status-circle-CANCELLED {
+      background-color: var(--v-statusCancelled-base);
+      border: 2px solid #fff;
+      left: calc(25% - 4px);
+    }
+
+    &.status-circle-ASSIGNED {
+      background-color: var(--v-statusAssigned-base);
+      border: 2px solid #fff;
+      left: calc(50% - 8px);
+    }
+
+    &.status-circle-REJECTED {
+      background-color: var(--v-statusRejected-base);
+      border: 2px solid #fff;
+      left: calc(75% - 12px);
+    }
+
+    &.status-circle-COMPLETED {
+      background-color: var(--v-statusCompleted-base);
+      border: 2px solid #fff;
+      left: calc(100% - 16px);
+    }
+
     &.status-circle-center {
       left: calc(50% - 8px);
     }
 
     &.status-circle-right {
-      right: 0;
+      left: calc(100% - 16px);
     }
   }
 }

--- a/web/components/FcStatusStudyRequest.vue
+++ b/web/components/FcStatusStudyRequest.vue
@@ -39,6 +39,7 @@ export default {
   name: 'FcStatusStudyRequest',
   props: {
     studyRequest: Object,
+    studyRequestChanges: Array,
   },
   computed: {
     circles() {

--- a/web/components/FcSummaryStudyRequest.vue
+++ b/web/components/FcSummaryStudyRequest.vue
@@ -12,9 +12,8 @@
         <v-col cols="6">
           <div class="subtitle-1">Requester</div>
           <div class="mt-1 display-1">
-            <span
-              v-if="studyRequestUsers.has(studyRequest.userId)">
-              {{studyRequestUsers.get(studyRequest.userId).uniqueName}}
+            <span v-if="requestedBy !== null">
+              {{requestedBy}}
             </span>
           </div>
         </v-col>
@@ -158,6 +157,18 @@ export default {
         return [];
       }
       return ['The study will be performed on one of these days.'];
+    },
+    requestedBy() {
+      const { studyRequest, studyRequestUsers } = this;
+      if (!studyRequestUsers.has(studyRequest.userId)) {
+        return null;
+      }
+      const { uniqueName } = studyRequestUsers.get(studyRequest.userId);
+      const i = uniqueName.indexOf('\\');
+      if (i === -1) {
+        return uniqueName;
+      }
+      return uniqueName.slice(i + 1);
     },
     ...mapState(['auth']),
   },

--- a/web/components/FcSummaryStudyRequest.vue
+++ b/web/components/FcSummaryStudyRequest.vue
@@ -6,7 +6,8 @@
           <div class="subtitle-1">Status</div>
           <FcStatusStudyRequest
             class="mt-2"
-            :study-request="studyRequest" />
+            :study-request="studyRequest"
+            :study-request-changes="studyRequestChanges" />
         </v-col>
         <v-col cols="6">
           <div class="subtitle-1">Requester</div>
@@ -136,6 +137,7 @@ export default {
   },
   props: {
     studyRequest: Object,
+    studyRequestChanges: Array,
     studyRequestUsers: Map,
   },
   computed: {

--- a/web/views/FcRequestsTrack.vue
+++ b/web/views/FcRequestsTrack.vue
@@ -504,7 +504,9 @@ export default {
 
         let requestedBy = null;
         if (this.studyRequestUsers.has(userId)) {
-          requestedBy = this.studyRequestUsers.get(userId);
+          const { uniqueName } = this.studyRequestUsers.get(userId);
+          const i = uniqueName.indexOf('\\');
+          requestedBy = i === -1 ? uniqueName : uniqueName.slice(i + 1);
         }
 
         return {

--- a/web/views/FcRequestsTrack.vue
+++ b/web/views/FcRequestsTrack.vue
@@ -549,7 +549,9 @@ export default {
       }
 
       this.loadingSaveStudyRequest.add(item.id);
-      const studyRequestUpdated = await this.saveStudyRequest(studyRequest);
+      const {
+        studyRequest: studyRequestUpdated,
+      } = await this.saveStudyRequest(studyRequest);
       /* eslint-disable-next-line no-param-reassign */
       item.studyRequest = studyRequestUpdated;
       this.loadingSaveStudyRequest.delete(item.id);


### PR DESCRIPTION
# Issue Addressed
This PR closes #410 .

# Description
It provides `<FcStatusStudyRequest>`, which uses the study request together with a list of historical status changes to graphically show how request fulfillment has proceeded to date.

These historical status changes are stored in a new table `study_request_changes`, accessed via `StudyRequestChangesDAO`, and returned in a format that matches the model `StudyRequestChange`.

# Tests
Automatic and manual tests.  This will require more testing post-release.
