### PR TITLE
Directory report: human-readable descriptions for numeric codes

### DIFF
--- a/lib/db/CollisionFactorDAO.js
+++ b/lib/db/CollisionFactorDAO.js
@@ -1,0 +1,53 @@
+import db from '@/lib/db/db';
+
+/**
+ * Since the set of collision factors is small and static, we cache it here to reduce DB load.
+ */
+let CACHE = null;
+
+async function init() {
+  CACHE = new Map();
+
+  const sqlTables = `
+SELECT table_name AS "tableName"
+FROM information_schema.tables
+WHERE table_schema = 'collision_factors'`;
+  const rowsTables = await db.manyOrNone(sqlTables);
+
+  const sqlByTable = rowsTables.map(
+    ({ tableName }) => `
+SELECT
+  "${tableName}"::smallint AS value,
+  description,
+  code
+FROM collision_factors."${tableName}"
+WHERE "${tableName}" IS NOT NULL
+AND "${tableName}" ~ '^[0-9]+$'`,
+  );
+  const tasksByTable = sqlByTable.map(sql => db.manyOrNone(sql));
+  const rowsByTable = await Promise.all(tasksByTable);
+
+  rowsByTable.forEach((rows, i) => {
+    const { tableName: field } = rowsTables[i];
+    const fieldEntries = new Map();
+    rows.forEach(({ code, description, value }) => {
+      fieldEntries.set(value, { code, description });
+    });
+    CACHE.set(field, fieldEntries);
+  });
+}
+
+class CollisionFactorDAO {
+  static isInited() {
+    return CACHE !== null;
+  }
+
+  static async all() {
+    if (!CollisionFactorDAO.isInited()) {
+      await init();
+    }
+    return CACHE;
+  }
+}
+
+export default CollisionFactorDAO;

--- a/lib/reports/ReportBaseCrash.js
+++ b/lib/reports/ReportBaseCrash.js
@@ -2,6 +2,7 @@
 import { ReportBlock } from '@/lib/Constants';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import CollisionDAO from '@/lib/db/CollisionDAO';
