### PR TITLE
Add indexes to centreline tables

### DIFF
--- a/scripts/airflow/tasks/copy_opendata_shapefiles/extract_opendata_shapefile.sh
+++ b/scripts/airflow/tasks/copy_opendata_shapefiles/extract_opendata_shapefile.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 
 set -euo pipefail
-GIT_ROOT=/home/ec2-user/flashcrow
-TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
 
 BASE_URL="https://ckan0.cf.opendata.inter.prod-toronto.ca/api/3"
-TASK_ID="{{ task.task_id }}"
 DATASET_ID="{{ params.dataset_id }}"
 NAME="{{ params.name }}"
 

--- a/scripts/airflow/tasks/copy_opendata_shapefiles/index_opendata.sh
+++ b/scripts/airflow/tasks/copy_opendata_shapefiles/index_opendata.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+GIT_ROOT=/home/ec2-user/flashcrow
+TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
+
+# shellcheck disable=SC2046
+env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 < "${TASKS_ROOT}/copy_opendata_shapefiles/index_opendata.sql"

--- a/scripts/airflow/tasks/copy_opendata_shapefiles/index_opendata.sql
+++ b/scripts/airflow/tasks/copy_opendata_shapefiles/index_opendata.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS centreline_geo_id ON gis.centreline (geo_id);
+CREATE INDEX IF NOT EXISTS centreline_intersection_int_id ON gis.centreline_intersection (int_id);

--- a/scripts/airflow/tasks/copy_opendata_shapefiles/load_shapefile.sh
+++ b/scripts/airflow/tasks/copy_opendata_shapefiles/load_shapefile.sh
@@ -1,15 +1,11 @@
 #!/bin/bash
 
 set -euo pipefail
-GIT_ROOT=/home/ec2-user/flashcrow
-TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
 
-TASK_ID="{{ task.task_id }}"
 NAME="{{ params.name }}"
 
 SHAPEFILE_DIR="/data/shapefile/${NAME}"
 SHAPEFILE_PATH=$(ls "${SHAPEFILE_DIR}"/*.shp)
-GEOJSON_PATH="/data/geojson/${NAME}.geojson"
 SQL_PATH="/data/gis_layers/${NAME}.sql"
 
 mkdir -p /data/gis_layers
@@ -55,4 +51,5 @@ USING GIST (ST_Transform(geom, 2952));
 REFRESH MATERIALIZED VIEW CONCURRENTLY "gis"."${NAME}";
 EOF
 
+# shellcheck disable=SC2046
 env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 < "${SQL_PATH}"

--- a/tests/load/load_testing.sh
+++ b/tests/load/load_testing.sh
@@ -25,20 +25,22 @@ for path_list in paths/*.txt; do
   echo "[${PATH_LIST_BASE}] computing practical response rate..."
   if (("${MAX_REQ}" <= 20)); then
     for req in $(seq 1 "${MAX_REQ}"); do
+      echo -n "[${PATH_LIST_BASE}]   ${req}: ${req} req/s "
       env WRK2_PATH_LIST="${path_list}" wrk -t2 -c100 -d20s -R"${req}" -s path_list.lua --latency https://move.intra.dev-toronto.ca > "results/${PATH_LIST_BASE}_R${req}.txt"
       tail -24 "results/${PATH_LIST_BASE}_R${req}.txt" > "results/${PATH_LIST_BASE}_R${req}.json"
       REQ_LATENCY=$(jq ".latency[3][1]" "results/${PATH_LIST_BASE}_R${req}.json")
       REQ_LATENCY_MS=$(echo "${REQ_LATENCY} / 1000" | bc)
-      echo "[${PATH_LIST_BASE}]   ${req}: ${req} req/s (p95 = ${REQ_LATENCY_MS} ms)"
+      echo "(p95 = ${REQ_LATENCY_MS} ms)"
     done
   else
     for pct in $(seq 20 5 80); do
-      PCT_REQ=$(echo "${MAX_REQ} * ${pct} / 100" | bc -l)
+      PCT_REQ=$(echo "${MAX_REQ} * ${pct} / 100" | bc)
+      echo -n "[${PATH_LIST_BASE}]   ${pct}%: ${PCT_REQ} req/s "
       env WRK2_PATH_LIST="${path_list}" wrk -t2 -c100 -d20s -R"${PCT_REQ}" -s path_list.lua --latency https://move.intra.dev-toronto.ca > "results/${PATH_LIST_BASE}_pct${pct}.txt"
       tail -24 "results/${PATH_LIST_BASE}_pct${pct}.txt" > "results/${PATH_LIST_BASE}_pct${pct}.json"
       PCT_LATENCY=$(jq ".latency[3][1]" "results/${PATH_LIST_BASE}_pct${pct}.json")
       PCT_LATENCY_MS=$(echo "${PCT_LATENCY} / 1000" | bc)
-      echo "[${PATH_LIST_BASE}]   ${pct}%: ${PCT_REQ} req/s (p95 = ${PCT_LATENCY_MS} ms)"
+      echo "(p95 = ${PCT_LATENCY_MS} ms)"
     done
   fi
   echo "[${PATH_LIST_BASE}] finished."


### PR DESCRIPTION
# Issue Addressed
This PR closes #475 .

# Description
We add indexes on `gis.centreline (geo_id)` and `gis.centreline_intersection (int_id)`.

Also cleaned up bash scripts here to pass shellcheck linting, and refactored `copy_opendata_shapefiles` DAG to use `create_bash_task_nested`.

# Tests
Ran `copy_opendata_shapefiles` DAG.  Re-ran load testing, observed 20x speedup on relevant endpoints.