### PR TITLE
Collision tabulation report

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -285,6 +285,9 @@ ReportBlock.init({
   METADATA: {
     suffix: 'Metadata',
   },
+  PAGE_BREAK: {
+    suffix: 'PageBreak',
+  },
   TABLE: {
     suffix: 'Table',
   },

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -1,6 +1,9 @@
 import {
   centrelineKey,
   POI_RADIUS,
+  ReportBlock,
+  ReportFormat,
+  ReportType,
 } from '@/lib/Constants';
 import BackendClient from '@/lib/api/BackendClient';
 import AuthState from '@/lib/model/AuthState';
@@ -15,6 +18,7 @@ import SuccessResponse from '@/lib/model/SuccessResponse';
 import User from '@/lib/model/User';
 
 const apiClient = new BackendClient('/api');
+const reporterClient = new BackendClient('/reporter');
 
 async function deleteStudyRequestComment(csrf, studyRequest, comment) {
   const { id: commentId } = comment;
@@ -156,6 +160,41 @@ async function getPoiByCentrelineSummary(feature) {
   const data = { centrelineId, centrelineType, radius: POI_RADIUS };
   const options = { data };
   return apiClient.fetch('/poi/byCentreline/summary', options);
+}
+
+async function getReport(type, id, format, reportParameters) {
+  const options = {
+    method: 'GET',
+    data: {
+      type,
+      id,
+      format,
+      ...reportParameters,
+    },
+  };
+  return reporterClient.fetch('/reports', options);
+}
+
+async function getReportWeb(type, id, reportParameters) {
+  const {
+    type: reportTypeStr,
+    date: reportDate,
+    content,
+  } = await getReport(type, id, ReportFormat.WEB, reportParameters);
+
+  const reportType = ReportType.enumValueOf(reportTypeStr);
+  const reportContent = content.map(({ type: blockTypeStr, options: blockOptions }) => {
+    const blockType = ReportBlock.enumValueOf(blockTypeStr);
+    return {
+      type: blockType,
+      options: blockOptions,
+    };
+  });
+  return {
+    type: reportType,
+    date: reportDate,
+    content: reportContent,
+  };
 }
 
 async function getUsersByIds(ids) {
@@ -364,6 +403,8 @@ const WebApi = {
   getLocationsByFeature,
   getLocationSuggestions,
   getPoiByCentrelineSummary,
+  getReport,
+  getReportWeb,
   getStudyRequest,
   getStudyRequests,
   getStudyRequestsByCentrelinePending,
@@ -391,6 +432,8 @@ export {
   getLocationsByFeature,
   getLocationSuggestions,
   getPoiByCentrelineSummary,
+  getReport,
+  getReportWeb,
   getStudyRequest,
   getStudyRequests,
   getStudyRequestsByCentrelinePending,

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -183,7 +183,17 @@ async function getReportWeb(type, id, reportParameters) {
   } = await getReport(type, id, ReportFormat.WEB, reportParameters);
 
   const reportType = ReportType.enumValueOf(reportTypeStr);
-  const reportContent = content.map(({ type: blockTypeStr, options: blockOptions }) => {
+  const reportContent = content.map((contentRow) => {
+    if (Array.isArray(contentRow)) {
+      return contentRow.map(({ type: blockTypeStr, options: blockOptions }) => {
+        const blockType = ReportBlock.enumValueOf(blockTypeStr);
+        return {
+          type: blockType,
+          options: blockOptions,
+        };
+      });
+    }
+    const { type: blockTypeStr, options: blockOptions } = contentRow;
     const blockType = ReportBlock.enumValueOf(blockTypeStr);
     return {
       type: blockType,

--- a/lib/db/CollisionDAO.js
+++ b/lib/db/CollisionDAO.js
@@ -15,6 +15,7 @@ const COLLISION_EVENTS_FIELDS = `
   e.acclass,
   e.accloc,
   e.traffictl,
+  e.impactype,
   e.visible,
   e.light,
   e.rdsfcond,
@@ -44,6 +45,7 @@ const COLLISION_INVOLVED_FIELDS = `
   i.collision_id AS "collisionId",
   i.veh_no AS "vehNo",
   i.vehtype,
+  i.initdir,
   i.imploc,
   i.per_no AS "perNo",
   i.invtype,
@@ -62,7 +64,16 @@ const COLLISION_INVOLVED_FIELDS = `
   i.cyccond,
   i.fatal_no AS "fatalNo",
   i.actual_speed AS "actualSpeed",
-  i.posted_speed AS "postedSpeed"
+  i.posted_speed AS "postedSpeed",
+  i.aggressive,
+  i.cyclist,
+  i.ksi,
+  i.motorcyclist,
+  i.older_adult AS "olderAdult",
+  i.pedestrian,
+  i.property_damage AS "propertyDamage",
+  i.school_child AS "schoolChild",
+  i.speeding
   FROM collisions.involved i`;
 
 function normalizeCollisionQuery(collisionQuery) {

--- a/lib/model/CollisionEvent.js
+++ b/lib/model/CollisionEvent.js
@@ -18,6 +18,7 @@ const PERSISTED_COLUMNS = {
   acclass: Joi.number().integer().min(0).allow(null),
   accloc: Joi.number().integer().min(0).allow(null),
   traffictl: Joi.number().integer().min(0).allow(null),
+  impactype: Joi.number().integer().min(0).allow(null),
   visible: Joi.number().integer().min(0).allow(null),
   light: Joi.number().integer().min(0).allow(null),
   rdsfcond: Joi.number().integer().min(0).allow(null),

--- a/lib/model/CollisionInvolved.js
+++ b/lib/model/CollisionInvolved.js
@@ -7,6 +7,7 @@ const PERSISTED_COLUMNS = {
   collisionId: Joi.number().integer().positive(),
   vehNo: Joi.number().integer().min(0).allow(null),
   vehtype: Joi.number().integer().min(0).allow(null),
+  initdir: Joi.number().integer().min(0).allow(null),
   imploc: Joi.number().integer().min(0).allow(null),
   // TODO: events 1-3
   perNo: Joi.number().integer().min(0).allow(null),
@@ -28,6 +29,15 @@ const PERSISTED_COLUMNS = {
   fatalNo: Joi.number().integer().min(0).allow(null),
   actualSpeed: Joi.number().integer().min(0).allow(null),
   postedSpeed: Joi.number().integer().min(0).allow(null),
+  aggressive: Joi.boolean(),
+  cyclist: Joi.boolean(),
+  ksi: Joi.boolean(),
+  motorcyclist: Joi.boolean(),
+  olderAdult: Joi.boolean(),
+  pedestrian: Joi.boolean(),
+  propertyDamage: Joi.boolean(),
+  schoolChild: Joi.boolean(),
+  speeding: Joi.boolean(),
 };
 
 const CollisionInvolved = new Model(ModelField.persisted(PERSISTED_COLUMNS));

--- a/lib/reports/ReportBaseCrash.js
+++ b/lib/reports/ReportBaseCrash.js
@@ -75,10 +75,18 @@ class ReportBaseCrash extends ReportBase {
     return { collisions, collisionSummary };
   }
 
-  getCollisionFactorEntry(field, value) {
-    // TODO: check for null collisionFactors
+  getCollisionFactorEntries(field) {
     const fieldEntries = this.collisionFactors.get(field);
     if (fieldEntries === undefined) {
+      return null;
+    }
+    return fieldEntries;
+  }
+
+  getCollisionFactorEntry(field, value) {
+    // TODO: check for null collisionFactors
+    const fieldEntries = this.getCollisionFactorEntries(field);
+    if (fieldEntries === null) {
       return null;
     }
     const entry = fieldEntries.get(value);

--- a/lib/reports/ReportCollisionDirectory.js
+++ b/lib/reports/ReportCollisionDirectory.js
@@ -65,6 +65,10 @@ class ReportCollisionDirectory extends ReportBaseCrash {
   }
 
   transformData(location, rawData) {
+    /*
+     * TODO: this violates the "no shared references" invariant in `ReportBase#transformData`.
+     * We should address that eventually, but there isn't time right now.
+     */
     const rawCollisions = rawData.collisions;
     const collisions = rawCollisions.map(
       ReportCollisionDirectory.getCollisionDirectoryEntry,

--- a/lib/reports/ReportCollisionDirectory.js
+++ b/lib/reports/ReportCollisionDirectory.js
@@ -65,15 +65,21 @@ class ReportCollisionDirectory extends ReportBaseCrash {
   }
 
   transformData(location, rawData) {
-    const collisions = rawData.collisions.map(
+    const rawCollisions = rawData.collisions;
+    const collisions = rawCollisions.map(
       ReportCollisionDirectory.getCollisionDirectoryEntry,
     );
     const collisionSummary = { ...rawData.collisionSummary };
-    return { collisions, collisionSummary };
+    return { collisions, collisionSummary, rawCollisions };
   }
 
-  generateCsv(/* location, { collisions } */) {
-    // TODO: implement this
+  generateCsv(location, { rawCollisions }) {
+    if (rawCollisions.length === 0) {
+      return { columns: [], rows: [] };
+    }
+    const columns = Object.keys(rawCollisions[0])
+      .map(key => ({ key, header: key }));
+    return { columns, rows: rawCollisions };
   }
 
   getTableDriverCells({

--- a/lib/reports/ReportCollisionDirectory.js
+++ b/lib/reports/ReportCollisionDirectory.js
@@ -35,17 +35,8 @@ class ReportCollisionDirectory extends ReportBaseCrash {
       return vehNo;
     });
 
-    const pedestrians = involved.filter(
-      ({ invtype }) => invtype === 3 || invtype === 17 || invtype === 19,
-    );
-    const cyclists = involved.filter(
-      ({ invtype, vehtype }) => invtype === 4
-        || invtype === 5
-        || invtype === 8
-        || invtype === 9
-        || vehtype === 3
-        || vehtype === 36,
-    );
+    const pedestrians = involved.filter(({ pedestrian }) => pedestrian);
+    const cyclists = involved.filter(({ cyclist }) => cyclist);
 
     const injured = [0, 0, 0, 0, 0, 0];
     involved.forEach(({ injury }) => {

--- a/lib/reports/ReportCollisionTabulation.js
+++ b/lib/reports/ReportCollisionTabulation.js
@@ -26,7 +26,37 @@ class ReportCollisionTabulation extends ReportBaseCrash {
         }
         return 1;
       },
-      involved: true,
+    };
+
+    const drivactEntries = this.getCollisionFactorEntries('drivact');
+    this.dimDrivact = {
+      description: 'Driver Action',
+      entries: drivactEntries,
+      fn: (event, { drivact, invtype }) => {
+        if (invtype === 1 || invtype === 6 || invtype === 18) {
+          return drivact;
+        }
+        return null;
+      },
+    };
+
+    const drivcondEntries = this.getCollisionFactorEntries('drivcond');
+    this.dimDrivcond = {
+      description: 'Driver Condition',
+      entries: drivcondEntries,
+      fn: (event, { drivcond, invtype }) => {
+        if (invtype === 1 || invtype === 6 || invtype === 18) {
+          return drivcond;
+        }
+        return null;
+      },
+    };
+
+    const impactypeEntries = this.getCollisionFactorEntries('impactype');
+    this.dimImpactype = {
+      description: 'Initial Impact Type',
+      entries: impactypeEntries,
+      fn: ({ impactype }) => impactype,
     };
 
     const initdirEntries = this.getCollisionFactorEntries('initdir');
@@ -39,7 +69,6 @@ class ReportCollisionTabulation extends ReportBaseCrash {
         }
         return null;
       },
-      involved: true,
     };
 
     const injuryEntries = this.getCollisionFactorEntries('injury');
@@ -47,7 +76,6 @@ class ReportCollisionTabulation extends ReportBaseCrash {
       description: 'Severity of Injury',
       entries: injuryEntries,
       fn: (event, { injury }) => injury,
-      involved: true,
     };
 
     const invtypeEntries = this.getCollisionFactorEntries('invtype');
@@ -55,7 +83,6 @@ class ReportCollisionTabulation extends ReportBaseCrash {
       description: 'Category of Person',
       entries: invtypeEntries,
       fn: (event, { invtype }) => invtype,
-      involved: true,
     };
 
     const manoeuverEntries = this.getCollisionFactorEntries('manoeuver');
@@ -68,7 +95,6 @@ class ReportCollisionTabulation extends ReportBaseCrash {
         }
         return null;
       },
-      involved: true,
     };
   }
 
@@ -98,7 +124,6 @@ class ReportCollisionTabulation extends ReportBaseCrash {
           return;
         }
         const tableY = table.get(y);
-        tableY.total += 1;
 
         const x = dimX.fn(event, person);
         if (x === null) {
@@ -106,6 +131,7 @@ class ReportCollisionTabulation extends ReportBaseCrash {
         }
         const valueX = tableY.values.get(x);
         tableY.values.set(x, valueX + 1);
+        tableY.total += 1;
       });
     });
     const orderX = ArrayUtils.sortBy(
@@ -207,8 +233,26 @@ class ReportCollisionTabulation extends ReportBaseCrash {
           type: ReportBlock.TABLE,
           options: this.getCrossTabulationTableOptions(
             collisions,
-            this.dimAge,
-            this.dimInvtype,
+            this.dimInitdir,
+            this.dimImpactype,
+          ),
+        },
+      ],
+      [
+        {
+          type: ReportBlock.TABLE,
+          options: this.getCrossTabulationTableOptions(
+            collisions,
+            this.dimInjury,
+            this.dimDrivcond,
+          ),
+        },
+        {
+          type: ReportBlock.TABLE,
+          options: this.getCrossTabulationTableOptions(
+            collisions,
+            this.dimInjury,
+            this.dimDrivact,
           ),
         },
       ],

--- a/lib/reports/ReportCollisionTabulation.js
+++ b/lib/reports/ReportCollisionTabulation.js
@@ -1,5 +1,6 @@
 /* eslint-disable class-methods-use-this */
-import { ReportBlock, ReportType } from '@/lib/Constants';
+import ArrayUtils from '@/lib/ArrayUtils';
+import { ReportBlock, ReportType, SortDirection } from '@/lib/Constants';
 import ReportBaseCrash from '@/lib/reports/ReportBaseCrash';
 
 class ReportCollisionTabulation extends ReportBaseCrash {
@@ -7,53 +8,123 @@ class ReportCollisionTabulation extends ReportBaseCrash {
     return ReportType.COLLISION_TABULATION;
   }
 
+  initDims() {
+    const injuryEntries = this.getCollisionFactorEntries('injury');
+    this.dimInjury = {
+      description: 'Severity of Injury',
+      entries: injuryEntries,
+      fn: (event, { injury }) => injury,
+      involved: true,
+    };
+
+    const invtypeEntries = this.getCollisionFactorEntries('invtype');
+    this.dimInvtype = {
+      description: 'Category of Person',
+      entries: invtypeEntries,
+      fn: (event, { invtype }) => invtype,
+      involved: true,
+    };
+  }
+
+  async fetchRawData(location, filters) {
+    const rawData = await super.fetchRawData(location, filters);
+    this.initDims();
+    return rawData;
+  }
+
   transformData(location, rawData) {
     return rawData;
   }
 
-  generateLayoutContent(location, { collisionSummary }) {
-    const collisionSummaryBlock = ReportBaseCrash.getCollisionsSummaryBlock(collisionSummary);
+  getCrossTabulation(collisions, dimX, dimY) {
+    const table = new Map();
+    dimY.entries.forEach((valueY, y) => {
+      const values = new Map();
+      dimX.entries.forEach((valueX, x) => {
+        values.set(x, 0);
+      });
+      table.set(y, { total: 0, values });
+    });
+    collisions.forEach(({ involved, ...event }) => {
+      involved.forEach((person) => {
+        const y = dimY.fn(event, person);
+        if (y === null) {
+          return;
+        }
+        const tableY = table.get(y);
+        tableY.total += 1;
 
-    const tableOptions = {
+        const x = dimX.fn(event, person);
+        if (x === null) {
+          return;
+        }
+        const valueX = tableY.values.get(x);
+        tableY.values.set(x, valueX + 1);
+      });
+    });
+    const orderX = ArrayUtils.sortBy(
+      Array.from(dimX.entries.keys()),
+      x => x,
+    );
+    const orderY = ArrayUtils.sortBy(
+      Array.from(dimY.entries.keys()),
+      y => table.get(y).total,
+      SortDirection.DESC,
+    );
+    return {
+      orderX,
+      orderY,
+      table,
+    };
+  }
+
+  getCrossTabulationTableOptions(collisions, dimX, dimY) {
+    const { orderX, orderY, table } = this.getCrossTabulation(collisions, dimX, dimY);
+    return {
       columnStyles: [
         { c: 0 },
-        { c: 1 },
       ],
       header: [
         [
-          { value: 'a' },
-          { value: 'b' },
+          { value: dimY.description, rowspan: 2 },
+          { value: dimX.description, colspan: orderX.length },
+          { value: 'Total', rowspan: 2 },
         ],
+        orderX.map(x => dimX.entries.get(x).description),
       ],
-      body: [
-        [
-          { value: 1 },
-          { value: 2 },
-        ],
-      ],
+      body: orderY.map((y) => {
+        const { description } = dimY.entries.get(y);
+        const { total, values } = table.get(y);
+        return [
+          { value: description },
+          ...orderX.map(x => ({ value: values.get(x) })),
+          { value: total },
+        ];
+      }),
     };
-    const barChartOptions1 = {
-      data: [1, 2, 3, 4, 5],
-      labelAxisX: 'to the Right',
-      labelAxisY: 'Up and',
-      title: 'Chart 1',
-    };
-    const barChartOptions2 = {
-      data: [5, 4, 3, 2, 1],
-      labelAxisX: 'to the Right',
-      labelAxisY: 'Down and',
-      title: 'Chart 1',
-    };
+  }
+
+  generateLayoutContent(location, { collisions, collisionSummary }) {
+    const collisionSummaryBlock = ReportBaseCrash.getCollisionsSummaryBlock(collisionSummary);
     return [
       collisionSummaryBlock,
       [
-        { type: ReportBlock.TABLE, options: tableOptions },
-        { type: ReportBlock.TABLE, options: tableOptions },
-        { type: ReportBlock.TABLE, options: tableOptions },
-      ],
-      [
-        { type: ReportBlock.BAR_CHART, options: barChartOptions1 },
-        { type: ReportBlock.BAR_CHART, options: barChartOptions2 },
+        {
+          type: ReportBlock.TABLE,
+          options: this.getCrossTabulationTableOptions(
+            collisions,
+            this.dimInjury,
+            this.dimInvtype,
+          ),
+        },
+        {
+          type: ReportBlock.TABLE,
+          options: this.getCrossTabulationTableOptions(
+            collisions,
+            this.dimInjury,
+            this.dimInvtype,
+          ),
+        },
       ],
     ];
   }

--- a/lib/reports/ReportCollisionTabulation.js
+++ b/lib/reports/ReportCollisionTabulation.js
@@ -1,6 +1,7 @@
 /* eslint-disable class-methods-use-this */
 import ArrayUtils from '@/lib/ArrayUtils';
 import { ReportBlock, ReportType, SortDirection } from '@/lib/Constants';
+import ArrayStats from '@/lib/math/ArrayStats';
 import ReportBaseCrash from '@/lib/reports/ReportBaseCrash';
 
 class ReportCollisionTabulation extends ReportBaseCrash {
@@ -28,6 +29,19 @@ class ReportCollisionTabulation extends ReportBaseCrash {
       involved: true,
     };
 
+    const initdirEntries = this.getCollisionFactorEntries('initdir');
+    this.dimInitdir = {
+      description: 'Initial Direction of Driver',
+      entries: initdirEntries,
+      fn: (event, { initdir, invtype }) => {
+        if (invtype === 1 || invtype === 6 || invtype === 18) {
+          return initdir;
+        }
+        return null;
+      },
+      involved: true,
+    };
+
     const injuryEntries = this.getCollisionFactorEntries('injury');
     this.dimInjury = {
       description: 'Severity of Injury',
@@ -41,6 +55,19 @@ class ReportCollisionTabulation extends ReportBaseCrash {
       description: 'Category of Person',
       entries: invtypeEntries,
       fn: (event, { invtype }) => invtype,
+      involved: true,
+    };
+
+    const manoeuverEntries = this.getCollisionFactorEntries('manoeuver');
+    this.dimManoeuver = {
+      description: 'Manoeuver',
+      entries: manoeuverEntries,
+      fn: (event, { invtype, manoeuver }) => {
+        if (invtype === 1 || invtype === 6 || invtype === 18) {
+          return manoeuver;
+        }
+        return null;
+      },
       involved: true,
     };
   }
@@ -99,7 +126,18 @@ class ReportCollisionTabulation extends ReportBaseCrash {
 
   getCrossTabulationTableOptions(collisions, dimX, dimY, limit = 10) {
     const { orderX, orderY, table } = this.getCrossTabulation(collisions, dimX, dimY);
+    const orderYLimit = orderY.slice(0, limit);
     const nx = orderX.length;
+
+    const orderXTotals = orderX.map(
+      x => ArrayStats.sum(
+        orderY.map(y => table.get(y).values.get(x)),
+      ),
+    );
+    const orderYTotal = ArrayStats.sum(
+      orderY.map(y => table.get(y).total),
+    );
+
     return {
       columnStyles: [
         { c: 0 },
@@ -114,16 +152,23 @@ class ReportCollisionTabulation extends ReportBaseCrash {
           value: dimX.entries.get(x).description,
         })),
       ],
-      body: orderY.slice(0, limit).map((y, i) => {
-        const { description } = dimY.entries.get(y);
-        const { total, values } = table.get(y);
-        const shade = i % 2 === 1;
-        return [
-          { value: description, style: { br: true, shade } },
-          ...orderX.map(x => ({ value: values.get(x), style: { shade } })),
-          { value: total, style: { bl: true, shade } },
-        ];
-      }),
+      body: [
+        ...orderYLimit.map((y, i) => {
+          const { description } = dimY.entries.get(y);
+          const { total, values } = table.get(y);
+          const shade = i % 2 === 1;
+          return [
+            { value: description, style: { br: true, shade } },
+            ...orderX.map(x => ({ value: values.get(x), style: { shade } })),
+            { value: total, style: { bl: true, shade } },
+          ];
+        }),
+        [
+          { value: 'Total', style: { bold: true, br: true, bt: true } },
+          ...orderXTotals.map(value => ({ value, style: { bold: true, bt: true } })),
+          { value: orderYTotal, style: { bold: true, bl: true, bt: true } },
+        ],
+      ],
     };
   }
 
@@ -138,6 +183,24 @@ class ReportCollisionTabulation extends ReportBaseCrash {
             collisions,
             this.dimInjury,
             this.dimInvtype,
+          ),
+        },
+        {
+          type: ReportBlock.TABLE,
+          options: this.getCrossTabulationTableOptions(
+            collisions,
+            this.dimAge,
+            this.dimInvtype,
+          ),
+        },
+      ],
+      [
+        {
+          type: ReportBlock.TABLE,
+          options: this.getCrossTabulationTableOptions(
+            collisions,
+            this.dimInitdir,
+            this.dimManoeuver,
           ),
         },
         {

--- a/lib/reports/ReportCollisionTabulation.js
+++ b/lib/reports/ReportCollisionTabulation.js
@@ -1,5 +1,5 @@
 /* eslint-disable class-methods-use-this */
-import { ReportType } from '@/lib/Constants';
+import { ReportBlock, ReportType } from '@/lib/Constants';
 import ReportBaseCrash from '@/lib/reports/ReportBaseCrash';
 
 class ReportCollisionTabulation extends ReportBaseCrash {
@@ -13,8 +13,25 @@ class ReportCollisionTabulation extends ReportBaseCrash {
 
   generateLayoutContent(location, { collisionSummary }) {
     const collisionSummaryBlock = ReportBaseCrash.getCollisionsSummaryBlock(collisionSummary);
+
+    const barChartOptions1 = {
+      data: [1, 2, 3, 4, 5],
+      labelAxisX: 'to the Right',
+      labelAxisY: 'Up and',
+      title: 'Chart 1',
+    };
+    const barChartOptions2 = {
+      data: [5, 4, 3, 2, 1],
+      labelAxisX: 'to the Right',
+      labelAxisY: 'Down and',
+      title: 'Chart 1',
+    };
     return [
       collisionSummaryBlock,
+      [
+        { type: ReportBlock.BAR_CHART, options: barChartOptions1 },
+        { type: ReportBlock.BAR_CHART, options: barChartOptions2 },
+      ],
     ];
   }
 }

--- a/lib/reports/ReportCollisionTabulation.js
+++ b/lib/reports/ReportCollisionTabulation.js
@@ -108,32 +108,41 @@ class ReportCollisionTabulation extends ReportBaseCrash {
     return rawData;
   }
 
-  getCrossTabulation(collisions, dimX, dimY) {
+  static getEmptyCrossTabulation(dimX, dimY) {
     const table = new Map();
     dimY.entries.forEach((valueY, y) => {
       const values = new Map();
       dimX.entries.forEach((valueX, x) => {
         values.set(x, 0);
       });
+      values.set(null, 0);
       table.set(y, { total: 0, values });
     });
-    collisions.forEach(({ involved, ...event }) => {
-      involved.forEach((person) => {
-        const y = dimY.fn(event, person);
-        if (y === null) {
-          return;
-        }
-        const tableY = table.get(y);
-
-        const x = dimX.fn(event, person);
-        if (x === null) {
-          return;
-        }
-        const valueX = tableY.values.get(x);
-        tableY.values.set(x, valueX + 1);
-        tableY.total += 1;
-      });
+    const nullValues = new Map();
+    dimX.entries.forEach((valueX, x) => {
+      nullValues.set(x, 0);
     });
+    nullValues.set(null, 0);
+    table.set(null, { total: 0, values: nullValues });
+    return table;
+  }
+
+  static incrCrossTabulation(table, x, y) {
+    // TODO: handle null values
+    if (y === null) {
+      return;
+    }
+    const tableY = table.get(y);
+    tableY.total += 1;
+
+    if (x === null) {
+      return;
+    }
+    const valueX = tableY.values.get(x);
+    tableY.values.set(x, valueX + 1);
+  }
+
+  static getDimOrders(table, dimX, dimY) {
     const orderX = ArrayUtils.sortBy(
       Array.from(dimX.entries.keys()),
       x => x,
@@ -143,15 +152,35 @@ class ReportCollisionTabulation extends ReportBaseCrash {
       y => table.get(y).total,
       SortDirection.DESC,
     );
-    return {
-      orderX,
-      orderY,
-      table,
-    };
+    return { orderX, orderY };
   }
 
-  getCrossTabulationTableOptions(collisions, dimX, dimY, limit = 10) {
-    const { orderX, orderY, table } = this.getCrossTabulation(collisions, dimX, dimY);
+  getEventCrossTabulation(collisions, dimX, dimY) {
+    const table = ReportCollisionTabulation.getEmptyCrossTabulation(dimX, dimY);
+    collisions.forEach((event) => {
+      const x = dimX.fn(event);
+      const y = dimY.fn(event);
+      ReportCollisionTabulation.incrCrossTabulation(table, x, y);
+    });
+    const { orderX, orderY } = ReportCollisionTabulation.getDimOrders(table, dimX, dimY);
+    return { orderX, orderY, table };
+  }
+
+  getInvolvedCrossTabulation(collisions, dimX, dimY) {
+    const table = ReportCollisionTabulation.getEmptyCrossTabulation(dimX, dimY);
+    collisions.forEach(({ involved, ...event }) => {
+      involved.forEach((person) => {
+        const x = dimX.fn(event, person);
+        const y = dimY.fn(event, person);
+        ReportCollisionTabulation.incrCrossTabulation(table, x, y);
+      });
+    });
+    const { orderX, orderY } = ReportCollisionTabulation.getDimOrders(table, dimX, dimY);
+    return { orderX, orderY, table };
+  }
+
+  getTableOptions(crossTabulation, dimX, dimY, limit) {
+    const { orderX, orderY, table } = crossTabulation;
     const orderYLimit = orderY.slice(0, limit);
     const nx = orderX.length;
 
@@ -198,6 +227,16 @@ class ReportCollisionTabulation extends ReportBaseCrash {
     };
   }
 
+  getEventTableOptions(collisions, dimX, dimY, limit = 10) {
+    const crossTabulation = this.getEventCrossTabulation(collisions, dimX, dimY);
+    return this.getTableOptions(crossTabulation, dimX, dimY, limit);
+  }
+
+  getInvolvedTableOptions(collisions, dimX, dimY, limit = 10) {
+    const crossTabulation = this.getInvolvedCrossTabulation(collisions, dimX, dimY);
+    return this.getTableOptions(crossTabulation, dimX, dimY, limit);
+  }
+
   generateLayoutContent(location, { collisions, collisionSummary }) {
     const collisionSummaryBlock = ReportBaseCrash.getCollisionsSummaryBlock(collisionSummary);
     return [
@@ -205,7 +244,7 @@ class ReportCollisionTabulation extends ReportBaseCrash {
       [
         {
           type: ReportBlock.TABLE,
-          options: this.getCrossTabulationTableOptions(
+          options: this.getInvolvedTableOptions(
             collisions,
             this.dimInjury,
             this.dimInvtype,
@@ -213,7 +252,7 @@ class ReportCollisionTabulation extends ReportBaseCrash {
         },
         {
           type: ReportBlock.TABLE,
-          options: this.getCrossTabulationTableOptions(
+          options: this.getInvolvedTableOptions(
             collisions,
             this.dimAge,
             this.dimInvtype,
@@ -223,7 +262,7 @@ class ReportCollisionTabulation extends ReportBaseCrash {
       [
         {
           type: ReportBlock.TABLE,
-          options: this.getCrossTabulationTableOptions(
+          options: this.getInvolvedTableOptions(
             collisions,
             this.dimInitdir,
             this.dimManoeuver,
@@ -231,7 +270,7 @@ class ReportCollisionTabulation extends ReportBaseCrash {
         },
         {
           type: ReportBlock.TABLE,
-          options: this.getCrossTabulationTableOptions(
+          options: this.getInvolvedTableOptions(
             collisions,
             this.dimInitdir,
             this.dimImpactype,
@@ -241,7 +280,7 @@ class ReportCollisionTabulation extends ReportBaseCrash {
       [
         {
           type: ReportBlock.TABLE,
-          options: this.getCrossTabulationTableOptions(
+          options: this.getInvolvedTableOptions(
             collisions,
             this.dimInjury,
             this.dimDrivcond,
@@ -249,7 +288,25 @@ class ReportCollisionTabulation extends ReportBaseCrash {
         },
         {
           type: ReportBlock.TABLE,
-          options: this.getCrossTabulationTableOptions(
+          options: this.getInvolvedTableOptions(
+            collisions,
+            this.dimInjury,
+            this.dimDrivact,
+          ),
+        },
+      ],
+      [
+        {
+          type: ReportBlock.TABLE,
+          options: this.getInvolvedTableOptions(
+            collisions,
+            this.dimInjury,
+            this.dimDrivcond,
+          ),
+        },
+        {
+          type: ReportBlock.TABLE,
+          options: this.getInvolvedTableOptions(
             collisions,
             this.dimInjury,
             this.dimDrivact,

--- a/lib/reports/ReportCollisionTabulation.js
+++ b/lib/reports/ReportCollisionTabulation.js
@@ -78,27 +78,31 @@ class ReportCollisionTabulation extends ReportBaseCrash {
     };
   }
 
-  getCrossTabulationTableOptions(collisions, dimX, dimY) {
+  getCrossTabulationTableOptions(collisions, dimX, dimY, ny = 10) {
     const { orderX, orderY, table } = this.getCrossTabulation(collisions, dimX, dimY);
+    const nx = orderX.length;
     return {
       columnStyles: [
         { c: 0 },
       ],
       header: [
         [
-          { value: dimY.description, rowspan: 2 },
-          { value: dimX.description, colspan: orderX.length },
-          { value: 'Total', rowspan: 2 },
+          { value: dimY.description, rowspan: 2, style: { br: true } },
+          { value: dimX.description, colspan: nx },
+          { value: 'Total', rowspan: 2, style: { bl: true } },
         ],
-        orderX.map(x => dimX.entries.get(x).description),
+        orderX.map(x => ({
+          value: dimX.entries.get(x).description,
+        })),
       ],
-      body: orderY.map((y) => {
+      body: orderY.slice(0, ny).map((y, i) => {
         const { description } = dimY.entries.get(y);
         const { total, values } = table.get(y);
+        const shade = i % 2 === 1;
         return [
-          { value: description },
-          ...orderX.map(x => ({ value: values.get(x) })),
-          { value: total },
+          { value: description, style: { br: true, shade } },
+          ...orderX.map(x => ({ value: values.get(x), style: { shade } })),
+          { value: total, style: { bl: true, shade } },
         ];
       }),
     };

--- a/lib/reports/ReportCollisionTabulation.js
+++ b/lib/reports/ReportCollisionTabulation.js
@@ -14,6 +14,24 @@ class ReportCollisionTabulation extends ReportBaseCrash {
   generateLayoutContent(location, { collisionSummary }) {
     const collisionSummaryBlock = ReportBaseCrash.getCollisionsSummaryBlock(collisionSummary);
 
+    const tableOptions = {
+      columnStyles: [
+        { c: 0 },
+        { c: 1 },
+      ],
+      header: [
+        [
+          { value: 'a' },
+          { value: 'b' },
+        ],
+      ],
+      body: [
+        [
+          { value: 1 },
+          { value: 2 },
+        ],
+      ],
+    };
     const barChartOptions1 = {
       data: [1, 2, 3, 4, 5],
       labelAxisX: 'to the Right',
@@ -28,6 +46,11 @@ class ReportCollisionTabulation extends ReportBaseCrash {
     };
     return [
       collisionSummaryBlock,
+      [
+        { type: ReportBlock.TABLE, options: tableOptions },
+        { type: ReportBlock.TABLE, options: tableOptions },
+        { type: ReportBlock.TABLE, options: tableOptions },
+      ],
       [
         { type: ReportBlock.BAR_CHART, options: barChartOptions1 },
         { type: ReportBlock.BAR_CHART, options: barChartOptions2 },

--- a/lib/reports/ReportCollisionTabulation.js
+++ b/lib/reports/ReportCollisionTabulation.js
@@ -3,6 +3,7 @@ import ArrayUtils from '@/lib/ArrayUtils';
 import { ReportBlock, ReportType, SortDirection } from '@/lib/Constants';
 import ArrayStats from '@/lib/math/ArrayStats';
 import ReportBaseCrash from '@/lib/reports/ReportBaseCrash';
+import TimeFormatters from '@/lib/time/TimeFormatters';
 
 class ReportCollisionTabulation extends ReportBaseCrash {
   type() {
@@ -10,6 +11,16 @@ class ReportCollisionTabulation extends ReportBaseCrash {
   }
 
   initDims() {
+    this.dimAccdateMonth = {
+      description: 'Month of Collision',
+      entries: new Map(
+        TimeFormatters.MONTHS_OF_YEAR.map(
+          (month, i) => [i + 1, { description: month }],
+        ),
+      ),
+      fn: ({ accdate }) => accdate.month,
+    };
+
     this.dimAge = {
       description: 'Age Group',
       entries: new Map([
@@ -77,6 +88,13 @@ class ReportCollisionTabulation extends ReportBaseCrash {
       entries: injuryEntries,
       fn: (event, { injury }) => injury,
     };
+    this.dimInjuryEvent = {
+      description: 'Severity of Injury',
+      entries: injuryEntries,
+      fn: ({ involved }) => Math.max(
+        ...involved.map(({ injury }) => injury),
+      ),
+    };
 
     const invtypeEntries = this.getCollisionFactorEntries('invtype');
     this.dimInvtype = {
@@ -118,12 +136,6 @@ class ReportCollisionTabulation extends ReportBaseCrash {
       values.set(null, 0);
       table.set(y, { total: 0, values });
     });
-    const nullValues = new Map();
-    dimX.entries.forEach((valueX, x) => {
-      nullValues.set(x, 0);
-    });
-    nullValues.set(null, 0);
-    table.set(null, { total: 0, values: nullValues });
     return table;
   }
 
@@ -142,31 +154,36 @@ class ReportCollisionTabulation extends ReportBaseCrash {
     tableY.values.set(x, valueX + 1);
   }
 
-  static getDimOrders(table, dimX, dimY) {
+  static getDimOrders(table, dimX, dimY, options) {
+    const {
+      sortY = true,
+    } = options;
     const orderX = ArrayUtils.sortBy(
       Array.from(dimX.entries.keys()),
       x => x,
     );
+    const keyY = sortY ? y => table.get(y).total : y => y;
+    const dirY = sortY ? SortDirection.DESC : SortDirection.ASC;
     const orderY = ArrayUtils.sortBy(
       Array.from(dimY.entries.keys()),
-      y => table.get(y).total,
-      SortDirection.DESC,
+      keyY,
+      dirY,
     );
     return { orderX, orderY };
   }
 
-  getEventCrossTabulation(collisions, dimX, dimY) {
+  getEventCrossTabulation(collisions, dimX, dimY, options) {
     const table = ReportCollisionTabulation.getEmptyCrossTabulation(dimX, dimY);
     collisions.forEach((event) => {
       const x = dimX.fn(event);
       const y = dimY.fn(event);
       ReportCollisionTabulation.incrCrossTabulation(table, x, y);
     });
-    const { orderX, orderY } = ReportCollisionTabulation.getDimOrders(table, dimX, dimY);
+    const { orderX, orderY } = ReportCollisionTabulation.getDimOrders(table, dimX, dimY, options);
     return { orderX, orderY, table };
   }
 
-  getInvolvedCrossTabulation(collisions, dimX, dimY) {
+  getInvolvedCrossTabulation(collisions, dimX, dimY, options) {
     const table = ReportCollisionTabulation.getEmptyCrossTabulation(dimX, dimY);
     collisions.forEach(({ involved, ...event }) => {
       involved.forEach((person) => {
@@ -175,11 +192,15 @@ class ReportCollisionTabulation extends ReportBaseCrash {
         ReportCollisionTabulation.incrCrossTabulation(table, x, y);
       });
     });
-    const { orderX, orderY } = ReportCollisionTabulation.getDimOrders(table, dimX, dimY);
+    const { orderX, orderY } = ReportCollisionTabulation.getDimOrders(table, dimX, dimY, options);
     return { orderX, orderY, table };
   }
 
-  getTableOptions(crossTabulation, dimX, dimY, limit) {
+  getTableOptions(crossTabulation, dimX, dimY, options) {
+    const {
+      limit = 10,
+    } = options;
+
     const { orderX, orderY, table } = crossTabulation;
     const orderYLimit = orderY.slice(0, limit);
     const nx = orderX.length;
@@ -227,14 +248,14 @@ class ReportCollisionTabulation extends ReportBaseCrash {
     };
   }
 
-  getEventTableOptions(collisions, dimX, dimY, limit = 10) {
-    const crossTabulation = this.getEventCrossTabulation(collisions, dimX, dimY);
-    return this.getTableOptions(crossTabulation, dimX, dimY, limit);
+  getEventTableOptions(collisions, dimX, dimY, options = {}) {
+    const crossTabulation = this.getEventCrossTabulation(collisions, dimX, dimY, options);
+    return this.getTableOptions(crossTabulation, dimX, dimY, options);
   }
 
-  getInvolvedTableOptions(collisions, dimX, dimY, limit = 10) {
-    const crossTabulation = this.getInvolvedCrossTabulation(collisions, dimX, dimY);
-    return this.getTableOptions(crossTabulation, dimX, dimY, limit);
+  getInvolvedTableOptions(collisions, dimX, dimY, options = {}) {
+    const crossTabulation = this.getInvolvedCrossTabulation(collisions, dimX, dimY, options);
+    return this.getTableOptions(crossTabulation, dimX, dimY, options);
   }
 
   generateLayoutContent(location, { collisions, collisionSummary }) {
@@ -298,18 +319,11 @@ class ReportCollisionTabulation extends ReportBaseCrash {
       [
         {
           type: ReportBlock.TABLE,
-          options: this.getInvolvedTableOptions(
+          options: this.getEventTableOptions(
             collisions,
-            this.dimInjury,
-            this.dimDrivcond,
-          ),
-        },
-        {
-          type: ReportBlock.TABLE,
-          options: this.getInvolvedTableOptions(
-            collisions,
-            this.dimInjury,
-            this.dimDrivact,
+            this.dimInjuryEvent,
+            this.dimAccdateMonth,
+            { limit: 12, sortY: false },
           ),
         },
       ],

--- a/lib/reports/ReportCollisionTabulation.js
+++ b/lib/reports/ReportCollisionTabulation.js
@@ -202,7 +202,7 @@ class ReportCollisionTabulation extends ReportBaseCrash {
     } = options;
 
     const { orderX, orderY, table } = crossTabulation;
-    const orderYLimit = orderY.slice(0, limit);
+    const orderYLimit = limit === null ? orderY : orderY.slice(0, limit);
     const nx = orderX.length;
 
     const orderXTotals = orderX.map(
@@ -258,8 +258,39 @@ class ReportCollisionTabulation extends ReportBaseCrash {
     return this.getTableOptions(crossTabulation, dimX, dimY, options);
   }
 
+  static getDimAccdateEntries(collisions) {
+    if (collisions.length === 0) {
+      return new Map();
+    }
+    let yearMin = Infinity;
+    let yearMax = -Infinity;
+    collisions.forEach(({ accdate }) => {
+      const { year } = accdate;
+      if (year < yearMin) {
+        yearMin = year;
+      }
+      if (year > yearMax) {
+        yearMax = year;
+      }
+    });
+    const years = ArrayUtils.range(yearMin, yearMax + 1);
+    return new Map(
+      years.map(y => [y, { description: y }]),
+    );
+  }
+
+  static getDimAccdateYear(collisions) {
+    const entries = ReportCollisionTabulation.getDimAccdateEntries(collisions);
+    return {
+      description: 'Year of Collision',
+      entries,
+      fn: ({ accdate }) => accdate.year,
+    };
+  }
+
   generateLayoutContent(location, { collisions, collisionSummary }) {
     const collisionSummaryBlock = ReportBaseCrash.getCollisionsSummaryBlock(collisionSummary);
+    const dimAccdateYear = ReportCollisionTabulation.getDimAccdateYear(collisions);
     return [
       collisionSummaryBlock,
       [
@@ -317,6 +348,15 @@ class ReportCollisionTabulation extends ReportBaseCrash {
         },
       ],
       [
+        {
+          type: ReportBlock.TABLE,
+          options: this.getEventTableOptions(
+            collisions,
+            this.dimInjuryEvent,
+            dimAccdateYear,
+            { limit: null, sortY: false },
+          ),
+        },
         {
           type: ReportBlock.TABLE,
           options: this.getEventTableOptions(

--- a/lib/reports/ReportCollisionTabulation.js
+++ b/lib/reports/ReportCollisionTabulation.js
@@ -279,6 +279,37 @@ class ReportCollisionTabulation extends ReportBaseCrash {
     );
   }
 
+  getDayOfWeekBarChartOptions(collisions) {
+    const data = [];
+    for (let i = 0; i < 7; i++) {
+      const tick = TimeFormatters.DAYS_OF_WEEK[i];
+      data.push({ tick, value: 0 });
+    }
+    collisions.forEach(({ accdate }) => {
+      const i = accdate.weekday % 7;
+      data[i].value += 1;
+    });
+    return {
+      data,
+      title: 'Collisions By Day of Week',
+    };
+  }
+
+  getHourOfDayBarChartOptions(collisions) {
+    const data = [];
+    for (let i = 0; i < 24; i++) {
+      data.push({ tick: i, value: 0 });
+    }
+    collisions.forEach(({ accdate }) => {
+      const i = accdate.hour;
+      data[i].value += 1;
+    });
+    return {
+      data,
+      title: 'Collisions By Hour of Day',
+    };
+  }
+
   static getDimAccdateYear(collisions) {
     const entries = ReportCollisionTabulation.getDimAccdateEntries(collisions);
     return {
@@ -365,6 +396,16 @@ class ReportCollisionTabulation extends ReportBaseCrash {
             this.dimAccdateMonth,
             { limit: 12, sortY: false },
           ),
+        },
+      ],
+      [
+        {
+          type: ReportBlock.BAR_CHART,
+          options: this.getDayOfWeekBarChartOptions(collisions),
+        },
+        {
+          type: ReportBlock.BAR_CHART,
+          options: this.getHourOfDayBarChartOptions(collisions),
         },
       ],
     ];

--- a/lib/reports/ReportCollisionTabulation.js
+++ b/lib/reports/ReportCollisionTabulation.js
@@ -9,6 +9,25 @@ class ReportCollisionTabulation extends ReportBaseCrash {
   }
 
   initDims() {
+    this.dimAge = {
+      description: 'Age Group',
+      entries: new Map([
+        [0, { description: 'School Child' }],
+        [1, { description: 'Adult' }],
+        [2, { description: 'Older Adult' }],
+      ]),
+      fn: (event, { olderAdult, schoolChild }) => {
+        if (olderAdult) {
+          return 2;
+        }
+        if (schoolChild) {
+          return 0;
+        }
+        return 1;
+      },
+      involved: true,
+    };
+
     const injuryEntries = this.getCollisionFactorEntries('injury');
     this.dimInjury = {
       description: 'Severity of Injury',
@@ -78,7 +97,7 @@ class ReportCollisionTabulation extends ReportBaseCrash {
     };
   }
 
-  getCrossTabulationTableOptions(collisions, dimX, dimY, ny = 10) {
+  getCrossTabulationTableOptions(collisions, dimX, dimY, limit = 10) {
     const { orderX, orderY, table } = this.getCrossTabulation(collisions, dimX, dimY);
     const nx = orderX.length;
     return {
@@ -95,7 +114,7 @@ class ReportCollisionTabulation extends ReportBaseCrash {
           value: dimX.entries.get(x).description,
         })),
       ],
-      body: orderY.slice(0, ny).map((y, i) => {
+      body: orderY.slice(0, limit).map((y, i) => {
         const { description } = dimY.entries.get(y);
         const { total, values } = table.get(y);
         const shade = i % 2 === 1;
@@ -125,7 +144,7 @@ class ReportCollisionTabulation extends ReportBaseCrash {
           type: ReportBlock.TABLE,
           options: this.getCrossTabulationTableOptions(
             collisions,
-            this.dimInjury,
+            this.dimAge,
             this.dimInvtype,
           ),
         },

--- a/lib/reports/ReportCollisionTabulation.js
+++ b/lib/reports/ReportCollisionTabulation.js
@@ -360,6 +360,7 @@ class ReportCollisionTabulation extends ReportBaseCrash {
           ),
         },
       ],
+      { type: ReportBlock.PAGE_BREAK, options: {} },
       [
         {
           type: ReportBlock.TABLE,
@@ -398,6 +399,7 @@ class ReportCollisionTabulation extends ReportBaseCrash {
           ),
         },
       ],
+      { type: ReportBlock.PAGE_BREAK, options: {} },
       [
         {
           type: ReportBlock.BAR_CHART,

--- a/lib/reports/ReportCountSummary24hGraphical.js
+++ b/lib/reports/ReportCountSummary24hGraphical.js
@@ -42,8 +42,9 @@ class ReportCountSummary24hGraphical extends ReportBaseFlow {
   }
 
   getBarChartOptions(reportData) {
+    const data = reportData.map((value, i) => ({ tick: i, value }));
     return {
-      data: reportData,
+      data,
       labelAxisX: 'Start Hour',
       labelAxisY: 'Number of Vehicles',
       title: 'Volume by Hour of Day',

--- a/lib/reports/format/MovePdfGenerator.js
+++ b/lib/reports/format/MovePdfGenerator.js
@@ -448,22 +448,40 @@ class MovePdfGenerator {
     return content;
   }
 
-  generateContent() {
+  generateContentForReportBlock({ type: blockType, options }) {
     const spaceM = FormatCss.var('--space-m');
+    const { suffix } = blockType;
+    const generateContentBlocks = this[`generate${suffix}`].bind(this);
+    const contentBlocks = generateContentBlocks(options);
+    let n = contentBlocks.length;
+    if (n === 0) {
+      contentBlocks.push({});
+      n = 1;
+    }
+    contentBlocks[n - 1].margin = [0, 0, 0, spaceM];
+    return contentBlocks;
+  }
+
+  generateContentRow(contentRow) {
+    if (Array.isArray(contentRow)) {
+      /*
+       * Arrays of report blocks are rendered into equal-width columns.  This process
+       * is non-recursive: to limit report complexity, you cannot nest columns within
+       * columns!
+       */
+      return [{
+        columns: contentRow.map(reportBlock => ({
+          stack: this.generateContentForReportBlock(reportBlock),
+        })),
+      }];
+    }
+    return this.generateContentForReportBlock(contentRow);
+  }
+
+  generateContent() {
     return Array.prototype.concat.apply(
       [],
-      this.content.map(({ type: blockType, options }) => {
-        const { suffix } = blockType;
-        const generateContentBlocks = this[`generate${suffix}`].bind(this);
-        const contentBlocks = generateContentBlocks(options);
-        let n = contentBlocks.length;
-        if (n === 0) {
-          contentBlocks.push({});
-          n = 1;
-        }
-        contentBlocks[n - 1].margin = [0, 0, 0, spaceM];
-        return contentBlocks;
-      }),
+      this.content.map(this.generateContentRow.bind(this)),
     );
   }
 

--- a/lib/reports/format/MovePdfGenerator.js
+++ b/lib/reports/format/MovePdfGenerator.js
@@ -218,6 +218,17 @@ class MovePdfGenerator {
     }));
   }
 
+  // ReportBlock.PAGE_BREAK
+
+  generatePageBreak() {
+    return [
+      {
+        pageBreak: 'after',
+        text: '',
+      },
+    ];
+  }
+
   // ReportBlock.TABLE
 
   static getNumSectionColumns(section) {

--- a/lib/reports/format/MovePdfGenerator.js
+++ b/lib/reports/format/MovePdfGenerator.js
@@ -136,11 +136,13 @@ class MovePdfGenerator {
 
   // ReportBlock.BAR_CHART
 
-  generateBarChart(options) {
+  generateBarChart(options, numColumns) {
     const colorBase = FormatCss.var('--base');
     const colorInk = FormatCss.var('--ink');
+    const spaceL = FormatCss.var('--space-l');
     const space3XL = FormatCss.var('--space-3xl');
-    const width = this.width - 2 * this.margin;
+    const widthTotal = this.width - 2 * this.margin - (numColumns - 1) * spaceL;
+    const width = widthTotal / numColumns;
     const height = space3XL * 4;
     const barChartOptions = {
       colorAxis: colorInk,
@@ -448,11 +450,11 @@ class MovePdfGenerator {
     return content;
   }
 
-  generateContentForReportBlock({ type: blockType, options }) {
+  generateContentForReportBlock({ type: blockType, options }, numColumns) {
     const spaceM = FormatCss.var('--space-m');
     const { suffix } = blockType;
     const generateContentBlocks = this[`generate${suffix}`].bind(this);
-    const contentBlocks = generateContentBlocks(options);
+    const contentBlocks = generateContentBlocks(options, numColumns);
     let n = contentBlocks.length;
     if (n === 0) {
       contentBlocks.push({});
@@ -463,19 +465,22 @@ class MovePdfGenerator {
   }
 
   generateContentRow(contentRow) {
+    const spaceL = FormatCss.var('--space-l');
     if (Array.isArray(contentRow)) {
       /*
        * Arrays of report blocks are rendered into equal-width columns.  This process
        * is non-recursive: to limit report complexity, you cannot nest columns within
        * columns!
        */
+      const n = contentRow.length;
       return [{
         columns: contentRow.map(reportBlock => ({
-          stack: this.generateContentForReportBlock(reportBlock),
+          stack: this.generateContentForReportBlock(reportBlock, n),
         })),
+        columnGap: spaceL,
       }];
     }
-    return this.generateContentForReportBlock(contentRow);
+    return this.generateContentForReportBlock(contentRow, 1);
   }
 
   generateContent() {

--- a/lib/reports/svg/BarChartGenerator.js
+++ b/lib/reports/svg/BarChartGenerator.js
@@ -60,7 +60,8 @@ class BarChartGenerator extends SvgGenerator {
       .range([this.unitsHeightBars, 0]);
     this.axisX = axisBottom(this.scaleX)
       .tickSize(0)
-      .tickPadding(8);
+      .tickPadding(8)
+      .tickFormat(i => this.data[i].tick);
     this.axisY = axisLeft(this.scaleY)
       .tickSize(0)
       .tickPadding(8);
@@ -100,7 +101,7 @@ class BarChartGenerator extends SvgGenerator {
     this.scaleX
       .domain([...this.data.keys()]);
     this.scaleY
-      .domain([0, max(this.data)]);
+      .domain([0, max(this.data.map(({ value }) => value))]);
 
     const bars = this.groupBars.selectAll('rect.bar')
       .data(this.data);
@@ -111,9 +112,9 @@ class BarChartGenerator extends SvgGenerator {
       .attr('class', 'bar')
       .style('fill', this.colorBars === null ? undefined : this.colorBars)
       .merge(bars)
-      .attrs((n, h) => {
-        const x = this.scaleX(h);
-        const y = this.scaleY(n);
+      .attrs((d, i) => {
+        const x = this.scaleX(i);
+        const y = this.scaleY(d.value);
         const width = this.scaleX.bandwidth();
         const height = this.unitsHeightBars - y;
         return {

--- a/lib/time/TimeFormatters.js
+++ b/lib/time/TimeFormatters.js
@@ -177,4 +177,6 @@ TimeFormatters.DAYS_OF_WEEK = [
   ...WEEKDAYS.slice(0, -1),
 ];
 
+TimeFormatters.MONTHS_OF_YEAR = Info.months('short');
+
 export default TimeFormatters;

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -143,15 +143,15 @@ import { saveAs } from 'file-saver';
 import { mapGetters, mapMutations, mapState } from 'vuex';
 
 import {
-  ReportBlock,
   ReportFormat,
   ReportType,
   StudyType,
 } from '@/lib/Constants';
-import { reporterFetch } from '@/lib/api/BackendClient';
 import {
   getCountsByCentreline,
   getLocationByFeature,
+  getReport,
+  getReportWeb,
 } from '@/lib/api/WebApi';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 import FcDialogConfirm from '@/web/components/dialogs/FcDialogConfirm.vue';
@@ -317,21 +317,10 @@ export default {
       }
       this.downloadLoading = true;
 
-      const type = activeReportType;
       const countInfoId = activeCount.id;
       const categoryId = activeCount.type.id;
       const id = `${categoryId}/${countInfoId}`;
-      const options = {
-        method: 'GET',
-        data: {
-          type,
-          id,
-          format,
-          ...reportParameters,
-        },
-      };
-
-      const reportData = await reporterFetch('/reports', options);
+      const reportData = await getReport(activeReportType, id, format, reportParameters);
       const filename = `report.${format}`;
       saveAs(reportData, filename);
 
@@ -380,38 +369,11 @@ export default {
       }
       this.loadingReportLayout = true;
 
-      const { name: type } = activeReportType;
       const countInfoId = activeCount.id;
       const categoryId = activeCount.type.id;
       const id = `${categoryId}/${countInfoId}`;
-      const options = {
-        method: 'GET',
-        data: {
-          type,
-          id,
-          format: ReportFormat.WEB,
-          ...reportParameters,
-        },
-      };
-
-      const {
-        type: reportTypeStr,
-        date: reportDate,
-        content,
-      } = await reporterFetch('/reports', options);
-      const reportType = ReportType.enumValueOf(reportTypeStr);
-      const reportContent = content.map(({ type: blockTypeStr, options: blockOptions }) => {
-        const blockType = ReportBlock.enumValueOf(blockTypeStr);
-        return {
-          type: blockType,
-          options: blockOptions,
-        };
-      });
-      this.reportLayout = {
-        type: reportType,
-        date: reportDate,
-        content: reportContent,
-      };
+      const reportLayout = await getReportWeb(activeReportType, id, reportParameters);
+      this.reportLayout = reportLayout;
 
       this.loadingReportLayout = false;
     },

--- a/web/components/reports/FcReport.vue
+++ b/web/components/reports/FcReport.vue
@@ -44,6 +44,8 @@ import FcReportBarChart
   from '@/web/components/reports/FcReportBarChart.vue';
 import FcReportMetadata
   from '@/web/components/reports/FcReportMetadata.vue';
+import FcReportPageBreak
+  from '@/web/components/reports/FcReportPageBreak.vue';
 import FcReportTable
   from '@/web/components/reports/FcReportTable.vue';
 
@@ -52,6 +54,7 @@ export default {
   components: {
     FcReportBarChart,
     FcReportMetadata,
+    FcReportPageBreak,
     FcReportTable,
   },
   props: {

--- a/web/components/reports/FcReport.vue
+++ b/web/components/reports/FcReport.vue
@@ -13,12 +13,25 @@
       </div>
     </header>
     <div>
-      <component
-        v-for="({ type: blockType, options }, i) in content"
-        :key="'block_' + i"
-        :is="'FcReport' + blockType.suffix"
-        v-bind="options"
-        class="pt-4" />
+      <template v-for="(contentRow, i) in content">
+        <div
+          v-if="Array.isArray(contentRow)"
+          :key="'content_' + i"
+          class="align-top d-flex">
+          <component
+            v-for="({ type: blockType, options }, j) in contentRow"
+            :key="'content_' + i + '_' + j"
+            :is="'FcReport' + blockType.suffix"
+            v-bind="options"
+            class="pt-4" />
+        </div>
+        <component
+          v-else
+          :key="'content_' + i"
+          :is="'FcReport' + contentRow.type.suffix"
+          v-bind="contentRow.options"
+          class="pt-4" />
+      </template>
     </div>
   </section>
 </template>

--- a/web/components/reports/FcReport.vue
+++ b/web/components/reports/FcReport.vue
@@ -14,17 +14,18 @@
     </header>
     <div>
       <template v-for="(contentRow, i) in content">
-        <div
+        <v-row
           v-if="Array.isArray(contentRow)"
-          :key="'content_' + i"
-          class="align-top d-flex">
-          <component
+          :key="'content_' + i">
+          <v-col
             v-for="({ type: blockType, options }, j) in contentRow"
-            :key="'content_' + i + '_' + j"
-            :is="'FcReport' + blockType.suffix"
-            v-bind="options"
-            class="pt-4" />
-        </div>
+            :key="'content_' + i + '_' + j">
+            <component
+              :is="'FcReport' + blockType.suffix"
+              v-bind="options"
+              class="pt-4" />
+          </v-col>
+        </v-row>
         <component
           v-else
           :key="'content_' + i"

--- a/web/components/reports/FcReportPageBreak.vue
+++ b/web/components/reports/FcReportPageBreak.vue
@@ -1,0 +1,9 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+export default {
+  name: 'FcReportPageBreak',
+};
+</script>


### PR DESCRIPTION
# Issue Addressed
This PR closes #444 .

# Description
We implement the collision tabulation report, which depends on a couple of key updates to MOVE reporting functionality:

- support for columnar layouts by passing arrays of report blocks;
- support for textual labels on bar charts across both web and PDF reports.

It also makes use of new columns in our `collisions.events` and `collisions.involved` tables, as added in #464 .

# Tests
Tested manually in browser.

(There's unfortunately very little automated testing here to cover this - the idea is to add some of that more gradually over the next couple of weeks.)
