### PR TITLE
Collision data: summary revamp

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -267,6 +267,20 @@ ReportParameter.init({
  */
 class ReportType extends Enum {}
 ReportType.init({
+  COLLISION_DIRECTORY: {
+    disabled: false,
+    formats: [ReportFormat.CSV, ReportFormat.PDF],
+    label: 'Directory Report',
+    orientation: PageOrientation.LANDSCAPE,
+    suffix: 'CollisionDirectory',
+  },
+  COLLISION_TABULATION: {
+    disabled: false,
+    formats: [ReportFormat.PDF],
+    label: 'Tabulation Report',
+    orientation: PageOrientation.LANDSCAPE,
+    suffix: 'CollisionTabulation',
+  },
   COUNT_SUMMARY_24H: {
     disabled: false,
     formats: [ReportFormat.CSV, ReportFormat.PDF],

--- a/lib/db/CollisionDAO.js
+++ b/lib/db/CollisionDAO.js
@@ -97,17 +97,24 @@ WHERE collision_id = $(id)`;
     }
     const sqlFilters = filters.join('\n  AND ');
     const sql = `
-WITH collisions AS (
-  SELECT i.collision_id, MAX(CONCAT('0', i.injury)::int) AS injury
+WITH collisions_involved_summary AS (
+  SELECT
+    i.collision_id,
+    MAX(CONCAT('0', i.injury)::int) AS injury
   FROM collisions.events e
   JOIN collisions.involved i ON e.collision_id = i.collision_id
   JOIN collisions.events_centreline ec ON e.collision_id = ec.collision_id
   WHERE ${sqlFilters}
   GROUP BY i.collision_id
+), collisions AS (
+  SELECT cis.*, e.changed
+  FROM collisions_involved_summary cis
+  JOIN collisions.events e USING (collision_id)
 )
 SELECT
-COUNT(*) AS total,
-COUNT(*) FILTER (WHERE injury >= 3) AS ksi
+  COUNT(*) AS total,
+  COUNT(*) FILTER (WHERE injury >= 3) AS ksi,
+  COUNT(*) FILTER (WHERE changed IS NOT NULL) AS validated
 FROM collisions`;
     return db.one(sql, params);
   }

--- a/lib/db/CollisionDAO.js
+++ b/lib/db/CollisionDAO.js
@@ -63,6 +63,10 @@ function normalizeInvolved(involved) {
   return { invtype, invage };
 }
 
+/**
+ * Data access layer for collisions.  Each collision record consists of a collision event and
+ * zero or more involved persons.
+ */
 class CollisionDAO {
   static async byIdPopupDetails(id) {
     const sqlEvent = `SELECT ${COLLISION_EVENT_FIELDS} WHERE e.collision_id = $(id)`;
@@ -78,6 +82,52 @@ WHERE collision_id = $(id)`;
     const rows = await db.manyOrNone(sqlInvolved, { id });
     const involved = rows.map(normalizeInvolved);
     return { event, involved };
+  }
+
+  /**
+   *
+   * @param {CentrelineType} centrelineType - type of centreline feature
+   * @param {number} centrelineId - ID of centreline feature
+   */
+  static async byCentreline(centrelineType, centrelineId) {
+    const params = { centrelineId, centrelineType };
+    const filters = [
+      'ec.centreline_id = $(centrelineId)',
+      'ec.centreline_type = $(centrelineType)',
+    ];
+    const sqlFilters = filters.join('\n  AND ');
+    const sqlEvents = `
+SELECT e.*
+FROM collisions.events e
+JOIN collisions.events_centreline ec ON e.collision_id = ec.collision_id
+WHERE ${sqlFilters}
+ORDER BY e.collision_id`;
+    const sqlInvolved = `
+SELECT i.*
+FROM collisions.involved i
+JOIN collisions.events_centreline ec ON i.collision_id = ec.collision_id
+WHERE ${sqlFilters}
+ORDER BY i.collision_id`;
+    const [rowsEvents, rowsInvolved] = await Promise.all([
+      db.manyOrNone(sqlEvents, params),
+      db.manyOrNone(sqlInvolved, params),
+    ]);
+    const events = rowsEvents.map(row => ({
+      ...normalizeEvent(row),
+      involved: [],
+    }));
+    let i = 0;
+    rowsInvolved.forEach((row) => {
+      const { collision_id: collisionId } = row;
+      while (events[i].collisionId < collisionId) {
+        i += 1;
+      }
+      if (events[i].collisionId === collisionId) {
+        const involved = normalizeInvolved(row);
+        events[i].involved.push(involved);
+      }
+    });
+    return events;
   }
 
   static async byCentrelineSummary(

--- a/lib/reports/ReportBaseCrash.js
+++ b/lib/reports/ReportBaseCrash.js
@@ -1,0 +1,61 @@
+/* eslint-disable class-methods-use-this */
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import CollisionDAO from '@/lib/db/CollisionDAO';
+import {
+  InvalidCentrelineTypeError,
+  InvalidReportIdError,
+} from '@/lib/error/MoveErrors';
+import ReportBase from '@/lib/reports/ReportBase';
+
+/**
+ * Base class for all CRASH-related reports, i.e. those reports that deal with collision data.
+ */
+class ReportBaseCrash extends ReportBase {
+  /**
+   * Parses an ID in the format `{centrelineType}/{centrelineId}`, and returns it
+   * as a location from {@link CentrelineDAO} for further processing.
+   *
+   * @param {string} rawId - ID to parse
+   * @throws {InvalidReportIdError}
+   */
+  async parseId(rawId) {
+    const parts = rawId.split('/');
+    if (parts.length !== 2) {
+      throw new InvalidReportIdError(rawId);
+    }
+
+    let centrelineType = parts.shift();
+    centrelineType = parseInt(centrelineType, 10);
+    if (Number.isNaN(centrelineType)) {
+      throw new InvalidReportIdError(rawId);
+    }
+
+    let centrelineId = parts.shift();
+    centrelineId = parseInt(centrelineId, 10);
+    if (Number.isNaN(centrelineId)) {
+      throw new InvalidReportIdError(rawId);
+    }
+
+    try {
+      const location = await CentrelineDAO.byIdAndType(centrelineId, centrelineType);
+      if (location === null) {
+        throw new InvalidReportIdError(rawId);
+      }
+      return location;
+    } catch (err) {
+      if (err instanceof InvalidCentrelineTypeError) {
+        throw new InvalidReportIdError(rawId);
+      }
+      throw err;
+    }
+  }
+
+  async fetchRawData(location) {
+    const { centrelineId, centrelineType } = location;
+    return CollisionDAO.byCentreline(centrelineType, centrelineId);
+  }
+
+  // TODO: metadata blocks?
+}
+
+export default ReportBaseCrash;

--- a/lib/reports/ReportCollisionDirectory.js
+++ b/lib/reports/ReportCollisionDirectory.js
@@ -1,0 +1,23 @@
+/* eslint-disable class-methods-use-this */
+import { ReportType } from '@/lib/Constants';
+import ReportBaseCrash from '@/lib/reports/ReportBaseCrash';
+
+class ReportCollisionDirectory extends ReportBaseCrash {
+  type() {
+    return ReportType.COLLISION_DIRECTORY;
+  }
+
+  transformData(/* location, collisions, filters */) {
+    // TODO: implement this
+  }
+
+  generateCsv(/* location, filteredCollisions */) {
+    // TODO: implement this
+  }
+
+  generateLayoutContent(/* location, filteredCollisions */) {
+    // TODO: implement this
+  }
+}
+
+export default ReportCollisionDirectory;

--- a/lib/reports/ReportCollisionTabulation.js
+++ b/lib/reports/ReportCollisionTabulation.js
@@ -1,0 +1,19 @@
+/* eslint-disable class-methods-use-this */
+import { ReportType } from '@/lib/Constants';
+import ReportBaseCrash from '@/lib/reports/ReportBaseCrash';
+
+class ReportCollisionTabulation extends ReportBaseCrash {
+  type() {
+    return ReportType.COLLISION_TABULATION;
+  }
+
+  transformData(/* location, collisions, filters */) {
+    // TODO: implement this
+  }
+
+  generateLayoutContent(/* location, filteredCollisions */) {
+    // TODO: implement this
+  }
+}
+
+export default ReportCollisionTabulation;

--- a/lib/reports/ReportFactory.js
+++ b/lib/reports/ReportFactory.js
@@ -1,4 +1,6 @@
 import { InvalidReportTypeError } from '@/lib/error/MoveErrors';
+import ReportCollisionDirectory from '@/lib/reports/ReportCollisionDirectory';
+import ReportCollisionTabulation from '@/lib/reports/ReportCollisionTabulation';
 import ReportCountSummary24h from '@/lib/reports/ReportCountSummary24h';
 import ReportCountSummary24hDetailed from '@/lib/reports/ReportCountSummary24hDetailed';
 import ReportCountSummary24hGraphical from '@/lib/reports/ReportCountSummary24hGraphical';
@@ -44,6 +46,8 @@ class ReportFactory {
  */
 ReportFactory.instances = new Map();
 
+ReportFactory.registerInstance(new ReportCollisionDirectory());
+ReportFactory.registerInstance(new ReportCollisionTabulation());
 ReportFactory.registerInstance(new ReportCountSummary24h());
 ReportFactory.registerInstance(new ReportCountSummary24hDetailed());
 ReportFactory.registerInstance(new ReportCountSummary24hGraphical());

--- a/web/components/FcDataTableCollisions.vue
+++ b/web/components/FcDataTableCollisions.vue
@@ -1,30 +1,18 @@
 <template>
   <FcDataTable
-    class="fc-data-table-studies"
+    class="fc-data-table-collisions"
     :columns="columns"
     disable-sort
     :loading="loading"
-    :items="countSummary">
-    <template v-slot:item.STUDY_REPORTS="{ item }">
-      <span>{{item.count.type.studyType.label}}</span>
-      <span
-        v-if="item.numPerCategory > 1"
-        class="secondary--text">
-        &#x2022; {{item.numPerCategory}}
-      </span>
+    :items="[collisionSummary]">
+    <template v-slot:item.AMOUNT="{ item }">
+      <span>{{item.total}}</span>
     </template>
-    <template v-slot:item.DATE="{ item }">
-      <span>
-        {{item.count.date | date}} ({{item.count.date | dayOfWeek}})
-      </span>
+    <template v-slot:item.KSI="{ item }">
+      <span>{{item.ksi}}</span>
     </template>
-    <template v-slot:item.HOURS="{ item }">
-      <span v-if="item.count.type.studyType.automatic">
-        {{item.count.duration | durationHuman}} ({{item.count.duration}} hrs)
-      </span>
-      <span v-else>
-        {{item.count.hours}}
-      </span>
+    <template v-slot:item.VALIDATED="{ item }">
+      <span>{{item.ksi}}</span>
     </template>
     <template v-slot:header.VIEW_REPORT>
       <span class="sr-only">Reports</span>
@@ -44,13 +32,13 @@ import FcDataTable from '@/web/components/FcDataTable.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 
 export default {
-  name: 'FcDataTableStudies',
+  name: 'FcDataTableCollisions',
   components: {
     FcButton,
     FcDataTable,
   },
   props: {
-    countSummary: Array,
+    collisionSummary: Object,
     loading: {
       type: Boolean,
       default: false,
@@ -58,14 +46,14 @@ export default {
   },
   data() {
     const columns = [{
-      value: 'STUDY_REPORTS',
-      text: 'Study Reports',
+      value: 'AMOUNT',
+      text: 'Amount',
     }, {
-      value: 'DATE',
-      text: 'Most Recent Date',
+      value: 'KSI',
+      text: 'KSI',
     }, {
-      value: 'HOURS',
-      text: 'Most Recent Hours',
+      value: 'VALIDATED',
+      text: 'Validated',
     }, {
       align: 'end',
       value: 'VIEW_REPORT',
@@ -79,7 +67,7 @@ export default {
 </script>
 
 <style lang="scss">
-.fc-data-table-studies {
+.fc-data-table-collisions {
   & th:first-child,
   & td:first-child {
     padding-left: 20px;

--- a/web/components/FcDataTableCollisions.vue
+++ b/web/components/FcDataTableCollisions.vue
@@ -12,7 +12,7 @@
       <span>{{item.ksi}}</span>
     </template>
     <template v-slot:item.VALIDATED="{ item }">
-      <span>{{item.ksi}}</span>
+      <span>{{item.validated}}</span>
     </template>
     <template v-slot:header.VIEW_REPORT>
       <span class="sr-only">Reports</span>

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -1,0 +1,304 @@
+<template>
+  <div class="fc-drawer-view-collision-reports d-flex flex-column">
+    <FcDialogConfirm
+      v-model="showConfirmLeave"
+      textCancel="Stay on this page"
+      textOk="Leave"
+      title="Leave Reports"
+      @action-ok="actionLeave">
+      <span class="body-1">
+        Leaving this page will cause you to switch to another location.
+        Are you sure you want to leave?
+      </span>
+    </FcDialogConfirm>
+    <v-progress-linear
+      v-if="loading"
+      indeterminate />
+    <template v-else>
+      <div>
+        <div class="align-center d-flex flex-grow-0 flex-shrink-0 px-3 pt-2">
+          <FcButton
+            type="secondary"
+            @click="actionNavigateBack">
+            <v-icon left>mdi-chevron-left</v-icon>
+            View Data
+          </FcButton>
+          <h1 class="headline ml-4">Collisions</h1>
+          <div
+            class="ml-1 font-weight-regular headline secondary--text">
+            <span>&#x2022; {{location.description}}</span>
+            <span v-if="filterChipsCollision.length > 0"> &#x2022;</span>
+          </div>
+          <div
+            v-if="filterChipsCollision.length > 0">
+            <v-chip
+              v-for="(filterChip, i) in filterChipsCollision"
+              :key="i"
+              class="ml-2 my-1"
+              filter
+              :input-value="true">
+              {{filterChip.label}}
+            </v-chip>
+          </div>
+        </div>
+
+        <v-tabs v-model="indexActiveReportType">
+          <v-tab
+            v-for="reportType in reportTypes"
+            :key="reportType.name">
+            {{reportType.label}}
+          </v-tab>
+        </v-tabs>
+        <v-divider></v-divider>
+      </div>
+
+      <section class="flex-grow-1 flex-shrink-1 overflow-y-auto pt-2">
+        <v-progress-circular
+          v-if="loadingReportLayout"
+          class="ma-3"
+          color="primary"
+          indeterminate
+          size="64" />
+        <div
+          v-else
+          class="fc-report-wrapper pa-3">
+          <FcReport v-bind="reportLayout" />
+          <div class="fc-report-actions pa-3">
+            <v-menu>
+              <template v-slot:activator="{ on, attrs }">
+                <FcButton
+                  v-bind="attrs"
+                  v-on="on"
+                  class="ml-2"
+                  type="secondary"
+                  :loading="loadingDownload">
+                  <v-icon color="primary" left>mdi-cloud-download</v-icon> Download
+                </FcButton>
+              </template>
+              <v-list>
+                <v-list-item
+                  v-for="{ label, value } in itemsDownloadFormats"
+                  :key="value"
+                  @click="actionDownload(value)">
+                  <v-list-item-title>
+                    {{label}}
+                  </v-list-item-title>
+                </v-list-item>
+              </v-list>
+            </v-menu>
+          </div>
+        </div>
+      </section>
+    </template>
+  </div>
+</template>
+
+<script>
+import { saveAs } from 'file-saver';
+import { mapGetters, mapMutations, mapState } from 'vuex';
+
+import { ReportFormat, ReportType } from '@/lib/Constants';
+import { reporterFetch } from '@/lib/api/BackendClient';
+import {
+  getLocationByFeature,
+} from '@/lib/api/WebApi';
+import FcDialogConfirm from '@/web/components/dialogs/FcDialogConfirm.vue';
+import FcButton from '@/web/components/inputs/FcButton.vue';
+import FcReport from '@/web/components/reports/FcReport.vue';
+import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
+
+const DOWNLOAD_FORMATS_SUPPORTED = [
+  ReportFormat.CSV,
+  ReportFormat.PDF,
+];
+
+export default {
+  name: 'FcDrawerViewReports',
+  mixins: [FcMixinRouteAsync],
+  components: {
+    FcButton,
+    FcDialogConfirm,
+    FcReport,
+  },
+  data() {
+    return {
+      indexActiveReportType: 0,
+      leaveConfirmed: false,
+      loadingDownload: false,
+      loadingReportLayout: false,
+      nextRoute: null,
+      reportLayout: null,
+      reportTypes: [
+        ReportType.COLLISION_TABULATION,
+        ReportType.COLLISION_DIRECTORY,
+      ],
+      showConfirmLeave: false,
+    };
+  },
+  computed: {
+    activeReportType() {
+      const { indexActiveReportType, reportTypes } = this;
+      if (indexActiveReportType >= reportTypes.length) {
+        return null;
+      }
+      return reportTypes[indexActiveReportType];
+    },
+    itemsDownloadFormats() {
+      if (this.downloadLoading || this.loadingReportLayout) {
+        return [];
+      }
+      return DOWNLOAD_FORMATS_SUPPORTED
+        .filter(reportFormat => this.activeReportType.formats.includes(reportFormat))
+        .map(({ name }) => ({ label: name, value: name }));
+    },
+    reportParameters() {
+      // TODO: we'll probably have to figure this one out...
+      return {};
+    },
+    ...mapState(['location']),
+    ...mapGetters('viewData', ['filterChipsCollision']),
+  },
+  watch: {
+    activeReportType() {
+      this.updateReportLayout();
+    },
+  },
+  beforeRouteLeave(to, from, next) {
+    if (this.leaveConfirmed) {
+      /*
+       * The user clicked Leave on the confirmation dialog, and it is safe to leave.
+       */
+      next();
+      return;
+    }
+    const { centrelineId, centrelineType } = from.params;
+    const { name } = to;
+    if (name === 'viewDataAtLocation') {
+      const { centrelineId: nextCentrelineId, centrelineType: nextCentrelineType } = to.params;
+      if (centrelineType === nextCentrelineType && centrelineId === nextCentrelineId) {
+        next();
+        return;
+      }
+    }
+    this.nextRoute = to;
+    this.showConfirmLeave = true;
+    next(false);
+  },
+  methods: {
+    async actionDownload(format) {
+      const { activeReportType, reportParameters } = this;
+      if (activeReportType === null) {
+        return;
+      }
+      this.downloadLoading = true;
+
+      const type = activeReportType;
+      const { centrelineId, centrelineType } = this.$route.params;
+      const id = `${centrelineType}/${centrelineId}`;
+      const options = {
+        method: 'GET',
+        data: {
+          type,
+          id,
+          format,
+          ...reportParameters,
+        },
+      };
+
+      const reportData = await reporterFetch('/reports', options);
+      const filename = `report.${format}`;
+      saveAs(reportData, filename);
+
+      this.downloadLoading = false;
+    },
+    actionLeave() {
+      this.leaveConfirmed = true;
+      this.$router.push(this.nextRoute);
+    },
+    actionNavigateBack() {
+      const { centrelineId, centrelineType } = this.$route.params;
+      this.$router.push({
+        name: 'viewDataAtLocation',
+        params: { centrelineId, centrelineType },
+      });
+    },
+    async loadAsyncForRoute(to) {
+      const { centrelineId, centrelineType } = to.params;
+      const tasks = [
+        getLocationByFeature({ centrelineId, centrelineType }),
+      ];
+      const [location] = await Promise.all(tasks);
+
+      if (this.location === null
+          || location.centrelineId !== this.location.centrelineId
+          || location.centrelineType !== this.location.centrelineType
+          || location.description !== this.location.description) {
+        this.setLocation(location);
+      }
+    },
+    async updateReportLayout() {
+      const { activeReportType } = this;
+      if (activeReportType === null) {
+        return;
+      }
+      this.loadingReportLayout = true;
+
+      /*
+      const { name: type } = activeReportType;
+      const { centrelineId, centrelineType } = this.$route.params;
+      const id = `${centrelineType}/${centrelineId}`;
+      const options = {
+        method: 'GET',
+        data: {
+          type,
+          id,
+          format: ReportFormat.WEB,
+          ...reportParameters,
+        },
+      };
+
+      const {
+        type: reportTypeStr,
+        date: reportDate,
+        content,
+      } = await reporterFetch('/reports', options);
+      const reportType = ReportType.enumValueOf(reportTypeStr);
+      const reportContent = content.map(({ type: blockTypeStr, options: blockOptions }) => {
+        const blockType = ReportBlock.enumValueOf(blockTypeStr);
+        return {
+          type: blockType,
+          options: blockOptions,
+        };
+      });
+      this.reportLayout = {
+        type: reportType,
+        date: reportDate,
+        content: reportContent,
+      };
+      */
+
+      this.loadingReportLayout = false;
+    },
+    ...mapMutations(['setLocation']),
+  },
+};
+</script>
+
+<style lang="scss">
+.fc-drawer-view-collision-reports {
+  max-height: 50vh;
+
+  .fc-report-wrapper {
+    position: relative;
+    & > .fc-report-actions {
+      position: absolute;
+      top: 0;
+      right: 0;
+    }
+  }
+}
+
+.drawer-open .fc-drawer-view-reports {
+  max-height: 100vh;
+}
+</style>

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="fc-drawer-view-data d-flex flex-column">
-    <div class="flex-grow-0 flex-shrink-0 pa-5 shading">
+    <div class="flex-grow-0 flex-shrink-0 pa-5">
       <FcSearchBarLocation />
     </div>
     <section class="flex-grow-1 flex-shrink-1 overflow-y-auto">
@@ -8,42 +8,18 @@
         v-if="loading"
         indeterminate />
       <template v-else>
-        <header class="px-5 pt-1 pb-5 shading">
-          <h1 class="display-3">{{location.description}}</h1>
-          <div class="label mt-1">
+        <header class="px-5 pt-1 pb-5">
+          <h1
+            class="display-3 text-truncate"
+            :title="location.description">
+            {{location.description}}
+          </h1>
+          <div class="label mt-5">
             <span v-if="locationFeatureType !== null">
               {{locationFeatureType.description}} &#x2022;
             </span>
             <span>{{countSummaryHeaderText}}</span>
           </div>
-          <v-row class="mt-4">
-            <v-col cols="2">
-              <div class="label mb-1">KSI</div>
-              <v-progress-circular
-                v-if="loadingCollisions"
-                color="primary"
-                indeterminate
-                size="27" />
-              <div
-                v-else
-                class="display-2">
-                {{collisionSummary.ksi}}
-              </div>
-            </v-col>
-            <v-col cols="2">
-              <div class="label mb-1">Collisions</div>
-              <v-progress-circular
-                v-if="loadingCollisions"
-                color="primary"
-                indeterminate
-                size="27" />
-              <div
-                v-else
-                class="display-2">
-                {{collisionSummary.total}}
-              </div>
-            </v-col>
-          </v-row>
           <div class="mt-4">
             <div class="label mb-1">Nearby</div>
             <div>
@@ -89,7 +65,55 @@
             </div>
           </div>
         </header>
+
         <v-divider></v-divider>
+
+        <section class="shading">
+          <header class="pa-5">
+            <div class="align-center d-flex">
+              <h2 class="headline">Collisions</h2>
+              <div class="pl-3 subtitle-1">{{collisionSummary.total}} total</div>
+              <v-spacer></v-spacer>
+              <FcDialogCollisionFilters
+                v-if="showFiltersCollision"
+                v-model="showFiltersCollision"
+                v-bind="filtersCollision"
+                @set-filters="setFiltersCollision">
+              </FcDialogCollisionFilters>
+              <FcButton
+                type="secondary"
+                @click.stop="showFiltersCollision = true">
+                <v-icon
+                  :color="colorIconFilterCollision"
+                  left>mdi-filter-variant</v-icon>
+                Filter
+              </FcButton>
+            </div>
+
+            <div
+              v-if="filterChipsCollision.length > 0"
+              class="mt-5">
+              <v-chip
+                v-for="(filterChip, i) in filterChipsCollision"
+                :key="i"
+                class="mb-2 mr-2 primary--text"
+                color="light-blue lighten-5"
+                @click="removeFilterCollision(filterChip)">
+                <v-icon left>mdi-check</v-icon>
+                {{filterChip.label}}
+              </v-chip>
+            </div>
+          </header>
+
+          <FcDataTableCollisions
+            class="shading"
+            :collision-summary="collisionSummary"
+            :loading="loadingCollisions"
+            @show-reports="actionShowReportsCollision" />
+        </section>
+
+        <v-divider></v-divider>
+
         <section>
           <header class="pa-5">
             <div class="align-center d-flex">
@@ -188,7 +212,9 @@ import {
 import ArrayStats from '@/lib/math/ArrayStats';
 import DateTime from '@/lib/time/DateTime';
 import TimeFormatters from '@/lib/time/TimeFormatters';
+import FcDataTableCollisions from '@/web/components/FcDataTableCollisions.vue';
 import FcDataTableStudies from '@/web/components/FcDataTableStudies.vue';
+import FcDialogCollisionFilters from '@/web/components/dialogs/FcDialogCollisionFilters.vue';
 import FcDialogStudyFilters from '@/web/components/dialogs/FcDialogStudyFilters.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcSearchBarLocation from '@/web/components/inputs/FcSearchBarLocation.vue';
@@ -203,7 +229,9 @@ export default {
   ],
   components: {
     FcButton,
+    FcDataTableCollisions,
     FcDataTableStudies,
+    FcDialogCollisionFilters,
     FcDialogStudyFilters,
     FcSearchBarLocation,
   },
@@ -220,12 +248,19 @@ export default {
         school: null,
       },
       showFilters: false,
+      showFiltersCollision: false,
       studyRequestsPending: [],
     };
   },
   computed: {
     colorIconFilter() {
       if (this.filterChips.length === 0) {
+        return 'unselected';
+      }
+      return 'primary';
+    },
+    colorIconFilterCollision() {
+      if (this.filterChipsCollision.length === 0) {
         return 'unselected';
       }
       return 'primary';
@@ -255,9 +290,13 @@ export default {
       }
       return `${n} total`;
     },
-    ...mapState('viewData', ['filters']),
+    ...mapState('viewData', ['filters', 'filtersCollision']),
     ...mapState(['auth', 'legendOptions', 'location']),
-    ...mapGetters('viewData', ['filterChips', 'filterParams']),
+    ...mapGetters('viewData', [
+      'filterChips',
+      'filterChipsCollision',
+      'filterParams',
+    ]),
     ...mapGetters(['locationFeatureType']),
   },
   watch: {
@@ -344,6 +383,9 @@ export default {
         params,
       });
     },
+    actionShowReportsCollision() {
+      // TODO: implement this
+    },
     async loadAsyncForRoute(to) {
       const { datesFrom } = this.legendOptions;
       const { centrelineId, centrelineType } = to.params;
@@ -389,6 +431,7 @@ export default {
     ...mapMutations('viewData', [
       'removeFilter',
       'setFilters',
+      'setFiltersCollision',
     ]),
     ...mapMutations([
       'setFilterCountTypes',

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -384,7 +384,15 @@ export default {
       });
     },
     actionShowReportsCollision() {
-      // TODO: implement this
+      const { centrelineId, centrelineType } = this.$route.params;
+      const params = {
+        centrelineId,
+        centrelineType,
+      };
+      this.$router.push({
+        name: 'viewCollisionReportsAtLocation',
+        params,
+      });
     },
     async loadAsyncForRoute(to) {
       const { datesFrom } = this.legendOptions;

--- a/web/components/dialogs/FcDialogCollisionFilters.vue
+++ b/web/components/dialogs/FcDialogCollisionFilters.vue
@@ -1,0 +1,68 @@
+<template>
+  <v-dialog
+    v-model="internalValue"
+    max-width="336"
+    scrollable>
+    <v-card role="dialog">
+      <v-card-title>
+        <h1 class="headline">Filter</h1>
+        <v-spacer></v-spacer>
+        <FcButton
+          type="secondary"
+          @click="actionClearAll">
+          Clear All
+        </FcButton>
+      </v-card-title>
+      <v-divider></v-divider>
+      <v-card-text>
+        <h2 class="body-1 mt-4">TODO: Filters</h2>
+      </v-card-text>
+      <v-divider></v-divider>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <FcButton
+          type="tertiary"
+          @click="internalValue = false">
+          Cancel
+        </FcButton>
+        <FcButton
+          type="tertiary"
+          @click="actionSave">
+          Save
+        </FcButton>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import FcButton from '@/web/components/inputs/FcButton.vue';
+import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+
+export default {
+  name: 'FcDialogCollisionFilters',
+  mixins: [FcMixinVModelProxy(Boolean)],
+  components: {
+    FcButton,
+  },
+  props: {
+    // TODO: filters here
+  },
+  computed: {
+    internalFilters() {
+      return {
+        // TODO: filters here
+      };
+    },
+  },
+  methods: {
+    actionClearAll() {
+      // TODO: set filters to default values
+    },
+    actionSave() {
+      this.$emit('set-filters', this.internalFilters);
+      this.internalValue = false;
+    },
+  },
+};
+</script>

--- a/web/router.js
+++ b/web/router.js
@@ -94,11 +94,24 @@ const router = new Router({
           next();
         },
       }, {
+        path: '/view/location/:centrelineType/:centrelineId/reports/collision',
+        name: 'viewCollisionReportsAtLocation',
+        meta: {
+          auth: { mode: 'try' },
+          title: 'View Collision Reports',
+          vertical: true,
+        },
+        component: () => import(/* webpackChunkName: "home" */ '@/web/components/FcDrawerViewCollisionReports.vue'),
+        beforeEnter(to, from, next) {
+          store.commit('setDrawerOpen', false);
+          next();
+        },
+      }, {
         path: '/view/location/:centrelineType/:centrelineId/reports/:studyTypeName',
         name: 'viewReportsAtLocation',
         meta: {
           auth: { mode: 'try' },
-          title: 'View Reports',
+          title: 'View Study Reports',
           vertical: true,
         },
         component: () => import(/* webpackChunkName: "home" */ '@/web/components/FcDrawerViewReports.vue'),

--- a/web/store/modules/viewData.js
+++ b/web/store/modules/viewData.js
@@ -9,6 +9,9 @@ export default {
       hours: [],
       studyTypes: [],
     },
+    filtersCollision: {
+      // TODO: filters here
+    },
   },
   getters: {
     filterChips(state) {
@@ -41,6 +44,9 @@ export default {
         filterChips.push(filterChip);
       });
       return filterChips;
+    },
+    filterChipsCollision(/* state */) {
+      return [];
     },
     filterParams(state, getters, rootState) {
       const {
@@ -79,8 +85,14 @@ export default {
         }
       }
     },
+    removeFilterCollision(/* state, { filter, value } */) {
+      // TODO: implement this
+    },
     setFilters(state, filters) {
       state.filters = filters;
+    },
+    setFiltersCollision(state, filtersCollision) {
+      state.filtersCollision = filtersCollision;
     },
   },
 };


### PR DESCRIPTION
# Issue Addressed
This PR closes #440 .

# Description
We break the collisions summary in View Data out into its own section with buttons for filtering and viewing reports.  The "View Reports" button links to a new route / page with a report drawer for collision reports.

We also start stubbing out the backend pieces of these new report types, from `ReportType` entries to their corresponding layout generators in MOVE Reporter (i.e. `@/lib/reports`).

# Tests
Pre-commit tests pass.  Ran frontend / backend and quickly checked that new UI components show as expected.  (We'll be testing this more and more rigorously as we get pieces of this functionality working end-to-end.)
