### PR TITLE
Fix user chip management, disallow top-level chip deselect

### DIFF
--- a/web/views/FcRequestsTrack.vue
+++ b/web/views/FcRequestsTrack.vue
@@ -10,7 +10,8 @@
             v-model="activeShortcutChip"
             active-class="fc-shortcut-chip-active"
             class="fc-shortcut-chips"
-            color="primary">
+            color="primary"
+            :mandatory="activeShortcutChip !== null">
             <v-chip
               v-for="({ text }, i) in SHORTCUT_CHIPS"
               :key="i"
@@ -411,7 +412,7 @@ export default {
         return null;
       },
       set(activeShortcutChip) {
-        const userOnly = !this.hasAuthScope(AuthScope.STUDY_REQUESTS_ADMIN);
+        const { userOnly } = this.filters;
         const { filters } = SHORTCUT_CHIPS[activeShortcutChip];
         this.filters = {
           ...filters,
@@ -537,6 +538,10 @@ export default {
       },
     },
     ...mapState(['auth']),
+  },
+  created() {
+    const userOnly = !this.hasAuthScope(AuthScope.STUDY_REQUESTS_ADMIN);
+    this.filters.userOnly = userOnly;
   },
   methods: {
     async actionAssignTo({ item, assignedTo }) {


### PR DESCRIPTION
# Issue Addressed
This PR closes #423 .

# Description
Addresses the "User" filter selection issue by setting this in the `created()` lifecycle hook of the `FcRequestsTrack` component, and by preserving `this.filters.userOnly` when clicking a top-level chip.

We use a dynamic value for the `<v-chip-group mandatory>` prop to prevent the user from deselecting a top-level chip, while still allowing those chips to be cleared by updating the filters via the "Filters" dialog.

# Tests
Manual testing in browser, using both a supervisor (i.e. `STUDY_REQUESTS_ADMIN`) and non-supervisor user.
