### PR TITLE
Allow symbol overlap in dynamic tiles

### DIFF
--- a/lib/geo/GeoStyle.js
+++ b/lib/geo/GeoStyle.js
@@ -395,22 +395,30 @@ class GeoStyle {
     return [
       getLayer(baseStyle, 'hospitalsLevel2', 'symbol', {
         layout: {
+          'icon-allow-overlap': true,
           'icon-image': 'hospital',
+          'text-allow-overlap': true,
         },
       }),
       getLayer(baseStyle, 'hospitalsLevel1', 'symbol', {
         layout: {
+          'icon-allow-overlap': true,
           'icon-image': 'hospital',
+          'text-allow-overlap': true,
         },
       }),
       getLayer(baseStyle, 'schoolsLevel2', 'symbol', {
         layout: {
+          'icon-allow-overlap': true,
           'icon-image': 'school',
+          'text-allow-overlap': true,
         },
       }),
       getLayer(baseStyle, 'schoolsLevel1', 'symbol', {
         layout: {
+          'icon-allow-overlap': true,
           'icon-image': 'school',
+          'text-allow-overlap': true,
         },
       }),
     ];
@@ -544,7 +552,9 @@ class GeoStyle {
         minzoom: MapZoom.LEVEL_2.minzoom,
         maxzoom: MapZoom.LEVEL_1.maxzoomSource + 1,
         layout: {
+          'icon-allow-overlap': true,
           'icon-image': 'count',
+          'text-allow-overlap': true,
           'text-field': [
             'case',
             ['>', ['get', 'numArteryCodes'], 1], ['to-string', ['get', 'numArteryCodes']],


### PR DESCRIPTION
# Issue Addressed
Together with the recent PR #430 , this PR closes #411 .

# Description
Uses the `icon-allow-overlap` and `text-allow-overlap` layout properties for Mapbox GL symbol layers to ensure that counts don't mysteriously disappear and re-appear.

# Tests
manual check in the browser: found a dense patch of counts near the Gardiner, zoomed in and out, verified that counts do not disappear and re-appear.