### PR TITLE
Fix eslint-disable scoping issues

### DIFF
--- a/lib/ClassUtils.js
+++ b/lib/ClassUtils.js
@@ -9,6 +9,7 @@ function pushEnumValue(enumClass, enumValue, name) {
   /* eslint-disable no-param-reassign */
   enumValue.name = name;
   enumValue.ordinal = enumClass.enumValues.length;
+  /* eslint-enable no-param-reassign */
   Object.defineProperty(enumClass, name, {
     value: enumValue,
     configurable: false,

--- a/lib/api/BackendClient.js
+++ b/lib/api/BackendClient.js
@@ -115,7 +115,6 @@ class BackendClient {
         * Create JSON response that looks similar to one returned by @hapi/boom - except
         * that there's (probably) no backend to return it!
         */
-        /* eslint-disable no-throw-literal */
         throw new Error(JSON.stringify({
           statusCode: response.status,
           error: response.statusText,

--- a/lib/email/EmailBase.js
+++ b/lib/email/EmailBase.js
@@ -1,3 +1,4 @@
+/* eslint-disable class-methods-use-this */
 import config from '@/lib/config/MoveConfig';
 import vueConfig from '@/vue.config';
 
@@ -59,7 +60,6 @@ class EmailBase {
     return `https://${domain}${port}${fullPath}`;
   }
 
-  /* eslint-disable no-empty-function, class-methods-use-this */
   /**
    * Performs any asynchronous data fetching required to render this email message.
    * This may include roundtrips to DB, other APIs, etc.
@@ -68,7 +68,9 @@ class EmailBase {
    *
    * @returns {Promise<undefined>} when data fetching is complete
    */
-  async init() {}
+  async init() {
+    /* eslint-disable-next-line no-empty-function */
+  }
 
   /**
    * Returns the sender email address.  Eventually, this will depend on which tier
@@ -81,7 +83,6 @@ class EmailBase {
     return emailSender;
   }
 
-  /* eslint-disable class-methods-use-this */
   /**
    * Returns a list of recipients.  For consistency, this should *always* return a list, never a
    * single String.
@@ -94,7 +95,6 @@ class EmailBase {
     throw new Error('getRecipients() not implemented!');
   }
 
-  /* eslint-disable class-methods-use-this */
   /**
    * Returns the email subject line.
    *
@@ -106,7 +106,6 @@ class EmailBase {
     throw new Error('getSubject() not implemented!');
   }
 
-  /* eslint-disable class-methods-use-this */
   /**
    * Returns the HTML body of the email, as a String.  Implementations should take care to
    * properly escape variables, e.g. through Mustache double-bracket (`{{}}`) syntax.

--- a/lib/geo/GeoStyle.js
+++ b/lib/geo/GeoStyle.js
@@ -69,11 +69,11 @@ function mapTextSize(textSize) {
   return textSize;
 }
 
-/* eslint-disable no-param-reassign */
 function normalizeAndSeparateLayers(style) {
   const nonSymbolLayers = [];
   const symbolLayers = [];
 
+  /* eslint-disable-next-line no-param-reassign */
   style.layers.forEach((layer) => {
     const { layout = {}, paint = {}, type } = layer;
     const {
@@ -122,12 +122,14 @@ function normalizeAndSeparateLayers(style) {
    * Mapbox GL spritemaps are structured.
    */
   const { origin } = window.location;
+  /* eslint-disable-next-line no-param-reassign */
   style.sprite = `${origin}/icons/map/sprite`;
 
   /*
    * Drop layers so that we can dynamically build layer sets based on map options
    * from non-symbol, feature, and symbol layer lists.
    */
+  /* eslint-disable-next-line no-param-reassign */
   style.layers = [];
 
   return [nonSymbolLayers, symbolLayers];

--- a/lib/reports/ReportBaseFlow.js
+++ b/lib/reports/ReportBaseFlow.js
@@ -1,3 +1,4 @@
+/* eslint-disable class-methods-use-this */
 import { ReportBlock, StudyType } from '@/lib/Constants';
 import CountDAO from '@/lib/db/CountDAO';
 import CountDataDAO from '@/lib/db/CountDataDAO';
@@ -10,8 +11,6 @@ import TimeFormatters from '@/lib/time/TimeFormatters';
  * and study data.
  */
 class ReportBaseFlow extends ReportBase {
-  /* eslint-disable class-methods-use-this */
-
   /**
    * Parses an ID in the format `{categoryId}/{id}`, and returns it as a
    * {@link Count}.

--- a/lib/reports/ReportBaseFlowDirectional.js
+++ b/lib/reports/ReportBaseFlowDirectional.js
@@ -1,3 +1,4 @@
+/* eslint-disable class-methods-use-this */
 import ArrayUtils from '@/lib/ArrayUtils';
 import {
   CardinalDirection,
@@ -18,8 +19,6 @@ import ReportBaseFlow from '@/lib/reports/ReportBaseFlow';
  * TODO: rename to reflect that this relates specifically to intersections / TMCs
  */
 class ReportBaseFlowDirectional extends ReportBaseFlow {
-  /* eslint-disable class-methods-use-this */
-
   static computeMovements(rawData) {
     const data = {};
 

--- a/lib/reports/ReportCountSummary24h.js
+++ b/lib/reports/ReportCountSummary24h.js
@@ -1,3 +1,4 @@
+/* eslint-disable class-methods-use-this */
 import ArrayUtils from '@/lib/ArrayUtils';
 import { ReportBlock, ReportType } from '@/lib/Constants';
 import ArteryDAO from '@/lib/db/ArteryDAO';
@@ -13,8 +14,6 @@ import TimeFormatters from '@/lib/time/TimeFormatters';
  * @see https://www.notion.so/bditto/24-Hour-Count-Summary-Report-573e17ae544749dab66c25f019281654
  */
 class ReportCountSummary24h extends ReportBaseFlow {
-  /* eslint-disable class-methods-use-this */
-
   type() {
     return ReportType.COUNT_SUMMARY_24H;
   }

--- a/lib/reports/ReportCountSummary24hDetailed.js
+++ b/lib/reports/ReportCountSummary24hDetailed.js
@@ -1,3 +1,4 @@
+/* eslint-disable class-methods-use-this */
 import ArrayUtils from '@/lib/ArrayUtils';
 import { ReportBlock, ReportType } from '@/lib/Constants';
 import ReportBaseFlow from '@/lib/reports/ReportBaseFlow';
@@ -10,8 +11,6 @@ import DateTime from '@/lib/time/DateTime';
  * @see https://www.notion.so/bditto/Detailed-24-Hour-Count-Summary-Report-ccb63a389d2944c7ad172f08c5e65235
  */
 class ReportCountSummary24hDetailed extends ReportBaseFlow {
-  /* eslint-disable class-methods-use-this */
-
   type() {
     return ReportType.COUNT_SUMMARY_24H_DETAILED;
   }

--- a/lib/reports/ReportCountSummary24hGraphical.js
+++ b/lib/reports/ReportCountSummary24hGraphical.js
@@ -1,3 +1,4 @@
+/* eslint-disable class-methods-use-this */
 import { ReportBlock, ReportType } from '@/lib/Constants';
 import ReportBaseFlow from '@/lib/reports/ReportBaseFlow';
 import DateTime from '@/lib/time/DateTime';
@@ -9,8 +10,6 @@ import DateTime from '@/lib/time/DateTime';
  * @see https://www.notion.so/bditto/Graphical-24-Hour-Count-Summary-Report-9ae5570bc6eb4dcbbd99182f2aa7f2c8
  */
 class ReportCountSummary24hGraphical extends ReportBaseFlow {
-  /* eslint-disable class-methods-use-this */
-
   type() {
     return ReportType.COUNT_SUMMARY_24H_GRAPHICAL;
   }

--- a/lib/reports/ReportCountSummaryTurningMovement.js
+++ b/lib/reports/ReportCountSummaryTurningMovement.js
@@ -1,3 +1,4 @@
+/* eslint-disable class-methods-use-this */
 import ArrayUtils from '@/lib/ArrayUtils';
 import { ReportBlock, ReportType } from '@/lib/Constants';
 import ReportBaseFlow from '@/lib/reports/ReportBaseFlow';
@@ -10,8 +11,6 @@ import TimeFormatters from '@/lib/time/TimeFormatters';
  * @see https://www.notion.so/bditto/Turning-Movement-Count-Summary-Report-d9bc143ed7e14acc894a4c0c0135c8a4
  */
 class ReportCountSummaryTurningMovement extends ReportBaseFlow {
-  /* eslint-disable class-methods-use-this */
-
   type() {
     return ReportType.COUNT_SUMMARY_TURNING_MOVEMENT;
   }

--- a/lib/reports/ReportCountSummaryTurningMovementDetailed.js
+++ b/lib/reports/ReportCountSummaryTurningMovementDetailed.js
@@ -1,3 +1,4 @@
+/* eslint-disable class-methods-use-this */
 import { ReportBlock, ReportType } from '@/lib/Constants';
 import ReportBaseFlow from '@/lib/reports/ReportBaseFlow';
 import ReportBaseFlowDirectional from '@/lib/reports/ReportBaseFlowDirectional';
@@ -9,8 +10,6 @@ import TimeFormatters from '@/lib/time/TimeFormatters';
  * @see https://www.notion.so/bditto/Intersection-Detailed-15-Minutes-Movement-Report-a40897bce24546d988c8a3717ccda812
  */
 class ReportCountSummaryTurningMovementDetailed extends ReportBaseFlow {
-  /* eslint-disable class-methods-use-this */
-
   type() {
     return ReportType.COUNT_SUMMARY_TURNING_MOVEMENT_DETAILED;
   }

--- a/lib/reports/ReportIntersectionSummary.js
+++ b/lib/reports/ReportIntersectionSummary.js
@@ -1,3 +1,4 @@
+/* eslint-disable class-methods-use-this */
 import ArrayUtils from '@/lib/ArrayUtils';
 import {
   CardinalDirection,
@@ -17,8 +18,6 @@ import TimeFormatters from '@/lib/time/TimeFormatters';
  * @see https://www.notion.so/bditto/Intersection-Summary-Report-6f06d430038c4421b5e727a478af1b34
  */
 class ReportIntersectionSummary extends ReportBaseFlowDirectional {
-  /* eslint-disable class-methods-use-this */
-
   type() {
     return ReportType.INTERSECTION_SUMMARY;
   }

--- a/lib/reports/ReportSpeedPercentile.js
+++ b/lib/reports/ReportSpeedPercentile.js
@@ -1,3 +1,4 @@
+/* eslint-disable class-methods-use-this */
 import { format } from 'd3-format';
 
 import ArrayUtils from '@/lib/ArrayUtils';
@@ -15,8 +16,6 @@ const FORMAT_PERCENT = format('.1%');
  * @see https://www.notion.so/bditto/Speed-Percentile-Report-Traxpro-3775545a80e34f568df1f082b626f35e
  */
 class ReportSpeedPercentile extends ReportBaseFlow {
-  /* eslint-disable class-methods-use-this */
-
   type() {
     return ReportType.SPEED_PERCENTILE;
   }

--- a/lib/reports/ReportWarrantTrafficSignalControl.js
+++ b/lib/reports/ReportWarrantTrafficSignalControl.js
@@ -1,3 +1,4 @@
+/* eslint-disable class-methods-use-this */
 import { format } from 'd3-format';
 
 import {
@@ -28,8 +29,6 @@ const FORMAT_PREVENTABLES_AVERAGE = format('.2f');
  * @see https://www.notion.so/bditto/Warrant-for-Installation-of-Traffic-Control-Signal-Report-0cdf7ff9198b40f788f62a2df8736e33
  */
 class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
-  /* eslint-disable class-methods-use-this */
-
   type() {
     return ReportType.WARRANT_TRAFFIC_SIGNAL_CONTROL;
   }

--- a/lib/reports/format/MovePdfGenerator.js
+++ b/lib/reports/format/MovePdfGenerator.js
@@ -1,3 +1,4 @@
+/* eslint-disable class-methods-use-this */
 import fs from 'fs';
 import path from 'path';
 import util from 'util';
@@ -139,7 +140,6 @@ class MovePdfGenerator {
 
   // ReportBlock.BAR_CHART
 
-  /* eslint-disable class-methods-use-this */
   generateBarChart(options) {
     const colorBase = FormatCss.var('--base');
     const colorInk = FormatCss.var('--ink');
@@ -211,7 +211,6 @@ class MovePdfGenerator {
     return rows;
   }
 
-  /* eslint-disable class-methods-use-this */
   generateCountMetadata({ entries }) {
     const spaceM = FormatCss.var('--space-m');
     const rows = MovePdfGenerator.getMetadataRows(entries);
@@ -395,7 +394,6 @@ class MovePdfGenerator {
     ];
   }
 
-  /* eslint-disable class-methods-use-this */
   generateTable({
     title = null,
     caption = null,

--- a/lib/reports/svg/SvgGenerator.js
+++ b/lib/reports/svg/SvgGenerator.js
@@ -1,4 +1,4 @@
-/* eslint-disable indent */
+/* eslint-disable class-methods-use-this, indent */
 import { NotImplementedError } from '@/lib/error/MoveErrors';
 
 /**
@@ -28,12 +28,10 @@ class SvgGenerator {
         .attr('xmlns', 'http://www.w3.org/2000/svg');
   }
 
-  /* eslint-disable class-methods-use-this, no-unused-vars */
   init() {
     throw new NotImplementedError();
   }
 
-  /* eslint-disable class-methods-use-this, no-unused-vars */
   update() {
     throw new NotImplementedError();
   }

--- a/lib/time/TimeFormatters.js
+++ b/lib/time/TimeFormatters.js
@@ -104,7 +104,7 @@ class TimeFormatters {
      */
     let bitMask = 0;
     daysOfWeek.forEach((d) => {
-      /* eslint-disable no-bitwise */
+      /* eslint-disable-next-line no-bitwise */
       bitMask |= 1 << d;
     });
     if (bitMask === 0x7f) { // 1111111

--- a/tests/jest/unit/ClassUtils.spec.js
+++ b/tests/jest/unit/ClassUtils.spec.js
@@ -38,9 +38,9 @@ GetterTest.init(getterTestValues);
 class NotAnEnum {}
 
 test('Enum non-tamperable', () => {
-  /* eslint-disable no-new */
   // cannot instantiate Enum after init()
   expect(() => {
+    /* eslint-disable-next-line no-new */
     new Color({});
   }).toThrow();
 

--- a/tests/jest/unit/reports/svg/SvgStringRenderer.spec.js
+++ b/tests/jest/unit/reports/svg/SvgStringRenderer.spec.js
@@ -2,10 +2,11 @@ import SvgGenerator from '@/lib/reports/svg/SvgGenerator';
 import SvgStringRenderer from '@/lib/reports/svg/SvgStringRenderer';
 import 'd3-selection-multi';
 
-/* eslint-disable class-methods-use-this */
 class NoopSvgGenerator extends SvgGenerator {
+  /* eslint-disable-next-line class-methods-use-this */
   init() {}
 
+  /* eslint-disable-next-line class-methods-use-this */
   update() {}
 }
 

--- a/web/components/reports/FcReportBarChart.vue
+++ b/web/components/reports/FcReportBarChart.vue
@@ -5,7 +5,6 @@
 </template>
 
 <script>
-/* eslint-disable no-underscore-dangle */
 import { select } from 'd3-selection';
 import Vue from 'vue';
 


### PR DESCRIPTION
# Issue Addressed
This PR closes #415 .

# Description
ESLint doesn't appear to offer block-scoped disables, but we were using it in several places as though it does.  This commit addresses that by moving common disables up to top-of-file, and by changing others to use `eslint-disable-next-line`.

# Tests
- search through codebase to find / triage instances (and make sure there aren't any others)
- pre-commit tests automatically lint this