+import CollisionFactorDAO from '@/lib/db/CollisionFactorDAO';
 import {
   InvalidCentrelineTypeError,
   InvalidReportIdError,
@@ -12,6 +13,11 @@ import ReportBase from '@/lib/reports/ReportBase';
  * Base class for all CRASH-related reports, i.e. those reports that deal with collision data.
  */
 class ReportBaseCrash extends ReportBase {
+  constructor() {
+    super();
+    this.collisionFactors = null;
+  }
+
   /**
    * Parses an ID in the format `{centrelineType}/{centrelineId}`, and returns it
    * as a location from {@link CentrelineDAO} for further processing.
@@ -52,6 +58,10 @@ class ReportBaseCrash extends ReportBase {
   }
 
   async fetchRawData(location, filters) {
+    if (this.collisionFactors === null) {
+      this.collisionFactors = await CollisionFactorDAO.all();
+    }
+
     const { centrelineId, centrelineType } = location;
     const collisionQuery = {
       centrelineId,
@@ -63,6 +73,35 @@ class ReportBaseCrash extends ReportBase {
       CollisionDAO.byCentrelineSummary(collisionQuery),
     ]);
     return { collisions, collisionSummary };
+  }
+
+  getCollisionFactorEntry(field, value) {
+    // TODO: check for null collisionFactors
+    const fieldEntries = this.collisionFactors.get(field);
+    if (fieldEntries === undefined) {
+      return null;
+    }
+    const entry = fieldEntries.get(value);
+    if (entry === undefined) {
+      return null;
+    }
+    return entry;
+  }
+
+  getCollisionFactorCode(field, value) {
+    const entry = this.getCollisionFactorEntry(field, value);
+    if (entry === null) {
+      return null;
+    }
+    return entry.code;
+  }
+
+  getCollisionFactorDescription(field, value) {
+    const entry = this.getCollisionFactorEntry(field, value);
+    if (entry === null) {
+      return null;
+    }
+    return entry.description;
   }
 
   static getCollisionsSummaryBlock({ amount, ksi, validated }) {

--- a/lib/reports/ReportCollisionDirectory.js
+++ b/lib/reports/ReportCollisionDirectory.js
@@ -56,9 +56,6 @@ class ReportCollisionDirectory extends ReportBaseCrash {
       }
     });
 
-    const alcohol = involved.some(({ drivcond }) => drivcond === 3 || drivcond === 4);
-    const redLight = traffictl === 1 && involved.some(({ drivact }) => drivact === 7);
-
     return {
       accnb,
       accdate,
@@ -71,8 +68,6 @@ class ReportCollisionDirectory extends ReportBaseCrash {
       pedestrians,
       cyclists,
       injured,
-      alcohol,
-      redLight,
       verified,
       hasMvaImage,
     };
@@ -118,20 +113,10 @@ class ReportCollisionDirectory extends ReportBaseCrash {
     pedestrians,
     cyclists,
     injured,
-    alcohol,
-    redLight,
     verified,
     hasMvaImage,
   }, i) {
     const [driver1 = {}, driver2 = {}] = drivers;
-    let pedestrianAge = null;
-    if (pedestrians.length > 0) {
-      pedestrianAge = pedestrians[0].invage;
-    }
-    let cyclistAge = null;
-    if (cyclists.length > 0) {
-      cyclistAge = cyclists[0].invage;
-    }
     const shade = i % 2 === 1;
     const row = [
       { value: accnb, style: { br: true } },
@@ -144,14 +129,10 @@ class ReportCollisionDirectory extends ReportBaseCrash {
       { value: this.getCollisionFactorCode('impactype', impactype) },
       ...this.getTableDriverCells(driver1),
       ...this.getTableDriverCells(driver2),
-      { value: pedestrianAge, style: { bl: true } },
-      { value: cyclistAge, style: { br: true } },
-      ...injured.map((value, j) => ({ value, style: { br: j === 5 } })),
-      { value: drivers.length },
+      { value: drivers.length, style: { bl: true } },
       { value: pedestrians.length },
       { value: cyclists.length, style: { br: true } },
-      { value: alcohol },
-      { value: redLight },
+      ...injured.map((value, j) => ({ value, style: { br: j === 5 } })),
       { value: verified },
       { value: hasMvaImage },
     ];
@@ -179,14 +160,10 @@ class ReportCollisionDirectory extends ReportBaseCrash {
           { value: null },
           { value: 'Driver 1', colspan: 5, style: { bl: true } },
           { value: 'Driver 2', colspan: 5, style: { bl: true } },
-          { value: 'Ped', style: { bl: true } },
-          { value: 'Bike', style: { br: true } },
-          { value: 'Injury', colspan: 6, style: { br: true } },
-          { value: '#' },
+          { value: '#', style: { bl: true } },
           { value: '#' },
           { value: '#', style: { br: true } },
-          { value: 'Alcohol' },
-          { value: 'Red' },
+          { value: 'Injury', colspan: 6, style: { br: true } },
           { value: 'Verif' },
           { value: 'MVA' },
         ], [
@@ -210,9 +187,10 @@ class ReportCollisionDirectory extends ReportBaseCrash {
           { value: 'Action' },
           { value: 'Cond' },
           { value: 'Age' },
-          // ---
-          { value: 'Age', style: { bl: true } },
-          { value: 'Age', style: { br: true } },
+          // counts (#)
+          { value: 'Driver', style: { bl: true } },
+          { value: 'Ped' },
+          { value: 'Cyclist', style: { br: true } },
           // injury
           { value: 'NO' },
           { value: 'MI' },
@@ -220,13 +198,7 @@ class ReportCollisionDirectory extends ReportBaseCrash {
           { value: 'MJ' },
           { value: 'FA' },
           { value: 'OT', style: { br: true } },
-          // counts (#)
-          { value: 'Driver' },
-          { value: 'Ped' },
-          { value: 'Cyclist', style: { br: true } },
           // ---
-          { value: 'Involv' },
-          { value: 'Light' },
           { value: 'ied' },
           { value: 'Img' },
         ],

--- a/lib/reports/ReportCollisionDirectory.js
+++ b/lib/reports/ReportCollisionDirectory.js
@@ -90,7 +90,7 @@ class ReportCollisionDirectory extends ReportBaseCrash {
     // TODO: implement this
   }
 
-  static getTableDriverCells({
+  getTableDriverCells({
     drivact = null,
     drivcond = null,
     initdir = null,
@@ -98,15 +98,15 @@ class ReportCollisionDirectory extends ReportBaseCrash {
     manoeuver = null,
   }) {
     return [
-      { value: initdir, style: { bl: true } },
-      { value: manoeuver },
-      { value: drivact },
-      { value: drivcond },
+      { value: this.getCollisionFactorCode('initdir', initdir), style: { bl: true } },
+      { value: this.getCollisionFactorCode('manoeuver', manoeuver) },
+      { value: this.getCollisionFactorCode('drivact', drivact) },
+      { value: this.getCollisionFactorCode('drivcond', drivcond) },
       { value: invage },
     ];
   }
 
-  static getTableCollisionRow({
+  getTableCollisionRow({
     accnb,
     accdate,
     acclass,
@@ -137,13 +137,13 @@ class ReportCollisionDirectory extends ReportBaseCrash {
       { value: accnb, style: { br: true } },
       { value: TimeFormatters.formatDefault(accdate) },
       { value: TimeFormatters.formatTimeOfDay(accdate) },
-      { value: acclass },
-      { value: traffictl },
-      { value: rdsfcond },
-      { value: visible },
-      { value: impactype },
-      ...ReportCollisionDirectory.getTableDriverCells(driver1),
-      ...ReportCollisionDirectory.getTableDriverCells(driver2),
+      { value: this.getCollisionFactorCode('acclass', acclass) },
+      { value: this.getCollisionFactorCode('traffictl', traffictl) },
+      { value: this.getCollisionFactorCode('rdsfcond', rdsfcond) },
+      { value: this.getCollisionFactorCode('visible', visible) },
+      { value: this.getCollisionFactorCode('impactype', impactype) },
+      ...this.getTableDriverCells(driver1),
+      ...this.getTableDriverCells(driver2),
       { value: pedestrianAge, style: { bl: true } },
       { value: cyclistAge, style: { br: true } },
       ...injured.map((value, j) => ({ value, style: { br: j === 5 } })),
@@ -231,7 +231,7 @@ class ReportCollisionDirectory extends ReportBaseCrash {
           { value: 'Img' },
         ],
       ],
-      body: collisions.map(ReportCollisionDirectory.getTableCollisionRow),
+      body: collisions.map(this.getTableCollisionRow.bind(this)),
     };
   }
 

--- a/scripts/test/db/startup.sh
+++ b/scripts/test/db/startup.sh
@@ -119,6 +119,7 @@ echo "localhost:5433:flashcrow:flashcrow:${PG_USER_PASSWORD}" >> ${RAMDISK_PGPAS
 # and run any database migrations
 echo "Setting up MOVE application database..."
 psql -h localhost -p 5433 -U flashcrow_dba postgres -v pgPassword="'$PG_USER_PASSWORD'" < "${GIT_ROOT}/scripts/dev/provision-db-vagrant.sql"
+psql -h localhost -p 5433 -U flashcrow flashcrow < "${GIT_ROOT}/scripts/deployment/rds/collision_factors.sql"
 psql -h localhost -p 5433 -U flashcrow flashcrow < "${GIT_ROOT}/scripts/db/db-update-install.sql"
 "${GIT_ROOT}/scripts/db/db-update.sh" --psqlArgs "-h localhost -p 5433 -U flashcrow flashcrow"
 

--- a/tests/jest/db/DAO.spec.js
+++ b/tests/jest/db/DAO.spec.js
@@ -16,6 +16,7 @@ import ArteryDAO from '@/lib/db/ArteryDAO';
 import CategoryDAO from '@/lib/db/CategoryDAO';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import CollisionDAO from '@/lib/db/CollisionDAO';
+import CollisionFactorDAO from '@/lib/db/CollisionFactorDAO';
 import CountDAO from '@/lib/db/CountDAO';
 import CountDataDAO from '@/lib/db/CountDataDAO';
 import DynamicTileDAO from '@/lib/db/DynamicTileDAO';
@@ -358,6 +359,19 @@ test('CollisionDAO.byCentrelineTotal', async () => {
 
   result = await CollisionDAO.byCentrelineTotal(CentrelineType.INTERSECTION, 13465434);
   expect(result).toBe(188);
+});
+
+test('CollisionFactorDAO', async () => {
+  expect(CollisionFactorDAO.isInited()).toBe(false);
+
+  const collisionFactors = await CollisionFactorDAO.all();
+  expect(collisionFactors).toBeInstanceOf(Map);
+  expect(collisionFactors.get('acclass')).toBeInstanceOf(Map);
+  expect(collisionFactors.get('acclass').get(1)).toEqual({
+    code: 'FA',
+    description: 'Fatal',
+  });
+  expect(CollisionFactorDAO.isInited()).toBe(true);
 });
 
 test('CountDAO.byCentreline()', async () => {


### PR DESCRIPTION
# Issue Addressed
This PR closes #443 .

# Description
We introduce `CollisionFactorDAO`, which reads and caches human-readable descriptions for various values in `collision_factors` tables.

We then use that DAO from `ReportCollisionDirectory` to show human-readable descriptions instead of the raw numeric codes, which should help with readability.

# Tests
Tested quickly in frontend.  More rigorous testing coming post-usability test.
