### PR TITLE
Preserve all features in point-of-interest layers

### DIFF
--- a/scripts/airflow/tasks/build_gis_layers_tiles.sh
+++ b/scripts/airflow/tasks/build_gis_layers_tiles.sh
@@ -8,5 +8,5 @@ mkdir -p /data/tiles
 env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -f "${TASKS_ROOT}/build_gis_layers_tiles/download_hospitalsLevel2.sql" > /data/tiles/hospitalsLevel2.json
 env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -f "${TASKS_ROOT}/build_gis_layers_tiles/download_schoolsLevel2.sql" > /data/tiles/schoolsLevel2.json
 
-tippecanoe --progress-interval=10 --force -o /data/tiles/hospitalsLevel2.mbtiles -l hospitalsLevel2 -Z14 -z16 /data/tiles/hospitalsLevel2.json
-tippecanoe --progress-interval=10 --force -o /data/tiles/schoolsLevel2.mbtiles -l schoolsLevel2 -Z14 -z16 /data/tiles/schoolsLevel2.json
+tippecanoe --progress-interval=10 --force -o /data/tiles/hospitalsLevel2.mbtiles -l hospitalsLevel2 -Z14 -z16 -r1 /data/tiles/hospitalsLevel2.json
+tippecanoe --progress-interval=10 --force -o /data/tiles/schoolsLevel2.mbtiles -l schoolsLevel2 -Z14 -z16 -r1 /data/tiles/schoolsLevel2.json


### PR DESCRIPTION
# Issue Addressed
This PR makes progress on #411 .

# Description
The same issue noted in #411 was also affecting our point-of-interest layers; this change causes those layers to _always_ contain _all_ matching features in tile boundaries, rather than dropping features at lower zoom levels.

# Tests
- re-ran DAG and verified all tasks pass;
- checked output by loading MOVE in browser.
