### PR TITLE
Add unit tests for EmailBase, Mailer

### DIFF
--- a/lib/email/EmailBase.js
+++ b/lib/email/EmailBase.js
@@ -54,7 +54,9 @@ class EmailBase {
    */
   static getUrl(path) {
     const port = webPort === PORT_HTTPS_DEFAULT ? '' : `:${webPort}`;
-    return `https://${domain}${port}${publicPath}${path}`;
+    let fullPath = `${publicPath}${path}`;
+    fullPath = fullPath.replace('//', '/');
+    return `https://${domain}${port}${fullPath}`;
   }
 
   /* eslint-disable no-empty-function, class-methods-use-this */

--- a/tests/jest/unit/email/EmailBase.spec.js
+++ b/tests/jest/unit/email/EmailBase.spec.js
@@ -1,0 +1,63 @@
+import EmailBase from '@/lib/email/EmailBase';
+
+test('EmailBase.getUrl', () => {
+  let url = EmailBase.getUrl('');
+  expect(url).toEqual('https://localhost:8080/');
+
+  url = EmailBase.getUrl('/');
+  expect(url).toEqual('https://localhost:8080/');
+
+  url = EmailBase.getUrl('requests/study/42');
+  expect(url).toEqual('https://localhost:8080/requests/study/42');
+
+  url = EmailBase.getUrl('/requests/study/42');
+  expect(url).toEqual('https://localhost:8080/requests/study/42');
+
+  url = EmailBase.getUrl('requests/study/42/');
+  expect(url).toEqual('https://localhost:8080/requests/study/42/');
+
+  url = EmailBase.getUrl('/requests/study/42/');
+  expect(url).toEqual('https://localhost:8080/requests/study/42/');
+});
+
+function incrementASAP(x) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(x + 1);
+    }, 0);
+  });
+}
+
+class EmailFoo extends EmailBase {
+  constructor(x) {
+    super();
+    this.x = x;
+  }
+
+  async init() {
+    this.y = await incrementASAP(this.x);
+  }
+
+  getRecipients() {
+    return [`move-ops+${this.y}@toronto.ca`];
+  }
+
+  getSubject() {
+    return `Foo: ${this.x} -> ${this.y}`;
+  }
+
+  render() {
+    return `<h1>Foo</h1><p>incremented to ${this.y}</p>`;
+  }
+}
+
+test('EmailBase.getOptions', async () => {
+  const email = new EmailFoo(1729);
+  await expect(email.getOptions()).resolves.toEqual({
+    from: 'move-team@email1.dev-toronto.ca',
+    to: ['move-ops+1730@toronto.ca'],
+    reply_to: 'move-team@toronto.ca',
+    subject: 'Foo: 1729 -> 1730',
+    html: '<h1>Foo</h1><p>incremented to 1730</p>',
+  });
+});

--- a/tests/jest/unit/email/Mailer.spec.js
+++ b/tests/jest/unit/email/Mailer.spec.js
@@ -1,0 +1,57 @@
+import EmailBase from '@/lib/email/EmailBase';
+import Mailer from '@/lib/email/Mailer';
+
+function incrementASAP(x) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(x + 1);
+    }, 0);
+  });
+}
+
+class EmailFoo extends EmailBase {
+  constructor(x) {
+    super();
+    this.x = x;
+  }
+
+  async init() {
+    this.y = await incrementASAP(this.x);
+  }
+
+  getRecipients() {
+    return [`move-ops+${this.y}@toronto.ca`];
+  }
+
+  getSubject() {
+    return `Foo: ${this.x} -> ${this.y}`;
+  }
+
+  render() {
+    return `<h1>Foo</h1><p>incremented to ${this.y}</p>`;
+  }
+}
+
+test('Mailer.convertToSes', async () => {
+  const email = new EmailFoo(17);
+  const options = await email.getOptions();
+  expect(Mailer.convertToSes(options)).toEqual({
+    Destination: {
+      ToAddresses: ['move-ops+18@toronto.ca'],
+    },
+    Message: {
+      Body: {
+        Html: {
+          Charset: 'UTF-8',
+          Data: '<h1>Foo</h1><p>incremented to 18</p>',
+        },
+      },
+      Subject: {
+        Charset: 'UTF-8',
+        Data: 'Foo: 17 -> 18',
+      },
+    },
+    Source: 'move-team@email1.dev-toronto.ca',
+    ReplyToAddresses: ['move-team@toronto.ca'],
+  });
+});


### PR DESCRIPTION
# Issue Addressed
This PR closes #382 .

# Description
Added a couple of unit tests for the parts of `EmailBase` and `Mailer` that build up the email to be sent, so that we have at least a bit of coverage here.

# Tests
`npm run test:test-unit`