### PR TITLE
Collision report stubs with summary header

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -212,6 +212,8 @@ MapZoom.init({
 MapZoom.MIN = MapZoom.LEVEL_3.minzoom;
 MapZoom.MAX = MapZoom.LEVEL_1.maxzoomSource;
 
+const ORG_NAME = 'Transportation Services';
+
 /**
  * Page orientations for printed documents.  Used by {@link FormatGenerator.pdf} to
  * render reports to pages, but can be used anywhere you want to print something.
@@ -953,6 +955,7 @@ const Constants = {
   FeatureCode,
   HttpStatus,
   MapZoom,
+  ORG_NAME,
   PageOrientation,
   POI_RADIUS,
   PT_PER_IN,
@@ -988,6 +991,7 @@ export {
   FeatureCode,
   HttpStatus,
   MapZoom,
+  ORG_NAME,
   PageOrientation,
   POI_RADIUS,
   PT_PER_IN,

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -261,8 +261,8 @@ ReportBlock.init({
   BAR_CHART: {
     suffix: 'BarChart',
   },
-  COUNT_METADATA: {
-    suffix: 'CountMetadata',
+  METADATA: {
+    suffix: 'Metadata',
   },
   TABLE: {
     suffix: 'Table',

--- a/lib/controller/CollisionController.js
+++ b/lib/controller/CollisionController.js
@@ -1,66 +1,10 @@
 import Boom from '@hapi/boom';
 
-import {
-  CentrelineType,
-  CollisionEmphasisArea,
-  CollisionRoadSurfaceCondition,
-} from '@/lib/Constants';
 import CollisionDAO from '@/lib/db/CollisionDAO';
 import CollisionEvent from '@/lib/model/CollisionEvent';
+import CollisionFilters from '@/lib/model/CollisionFilters';
 import Joi from '@/lib/model/Joi';
-import TimeFormatters from '@/lib/time/TimeFormatters';
-
-const DAYS_OF_WEEK_ALL = TimeFormatters.DAYS_OF_WEEK.map((_, i) => i);
-
-const COLLISION_QUERY = {
-  centrelineId: Joi.number().integer().positive().required(),
-  centrelineType: Joi.number().valid(
-    CentrelineType.SEGMENT,
-    CentrelineType.INTERSECTION,
-  ).required(),
-  dateRangeEnd: Joi.dateTime().optional(),
-  dateRangeStart: Joi.dateTime().optional(),
-  daysOfWeek: Joi.array().single().items(
-    Joi.number().valid(...DAYS_OF_WEEK_ALL).required(),
-  ).default(null),
-  emphasisAreas: Joi.array().single().items(
-    Joi.enum().ofType(CollisionEmphasisArea).required(),
-  ).default(null),
-  hoursOfDayEnd: Joi.number().integer().min(0).optional(),
-  hoursOfDayStart: Joi.number().integer().min(0).optional(),
-  roadSurfaceConditions: Joi.array().single().items(
-    Joi.enum().ofType(CollisionRoadSurfaceCondition).required(),
-  ).default(null),
-};
-
-function normalizeCollisionQuery(collisionQuery) {
-  const {
-    dateRangeEnd,
-    dateRangeStart,
-    hoursOfDayEnd,
-    hoursOfDayStart,
-    ...collisionQueryRest
-  } = collisionQuery;
-  let dateRange = null;
-  if (dateRangeStart !== undefined && dateRangeEnd !== undefined) {
-    if (dateRangeStart.valueOf() > dateRangeEnd.valueOf()) {
-      throw Boom.badRequest('invalid date range: start is after end');
-    }
-    dateRange = { start: dateRangeStart, end: dateRangeEnd };
-  }
-  let hoursOfDay = null;
-  if (hoursOfDayStart !== undefined && hoursOfDayEnd !== undefined) {
-    if (hoursOfDayStart > hoursOfDayEnd) {
-      throw Boom.badRequest('invalid hours of day: start is after end');
-    }
-    hoursOfDay = [hoursOfDayStart, hoursOfDayEnd];
-  }
-  return {
-    ...collisionQueryRest,
-    dateRange,
-    hoursOfDay,
-  };
-}
+import CentrelineFeature from '@/lib/model/helpers/CentrelineFeature';
 
 /**
  * Routes related to collisions data.
@@ -114,13 +58,13 @@ CollisionController.push({
       schema: Joi.array().items(CollisionEvent.read),
     },
     validate: {
-      query: COLLISION_QUERY,
+      query: {
+        ...CentrelineFeature,
+        ...CollisionFilters,
+      },
     },
   },
-  handler: async (request) => {
-    const collisionQuery = normalizeCollisionQuery(request.query);
-    return CollisionDAO.byCentreline(collisionQuery);
-  },
+  handler: async request => CollisionDAO.byCentreline(request.query),
 });
 
 /**
@@ -141,13 +85,7 @@ CollisionController.push({
       },
     },
     validate: {
-      query: {
-        centrelineId: Joi.number().integer().positive().required(),
-        centrelineType: Joi.number().valid(
-          CentrelineType.SEGMENT,
-          CentrelineType.INTERSECTION,
-        ).required(),
-      },
+      query: CentrelineFeature,
     },
   },
   handler: async (request) => {
@@ -176,13 +114,13 @@ CollisionController.push({
       },
     },
     validate: {
-      query: COLLISION_QUERY,
+      query: {
+        ...CentrelineFeature,
+        ...CollisionFilters,
+      },
     },
   },
-  handler: async (request) => {
-    const collisionQuery = normalizeCollisionQuery(request.query);
-    return CollisionDAO.byCentrelineSummary(collisionQuery);
-  },
+  handler: async request => CollisionDAO.byCentrelineSummary(request.query),
 });
 
 export default CollisionController;

--- a/lib/controller/ReportController.js
+++ b/lib/controller/ReportController.js
@@ -7,6 +7,7 @@ import {
   ReportType,
 } from '@/lib/Constants';
 import { EnumValueError } from '@/lib/error/MoveErrors';
+import CollisionFilters from '@/lib/model/CollisionFilters';
 import Joi from '@/lib/model/Joi';
 import ReportFactory from '@/lib/reports/ReportFactory';
 
@@ -51,7 +52,12 @@ function getSchemaForReportParameter(reportParameter) {
  *
  * @param {ReportType} reportType - type of report to get parameter schema for
  */
-function getSchemaForReportType({ options = {} }) {
+function getSchemaForReportType(reportType) {
+  if (reportType === ReportType.COLLISION_DIRECTORY
+    || reportType === ReportType.COLLISION_TABULATION) {
+    return Joi.object().keys(CollisionFilters);
+  }
+  const { options = {} } = reportType;
   const schema = {};
   Object.entries(options).forEach(([name, reportParameter]) => {
     const reportParameterSchema = getSchemaForReportParameter(reportParameter);

--- a/lib/db/CollisionDAO.js
+++ b/lib/db/CollisionDAO.js
@@ -1,5 +1,6 @@
 import { formatCombinedStreet } from '@/lib/StringFormatters';
 import db from '@/lib/db/db';
+import { InvalidCollisionQueryError } from '@/lib/error/MoveErrors';
 import CollisionEvent from '@/lib/model/CollisionEvent';
 import Joi from '@/lib/model/Joi';
 
@@ -63,6 +64,35 @@ const COLLISION_INVOLVED_FIELDS = `
   i.actual_speed AS "actualSpeed",
   i.posted_speed AS "postedSpeed"
   FROM collisions.involved i`;
+
+function normalizeCollisionQuery(collisionQuery) {
+  const {
+    dateRangeEnd,
+    dateRangeStart,
+    hoursOfDayEnd,
+    hoursOfDayStart,
+    ...collisionQueryRest
+  } = collisionQuery;
+  let dateRange = null;
+  if (dateRangeStart !== undefined && dateRangeEnd !== undefined) {
+    if (dateRangeStart.valueOf() > dateRangeEnd.valueOf()) {
+      throw new InvalidCollisionQueryError('invalid date range: start is after end');
+    }
+    dateRange = { start: dateRangeStart, end: dateRangeEnd };
+  }
+  let hoursOfDay = null;
+  if (hoursOfDayStart !== undefined && hoursOfDayEnd !== undefined) {
+    if (hoursOfDayStart > hoursOfDayEnd) {
+      throw new InvalidCollisionQueryError('invalid hours of day: start is after end');
+    }
+    hoursOfDay = [hoursOfDayStart, hoursOfDayEnd];
+  }
+  return {
+    ...collisionQueryRest,
+    dateRange,
+    hoursOfDay,
+  };
+}
 
 function normalizeCollisionEvent(event) {
   const {
@@ -176,7 +206,8 @@ class CollisionDAO {
   }
 
   static async byCentreline(collisionQuery) {
-    const { filters, params } = getCollisionFilters(collisionQuery);
+    const collisionQueryNormalized = normalizeCollisionQuery(collisionQuery);
+    const { filters, params } = getCollisionFilters(collisionQueryNormalized);
     const sqlFilters = filters.join('\n  AND ');
     const sqlEvents = `
 SELECT ${COLLISION_EVENTS_FIELDS}
@@ -196,7 +227,8 @@ ORDER BY i.collision_id`;
   }
 
   static async byCentrelineSummary(collisionQuery) {
-    const { filters, params } = getCollisionFilters(collisionQuery);
+    const collisionQueryNormalized = normalizeCollisionQuery(collisionQuery);
+    const { filters, params } = getCollisionFilters(collisionQueryNormalized);
     const sqlFilters = filters.join('\n  AND ');
     const sql = `
 SELECT

--- a/lib/error/MoveErrors.js
+++ b/lib/error/MoveErrors.js
@@ -34,6 +34,12 @@ class EnumValueError extends Error {}
 class InvalidCentrelineTypeError extends Error {}
 
 /**
+ * Thrown by {@link CollisionDAO} methods when passed an invalid collision
+ * query.
+ */
+class InvalidCollisionQueryError extends Error {}
+
+/**
  * Thrown by {@link FormatColors.var} for unknown variables.
  *
  * @memberof MoveErrors
@@ -97,6 +103,7 @@ const MoveErrors = {
   EnumInstantiationError,
   EnumValueError,
   InvalidCentrelineTypeError,
+  InvalidCollisionQueryError,
   InvalidCssVariableError,
   InvalidDynamicTileLayerError,
   InvalidOpenIdTokenError,
@@ -111,6 +118,7 @@ export {
   EnumInstantiationError,
   EnumValueError,
   InvalidCentrelineTypeError,
+  InvalidCollisionQueryError,
   InvalidCssVariableError,
   InvalidDynamicTileLayerError,
   InvalidOpenIdTokenError,

--- a/lib/model/CollisionFilters.js
+++ b/lib/model/CollisionFilters.js
@@ -1,0 +1,24 @@
+import {
+  CollisionEmphasisArea,
+  CollisionRoadSurfaceCondition,
+} from '@/lib/Constants';
+import Joi from '@/lib/model/Joi';
+import TimeFormatters from '@/lib/time/TimeFormatters';
+
+const DAYS_OF_WEEK_ALL = TimeFormatters.DAYS_OF_WEEK.map((_, i) => i);
+
+export default {
+  dateRangeEnd: Joi.dateTime().optional(),
+  dateRangeStart: Joi.dateTime().optional(),
+  daysOfWeek: Joi.array().single().items(
+    Joi.number().valid(...DAYS_OF_WEEK_ALL).required(),
+  ).default(null),
+  emphasisAreas: Joi.array().single().items(
+    Joi.enum().ofType(CollisionEmphasisArea).required(),
+  ).default(null),
+  hoursOfDayEnd: Joi.number().integer().min(0).optional(),
+  hoursOfDayStart: Joi.number().integer().min(0).optional(),
+  roadSurfaceConditions: Joi.array().single().items(
+    Joi.enum().ofType(CollisionRoadSurfaceCondition).required(),
+  ).default(null),
+};

--- a/lib/model/helpers/CentrelineFeature.js
+++ b/lib/model/helpers/CentrelineFeature.js
@@ -1,0 +1,10 @@
+import { CentrelineType } from '@/lib/Constants';
+import Joi from '@/lib/model/Joi';
+
+export default {
+  centrelineId: Joi.number().integer().positive().required(),
+  centrelineType: Joi.number().valid(
+    CentrelineType.SEGMENT,
+    CentrelineType.INTERSECTION,
+  ).required(),
+};

--- a/lib/reports/ReportBase.js
+++ b/lib/reports/ReportBase.js
@@ -67,9 +67,11 @@ class ReportBase {
    *
    * @abstract
    * @param {Object} parsedId - ID as parsed for convenience by {@link parseId}
-   * @returns {*} data for the given ID
+   * @param {Object} options - extra report-specific options parsed from
+   * {@link ReportController#getReport}
+   * @returns {*} data for the given ID and options
    */
-  async fetchRawData(parsedId) {
+  async fetchRawData(parsedId, options) {
     throw new NotImplementedError();
   }
 
@@ -116,7 +118,7 @@ class ReportBase {
    */
   async generate(id, format, options) {
     const parsedId = await this.parseId(id);
-    const rawData = await this.fetchRawData(parsedId);
+    const rawData = await this.fetchRawData(parsedId, options);
     const transformedData = this.transformData(parsedId, rawData, options);
     if (format === ReportFormat.JSON) {
       return {

--- a/lib/reports/ReportBaseCrash.js
+++ b/lib/reports/ReportBaseCrash.js
@@ -1,4 +1,5 @@
 /* eslint-disable class-methods-use-this */
+import { ReportBlock } from '@/lib/Constants';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import CollisionDAO from '@/lib/db/CollisionDAO';
 import {
@@ -50,12 +51,33 @@ class ReportBaseCrash extends ReportBase {
     }
   }
 
-  async fetchRawData(location) {
+  async fetchRawData(location, filters) {
     const { centrelineId, centrelineType } = location;
-    return CollisionDAO.byCentreline(centrelineType, centrelineId);
+    const collisionQuery = {
+      centrelineId,
+      centrelineType,
+      ...filters,
+    };
+    const [collisions, collisionSummary] = await Promise.all([
+      CollisionDAO.byCentreline(collisionQuery),
+      CollisionDAO.byCentrelineSummary(collisionQuery),
+    ]);
+    return { collisions, collisionSummary };
   }
 
-  // TODO: metadata blocks?
+  static getCollisionsSummaryBlock({ amount, ksi, validated }) {
+    const options = {
+      entries: [
+        { cols: 3, name: 'Amount', value: amount },
+        { cols: 3, name: 'KSI', value: ksi },
+        { cols: 3, name: 'Validated', value: validated },
+      ],
+    };
+    return {
+      type: ReportBlock.METADATA,
+      options,
+    };
+  }
 }
 
 export default ReportBaseCrash;

--- a/lib/reports/ReportBaseFlow.js
+++ b/lib/reports/ReportBaseFlow.js
@@ -94,7 +94,7 @@ class ReportBaseFlow extends ReportBase {
       ],
     };
     return {
-      type: ReportBlock.COUNT_METADATA,
+      type: ReportBlock.METADATA,
       options,
     };
   }

--- a/lib/reports/ReportCollisionDirectory.js
+++ b/lib/reports/ReportCollisionDirectory.js
@@ -7,16 +7,19 @@ class ReportCollisionDirectory extends ReportBaseCrash {
     return ReportType.COLLISION_DIRECTORY;
   }
 
-  transformData(/* location, collisions, filters */) {
+  transformData(location, rawData) {
+    return rawData;
+  }
+
+  generateCsv(/* location, { collisions } */) {
     // TODO: implement this
   }
 
-  generateCsv(/* location, filteredCollisions */) {
-    // TODO: implement this
-  }
-
-  generateLayoutContent(/* location, filteredCollisions */) {
-    // TODO: implement this
+  generateLayoutContent(location, { collisionSummary }) {
+    const collisionSummaryBlock = ReportBaseCrash.getCollisionsSummaryBlock(collisionSummary);
+    return [
+      collisionSummaryBlock,
+    ];
   }
 }
 

--- a/lib/reports/ReportCollisionTabulation.js
+++ b/lib/reports/ReportCollisionTabulation.js
@@ -7,12 +7,15 @@ class ReportCollisionTabulation extends ReportBaseCrash {
     return ReportType.COLLISION_TABULATION;
   }
 
-  transformData(/* location, collisions, filters */) {
-    // TODO: implement this
+  transformData(location, rawData) {
+    return rawData;
   }
 
-  generateLayoutContent(/* location, filteredCollisions */) {
-    // TODO: implement this
+  generateLayoutContent(location, { collisionSummary }) {
+    const collisionSummaryBlock = ReportBaseCrash.getCollisionsSummaryBlock(collisionSummary);
+    return [
+      collisionSummaryBlock,
+    ];
   }
 }
 

--- a/lib/reports/format/MovePdfGenerator.js
+++ b/lib/reports/format/MovePdfGenerator.js
@@ -6,6 +6,7 @@ import util from 'util';
 import PdfPrinter from 'pdfmake';
 
 import {
+  ORG_NAME,
   PageOrientation,
   PT_PER_IN,
 } from '@/lib/Constants';
@@ -119,7 +120,7 @@ class MovePdfGenerator {
               margin: [spaceL, spaceS, 0, 0],
               stack: [
                 {
-                  text: MovePdfGenerator.ORG_NAME,
+                  text: ORG_NAME,
                   alignment: 'left',
                   color: colorPrimaryDark,
                 },
@@ -575,11 +576,6 @@ MovePdfGenerator.ICON_CHECK = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="
  * @type {string}
  */
 MovePdfGenerator.ICON_TIMES = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 352 512"><path d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"/></svg>';
-
-/**
- * @type {string}
- */
-MovePdfGenerator.ORG_NAME = 'Traffic Safety Unit';
 
 /**
  * {@link PdfPrinter} instance for generating PDFs.  We initialize this once

--- a/lib/reports/format/MovePdfGenerator.js
+++ b/lib/reports/format/MovePdfGenerator.js
@@ -160,7 +160,7 @@ class MovePdfGenerator {
     }];
   }
 
-  // ReportBlock.COUNT_METADATA
+  // ReportBlock.METADATA
 
   static getMetadataBlock({ cols, name, value }) {
     const fontSizeM = FormatCss.var('--font-size-m');
@@ -212,7 +212,7 @@ class MovePdfGenerator {
     return rows;
   }
 
-  generateCountMetadata({ entries }) {
+  generateMetadata({ entries }) {
     const spaceM = FormatCss.var('--space-m');
     const rows = MovePdfGenerator.getMetadataRows(entries);
     return rows.map(row => ({

--- a/tests/jest/db/DAO.spec.js
+++ b/tests/jest/db/DAO.spec.js
@@ -299,17 +299,16 @@ test('CollisionDAO.byCollisionId', async () => {
 });
 
 test('CollisionDAO.byCentreline', async () => {
-  const start = DateTime.fromObject({ year: 2017, month: 1, day: 1 });
-  const end = DateTime.fromObject({ year: 2020, month: 1, day: 1 });
-  const dateRange = { start, end };
+  const dateRangeStart = DateTime.fromObject({ year: 2017, month: 1, day: 1 });
+  const dateRangeEnd = DateTime.fromObject({ year: 2020, month: 1, day: 1 });
 
   let result = await CollisionDAO.byCentreline({
     centrelineId: 1142194,
     centrelineType: CentrelineType.SEGMENT,
-    dateRange,
+    dateRangeEnd,
+    dateRangeStart,
     daysOfWeek: null,
     emphasisAreas: null,
-    hoursOfDay: null,
     roadSurfaceConditions: null,
   });
   expect(result).toHaveLength(31);
@@ -317,27 +316,26 @@ test('CollisionDAO.byCentreline', async () => {
   result = await CollisionDAO.byCentreline({
     centrelineId: 13465434,
     centrelineType: CentrelineType.INTERSECTION,
-    dateRange,
+    dateRangeEnd,
+    dateRangeStart,
     daysOfWeek: null,
     emphasisAreas: null,
-    hoursOfDay: null,
     roadSurfaceConditions: null,
   });
   expect(result).toHaveLength(27);
 });
 
 test('CollisionDAO.byCentrelineSummary', async () => {
-  const start = DateTime.fromObject({ year: 2017, month: 1, day: 1 });
-  const end = DateTime.fromObject({ year: 2020, month: 1, day: 1 });
-  const dateRange = { start, end };
+  const dateRangeStart = DateTime.fromObject({ year: 2017, month: 1, day: 1 });
+  const dateRangeEnd = DateTime.fromObject({ year: 2020, month: 1, day: 1 });
 
   let result = await CollisionDAO.byCentrelineSummary({
     centrelineId: 1142194,
     centrelineType: CentrelineType.SEGMENT,
-    dateRange,
+    dateRangeEnd,
+    dateRangeStart,
     daysOfWeek: null,
     emphasisAreas: null,
-    hoursOfDay: null,
     roadSurfaceConditions: null,
   });
   expect(result).toEqual({ amount: 31, ksi: 0, validated: 26 });
@@ -345,10 +343,10 @@ test('CollisionDAO.byCentrelineSummary', async () => {
   result = await CollisionDAO.byCentrelineSummary({
     centrelineId: 13465434,
     centrelineType: CentrelineType.INTERSECTION,
-    dateRange,
+    dateRangeEnd,
+    dateRangeStart,
     daysOfWeek: null,
     emphasisAreas: null,
-    hoursOfDay: null,
     roadSurfaceConditions: null,
   });
   expect(result).toEqual({ amount: 27, ksi: 1, validated: 16 });

--- a/web/App.vue
+++ b/web/App.vue
@@ -27,8 +27,9 @@
         dense>
         <FcDashboardNavItem
           :active-route-names="[
+            'viewCollisionReportsAtLocation',
             'viewDataAtLocation',
-            'viewReportsAtLocation',
+            'viewStudyReportsAtLocation',
           ]"
           icon="map"
           label="View Map"

--- a/web/components/FcDataTableCollisions.vue
+++ b/web/components/FcDataTableCollisions.vue
@@ -20,6 +20,7 @@
     <template v-slot:item.VIEW_REPORT="{ item }">
       <FcButton
         type="tertiary"
+        :disabled="item.amount === 0"
         @click="$emit('show-reports', item)">
         <span>View Reports</span>
       </FcButton>

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -104,7 +104,7 @@
 import { saveAs } from 'file-saver';
 import { mapGetters, mapMutations, mapState } from 'vuex';
 
-import { ReportFormat, ReportType } from '@/lib/Constants';
+import { ReportBlock, ReportFormat, ReportType } from '@/lib/Constants';
 import { reporterFetch } from '@/lib/api/BackendClient';
 import {
   getLocationByFeature,
@@ -163,7 +163,7 @@ export default {
       return {};
     },
     ...mapState(['location']),
-    ...mapGetters('viewData', ['filterChipsCollision']),
+    ...mapGetters('viewData', ['filterChipsCollision', 'filterParamsCollision']),
   },
   watch: {
     activeReportType() {
@@ -244,13 +244,12 @@ export default {
       }
     },
     async updateReportLayout() {
-      const { activeReportType } = this;
+      const { activeReportType, filterParamsCollision } = this;
       if (activeReportType === null) {
         return;
       }
       this.loadingReportLayout = true;
 
-      /*
       const { name: type } = activeReportType;
       const { centrelineId, centrelineType } = this.$route.params;
       const id = `${centrelineType}/${centrelineId}`;
@@ -260,7 +259,7 @@ export default {
           type,
           id,
           format: ReportFormat.WEB,
-          ...reportParameters,
+          ...filterParamsCollision,
         },
       };
 
@@ -282,7 +281,6 @@ export default {
         date: reportDate,
         content: reportContent,
       };
-      */
 
       this.loadingReportLayout = false;
     },

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -113,7 +113,7 @@ const DOWNLOAD_FORMATS_SUPPORTED = [
 ];
 
 export default {
-  name: 'FcDrawerViewReports',
+  name: 'FcDrawerViewCollisionReports',
   mixins: [FcMixinRouteAsync],
   components: {
     FcButton,
@@ -298,7 +298,7 @@ export default {
   }
 }
 
-.drawer-open .fc-drawer-view-reports {
+.drawer-open .fc-drawer-view-collision-reports {
   max-height: 100vh;
 }
 </style>

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -53,12 +53,19 @@
       </div>
 
       <section class="flex-grow-1 flex-shrink-1 overflow-y-auto pt-2">
-        <v-progress-circular
+        <div
           v-if="loadingReportLayout"
-          class="ma-3"
-          color="primary"
-          indeterminate
-          size="64" />
+          class="ma-3 text-center">
+          <v-progress-circular
+            v-if="loadingReportLayout"
+            class="ma-3"
+            color="primary"
+            indeterminate
+            size="80" />
+          <div class="font-weight-regular headline secondary--text">
+            This page is loading, please wait.
+          </div>
+        </div>
         <div
           v-else
           class="fc-report-wrapper pa-3">

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -175,7 +175,7 @@
             v-else
             :count-summary="countSummary"
             :loading="loadingCounts"
-            @show-reports="actionShowReports" />
+            @show-reports="actionShowReportsStudy" />
           <div class="pa-5">
             <div
               v-for="studyRequest in studyRequestsPending"
@@ -360,18 +360,6 @@ export default {
     actionRequestStudy() {
       this.$router.push({ name: 'requestStudyNew' });
     },
-    actionShowReports({ category: { studyType } }) {
-      const { centrelineId, centrelineType } = this.$route.params;
-      const params = {
-        centrelineId,
-        centrelineType,
-        studyTypeName: studyType.name,
-      };
-      this.$router.push({
-        name: 'viewReportsAtLocation',
-        params,
-      });
-    },
     actionShowReportsCollision() {
       const { centrelineId, centrelineType } = this.$route.params;
       const params = {
@@ -380,6 +368,18 @@ export default {
       };
       this.$router.push({
         name: 'viewCollisionReportsAtLocation',
+        params,
+      });
+    },
+    actionShowReportsStudy({ category: { studyType } }) {
+      const { centrelineId, centrelineType } = this.$route.params;
+      const params = {
+        centrelineId,
+        centrelineType,
+        studyTypeName: studyType.name,
+      };
+      this.$router.push({
+        name: 'viewStudyReportsAtLocation',
         params,
       });
     },

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -77,12 +77,19 @@
       </div>
 
       <section class="flex-grow-1 flex-shrink-1 overflow-y-auto pt-2">
-        <v-progress-circular
+        <div
           v-if="loadingReportLayout"
-          class="ma-3"
-          color="primary"
-          indeterminate
-          size="64" />
+          class="ma-3 text-center">
+          <v-progress-circular
+            v-if="loadingReportLayout"
+            class="ma-3"
+            color="primary"
+            indeterminate
+            size="80" />
+          <div class="font-weight-regular headline secondary--text">
+            This page is loading, please wait.
+          </div>
+        </div>
         <div
           v-else
           class="fc-report-wrapper pa-3">

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fc-drawer-view-reports d-flex flex-column">
+  <div class="fc-drawer-view-study-reports d-flex flex-column">
     <FcDialogConfirm
       v-model="showConfirmLeave"
       textCancel="Stay on this page"
@@ -159,7 +159,7 @@ const DOWNLOAD_FORMATS_SUPPORTED = [
 ];
 
 export default {
-  name: 'FcDrawerViewReports',
+  name: 'FcDrawerViewStudyReports',
   mixins: [FcMixinRouteAsync],
   components: {
     FcButton,
@@ -414,7 +414,7 @@ export default {
 </script>
 
 <style lang="scss">
-.fc-drawer-view-reports {
+.fc-drawer-view-study-reports {
   max-height: 50vh;
 
   .fc-report-wrapper {
@@ -427,7 +427,7 @@ export default {
   }
 }
 
-.drawer-open .fc-drawer-view-reports {
+.drawer-open .fc-drawer-view-study-reports {
   max-height: 100vh;
 }
 </style>

--- a/web/components/inputs/FcSearchBarLocation.vue
+++ b/web/components/inputs/FcSearchBarLocation.vue
@@ -1,7 +1,23 @@
 <template>
   <div class="fc-search-bar-location-wrapper">
+    <v-tooltip
+      v-if="collapseSearchBar"
+      right
+      :z-index="100">
+      <template v-slot:activator="{ on }">
+        <FcButton
+          aria-label="Search for new location"
+          class="fc-search-bar-open"
+          type="fab-text"
+          @click="$router.push({ name: 'viewData' })"
+          v-on="on">
+          <v-icon class="unselected--text">mdi-magnify</v-icon>
+        </FcButton>
+      </template>
+      <span>Search for new location</span>
+    </v-tooltip>
     <v-autocomplete
-      v-if="$route.name !== 'viewReportsAtLocation'"
+      v-else
       v-model="internalLocation"
       append-icon="mdi-magnify"
       class="fc-search-bar-location elevation-2"
@@ -28,22 +44,6 @@
         </v-list-item>
       </template>
     </v-autocomplete>
-    <v-tooltip
-      v-else
-      right
-      :z-index="100">
-      <template v-slot:activator="{ on }">
-        <FcButton
-          aria-label="Search for new location"
-          class="fc-search-bar-open"
-          type="fab-text"
-          @click="$router.push({ name: 'viewData' })"
-          v-on="on">
-          <v-icon class="unselected--text">mdi-magnify</v-icon>
-        </FcButton>
-      </template>
-      <span>Search for new location</span>
-    </v-tooltip>
   </div>
 </template>
 
@@ -68,6 +68,11 @@ export default {
     };
   },
   computed: {
+    collapseSearchBar() {
+      const { name } = this.$route;
+      return name === 'viewCollisionReportsAtLocation'
+        || name === 'viewStudyReportsAtLocation';
+    },
     internalLocation: {
       get() {
         return this.location;

--- a/web/components/reports/FcReport.vue
+++ b/web/components/reports/FcReport.vue
@@ -28,8 +28,8 @@ import { ORG_NAME, ReportType } from '@/lib/Constants';
 import DateTime from '@/lib/time/DateTime';
 import FcReportBarChart
   from '@/web/components/reports/FcReportBarChart.vue';
-import FcReportCountMetadata
-  from '@/web/components/reports/FcReportCountMetadata.vue';
+import FcReportMetadata
+  from '@/web/components/reports/FcReportMetadata.vue';
 import FcReportTable
   from '@/web/components/reports/FcReportTable.vue';
 
@@ -37,7 +37,7 @@ export default {
   name: 'FcReport',
   components: {
     FcReportBarChart,
-    FcReportCountMetadata,
+    FcReportMetadata,
     FcReportTable,
   },
   props: {

--- a/web/components/reports/FcReport.vue
+++ b/web/components/reports/FcReport.vue
@@ -24,7 +24,7 @@
 </template>
 
 <script>
-import { ReportType } from '@/lib/Constants';
+import { ORG_NAME, ReportType } from '@/lib/Constants';
 import DateTime from '@/lib/time/DateTime';
 import FcReportBarChart
   from '@/web/components/reports/FcReportBarChart.vue';
@@ -47,7 +47,7 @@ export default {
   },
   data() {
     return {
-      ORG_NAME: 'Traffic Safety Unit',
+      ORG_NAME,
     };
   },
 };

--- a/web/components/reports/FcReportMetadata.vue
+++ b/web/components/reports/FcReportMetadata.vue
@@ -15,7 +15,7 @@
 
 <script>
 export default {
-  name: 'FcReportCountMetadata',
+  name: 'FcReportMetadata',
   props: {
     entries: Array,
   },

--- a/web/router.js
+++ b/web/router.js
@@ -108,13 +108,13 @@ const router = new Router({
         },
       }, {
         path: '/view/location/:centrelineType/:centrelineId/reports/:studyTypeName',
-        name: 'viewReportsAtLocation',
+        name: 'viewStudyReportsAtLocation',
         meta: {
           auth: { mode: 'try' },
           title: 'View Study Reports',
           vertical: true,
         },
-        component: () => import(/* webpackChunkName: "home" */ '@/web/components/FcDrawerViewReports.vue'),
+        component: () => import(/* webpackChunkName: "home" */ '@/web/components/FcDrawerViewStudyReports.vue'),
         beforeEnter(to, from, next) {
           store.commit('setDrawerOpen', false);
           next();


### PR DESCRIPTION
# Issue Addressed
This PR closes #442 .

# Description
We implement stub versions of `ReportCollisionDirectory` and `ReportCollisionTabulation`, which for now just show a header with the same summary statistics as the View Data page.

These implementations share base class `ReportBaseCrash`, which uses the collision filters as report parameters to fetch collisions via `CollisionDAO.byCentreline`.

# Tests
Ran the frontend, backend, and reporter, and tested manually in browser; `npm run test:test-db` to test database / DAO changes. 