### PR TITLE
Ensure sampled tables in dev dataset have indexes

### DIFF
--- a/scripts/airflow/tasks/dump_dev_data.sh
+++ b/scripts/airflow/tasks/dump_dev_data.sh
@@ -54,7 +54,6 @@ env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t flashcrow_dev_data.tra
 env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t flashcrow_dev_data.traffic_det -x --no-owner --clean --if-exists --schema-only | sed 's/flashcrow_dev_data.traffic_det/"TRAFFIC"."DET"/g' >> "${FLASHCROW_DEV_DATA}"
 env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t flashcrow_dev_data.traffic_countinfo -x --no-owner --clean --if-exists --schema-only | sed 's/flashcrow_dev_data.traffic_countinfo/"TRAFFIC"."COUNTINFO"/g' >> "${FLASHCROW_DEV_DATA}"
 env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t flashcrow_dev_data.traffic_cnt_det -x --no-owner --clean --if-exists --schema-only | sed 's/flashcrow_dev_data.traffic_cnt_det/"TRAFFIC"."CNT_DET"/g' >> "${FLASHCROW_DEV_DATA}"
-env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t flashcrow_dev_data.traffic_cnt_spd -x --no-owner --clean --if-exists --schema-only | sed 's/flashcrow_dev_data.traffic_cnt_spd/"TRAFFIC"."CNT_SPD"/g' >> "${FLASHCROW_DEV_DATA}"
 
 # copy data for sampled tables / views
 echo 'COPY collisions.events FROM stdin;' >> "${FLASHCROW_DEV_DATA}"
@@ -78,9 +77,6 @@ env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -c "COPY 
 echo '\.' >> "${FLASHCROW_DEV_DATA}"
 echo 'COPY "TRAFFIC"."CNT_DET" FROM stdin;' >> "${FLASHCROW_DEV_DATA}"
 env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -c "COPY (SELECT * FROM flashcrow_dev_data.traffic_cnt_det) TO stdout (FORMAT text, ENCODING 'UTF-8')" >> "${FLASHCROW_DEV_DATA}"
-echo '\.' >> "${FLASHCROW_DEV_DATA}"
-echo 'COPY "TRAFFIC"."CNT_SPD" FROM stdin;' >> "${FLASHCROW_DEV_DATA}"
-env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -c "COPY (SELECT * FROM flashcrow_dev_data.traffic_cnt_spd) TO stdout (FORMAT text, ENCODING 'UTF-8')" >> "${FLASHCROW_DEV_DATA}"
 echo '\.' >> "${FLASHCROW_DEV_DATA}"
 
 # copy view definitions where appropriate

--- a/scripts/airflow/tasks/sample_dev_data/sample_dev_data.sql
+++ b/scripts/airflow/tasks/sample_dev_data/sample_dev_data.sql
@@ -32,45 +32,36 @@ drop table if exists flashcrow_dev_data.traffic_countinfomics;
 drop table if exists flashcrow_dev_data.traffic_det;
 drop table if exists flashcrow_dev_data.traffic_countinfo;
 drop table if exists flashcrow_dev_data.traffic_cnt_det;
-drop table if exists flashcrow_dev_data.traffic_cnt_spd;
 
-create table flashcrow_dev_data.collisions_events as
+create table flashcrow_dev_data.collisions_events (like collisions.events including indexes);
+insert into flashcrow_dev_data.collisions_events
   select * from collisions.events tablesample bernoulli (18)
   where accdate >= '2009-01-01';
-create table flashcrow_dev_data.collisions_events_centreline as
+insert into flashcrow_dev_data.collisions_events
+  select t.* from collisions.events as t
+  join collisions.events_centreline as u USING (collision_id)
+  where (u.centreline_type, u.centreline_id) in (
+    (1, 1142194),
+    (2, 13465434)
+  )
+on conflict do nothing;
+
+create table flashcrow_dev_data.collisions_events_centreline (like collisions.events_centreline including indexes);
+insert into flashcrow_dev_data.collisions_events_centreline
   select t.* from collisions.events_centreline as t
     inner join flashcrow_dev_data.collisions_events as u
     on t.collision_id = u.collision_id;
-create table flashcrow_dev_data.collisions_involved as
+
+create table flashcrow_dev_data.collisions_involved (like collisions.involved including indexes);
+insert into flashcrow_dev_data.collisions_involved
   select t.* from collisions.involved as t
     inner join flashcrow_dev_data.collisions_events as u
     on t.collision_id = u.collision_id;
 
-create table flashcrow_dev_data.traffic_countinfomics as
+create table flashcrow_dev_data.traffic_countinfomics (like "TRAFFIC"."COUNTINFOMICS" including indexes);
+insert into flashcrow_dev_data.traffic_countinfomics
   select * from "TRAFFIC"."COUNTINFOMICS" tablesample bernoulli (7.79)
   where "COUNT_DATE" >= '2009-01-01';
