### PR TITLE
Update event-level rollups to match legacy views

### DIFF
--- a/scripts/airflow/tasks/crash_geocoding/A1_events_fields_raw.sql
+++ b/scripts/airflow/tasks/crash_geocoding/A1_events_fields_raw.sql
@@ -33,7 +33,7 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS collisions.events_fields_raw AS (
       --max("SENT_DATE") AS sent_date,
       --max("STATUS") AS status,
       --max("CITY_AREA") AS city_area,
-      --max("COMMENTS") AS comments,
+      max("COMMENTS") AS comments,
       --max("MTP_DIVISION") AS mtp_division,
       --max("POLICE_AGENCY") AS police_agency,
       --max("SUBMIT_BADGE_NUMBER") AS submit_badge_number,

--- a/scripts/airflow/tasks/crash_geocoding/A3_events_fields_norm.sql
+++ b/scripts/airflow/tasks/crash_geocoding/A3_events_fields_norm.sql
@@ -22,6 +22,7 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS collisions.events_fields_norm AS (
     CASE WHEN light IS NULL OR trim(light) = '' THEN NULL ELSE light::smallint END AS light,
     CASE WHEN rdsfcond IS NULL OR trim(rdsfcond) = '' THEN NULL ELSE rdsfcond::smallint END AS rdsfcond,
     changed,
+    CASE WHEN comments IS NULL OR trim(comments) = '' THEN NULL ELSE comments END AS comments,
     CASE WHEN private_property = 'Y' THEN TRUE ELSE FALSE END AS private_property,
     CASE WHEN road_class IS NULL OR trim(road_class) = '' THEN NULL ELSE road_class END AS road_class,
     mvaimg,

--- a/scripts/airflow/tasks/crash_geocoding/A4_events.sql
+++ b/scripts/airflow/tasks/crash_geocoding/A4_events.sql
@@ -4,14 +4,33 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS collisions.events AS (
   WITH involved_vision_zero AS (
     SELECT
       collision_id,
-      count(*) FILTER (WHERE drivact IN (2, 3, 4, 7, 8, 9)) AS aggressive,
+      count(*) FILTER (
+        WHERE drivact IN (2, 3, 4, 7, 8, 9)
+        OR actual_speed > posted_speed
+      ) AS aggressive,
       count(*) FILTER (WHERE invage >= 4 AND invage <= 19) AS child,
-      count(*) FILTER (WHERE invtype = 4) AS cyclist,
+      count(*) FILTER (
+        WHERE invtype IN (4, 5, 8, 9)
+        OR vehtype IN (3, 36)
+      ) AS cyclist,
       count(*) FILTER (WHERE injury >= 3) AS ksi,
-      count(*) FILTER (WHERE vehtype IN (2, 3)) AS motorcyclist,
+      count(*) FILTER (
+        WHERE vehtype IN (2, 3)
+        OR invtype IN (6, 7)
+      ) AS motorcyclist,
       count(*) FILTER (WHERE invage >= 55) AS older_adult,
-      count(*) FILTER (WHERE invtype = 3) AS pedestrian,
-      count(*) FILTER (WHERE drivact IN (3, 4) OR actual_speed > posted_speed) AS speeding
+      count(*) FILTER (
+        WHERE invtype IN (3, 17, 19)
+      ) AS pedestrian,
+      count(*) FILTER (
+        WHERE (event1 BETWEEN 50 AND 66)
+        OR (event2 BETWEEN 50 AND 66)
+        OR (event3 BETWEEN 50 AND 66)
+      ) AS property_damage,
+      count(*) FILTER (
+        WHERE drivact IN (3, 4)
+        OR actual_speed > posted_speed
+      ) AS speeding
     FROM collisions.involved
     GROUP BY collision_id
   )
@@ -23,7 +42,14 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS collisions.events AS (
     CASE WHEN ivz.motorcyclist > 0 THEN TRUE ELSE FALSE END AS motorcyclist,
     CASE WHEN ivz.older_adult > 0 THEN TRUE ELSE FALSE END AS older_adult,
     CASE WHEN ivz.pedestrian > 0 THEN TRUE ELSE FALSE END AS pedestrian,
-    CASE WHEN efn.acclass = 3 THEN TRUE ELSE FALSE END AS property_damage,
+    -- for property damage, filter to public property and check for property damage in comments
+    CASE
+      WHEN efn.private_property THEN FALSE
+      WHEN ivz.property_damage > 0 THEN TRUE
+      WHEN efn.comments LIKE '%Property Damage:%' THEN TRUE
+      ELSE FALSE
+    END AS property_damage,
+    -- for schoolchildren, filter (roughly) to school days
     CASE
       WHEN ivz.child = 0 THEN FALSE
       WHEN date_part('DOW', efn.accdate) IN (0, 6) THEN FALSE


### PR DESCRIPTION
# Issue Addressed
This PR closes #456 .

# Description
We noticed a mismatch between legacy views and the `crash_geocoding` pipeline in terms of relating collisions to various Vision Zero emphasis areas and other City processes.

Fixing those here.

# Tests
Ran end-to-end via Airflow.  Regenerated dev dataset, copied to local dev environment, ran MOVE and quickly checked that nothing breaks.
