### PR TITLE
Above-the-fold report info

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -416,7 +416,7 @@ ReportType.init({
     label: 'TMC Summary Report',
     orientation: PageOrientation.LANDSCAPE,
     tmcRelated: true,
-    size: PageSize.LETTER,
+    size: PageSize.LEGAL,
     speedRelated: false,
     suffix: 'CountSummaryTurningMovement',
   },

--- a/lib/db/CountDAO.js
+++ b/lib/db/CountDAO.js
@@ -524,7 +524,7 @@ ORDER BY cim."ARTERYCODE" ASC, cim."COUNT_DATE" ASC`;
       endDate,
       startDate,
     });
-    return rows.map(row => countInfoToCount(row, categories));
+    return rows.map(row => countInfomicsToCount(row, categories));
   }
 
   // COMBINED

--- a/lib/reports/ReportBaseFlow.js
+++ b/lib/reports/ReportBaseFlow.js
@@ -1,10 +1,9 @@
 /* eslint-disable class-methods-use-this */
-import { ReportBlock, StudyType } from '@/lib/Constants';
+import { StudyType } from '@/lib/Constants';
 import StudyDAO from '@/lib/db/StudyDAO';
 import StudyDataDAO from '@/lib/db/StudyDataDAO';
 import { InvalidReportIdError } from '@/lib/error/MoveErrors';
 import ReportBase from '@/lib/reports/ReportBase';
-import TimeFormatters from '@/lib/time/TimeFormatters';
 
 /**
  * Base class for all FLOW-related reports, i.e. those reports that deal with traffic count
@@ -70,31 +69,6 @@ class ReportBaseFlow extends ReportBase {
 
   async fetchRawData(study) {
     return StudyDataDAO.byStudy(study);
-  }
-
-  static getCountMetadataBlock({
-    arteryGroupId,
-    // locationDesc,
-    // notes,
-    startDate,
-    // stationCode,
-  }) {
-    // TODO: switch to more useful info
-    const dateStr = TimeFormatters.formatDefault(startDate);
-    const dayOfWeekStr = TimeFormatters.formatDayOfWeek(startDate);
-    const startDateStr = `${dateStr} (${dayOfWeekStr})`;
-    const options = {
-      entries: [
-        { cols: 3, name: 'Start Date', value: startDateStr },
-        // { cols: 6, name: 'Location', value: locationDesc },
-        { cols: 3, name: 'Artery Code', value: arteryGroupId },
-        // { cols: 6, name: 'Notes', value: notes },
-      ],
-    };
-    return {
-      type: ReportBlock.METADATA,
-      options,
-    };
   }
 }
 

--- a/lib/reports/ReportBaseFlow.js
+++ b/lib/reports/ReportBaseFlow.js
@@ -78,7 +78,6 @@ class ReportBaseFlow extends ReportBase {
     // notes,
     startDate,
     // stationCode,
-    type: { studyType },
   }) {
     // TODO: switch to more useful info
     const dateStr = TimeFormatters.formatDefault(startDate);
@@ -86,7 +85,6 @@ class ReportBaseFlow extends ReportBase {
     const startDateStr = `${dateStr} (${dayOfWeekStr})`;
     const options = {
       entries: [
-        { cols: 3, name: 'Study Category', value: studyType.label },
         { cols: 3, name: 'Start Date', value: startDateStr },
         // { cols: 6, name: 'Location', value: locationDesc },
         { cols: 3, name: 'Artery Code', value: arteryGroupId },

--- a/lib/reports/ReportBaseFlowDirectional.js
+++ b/lib/reports/ReportBaseFlowDirectional.js
@@ -280,27 +280,10 @@ class ReportBaseFlowDirectional extends ReportBaseFlow {
     );
   }
 
-  async fetchRawData(study) {
-    const { counts, studyData } = await super.fetchRawData(study);
-    if (counts.length === 0) {
-      return null;
-    }
-    const rawData = studyData.get(counts[0].id);
-
+  static getDirectionalStats(study, { countData: rawData, intersection, segments }) {
     const countData = ReportBaseFlowDirectional.computeAllMovementAndVehicleTotals(rawData);
 
-    /*
-     * Directional reports rely on distinguishing major / minor roads (or, as per OTM,
-     * main / side roads.)
-     *
-     * We start by identifying the segments incident on the intersection under study...
-     */
-    const { centrelineId, centrelineType } = study;
-    const [intersection, segments] = await Promise.all([
-      CentrelineDAO.byIdAndType(centrelineId, centrelineType),
-      CentrelineDAO.featuresIncidentTo(centrelineType, centrelineId),
-    ]);
-    // ...then use `roadId` to group these into roads.
+    // We use `roadId` to group incident segments into roads.
     const roads = ArrayUtils.groupBy(segments, ({ roadId }) => roadId);
 
     /*
@@ -357,6 +340,35 @@ class ReportBaseFlowDirectional extends ReportBaseFlow {
       hourlyMinorDirections,
       intersection,
       minFeatureCode,
+      segments,
+    };
+  }
+
+  async fetchRawData(study) {
+    const { counts, studyData } = await super.fetchRawData(study);
+    if (counts.length === 0) {
+      return null;
+    }
+    const [count] = counts;
+    const { id } = count;
+    const countData = studyData.get(id);
+
+    /*
+     * Directional reports rely on distinguishing major / minor roads (or, as per OTM,
+     * main / side roads.)
+     *
+     * We start by identifying the segments incident on the intersection under study.
+     */
+    const { centrelineId, centrelineType } = study;
+    const [intersection, segments] = await Promise.all([
+      CentrelineDAO.byIdAndType(centrelineId, centrelineType),
+      CentrelineDAO.featuresIncidentTo(centrelineType, centrelineId),
+    ]);
+
+    return {
+      count,
+      countData,
+      intersection,
       segments,
     };
   }

--- a/lib/reports/ReportCountSummary24hDetailed.js
+++ b/lib/reports/ReportCountSummary24hDetailed.js
@@ -99,8 +99,11 @@ class ReportCountSummary24hDetailed extends ReportBaseFlow {
 
   generateLayoutContent(count, reportData) {
     const layout = [];
-    reportData.forEach((reportBlock) => {
+    reportData.forEach((reportBlock, i) => {
       const tableOptions = this.getTableOptions(reportBlock);
+      if (i !== 0) {
+        layout.push({ type: ReportBlock.PAGE_BREAK, options: {} });
+      }
       layout.push({ type: ReportBlock.TABLE, options: tableOptions });
     });
     return layout;

--- a/lib/reports/ReportCountSummaryTurningMovement.js
+++ b/lib/reports/ReportCountSummaryTurningMovement.js
@@ -5,6 +5,8 @@ import ReportBaseFlow from '@/lib/reports/ReportBaseFlow';
 import ReportBaseFlowDirectional from '@/lib/reports/ReportBaseFlowDirectional';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 
+const REGEX_PX = /PX (\d+)/;
+
 /**
  * Subclass of {@link ReportBaseFlow} for the Turning Movement Count Summary Report.
  *
@@ -89,12 +91,7 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
     };
   }
 
-  transformData(study, { counts, studyData }) {
-    if (counts.length === 0) {
-      return [];
-    }
-    const countData = studyData.get(counts[0].id);
-
+  static transformCountData(countData) {
     const totaledData = ReportBaseFlowDirectional.computeAllMovementAndVehicleTotals(
       countData,
     );
@@ -164,14 +161,43 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
     };
   }
 
-  generateCsv(count, {
-    amPeak,
-    pmPeak,
-    offHours,
-    am,
-    pm,
-    all,
-  }) {
+  static getTrafficSignalId({ locationDesc = null }) {
+    if (locationDesc === null) {
+      return null;
+    }
+    const match = REGEX_PX.exec(locationDesc);
+    if (match === null) {
+      return null;
+    }
+    const px = parseInt(match[1], 10);
+    if (Number.isNaN(px)) {
+      return null;
+    }
+    return px;
+  }
+
+  transformData(study, { counts, studyData }) {
+    if (counts.length === 0) {
+      return [];
+    }
+    const [count] = counts;
+    const { hours, id } = count;
+    const px = ReportCountSummaryTurningMovement.getTrafficSignalId(count);
+    const countData = studyData.get(id);
+    const stats = ReportCountSummaryTurningMovement.transformCountData(countData);
+
+    return { hours, px, stats };
+  }
+
+  generateCsv(count, { stats }) {
+    const {
+      amPeak,
+      pmPeak,
+      offHours,
+      am,
+      pm,
+      all,
+    } = stats;
     const dataKeys = Object.keys(amPeak.sum);
     const dataColumns = dataKeys.map(key => ({ key, header: key }));
     const columns = [
@@ -420,11 +446,33 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
     };
   }
 
+  static getCountMetadataOptions({ hours, px, stats }) {
+    const {
+      BIKE_TOTAL,
+      PEDS_TOTAL,
+      TOTAL,
+      VEHICLE_TOTAL,
+    } = stats.all.sum;
+    const hoursStr = hours === null ? null : hours.description;
+    const entries = [
+      { cols: 3, name: '8 Hr Volume', value: TOTAL },
+      { cols: 3, name: '8 Hr Vehicles', value: VEHICLE_TOTAL },
+      { cols: 3, name: '8 Hr Cyclists', value: BIKE_TOTAL },
+      { cols: 3, name: '8 Hr Pedestrians', value: PEDS_TOTAL },
+      { cols: 3, name: 'Study Hours', value: hoursStr },
+      { cols: 3, name: 'Traffic Signal #', value: px },
+    ];
+    return { entries };
+  }
+
   generateLayoutContent(count, reportData) {
-    const countMetadataBlock = ReportBaseFlow.getCountMetadataBlock(count);
-    const tableOptions = ReportCountSummaryTurningMovement.getTableOptions(reportData);
+    const countMetadataOptions = ReportCountSummaryTurningMovement.getCountMetadataOptions(
+      reportData,
+    );
+    const { stats } = reportData;
+    const tableOptions = ReportCountSummaryTurningMovement.getTableOptions(stats);
     return [
-      countMetadataBlock,
+      { type: ReportBlock.METADATA, options: countMetadataOptions },
       { type: ReportBlock.TABLE, options: tableOptions },
     ];
   }

--- a/lib/reports/ReportCountSummaryTurningMovement.js
+++ b/lib/reports/ReportCountSummaryTurningMovement.js
@@ -284,7 +284,7 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
         },
         {
           value: null,
-          colspan: 3,
+          colspan: 5,
         },
       ],
       [
@@ -292,9 +292,11 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
         ...dirs,
         ...dirs,
         ...dirs,
-        { value: 'Peds' },
-        { value: 'Bike' },
-        { value: 'Other' },
+        { value: 'N' },
+        { value: 'E' },
+        { value: 'S' },
+        { value: 'W' },
+        { value: 'Total' },
       ],
     ];
   }
@@ -308,7 +310,6 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
         {
           value: timeRangeHuman,
           header: true,
-          rowspan: 2,
           style: { br: true, shade },
         },
         { value: 'CAR', header: true, style: { shade } },
@@ -322,12 +323,20 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
             style: { shade },
           })),
         ])),
-        { value: 'N', header: true, style: { bl: true, shade } },
-        { value: sectionData.N_PEDS, style: { shade } },
-        { value: sectionData.N_BIKE, style: { shade } },
-        { value: sectionData.N_OTHER, style: { shade } },
+        { value: 'PED', header: true, style: { bl: true, br: true, shade } },
+        ...dirs.map(dir => ({
+          value: sectionData[`${dir}_PEDS`],
+          style: { shade },
+        })),
+        { value: sectionData.PEDS_TOTAL, style: { bl: true, shade } },
       ],
       [
+        {
+          value: title,
+          header: true,
+          rowspan: 2,
+          style: { br: true, shade },
+        },
         { value: 'TRUCK', header: true, style: { shade } },
         ...Array.prototype.concat.apply([], dirs.map(dir => [
           {
@@ -339,18 +348,14 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
             style: { shade },
           })),
         ])),
-        { value: 'S', header: true, style: { bl: true, shade } },
-        { value: sectionData.S_PEDS, style: { shade } },
-        { value: sectionData.S_BIKE, style: { shade } },
-        { value: sectionData.S_OTHER, style: { shade } },
+        { value: 'BIKE', header: true, style: { bl: true, br: true, shade } },
+        ...dirs.map(dir => ({
+          value: sectionData[`${dir}_BIKE`],
+          style: { shade },
+        })),
+        { value: sectionData.BIKE_TOTAL, style: { bl: true, shade } },
       ],
       [
-        {
-          value: title,
-          header: true,
-          rowspan: 2,
-          style: { br: true, shade },
-        },
         { value: 'BUS', header: true, style: { shade } },
         ...Array.prototype.concat.apply([], dirs.map(dir => [
           {
@@ -362,24 +367,19 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
             style: { shade },
           })),
         ])),
-        { value: 'E', header: true, style: { bl: true, shade } },
-        { value: sectionData.E_PEDS, style: { shade } },
-        { value: sectionData.E_BIKE, style: { shade } },
-        { value: sectionData.E_OTHER, style: { shade } },
+        { value: 'OTHER', header: true, style: { bl: true, br: true, shade } },
+        ...dirs.map(dir => ({
+          value: sectionData[`${dir}_OTHER`],
+          style: { shade },
+        })),
+        { value: sectionData.OTHER_TOTAL, style: { bl: true, shade } },
       ],
       [
-        { value: null, style: { shade } },
-        ...Array.prototype.concat.apply([], dirs.map(() => [
-          { value: null, style: { bl: true, shade } },
-          ...turns.map(() => ({ value: null, style: { shade } })),
-        ])),
-        { value: 'W', header: true, style: { bl: true, shade } },
-        { value: sectionData.W_PEDS, style: { shade } },
-        { value: sectionData.W_BIKE, style: { shade } },
-        { value: sectionData.W_OTHER, style: { shade } },
-      ],
-      [
-        { value: null, header: true, style: { br: true, shade } },
+        {
+          value: sectionData.TOTAL,
+          header: true,
+          style: { br: true, shade },
+        },
         { value: 'TOTAL', header: true, style: { bt: true, shade } },
         ...Array.prototype.concat.apply([], dirs.map(dir => [
           {
@@ -391,10 +391,24 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
             style: { bt: true, shade },
           })),
         ])),
-        { value: null, header: true, style: { bt: true, bl: true, shade } },
-        { value: sectionData.PEDS_TOTAL, style: { bt: true, shade } },
-        { value: sectionData.BIKE_TOTAL, style: { bt: true, shade } },
-        { value: sectionData.OTHER_TOTAL, style: { bt: true, shade } },
+        {
+          value: sectionData.VEHICLE_TOTAL,
+          style: {
+            bl: true,
+            bt: true,
+            br: true,
+            bb: true,
+            shade,
+          },
+        },
+        {
+          value: null,
+          colspan: 5,
+          style: { shade },
+        },
+      ],
+      [
+        { value: null, colspan: 28 },
       ],
     ];
   }
@@ -403,44 +417,49 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
     const header = ReportCountSummaryTurningMovement.getTableHeader();
     const body = [
       ...ReportCountSummaryTurningMovement.getTableSectionLayout(
+        reportData.all.sum,
+        reportData.all.timeRange,
+        '8 HR SUM',
+        false,
+      ),
+      ...ReportCountSummaryTurningMovement.getTableSectionLayout(
         reportData.amPeak.sum,
         reportData.amPeak.timeRange,
         'AM PEAK',
-        false,
+        true,
       ),
       ...ReportCountSummaryTurningMovement.getTableSectionLayout(
         reportData.pmPeak.sum,
         reportData.pmPeak.timeRange,
         'PM PEAK',
-        true,
+        false,
       ),
       ...ReportCountSummaryTurningMovement.getTableSectionLayout(
         reportData.offHours.avg,
         reportData.offHours.timeRange,
         'OFF HR AVG',
-        false,
+        true,
       ),
       ...ReportCountSummaryTurningMovement.getTableSectionLayout(
         reportData.am.sum,
         reportData.am.timeRange,
         '2 HR AM',
-        true,
+        false,
       ),
       ...ReportCountSummaryTurningMovement.getTableSectionLayout(
         reportData.pm.sum,
         reportData.pm.timeRange,
         '2 HR PM',
-        false,
-      ),
-      ...ReportCountSummaryTurningMovement.getTableSectionLayout(
-        reportData.all.sum,
-        reportData.all.timeRange,
-        '8 HR SUM',
         true,
       ),
     ];
     return {
       tableStyle: { fontSize: 'xs' },
+      columnStyles: [
+        { c: 0 },
+        { c: 1 },
+        { c: 22 },
+      ],
       header,
       body,
     };

--- a/lib/reports/ReportCountSummaryTurningMovementDetailed.js
+++ b/lib/reports/ReportCountSummaryTurningMovementDetailed.js
@@ -1,7 +1,9 @@
 /* eslint-disable class-methods-use-this */
+import ArrayUtils from '@/lib/ArrayUtils';
 import { ReportBlock, ReportType } from '@/lib/Constants';
 import ReportBaseFlow from '@/lib/reports/ReportBaseFlow';
 import ReportBaseFlowDirectional from '@/lib/reports/ReportBaseFlowDirectional';
+import ReportCountSummaryTurningMovement from '@/lib/reports/ReportCountSummaryTurningMovement';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 
 /**
@@ -18,14 +20,29 @@ class ReportCountSummaryTurningMovementDetailed extends ReportBaseFlow {
     if (counts.length === 0) {
       return [];
     }
-    const countData = studyData.get(counts[0].id);
-    return countData.map(({ t, data: rawData }) => {
-      const data = ReportBaseFlowDirectional.computeMovements(rawData);
+    const [count] = counts;
+    const { hours, id } = count;
+    const px = ReportCountSummaryTurningMovement.getTrafficSignalId(count);
+    const countData = studyData.get(id);
+
+    const rawData = countData.map(({ data }) => data);
+    let all = ArrayUtils.sumObjects(rawData);
+    all = ReportBaseFlowDirectional.computeMovementAndVehicleTotals(all);
+
+    const raw = countData.map(({ t }, i) => {
+      const data = ReportBaseFlowDirectional.computeMovements(rawData[i]);
       return { t, data };
     });
+
+    return {
+      all,
+      hours,
+      px,
+      raw,
+    };
   }
 
-  generateCsv(count, totaledData) {
+  generateCsv(count, { raw: totaledData }) {
     const dataKeys = Object.keys(totaledData[0].data);
     const dataColumns = dataKeys.map(key => ({ key, header: key }));
     const columns = [
@@ -82,7 +99,7 @@ class ReportCountSummaryTurningMovementDetailed extends ReportBaseFlow {
         },
         {
           value: null,
-          colspan: 3,
+          colspan: 4,
         },
       ],
       [
@@ -90,9 +107,10 @@ class ReportCountSummaryTurningMovementDetailed extends ReportBaseFlow {
         ...dirs,
         ...dirs,
         ...dirs,
-        { value: 'Peds' },
-        { value: 'Bike' },
-        { value: 'Other' },
+        { value: 'N' },
+        { value: 'E' },
+        { value: 'S' },
+        { value: 'W' },
       ],
     ];
   }
@@ -106,7 +124,7 @@ class ReportCountSummaryTurningMovementDetailed extends ReportBaseFlow {
         {
           value: timeHuman,
           header: true,
-          rowspan: 4,
+          rowspan: 3,
           style: { br: true, shade },
         },
         { value: 'CAR', header: true, style: { shade } },
@@ -116,10 +134,11 @@ class ReportCountSummaryTurningMovementDetailed extends ReportBaseFlow {
             style: { bl: turn === 'L', shade },
           })),
         ])),
-        { value: 'N', header: true, style: { bl: true, shade } },
-        { value: sectionData.N_PEDS, style: { shade } },
-        { value: sectionData.N_BIKE, style: { shade } },
-        { value: sectionData.N_OTHER, style: { shade } },
+        { value: 'PED', header: true, style: { bl: true, br: true, shade } },
+        ...dirs.map(dir => ({
+          value: sectionData[`${dir}_PEDS`],
+          style: { shade },
+        })),
       ],
       [
         { value: 'TRUCK', header: true, style: { shade } },
@@ -129,10 +148,11 @@ class ReportCountSummaryTurningMovementDetailed extends ReportBaseFlow {
             style: { bl: turn === 'L', shade },
           })),
         ])),
-        { value: 'S', header: true, style: { bl: true, shade } },
-        { value: sectionData.S_PEDS, style: { shade } },
-        { value: sectionData.S_BIKE, style: { shade } },
-        { value: sectionData.S_OTHER, style: { shade } },
+        { value: 'BIKE', header: true, style: { bl: true, br: true, shade } },
+        ...dirs.map(dir => ({
+          value: sectionData[`${dir}_BIKE`],
+          style: { shade },
+        })),
       ],
       [
         { value: 'BUS', header: true, style: { shade } },
@@ -142,28 +162,19 @@ class ReportCountSummaryTurningMovementDetailed extends ReportBaseFlow {
             style: { bl: turn === 'L', shade },
           })),
         ])),
-        { value: 'E', header: true, style: { bl: true, shade } },
-        { value: sectionData.E_PEDS, style: { shade } },
-        { value: sectionData.E_BIKE, style: { shade } },
-        { value: sectionData.E_OTHER, style: { shade } },
+        { value: 'OTHER', header: true, style: { bl: true, br: true, shade } },
+        ...dirs.map(dir => ({
+          value: sectionData[`${dir}_OTHER`],
+          style: { shade },
+        })),
       ],
       [
-        { value: null, header: true, style: { shade } },
-        ...Array.prototype.concat.apply([], dirs.map(() => [
-          ...turns.map(turn => ({
-            value: null,
-            style: { bl: turn === 'L', shade },
-          })),
-        ])),
-        { value: 'W', header: true, style: { bl: true, shade } },
-        { value: sectionData.W_PEDS, style: { shade } },
-        { value: sectionData.W_BIKE, style: { shade } },
-        { value: sectionData.W_OTHER, style: { shade } },
+        { value: null, colspan: 19 },
       ],
     ];
   }
 
-  static getTableOptions(reportData) {
+  static getTableOptions({ raw: reportData }) {
     const header = ReportCountSummaryTurningMovementDetailed.getTableHeader();
     const body = Array.prototype.concat.apply([], reportData.map(
       (section, i) => ReportCountSummaryTurningMovementDetailed.getTableSectionLayout(
@@ -181,11 +192,32 @@ class ReportCountSummaryTurningMovementDetailed extends ReportBaseFlow {
     };
   }
 
+  static getCountMetadataOptions({ all, hours, px }) {
+    const {
+      BIKE_TOTAL,
+      PEDS_TOTAL,
+      TOTAL,
+      VEHICLE_TOTAL,
+    } = all;
+    const hoursStr = hours === null ? null : hours.description;
+    const entries = [
+      { cols: 3, name: '8 Hr Volume', value: TOTAL },
+      { cols: 3, name: '8 Hr Vehicles', value: VEHICLE_TOTAL },
+      { cols: 3, name: '8 Hr Cyclists', value: BIKE_TOTAL },
+      { cols: 3, name: '8 Hr Pedestrians', value: PEDS_TOTAL },
+      { cols: 3, name: 'Study Hours', value: hoursStr },
+      { cols: 3, name: 'Traffic Signal #', value: px },
+    ];
+    return { entries };
+  }
+
   generateLayoutContent(study, reportData) {
-    const countMetadataBlock = ReportBaseFlow.getCountMetadataBlock(study);
+    const countMetadataOptions = ReportCountSummaryTurningMovementDetailed.getCountMetadataOptions(
+      reportData,
+    );
     const tableOptions = ReportCountSummaryTurningMovementDetailed.getTableOptions(reportData);
     return [
-      countMetadataBlock,
+      { type: ReportBlock.METADATA, options: countMetadataOptions },
       { type: ReportBlock.TABLE, options: tableOptions },
     ];
   }

--- a/lib/reports/ReportIntersectionSummary.js
+++ b/lib/reports/ReportIntersectionSummary.js
@@ -306,7 +306,7 @@ class ReportIntersectionSummary extends ReportBaseFlowDirectional {
     } = totals;
     const hoursStr = hours === null ? null : hours.description;
     const entries = [
-      { cols: 3, name: '8 Hr Volume', value: TOTAL },
+      { cols: 3, name: '8 Hr Total Approaches', value: TOTAL },
       { cols: 3, name: '8 Hr Major Approaches', value: MAJOR_APPROACHES },
       { cols: 3, name: '8 Hr Minor Approaches', value: MINOR_APPROACHES },
       { cols: 3, name: '8 Hr Major Crossings', value: MAJOR_CROSSING_TOTAL },

--- a/lib/reports/ReportIntersectionSummary.js
+++ b/lib/reports/ReportIntersectionSummary.js
@@ -10,6 +10,7 @@ import ObjectUtils from '@/lib/ObjectUtils';
 import ArrayStats from '@/lib/math/ArrayStats';
 import ReportBaseFlow from '@/lib/reports/ReportBaseFlow';
 import ReportBaseFlowDirectional from '@/lib/reports/ReportBaseFlowDirectional';
+import ReportCountSummaryTurningMovement from '@/lib/reports/ReportCountSummaryTurningMovement';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 
 /**
@@ -22,9 +23,7 @@ class ReportIntersectionSummary extends ReportBaseFlowDirectional {
     return ReportType.INTERSECTION_SUMMARY;
   }
 
-  static computeHourlyTotals(rawData, majorDirections, minorDirections) {
-    const tmcData = ReportBaseFlowDirectional.computeMovementAndVehicleTotals(rawData);
-
+  static computeHourlyTotals(tmcData, majorDirections, minorDirections) {
     const data = {};
 
     /*
@@ -134,12 +133,23 @@ class ReportIntersectionSummary extends ReportBaseFlowDirectional {
     return { start, end };
   }
 
-  transformData(parsedId, {
-    countData,
-    hourlyData,
-    hourlyMajorDirections,
-    hourlyMinorDirections,
+  transformData(study, {
+    count,
+    countData: rawData,
+    intersection,
+    segments,
   }) {
+    const {
+      countData,
+      hourlyData,
+      hourlyMajorDirections,
+      hourlyMinorDirections,
+    } = ReportBaseFlowDirectional.getDirectionalStats(study, {
+      countData: rawData,
+      intersection,
+      segments,
+    });
+
     /*
      * In the TMC Summary report, we could compute per-bucket totals and then rollup
      * into AM / PM peak, AM / PM 2-hour, etc. aggregations.
@@ -166,8 +176,13 @@ class ReportIntersectionSummary extends ReportBaseFlowDirectional {
       ),
     );
     const totalsRounded = ObjectUtils.map(totals, value => Math.round(value));
+
+    const { hours } = count;
+    const px = ReportCountSummaryTurningMovement.getTrafficSignalId(count);
     return {
       hourlyTotals: hourlyTotalsRounded,
+      hours,
+      px,
       timeRanges,
       totals: totalsRounded,
     };
@@ -282,15 +297,36 @@ class ReportIntersectionSummary extends ReportBaseFlowDirectional {
     };
   }
 
+  static getCountMetadataOptions({ hours, px, totals }) {
+    const {
+      MAJOR_APPROACHES,
+      MAJOR_CROSSING_TOTAL,
+      MINOR_APPROACHES,
+      TOTAL,
+    } = totals;
+    const hoursStr = hours === null ? null : hours.description;
+    const entries = [
+      { cols: 3, name: '8 Hr Volume', value: TOTAL },
+      { cols: 3, name: '8 Hr Major Approaches', value: MAJOR_APPROACHES },
+      { cols: 3, name: '8 Hr Minor Approaches', value: MINOR_APPROACHES },
+      { cols: 3, name: '8 Hr Major Crossings', value: MAJOR_CROSSING_TOTAL },
+      { cols: 3, name: 'Study Hours', value: hoursStr },
+      { cols: 3, name: 'Traffic Signal #', value: px },
+    ];
+    return { entries };
+  }
+
   generateLayoutContent(count, reportData) {
     if (reportData === null) {
       return [];
     }
 
-    const countMetadataBlock = ReportBaseFlow.getCountMetadataBlock(count);
+    const countMetadataOptions = ReportIntersectionSummary.getCountMetadataOptions(
+      reportData,
+    );
     const tableOptions = ReportIntersectionSummary.getTableOptions(reportData);
     return [
-      countMetadataBlock,
+      { type: ReportBlock.METADATA, options: countMetadataOptions },
       { type: ReportBlock.TABLE, options: tableOptions },
     ];
   }

--- a/lib/reports/ReportSpeedPercentile.js
+++ b/lib/reports/ReportSpeedPercentile.js
@@ -284,30 +284,27 @@ class ReportSpeedPercentile extends ReportBaseFlow {
     return { columns, rows };
   }
 
-  static getHoursHuman(date) {
+  static getHoursHuman() {
     const hoursHuman = [];
     for (let h = 0; h < 24; h++) {
-      if (h === 0) {
-        const dateStr = TimeFormatters.formatDefault(date);
-        hoursHuman.push(dateStr);
-      } else {
-        const hStr = h < 10 ? `0${h}:00` : `${h}:00`;
-        hoursHuman.push(hStr);
-      }
+      const hStr = h < 10 ? `0${h}:00` : `${h}:00`;
+      hoursHuman.push(hStr);
     }
     return hoursHuman;
   }
 
-  static getRowOptions(reportData, hoursHuman, {
+  static getRowOptions(reportData, date, hoursHuman, {
     volume,
     total,
     pct85,
     pct95,
   }, h) {
+    const dateStr = TimeFormatters.formatDefault(date);
+    const hourHuman = h === 0 ? dateStr : hoursHuman[h];
     const shade = h % 2 === 1;
     return [
       {
-        value: hoursHuman[h],
+        value: hourHuman,
         header: true,
         style: { bt: h === 12, br: true, shade },
       },
@@ -355,12 +352,12 @@ class ReportSpeedPercentile extends ReportBaseFlow {
     const dateStr = TimeFormatters.formatDefault(date);
     const dayOfWeekStr = TimeFormatters.formatDayOfWeek(date);
     const fullDateStr = `${dateStr} (${dayOfWeekStr})`;
-    const caption = direction === null ? 'All Directions' : direction.bound;
+    const directionStr = direction === null ? 'All Directions' : direction.bound;
     const { totalStats } = stats;
     return {
       entries: [
         { cols: 3, name: 'Date', value: fullDateStr },
-        { cols: 3, name: 'Direction', value: caption },
+        { cols: 3, name: 'Direction', value: directionStr },
         { cols: 3, name: 'Total Vehicles', value: totalStats.total },
         { cols: 3, name: 'Mean Speed', value: totalStats.mu },
         { cols: 3, name: '15th Percentile', value: totalStats.pct15 },
@@ -372,13 +369,11 @@ class ReportSpeedPercentile extends ReportBaseFlow {
     };
   }
 
-  static getTableOptions({ date, direction, stats: reportData }) {
-    const hoursHuman = ReportSpeedPercentile.getHoursHuman(date);
-    const caption = direction === null ? 'All Directions' : direction.bound;
+  static getTableOptions({ date, stats: reportData }) {
+    const hoursHuman = ReportSpeedPercentile.getHoursHuman();
     return {
       tableStyle: { fontSize: 'xs' },
       columnStyles: SPEED_CLASSES.map((_, i) => ({ c: i + 1 })),
-      caption,
       header: [
         [
           { value: 'Start', style: { br: true } },
@@ -401,6 +396,7 @@ class ReportSpeedPercentile extends ReportBaseFlow {
       body: [
         ...reportData.countDataByHour.map((section, h) => ReportSpeedPercentile.getRowOptions(
           reportData,
+          date,
           hoursHuman,
           section,
           h,
@@ -488,8 +484,6 @@ class ReportSpeedPercentile extends ReportBaseFlow {
   }
 
   generateLayoutContent(count, reportData) {
-    // const countMetadataBlock = ReportBaseFlow.getCountMetadataBlock(count);
-
     const layout = [];
     reportData.forEach((reportBlock) => {
       const countMetadataOptions = ReportSpeedPercentile.getCountMetadataOptions(reportBlock);

--- a/lib/reports/ReportWarrantTrafficSignalControl.js
+++ b/lib/reports/ReportWarrantTrafficSignalControl.js
@@ -7,8 +7,8 @@ import {
   ReportType,
 } from '@/lib/Constants';
 import ArrayStats from '@/lib/math/ArrayStats';
-import ReportBaseFlow from '@/lib/reports/ReportBaseFlow';
 import ReportBaseFlowDirectional from '@/lib/reports/ReportBaseFlowDirectional';
+import ReportCountSummaryTurningMovement from '@/lib/reports/ReportCountSummaryTurningMovement';
 import ReportIntersectionSummary from '@/lib/reports/ReportIntersectionSummary';
 
 const FORMAT_PREVENTABLES_AVERAGE = format('.2f');
@@ -118,6 +118,8 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
     );
 
     return {
+      isTwoLane,
+      isXIntersection,
       threshold1A,
       threshold1B,
       threshold2A,
@@ -366,17 +368,29 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
    * @see https://www.toronto.ca/wp-content/uploads/2018/01/950a-Road-Classification_Summary-Document.pdf
    * @see https://www.library.mto.gov.on.ca/SydneyPLUS/Sydney/Portal/default.aspx?component=AAAAIY&record=59cabe78-8aaf-4347-95ab-d6c066099015
    */
-  transformData(parsedId, {
-    hourlyData,
-    hourlyMajorDirections,
-    hourlyMinorDirections,
-    minFeatureCode,
+  transformData(study, {
+    count,
+    countData: rawData,
+    intersection,
     segments,
   }, options) {
+    const {
+      hourlyData,
+      hourlyMajorDirections,
+      hourlyMinorDirections,
+      minFeatureCode,
+    } = ReportBaseFlowDirectional.getDirectionalStats(study, {
+      countData: rawData,
+      intersection,
+      segments,
+    });
+
     /*
      * First, we establish thresholds as per warrant criteria.
      */
     const {
+      isTwoLane,
+      isXIntersection,
       threshold1A,
       threshold1B,
       threshold2A,
@@ -420,11 +434,17 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
       delayToCross,
     );
 
+    const { hours } = count;
+    const px = ReportCountSummaryTurningMovement.getTrafficSignalId(count);
     return {
       minVolume,
       delayToCross,
       collisionHazard,
       combination,
+      hours,
+      isTwoLane,
+      isXIntersection,
+      px,
     };
   }
 
@@ -812,6 +832,24 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
     };
   }
 
+  static getCountMetadataOptions({
+    hours,
+    isTwoLane,
+    isXIntersection,
+    px,
+  }) {
+    const hoursStr = hours === null ? null : hours.description;
+    const intersectionTypeStr = isXIntersection ? 'X' : 'T';
+    const lanesStr = isTwoLane ? '2' : '3 or more';
+    const entries = [
+      { cols: 3, name: 'Intersection Type', value: intersectionTypeStr },
+      { cols: 3, name: 'Lanes', value: lanesStr },
+      { cols: 3, name: 'Study Hours', value: hoursStr },
+      { cols: 3, name: 'Traffic Signal #', value: px },
+    ];
+    return { entries };
+  }
+
   generateLayoutContent(count, reportData) {
     if (reportData === null) {
       return [];
@@ -819,7 +857,9 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
 
     const { COMPLIANCE_PARTIAL } = ReportWarrantTrafficSignalControl;
 
-    const countMetadataBlock = ReportBaseFlow.getCountMetadataBlock(count);
+    const countMetadataOptions = ReportWarrantTrafficSignalControl.getCountMetadataOptions(
+      reportData,
+    );
     const summaryTableOptions = ReportWarrantTrafficSignalControl.getSummaryTableOptions(
       reportData,
     );
@@ -862,7 +902,7 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
     );
 
     return [
-      countMetadataBlock,
+      { type: ReportBlock.METADATA, options: countMetadataOptions },
       { type: ReportBlock.TABLE, options: summaryTableOptions },
       { type: ReportBlock.TABLE, options: section1ATableOptions },
       { type: ReportBlock.TABLE, options: section1BTableOptions },

--- a/tests/jest/unit/reports/ReportCountSummaryTurningMovement.spec.js
+++ b/tests/jest/unit/reports/ReportCountSummaryTurningMovement.spec.js
@@ -2,7 +2,7 @@
 import path from 'path';
 
 import ArrayUtils from '@/lib/ArrayUtils';
-import { StudyType } from '@/lib/Constants';
+import { StudyHours, StudyType } from '@/lib/Constants';
 import Random from '@/lib/Random';
 import ArrayStats from '@/lib/math/ArrayStats';
 import ReportCountSummaryTurningMovement from '@/lib/reports/ReportCountSummaryTurningMovement';
@@ -41,6 +41,8 @@ test('ReportCountSummaryTurningMovement#transformData [Gerrard and Sumach: 5/367
 
   const count = {
     date: DateTime.fromSQL('2018-02-27 00:00:00'),
+    hours: StudyHours.SCHOOL,
+    id: 1,
     locationDesc: 'GERRARD ST AT SUMACH ST (PX 1390)',
     type: { studyType: StudyType.TMC },
   };
@@ -55,9 +57,14 @@ test('ReportCountSummaryTurningMovement#transformData [Gerrard and Sumach: 5/367
    * (e.g. a "total" value is the sum of the values it includes), or c) the update is in one
    * of the base values, suggesting that it was in fact incorrect in the legacy report.
    */
-  const counts = [{ id: 1 }];
+  const counts = [count];
   const studyData = new Map([[1, countData_5_36781]]);
-  const transformedData = reportInstance.transformData(count, { counts, studyData });
+  let transformedData = reportInstance.transformData(count, { counts, studyData });
+  const { hours, px, stats } = transformedData;
+  expect(hours).toBe(StudyHours.SCHOOL);
+  expect(px).toBe(1390);
+  transformedData = stats;
+
   expect(transformedData).toEqual(transformedData_COUNT_SUMMARY_TURNING_MOVEMENT_5_36781);
 });
 
@@ -66,11 +73,13 @@ test('ReportCountSummaryTurningMovement#generateCsv [Gerrard and Sumach: 5/36781
 
   const count = {
     date: DateTime.fromSQL('2018-02-27 00:00:00'),
+    hours: StudyHours.SCHOOL,
+    id: 1,
     locationDesc: 'GERRARD ST AT SUMACH ST (PX 1390)',
     type: { studyType: StudyType.TMC },
   };
 
-  const counts = [{ id: 1 }];
+  const counts = [count];
   const studyData = new Map([[1, countData_5_36781]]);
   const transformedData = reportInstance.transformData(count, { counts, studyData });
   expect(() => {

--- a/tests/jest/unit/reports/ReportCountSummaryTurningMovementDetailed.spec.js
+++ b/tests/jest/unit/reports/ReportCountSummaryTurningMovementDetailed.spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import path from 'path';
 
-import { StudyType } from '@/lib/Constants';
+import { StudyHours, StudyType } from '@/lib/Constants';
 import ReportCountSummaryTurningMovementDetailed
   from '@/lib/reports/ReportCountSummaryTurningMovementDetailed';
 import { loadJsonSync } from '@/lib/test/TestDataLoader';
@@ -22,14 +22,21 @@ test('ReportCountSummaryTurningMovementDetailed#transformData [Gerrard and Sumac
 
   const count = {
     date: DateTime.fromSQL('2018-02-27 00:00:00'),
+    hours: StudyHours.SCHOOL,
+    id: 1,
     locationDesc: 'GERRARD ST AT SUMACH ST (PX 1390)',
     type: { studyType: StudyType.TMC },
   };
 
   // TODO: actually export proper count JSON
-  const counts = [{ id: 1 }];
+  const counts = [count];
   const studyData = new Map([[1, countData_5_36781]]);
-  const transformedData = reportInstance.transformData(count, { counts, studyData });
+  let transformedData = reportInstance.transformData(count, { counts, studyData });
+  const { hours, px, raw } = transformedData;
+  expect(hours).toBe(StudyHours.SCHOOL);
+  expect(px).toBe(1390);
+  transformedData = raw;
+
   expect(transformedData).toEqual(transformedData_COUNT_SUMMARY_TURNING_MOVEMENT_DETAILED_5_36781);
 });
 

--- a/tests/jest/unit/reports/ReportIntersectionSummary.spec.js
+++ b/tests/jest/unit/reports/ReportIntersectionSummary.spec.js
@@ -1,15 +1,13 @@
 /* eslint-disable camelcase */
 import path from 'path';
 
-import { CardinalDirection, StudyType } from '@/lib/Constants';
-import ReportBaseFlowDirectional from '@/lib/reports/ReportBaseFlowDirectional';
+import {
+  CentrelineType,
+  StudyHours,
+  StudyType,
+} from '@/lib/Constants';
 import ReportIntersectionSummary from '@/lib/reports/ReportIntersectionSummary';
 import { loadJsonSync } from '@/lib/test/TestDataLoader';
-import {
-  generateHourlyMajorAndMinorDirections,
-  generateTmc,
-} from '@/lib/test/random/CountDataGenerator';
-import DateTime from '@/lib/time/DateTime';
 
 const countData_5_38661 = loadJsonSync(
   path.resolve(__dirname, './data/countData_5_38661.json'),
@@ -18,76 +16,147 @@ const transformedData_INTERSECTION_SUMMARY_5_38661 = loadJsonSync(
   path.resolve(__dirname, './data/transformedData_INTERSECTION_SUMMARY_5_38661.json'),
 );
 
-test('ReportIntersectionSummary#transformData', () => {
-  const reportInstance = new ReportIntersectionSummary();
+function setup_5_38661() {
+  const study = {
+    centrelineId: 13456854,
+    centrelineType: CentrelineType.INTERSECTION,
+    countGroupId: 38661,
+    type: { id: 5, studyType: StudyType.TMC },
+  };
 
-  // fuzz test
-  for (let i = 0; i < 25; i++) {
-    const countData = generateTmc();
-    const hourlyData = ReportBaseFlowDirectional.sumHourly(countData);
-    const {
-      hourlyMajorDirections,
-      hourlyMinorDirections,
-    } = generateHourlyMajorAndMinorDirections(hourlyData);
-    expect(() => {
-      reportInstance.transformData(null, {
-        countData,
-        hourlyData,
-        hourlyMajorDirections,
-        hourlyMinorDirections,
-      });
-    }).not.toThrow();
-  }
-});
+  const count = {
+    hours: StudyHours.ROUTINE,
+    id: 38661,
+    locationDesc: 'OVERLEA BLVD AT THORNCLIFFE PARK DR & E TCS (PX 679)',
+  };
+  const intersection = {
+    geom: {
+      type: 'Point',
+      coordinates: [-79.343625497, 43.70747321],
+    },
+  };
+  const segments = [
+    {
+      centrelineId: 649,
+      geom: {
+        type: 'LineString',
+        coordinates: [
+          [-79.349877201, 43.70500665],
+          [-79.349308494, 43.705553926],
+          [-79.349210149, 43.705648311],
+          [-79.349133972, 43.70572022],
+          [-79.349046938, 43.705796617],
+          [-79.348959121, 43.705868512],
+          [-79.348795579, 43.705989814],
+          [-79.34868914, 43.706070684],
+          [-79.348574187, 43.706142543],
+          [-79.348422744, 43.706227855],
+          [-79.348288444, 43.706286182],
+          [-79.348150225, 43.706353505],
+          [-79.347957711, 43.706434255],
+          [-79.347774907, 43.706497017],
+          [-79.347603766, 43.706555292],
+          [-79.347433416, 43.706604568],
+          [-79.34728871, 43.706635875],
+          [-79.34720954, 43.706662772],
+          [-79.343625497, 43.70747321],
+        ],
+      },
+      roadId: 278,
+    },
+    {
+      centrelineId: 3829449,
+      geom: {
+        type: 'LineString',
+        coordinates: [
+          [-79.342780375, 43.705549757],
+          [-79.342832909, 43.705620743],
+          [-79.342877636, 43.705707982],
+          [-79.342922628, 43.705807202],
+          [-79.342964689, 43.705903473],
+          [-79.342983796, 43.705947236],
+          [-79.343026878, 43.706042077],
+          [-79.343056291, 43.706120807],
+          [-79.343088579, 43.706206083],
+          [-79.343625497, 43.70747321],
+        ],
+      },
+      roadId: 354,
+    },
+    {
+      centrelineId: 6853474,
+      geom: {
+        type: 'LineString',
+        coordinates: [
+          [-79.343625497, 43.70747321],
+          [-79.341387089, 43.708017748],
+        ],
+      },
+      roadId: 278,
+    },
+    {
+      centrelineId: 8895679,
+      geom: {
+        type: 'LineString',
+        coordinates: [
+          [-79.343625497, 43.70747321],
+          [-79.343716829, 43.7076292],
+          [-79.3439986, 43.708259097],
+        ],
+      },
+      roadId: 354,
+    },
+  ];
+
+  return {
+    count,
+    countData: countData_5_38661,
+    intersection,
+    segments,
+    study,
+  };
+}
 
 test('ReportIntersectionSummary#transformData [Overlea and Thorncliffe: 5/38661]', () => {
   const reportInstance = new ReportIntersectionSummary();
 
-  const count = {
-    date: DateTime.fromSQL('2019-04-13 00:00:00'),
-    locationDesc: 'OVERLEA BLVD AT THORNCLIFFE PARK DR & E TCS (PX 679)',
-    type: { studyType: StudyType.TMC },
-  };
+  const {
+    count,
+    countData,
+    intersection,
+    segments,
+    study,
+  } = setup_5_38661();
 
-  const hourlyData = ReportBaseFlowDirectional.sumHourly(countData_5_38661);
-  const hourlyMajorDirections = hourlyData.map(
-    () => [CardinalDirection.EAST, CardinalDirection.WEST],
-  );
-  const hourlyMinorDirections = hourlyData.map(
-    () => [CardinalDirection.NORTH, CardinalDirection.SOUTH],
-  );
-
-  const transformedData = reportInstance.transformData(count, {
-    countData: countData_5_38661,
-    hourlyData,
-    hourlyMajorDirections,
-    hourlyMinorDirections,
+  let transformedData = reportInstance.transformData(study, {
+    count,
+    countData,
+    intersection,
+    segments,
   });
+  const { hours, px, ...transformedDataRest } = transformedData;
+  expect(hours).toBe(StudyHours.ROUTINE);
+  expect(px).toBe(679);
+  transformedData = transformedDataRest;
   expect(transformedData).toEqual(transformedData_INTERSECTION_SUMMARY_5_38661);
 });
 
 test('ReportIntersectionSummary#generateCsv [Overlea and Thorncliffe: 5/38661]', () => {
   const reportInstance = new ReportIntersectionSummary();
 
-  const count = {
-    date: DateTime.fromSQL('2019-04-13 00:00:00'),
-    locationDesc: 'OVERLEA BLVD AT THORNCLIFFE PARK DR & E TCS (PX 679)',
-    type: { studyType: StudyType.TMC },
-  };
+  const {
+    count,
+    countData,
+    intersection,
+    segments,
+    study,
+  } = setup_5_38661();
 
-  const hourlyData = ReportBaseFlowDirectional.sumHourly(countData_5_38661);
-  const hourlyMajorDirections = hourlyData.map(
-    () => [CardinalDirection.EAST, CardinalDirection.WEST],
-  );
-  const hourlyMinorDirections = hourlyData.map(
-    () => [CardinalDirection.NORTH, CardinalDirection.SOUTH],
-  );
-
-  const transformedData = reportInstance.transformData(count, {
-    countData: countData_5_38661,
-    hourlyData,
-    hourlyMajorDirections,
-    hourlyMinorDirections,
+  const transformedData = reportInstance.transformData(study, {
+    count,
+    countData,
+    intersection,
+    segments,
   });
   expect(() => {
     reportInstance.generateCsv(count, transformedData);

--- a/tests/jest/unit/reports/ReportWarrantTrafficSignalControl.spec.js
+++ b/tests/jest/unit/reports/ReportWarrantTrafficSignalControl.spec.js
@@ -1,16 +1,10 @@
 /* eslint-disable camelcase */
 import path from 'path';
 
-import { CardinalDirection, FeatureCode, StudyType } from '@/lib/Constants';
+import { CentrelineType, StudyHours, StudyType } from '@/lib/Constants';
 import { NotImplementedError } from '@/lib/error/MoveErrors';
-import ReportBaseFlowDirectional from '@/lib/reports/ReportBaseFlowDirectional';
 import ReportWarrantTrafficSignalControl from '@/lib/reports/ReportWarrantTrafficSignalControl';
 import { loadJsonSync } from '@/lib/test/TestDataLoader';
-import {
-  generateHourlyMajorAndMinorDirections,
-  generateTmc,
-} from '@/lib/test/random/CountDataGenerator';
-import DateTime from '@/lib/time/DateTime';
 
 const countData_5_38661 = loadJsonSync(
   path.resolve(__dirname, './data/countData_5_38661.json'),
@@ -19,107 +13,163 @@ const transformedData_WARRANT_TRAFFIC_SIGNAL_CONTROL_5_38661 = loadJsonSync(
   path.resolve(__dirname, './data/transformedData_WARRANT_TRAFFIC_SIGNAL_CONTROL_5_38661.json'),
 );
 
-test('ReportWarrantTrafficSignalControl#transformData', () => {
-  const reportInstance = new ReportWarrantTrafficSignalControl();
+function setup_5_38661() {
+  const study = {
+    centrelineId: 13456854,
+    centrelineType: CentrelineType.INTERSECTION,
+    countGroupId: 38661,
+    type: { id: 5, studyType: StudyType.TMC },
+  };
 
-  // fuzz test
-  for (let i = 0; i < 25; i++) {
-    const countData = generateTmc();
-    const hourlyData = ReportBaseFlowDirectional.sumHourly(countData);
-    // TODO: generate minFeatureCode
-    const minFeatureCode = FeatureCode.MINOR_ARTERIAL;
-    const {
-      hourlyMajorDirections,
-      hourlyMinorDirections,
-    } = generateHourlyMajorAndMinorDirections(hourlyData);
-    // TODO: generate segments
-    const segments = new Array(4).fill(0);
-    const options = {
-      adequateTrial: true,
-      preparedBy: 'Foo Bar',
-      preventablesByYear: [3, 5, 10],
-      startYear: 2016,
-    };
-    expect(() => {
-      reportInstance.transformData(null, {
-        countData,
-        hourlyData,
-        hourlyMajorDirections,
-        hourlyMinorDirections,
-        minFeatureCode,
-        segments,
-      }, options);
-    }).not.toThrow();
-  }
-});
+  const count = {
+    hours: StudyHours.ROUTINE,
+    id: 38661,
+    locationDesc: 'OVERLEA BLVD AT THORNCLIFFE PARK DR & E TCS (PX 679)',
+  };
+  const intersection = {
+    geom: {
+      type: 'Point',
+      coordinates: [-79.343625497, 43.70747321],
+    },
+  };
+  const segments = [
+    {
+      centrelineId: 649,
+      geom: {
+        type: 'LineString',
+        coordinates: [
+          [-79.349877201, 43.70500665],
+          [-79.349308494, 43.705553926],
+          [-79.349210149, 43.705648311],
+          [-79.349133972, 43.70572022],
+          [-79.349046938, 43.705796617],
+          [-79.348959121, 43.705868512],
+          [-79.348795579, 43.705989814],
+          [-79.34868914, 43.706070684],
+          [-79.348574187, 43.706142543],
+          [-79.348422744, 43.706227855],
+          [-79.348288444, 43.706286182],
+          [-79.348150225, 43.706353505],
+          [-79.347957711, 43.706434255],
+          [-79.347774907, 43.706497017],
+          [-79.347603766, 43.706555292],
+          [-79.347433416, 43.706604568],
+          [-79.34728871, 43.706635875],
+          [-79.34720954, 43.706662772],
+          [-79.343625497, 43.70747321],
+        ],
+      },
+      roadId: 278,
+    },
+    {
+      centrelineId: 3829449,
+      geom: {
+        type: 'LineString',
+        coordinates: [
+          [-79.342780375, 43.705549757],
+          [-79.342832909, 43.705620743],
+          [-79.342877636, 43.705707982],
+          [-79.342922628, 43.705807202],
+          [-79.342964689, 43.705903473],
+          [-79.342983796, 43.705947236],
+          [-79.343026878, 43.706042077],
+          [-79.343056291, 43.706120807],
+          [-79.343088579, 43.706206083],
+          [-79.343625497, 43.70747321],
+        ],
+      },
+      roadId: 354,
+    },
+    {
+      centrelineId: 6853474,
+      geom: {
+        type: 'LineString',
+        coordinates: [
+          [-79.343625497, 43.70747321],
+          [-79.341387089, 43.708017748],
+        ],
+      },
+      roadId: 278,
+    },
+    {
+      centrelineId: 8895679,
+      geom: {
+        type: 'LineString',
+        coordinates: [
+          [-79.343625497, 43.70747321],
+          [-79.343716829, 43.7076292],
+          [-79.3439986, 43.708259097],
+        ],
+      },
+      roadId: 354,
+    },
+  ];
+
+  return {
+    count,
+    countData: countData_5_38661,
+    intersection,
+    segments,
+    study,
+  };
+}
 
 test('ReportWarrantTrafficSignalControl#transformData [Overlea and Thorncliffe: 5/38661]', () => {
   const reportInstance = new ReportWarrantTrafficSignalControl();
-
-  const count = {
-    date: DateTime.fromSQL('2019-04-13 00:00:00'),
-    locationDesc: 'OVERLEA BLVD AT THORNCLIFFE PARK DR & E TCS (PX 679)',
-    type: { studyType: StudyType.TMC },
-  };
-
-  const hourlyData = ReportBaseFlowDirectional.sumHourly(countData_5_38661);
-  const hourlyMajorDirections = hourlyData.map(
-    () => [CardinalDirection.EAST, CardinalDirection.WEST],
-  );
-  const hourlyMinorDirections = hourlyData.map(
-    () => [CardinalDirection.NORTH, CardinalDirection.SOUTH],
-  );
-  const minFeatureCode = FeatureCode.MAJOR_ARTERIAL;
-  const segments = new Array(4).fill(0);
-
+  const {
+    count,
+    countData,
+    intersection,
+    segments,
+    study,
+  } = setup_5_38661();
   const options = {
     adequateTrial: true,
     preparedBy: 'Foo Bar',
     preventablesByYear: [3, 5, 10],
     startYear: 2016,
   };
-  const transformedData = reportInstance.transformData(count, {
-    countData: countData_5_38661,
-    hourlyData,
-    hourlyMajorDirections,
-    hourlyMinorDirections,
-    minFeatureCode,
+
+  let transformedData = reportInstance.transformData(study, {
+    count,
+    countData,
+    intersection,
     segments,
   }, options);
+  const {
+    hours,
+    isTwoLane,
+    isXIntersection,
+    px,
+    ...transformedDataRest
+  } = transformedData;
+  expect(hours).toBe(StudyHours.ROUTINE);
+  expect(isTwoLane).toBe(false);
+  expect(isXIntersection).toBe(true);
+  expect(px).toBe(679);
+  transformedData = transformedDataRest;
   expect(transformedData).toEqual(transformedData_WARRANT_TRAFFIC_SIGNAL_CONTROL_5_38661);
 });
 
 test('ReportWarrantTrafficSignalControl#generateCsv [Overlea and Thorncliffe: 5/38661]', () => {
   const reportInstance = new ReportWarrantTrafficSignalControl();
-
-  const count = {
-    date: DateTime.fromSQL('2019-04-13 00:00:00'),
-    locationDesc: 'OVERLEA BLVD AT THORNCLIFFE PARK DR & E TCS (PX 679)',
-    type: { studyType: StudyType.TMC },
-  };
-
-  const hourlyData = ReportBaseFlowDirectional.sumHourly(countData_5_38661);
-  const hourlyMajorDirections = hourlyData.map(
-    () => [CardinalDirection.EAST, CardinalDirection.WEST],
-  );
-  const hourlyMinorDirections = hourlyData.map(
-    () => [CardinalDirection.NORTH, CardinalDirection.SOUTH],
-  );
-  const minFeatureCode = FeatureCode.MAJOR_ARTERIAL;
-  const segments = new Array(4).fill(0);
-
+  const {
+    count,
+    countData,
+    intersection,
+    segments,
+    study,
+  } = setup_5_38661();
   const options = {
     adequateTrial: true,
     preparedBy: 'Foo Bar',
     preventablesByYear: [3, 5, 10],
     startYear: 2016,
   };
-  const transformedData = reportInstance.transformData(count, {
-    countData: countData_5_38661,
-    hourlyData,
-    hourlyMajorDirections,
-    hourlyMinorDirections,
-    minFeatureCode,
+  const transformedData = reportInstance.transformData(study, {
+    count,
+    countData,
+    intersection,
     segments,
   }, options);
   expect(() => {

--- a/tests/jest/unit/reports/format/MovePdfGenerator.spec.js
+++ b/tests/jest/unit/reports/format/MovePdfGenerator.spec.js
@@ -1,0 +1,48 @@
+/* eslint-disable camelcase */
+import path from 'path';
+
+import {
+  ReportFormat,
+  ReportType,
+  StudyHours,
+  StudyType,
+} from '@/lib/Constants';
+import StudyDAO from '@/lib/db/StudyDAO';
+import StudyDataDAO from '@/lib/db/StudyDataDAO';
+import ReportFactory from '@/lib/reports/ReportFactory';
+import MovePdfGenerator from '@/lib/reports/format/MovePdfGenerator';
+import { loadJsonSync } from '@/lib/test/TestDataLoader';
+
+jest.mock('@/lib/db/StudyDAO');
+jest.mock('@/lib/db/StudyDataDAO');
+
+const countData_5_36781 = loadJsonSync(
+  path.resolve(__dirname, '../data/countData_5_36781.json'),
+);
+
+beforeAll(MovePdfGenerator.init);
+
+function getNumPages(doc) {
+  const range = doc.bufferedPageRange();
+  return range.start + range.count;
+}
+
+test('COUNT_SUMMARY_TURNING_MOVEMENT', async () => {
+  const study = {
+    countGroupId: 36781,
+    type: { id: 5, studyType: StudyType.TMC },
+  };
+  StudyDAO.byCategoryAndCountGroup.mockResolvedValue(study);
+
+  const counts = [{
+    hours: StudyHours.SCHOOL,
+    id: 36781,
+    locationDesc: 'GERRARD ST AT SUMACH ST (PX 1390)',
+  }];
+  const studyData = new Map([[36781, countData_5_36781]]);
+  StudyDataDAO.byStudy.mockResolvedValue({ counts, studyData });
+
+  const reportInstance = ReportFactory.getInstance(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT);
+  const doc = await reportInstance.generate('5/36781', ReportFormat.PDF, {});
+  expect(getNumPages(doc)).toBe(1);
+});

--- a/tests/jest/unit/reports/format/MovePdfGenerator.spec.js
+++ b/tests/jest/unit/reports/format/MovePdfGenerator.spec.js
@@ -2,32 +2,33 @@
 import path from 'path';
 
 import {
+  CentrelineType,
   ReportFormat,
   ReportType,
   StudyHours,
   StudyType,
 } from '@/lib/Constants';
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import StudyDAO from '@/lib/db/StudyDAO';
 import StudyDataDAO from '@/lib/db/StudyDataDAO';
 import ReportFactory from '@/lib/reports/ReportFactory';
 import MovePdfGenerator from '@/lib/reports/format/MovePdfGenerator';
 import { loadJsonSync } from '@/lib/test/TestDataLoader';
 
+jest.mock('@/lib/db/CentrelineDAO');
 jest.mock('@/lib/db/StudyDAO');
 jest.mock('@/lib/db/StudyDataDAO');
 
 const countData_5_36781 = loadJsonSync(
   path.resolve(__dirname, '../data/countData_5_36781.json'),
 );
+const countData_5_38661 = loadJsonSync(
+  path.resolve(__dirname, '../data/countData_5_38661.json'),
+);
 
 beforeAll(MovePdfGenerator.init);
 
-function getNumPages(doc) {
-  const range = doc.bufferedPageRange();
-  return range.start + range.count;
-}
-
-test('COUNT_SUMMARY_TURNING_MOVEMENT', async () => {
+function setup_5_36781() {
   const study = {
     countGroupId: 36781,
     type: { id: 5, studyType: StudyType.TMC },
@@ -41,8 +42,144 @@ test('COUNT_SUMMARY_TURNING_MOVEMENT', async () => {
   }];
   const studyData = new Map([[36781, countData_5_36781]]);
   StudyDataDAO.byStudy.mockResolvedValue({ counts, studyData });
+}
+
+function setup_5_38661() {
+  const study = {
+    centrelineId: 13456854,
+    centrelineType: CentrelineType.INTERSECTION,
+    countGroupId: 38661,
+    type: { id: 5, studyType: StudyType.TMC },
+  };
+  StudyDAO.byCategoryAndCountGroup.mockResolvedValue(study);
+
+  const counts = [{
+    hours: StudyHours.ROUTINE,
+    id: 38661,
+    locationDesc: 'OVERLEA BLVD AT THORNCLIFFE PARK DR & E TCS (PX 679)',
+  }];
+  const studyData = new Map([[38661, countData_5_38661]]);
+  StudyDataDAO.byStudy.mockResolvedValue({ counts, studyData });
+  CentrelineDAO.byIdAndType.mockResolvedValue({
+    geom: {
+      type: 'Point',
+      coordinates: [-79.343625497, 43.70747321],
+    },
+  });
+  CentrelineDAO.featuresIncidentTo.mockResolvedValue([
+    {
+      centrelineId: 649,
+      geom: {
+        type: 'LineString',
+        coordinates: [
+          [-79.349877201, 43.70500665],
+          [-79.349308494, 43.705553926],
+          [-79.349210149, 43.705648311],
+          [-79.349133972, 43.70572022],
+          [-79.349046938, 43.705796617],
+          [-79.348959121, 43.705868512],
+          [-79.348795579, 43.705989814],
+          [-79.34868914, 43.706070684],
+          [-79.348574187, 43.706142543],
+          [-79.348422744, 43.706227855],
+          [-79.348288444, 43.706286182],
+          [-79.348150225, 43.706353505],
+          [-79.347957711, 43.706434255],
+          [-79.347774907, 43.706497017],
+          [-79.347603766, 43.706555292],
+          [-79.347433416, 43.706604568],
+          [-79.34728871, 43.706635875],
+          [-79.34720954, 43.706662772],
+          [-79.343625497, 43.70747321],
+        ],
+      },
+      roadId: 278,
+    },
+    {
+      centrelineId: 3829449,
+      geom: {
+        type: 'LineString',
+        coordinates: [
+          [-79.342780375, 43.705549757],
+          [-79.342832909, 43.705620743],
+          [-79.342877636, 43.705707982],
+          [-79.342922628, 43.705807202],
+          [-79.342964689, 43.705903473],
+          [-79.342983796, 43.705947236],
+          [-79.343026878, 43.706042077],
+          [-79.343056291, 43.706120807],
+          [-79.343088579, 43.706206083],
+          [-79.343625497, 43.70747321],
+        ],
+      },
+      roadId: 354,
+    },
+    {
+      centrelineId: 6853474,
+      geom: {
+        type: 'LineString',
+        coordinates: [
+          [-79.343625497, 43.70747321],
+          [-79.341387089, 43.708017748],
+        ],
+      },
+      roadId: 278,
+    },
+    {
+      centrelineId: 8895679,
+      geom: {
+        type: 'LineString',
+        coordinates: [
+          [-79.343625497, 43.70747321],
+          [-79.343716829, 43.7076292],
+          [-79.3439986, 43.708259097],
+        ],
+      },
+      roadId: 354,
+    },
+  ]);
+}
+
+function getNumPages(doc) {
+  const range = doc.bufferedPageRange();
+  return range.start + range.count;
+}
+
+test('COUNT_SUMMARY_TURNING_MOVEMENT', async () => {
+  setup_5_36781();
 
   const reportInstance = ReportFactory.getInstance(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT);
   const doc = await reportInstance.generate('5/36781', ReportFormat.PDF, {});
   expect(getNumPages(doc)).toBe(1);
+});
+
+test('COUNT_SUMMARY_TURNING_MOVEMENT_DETAILED', async () => {
+  setup_5_36781();
+
+  const reportInstance = ReportFactory.getInstance(
+    ReportType.COUNT_SUMMARY_TURNING_MOVEMENT_DETAILED,
+  );
+  const doc = await reportInstance.generate('5/36781', ReportFormat.PDF, {});
+  expect(getNumPages(doc)).toBe(3);
+});
+
+test('INTERSECTION_SUMMARY', async () => {
+  setup_5_38661();
+
+  const reportInstance = ReportFactory.getInstance(ReportType.INTERSECTION_SUMMARY);
+  const doc = await reportInstance.generate('5/38661', ReportFormat.PDF, {});
+  expect(getNumPages(doc)).toBe(1);
+});
+
+test('WARRANT_TRAFFIC_SIGNAL_CONTROL', async () => {
+  setup_5_38661();
+
+  const reportInstance = ReportFactory.getInstance(ReportType.WARRANT_TRAFFIC_SIGNAL_CONTROL);
+  const doc = await reportInstance.generate('5/38661', ReportFormat.PDF, {
+    adequateTrial: true,
+    preparedBy: 'Foo Bar',
+    preventablesByYear: [3, 5, 10],
+    startYear: 2016,
+  });
+  expect(getNumPages(doc)).toBe(2);
 });

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -268,6 +268,6 @@ export default {
 }
 
 .drawer-open .fc-drawer-view-collision-reports {
-  max-height: 100vh;
+  max-height: calc(100vh - 60px);
 }
 </style>

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -106,7 +106,7 @@
               v-if="activeReportType.name === 'WARRANT_TRAFFIC_SIGNAL_CONTROL'"
               type="secondary"
               @click.stop="showReportParameters = true">
-              <v-icon color="primary" left>mdi-settings</v-icon>
+              <v-icon color="primary" left>mdi-cog</v-icon>
               Set Parameters
             </FcButton>
             <v-menu>
@@ -393,6 +393,6 @@ export default {
 }
 
 .drawer-open .fc-drawer-view-study-reports {
-  max-height: 100vh;
+  max-height: calc(100vh - 60px);
 }
 </style>


### PR DESCRIPTION
# Issue Addressed
This PR closes #471 .

# Description
We update all FLOW report types to prioritize more useful information, especially in TMC-related reports.  Many "above-the-fold" metadata blocks now have report-specific summary statistics; in other reports, especially where the reports themselves are short and contain clearly marked summary statistics, these blocks have been removed altogether.

We also add a page count test for different report types, allowing us to check that these fit on a single page.  In the process, we also update unit tests for each report type, wrapping the existing end-to-end data comparison tests to take these changes into account.

# Tests
Run unit tests; check different report types at different locations in the browser.