-create table flashcrow_dev_data.traffic_det as
-  select t.* from "TRAFFIC"."DET" as t
-   inner join flashcrow_dev_data.traffic_countinfomics as u
-   on t."COUNT_INFO_ID" = u."COUNT_INFO_ID";
-
-create table flashcrow_dev_data.traffic_countinfo as
-  select * from "TRAFFIC"."COUNTINFO" tablesample bernoulli (1.17)
-  where "COUNT_DATE" >= '2009-01-01';
-create table flashcrow_dev_data.traffic_cnt_det as
-  select t.* from "TRAFFIC"."CNT_DET" as t
-   inner join flashcrow_dev_data.traffic_countinfo as u
-   on t."COUNT_INFO_ID" = u."COUNT_INFO_ID";
-create table flashcrow_dev_data.traffic_cnt_spd as
-  select t.* from "TRAFFIC"."CNT_SPD" as t
-   inner join flashcrow_dev_data.traffic_countinfo as u
-   on t."COUNT_INFO_ID" = u."COUNT_INFO_ID";
-
--- SPECIFIC DATA NEEDED FOR TESTS
-
-alter table flashcrow_dev_data.traffic_countinfomics add primary key ("COUNT_INFO_ID");
-alter table flashcrow_dev_data.traffic_countinfo add primary key ("COUNT_INFO_ID");
-
 insert into flashcrow_dev_data.traffic_countinfomics
   select t.* from "TRAFFIC"."COUNTINFOMICS" as t
   join prj_volume.artery_centreline as u
@@ -83,7 +74,21 @@ insert into flashcrow_dev_data.traffic_countinfomics
     (1, 9278884)
   )
 on conflict do nothing;
+insert into flashcrow_dev_data.traffic_countinfomics (
+  select * from "TRAFFIC"."COUNTINFOMICS"
+  where "COUNT_INFO_ID" = 26177
+) on conflict do nothing;
 
+create table flashcrow_dev_data.traffic_det (like "TRAFFIC"."DET" including indexes);
+insert into flashcrow_dev_data.traffic_det
+  select t.* from "TRAFFIC"."DET" as t
+   inner join flashcrow_dev_data.traffic_countinfomics as u
+   on t."COUNT_INFO_ID" = u."COUNT_INFO_ID";
+
+create table flashcrow_dev_data.traffic_countinfo (like "TRAFFIC"."COUNTINFO" including indexes);
+insert into flashcrow_dev_data.traffic_countinfo
+  select * from "TRAFFIC"."COUNTINFO" tablesample bernoulli (1.17)
+  where "COUNT_DATE" >= '2009-01-01';
 insert into flashcrow_dev_data.traffic_countinfo (
   select t.* from "TRAFFIC"."COUNTINFO" as t
   join prj_volume.artery_centreline as u
@@ -96,25 +101,16 @@ insert into flashcrow_dev_data.traffic_countinfo (
     (1, 9278884)
   )
 ) on conflict do nothing;
-
-insert into flashcrow_dev_data.traffic_countinfomics (
-  select * from "TRAFFIC"."COUNTINFOMICS"
-  where "COUNT_INFO_ID" = 26177
-) on conflict do nothing;
-insert into flashcrow_dev_data.traffic_det (
-  select * from "TRAFFIC"."DET"
-  where "COUNT_INFO_ID" = 26177
-) on conflict do nothing;
-
 insert into flashcrow_dev_data.traffic_countinfo (
   select * from "TRAFFIC"."COUNTINFO"
-  where "COUNT_INFO_ID" = 1415698
+  where "COUNT_INFO_ID" in (
+    1206023,
+    1415698
+  )
 ) on conflict do nothing;
-insert into flashcrow_dev_data.traffic_cnt_det (
-  select * from "TRAFFIC"."CNT_DET"
-  where "COUNT_INFO_ID" = 1415698
-) on conflict do nothing;
-insert into flashcrow_dev_data.traffic_cnt_spd (
-  select * from "TRAFFIC"."CNT_SPD"
-  where "COUNT_INFO_ID" = 1415698
-) on conflict do nothing;
+
+create table flashcrow_dev_data.traffic_cnt_det (like "TRAFFIC"."CNT_DET" including indexes);
+insert into flashcrow_dev_data.traffic_cnt_det
+  select t.* from "TRAFFIC"."CNT_DET" as t
+   inner join flashcrow_dev_data.traffic_countinfo as u
+   on t."COUNT_INFO_ID" = u."COUNT_INFO_ID";


### PR DESCRIPTION
# Issue Addressed
This PR closes #449 .

# Description
We fix an issue where the `dev_data` Airflow DAG was creating sampled tables without indexes, causing queries on those tables to be _less_ efficient in development even with the smaller dataset size!

# Tests
Ran `dev_data` DAG from Airflow.  `scp`'d data into local development VM, reloaded it, and ran MOVE locally to double-check that dev dataset loads / functions properly.  Ran `npm run test:test-db` to ensure that dataset works properly for database tests.
