### PR TITLE
Fix report crash on empty datasets

### DIFF
--- a/lib/reports/ReportCountSummary24h.js
+++ b/lib/reports/ReportCountSummary24h.js
@@ -48,9 +48,8 @@ class ReportCountSummary24h extends ReportBaseFlow {
     return { indexStart, indexEnd, sum: peakVolume };
   }
 
-  static timeRange(countData, indexStart, indexEnd) {
-    const countDate = countData[0].t;
-    const { year, month, day } = countDate;
+  static timeRange(count, indexStart, indexEnd) {
+    const { year, month, day } = count.date;
 
     let hour = Math.floor(indexStart / ReportBaseFlow.ROWS_PER_HOUR);
     let minute = (indexStart % ReportBaseFlow.ROWS_PER_HOUR) * ReportBaseFlow.MINUTES_PER_ROW;
@@ -75,14 +74,14 @@ class ReportCountSummary24h extends ReportBaseFlow {
     return { start, end };
   }
 
-  static peakSection(countData, volumeByBucket, lo, hi) {
+  static peakSection(count, volumeByBucket, lo, hi) {
     const { indexStart, indexEnd, sum } = ReportCountSummary24h.peak(
       volumeByBucket,
       lo,
       hi,
       ReportBaseFlow.ROWS_PER_HOUR,
     );
-    const timeRange = ReportCountSummary24h.timeRange(countData, indexStart, indexEnd);
+    const timeRange = ReportCountSummary24h.timeRange(count, indexStart, indexEnd);
     return {
       indices: ArrayUtils.range(indexStart, indexEnd),
       sum,
@@ -90,7 +89,7 @@ class ReportCountSummary24h extends ReportBaseFlow {
     };
   }
 
-  static offPeakSection(countData, volumeByBucket, amPeak, pmPeak) {
+  static offPeakSection(count, volumeByBucket, amPeak, pmPeak) {
     const k = ReportBaseFlow.ROWS_PER_HOUR;
 
     const { indexStart, sum } = ReportCountSummary24h.peak(
@@ -100,7 +99,7 @@ class ReportCountSummary24h extends ReportBaseFlow {
       ReportBaseFlow.ROWS_PER_HOUR,
     );
     const indexEnd = indexStart + k;
-    const timeRange = ReportCountSummary24h.timeRange(countData, indexStart, indexEnd);
+    const timeRange = ReportCountSummary24h.timeRange(count, indexStart, indexEnd);
     return {
       indices: ArrayUtils.range(indexStart, indexEnd),
       sum,
@@ -114,19 +113,19 @@ class ReportCountSummary24h extends ReportBaseFlow {
     const dayOfWeek = TimeFormatters.formatDayOfWeek(count.date);
 
     const amPeak = ReportCountSummary24h.peakSection(
-      countData,
+      count,
       volumeByBucket,
       0,
       ReportCountSummary24h.HOURS_PER_DAY / 2 * ReportBaseFlow.ROWS_PER_HOUR,
     );
     const pmPeak = ReportCountSummary24h.peakSection(
-      countData,
+      count,
       volumeByBucket,
       ReportCountSummary24h.HOURS_PER_DAY / 2 * ReportBaseFlow.ROWS_PER_HOUR,
       ReportCountSummary24h.HOURS_PER_DAY * ReportBaseFlow.ROWS_PER_HOUR,
     );
     const offPeak = ReportCountSummary24h.offPeakSection(
-      countData,
+      count,
       volumeByBucket,
       amPeak,
       pmPeak,

--- a/lib/reports/ReportCountSummary24hDetailed.js
+++ b/lib/reports/ReportCountSummary24hDetailed.js
@@ -16,11 +16,10 @@ class ReportCountSummary24hDetailed extends ReportBaseFlow {
     return ReportType.COUNT_SUMMARY_24H_DETAILED;
   }
 
-  static transformCountData(countData) {
+  static transformCountData(count, countData) {
     const volumeByBucket = ReportCountSummary24h.volumeByBucket(countData);
-    const countDate = countData[0].t;
-    const { year, month, day } = countDate;
-    return volumeByBucket.map((count, i) => {
+    const { year, month, day } = count.date;
+    return volumeByBucket.map((n, i) => {
       const hour = Math.floor(i / ReportBaseFlow.ROWS_PER_HOUR);
       const minute = (i % ReportBaseFlow.ROWS_PER_HOUR) * ReportBaseFlow.MINUTES_PER_ROW;
       const t = DateTime.fromObject({
@@ -30,7 +29,7 @@ class ReportCountSummary24hDetailed extends ReportBaseFlow {
         hour,
         minute,
       });
-      return { t, count };
+      return { t, count: n };
     });
   }
 
@@ -41,7 +40,7 @@ class ReportCountSummary24hDetailed extends ReportBaseFlow {
       const direction = artery.approachDir;
       const countData = studyData.get(id);
 
-      const volumeByBucket = ReportCountSummary24hDetailed.transformCountData(countData);
+      const volumeByBucket = ReportCountSummary24hDetailed.transformCountData(count, countData);
       return { date, direction, volumeByBucket };
     });
   }

--- a/tests/jest/unit/reports/ReportCountSummary24h.spec.js
+++ b/tests/jest/unit/reports/ReportCountSummary24h.spec.js
@@ -12,6 +12,9 @@ const countData_4_2156283 = loadJsonSync(
 const transformedData_COUNT_SUMMARY_24H_4_2156283 = loadJsonSync(
   path.resolve(__dirname, './data/transformedData_COUNT_SUMMARY_24H_4_2156283.json'),
 );
+const transformedData_COUNT_SUMMARY_24H_4_2156283_empty = loadJsonSync(
+  path.resolve(__dirname, './data/transformedData_COUNT_SUMMARY_24H_4_2156283_empty.json'),
+);
 
 test('ReportCountSummary24h.peak', () => {
   const volumeByBucket = [3, 5, 10, 15, 6, 2, 1, 5, 14, 0];
@@ -36,11 +39,11 @@ test('ReportCountSummary24h.peak', () => {
 });
 
 test('ReportCountSummary24h.timeRange', () => {
-  const countData = [{
-    t: DateTime.fromObject({ year: 2000, month: 1, day: 1 }),
-  }];
+  const count = {
+    date: DateTime.fromObject({ year: 2000, month: 1, day: 1 }),
+  };
 
-  expect(ReportCountSummary24h.timeRange(countData, 0, 4)).toEqual({
+  expect(ReportCountSummary24h.timeRange(count, 0, 4)).toEqual({
     start: DateTime.fromObject({
       year: 2000,
       month: 1,
@@ -57,7 +60,7 @@ test('ReportCountSummary24h.timeRange', () => {
     }),
   });
 
-  expect(ReportCountSummary24h.timeRange(countData, 13, 22)).toEqual({
+  expect(ReportCountSummary24h.timeRange(count, 13, 22)).toEqual({
     start: DateTime.fromObject({
       year: 2000,
       month: 1,
@@ -73,6 +76,30 @@ test('ReportCountSummary24h.timeRange', () => {
       minute: 30,
     }),
   });
+});
+
+test('ReportCountSummary24h#transformData [empty dataset]', () => {
+  const reportInstance = new ReportCountSummary24h();
+
+  const artery = {
+    approachDir: CardinalDirection.NORTH,
+    arteryCode: 2946,
+    stationCode: 2946,
+    street1: 'MORNINGSIDE AVE',
+  };
+  const count = {
+    arteryCode: 2946,
+    date: DateTime.fromSQL('2019-03-07 00:00:00'),
+    id: 17,
+    locationDesc: 'MORNINGSIDE AVE N/B S OF LAWRENCE AVE',
+    type: { studyType: StudyType.ATR_SPEED_VOLUME },
+  };
+  const counts = [count];
+  const arteries = new Map([[2946, artery]]);
+  const studyData = new Map([[17, []]]);
+
+  const transformedData = reportInstance.transformData(count, { arteries, counts, studyData });
+  expect(transformedData).toEqual(transformedData_COUNT_SUMMARY_24H_4_2156283_empty);
 });
 
 test('ReportCountSummary24h#transformData [Morningside S of Lawrence: 4/2156283]', () => {

--- a/tests/jest/unit/reports/ReportCountSummary24hDetailed.spec.js
+++ b/tests/jest/unit/reports/ReportCountSummary24hDetailed.spec.js
@@ -13,15 +13,54 @@ const transformedData_COUNT_SUMMARY_24H_DETAILED_4_2156283 = loadJsonSync(
   path.resolve(__dirname, './data/transformedData_COUNT_SUMMARY_24H_DETAILED_4_2156283.json'),
 );
 
+test('ReportCountSummary24hDetailed#transformData [empty dataset]', () => {
+  const reportInstance = new ReportCountSummary24hDetailed();
+
+  const countDate = DateTime.fromObject({ year: 2019, month: 3, day: 7 });
+  const study = {
+    endDate: countDate,
+    locationDesc: 'MORNINGSIDE AVE N/B S OF LAWRENCE AVE',
+    startDate: countDate,
+    type: { name: 'SPEED' },
+  };
+  const counts = [{
+    arteryCode: 42,
+    date: countDate,
+    id: 17,
+  }];
+  const arteries = new Map([[42, {
+    approachDir: CardinalDirection.NORTH,
+  }]]);
+  const studyData = new Map([[17, []]]);
+
+  /*
+   * Note that this is a speed / volume ATR count, so we're actually getting more than
+   * one data point per hour.  This allows us to test that the 24-hour detailed report
+   * works in this case.
+   */
+  let transformedData = reportInstance.transformData(study, { arteries, counts, studyData });
+  expect(transformedData).toHaveLength(1);
+  const { date, direction, volumeByBucket } = transformedData[0];
+  expect(date.equals(countDate)).toBe(true);
+  expect(direction).toBe(CardinalDirection.NORTH);
+  transformedData = volumeByBucket;
+
+  const expectedData = transformedData_COUNT_SUMMARY_24H_DETAILED_4_2156283.map(
+    ({ t }) => ({ t, count: 0 }),
+  );
+  expect(transformedData).toEqual(expectedData);
+});
+
 test('ReportCountSummary24hDetailed#transformData [Morningside S of Lawrence: 4/2156283]', () => {
   const reportInstance = new ReportCountSummary24hDetailed();
 
-  const count = {
-    date: DateTime.fromSQL('2019-03-07 00:00:00'),
+  const countDate = DateTime.fromObject({ year: 2019, month: 3, day: 7 });
+  const study = {
+    endDate: countDate,
     locationDesc: 'MORNINGSIDE AVE N/B S OF LAWRENCE AVE',
+    startDate: countDate,
     type: { name: 'SPEED' },
   };
-  const countDate = DateTime.fromObject({ year: 2018, month: 1, day: 1 });
   const counts = [{
     arteryCode: 42,
     date: countDate,
@@ -37,7 +76,7 @@ test('ReportCountSummary24hDetailed#transformData [Morningside S of Lawrence: 4/
    * one data point per hour.  This allows us to test that the 24-hour detailed report
    * works in this case.
    */
-  let transformedData = reportInstance.transformData(count, { arteries, counts, studyData });
+  let transformedData = reportInstance.transformData(study, { arteries, counts, studyData });
   expect(transformedData).toHaveLength(1);
   const { date, direction, volumeByBucket } = transformedData[0];
   expect(date.equals(countDate)).toBe(true);
@@ -50,12 +89,13 @@ test('ReportCountSummary24hDetailed#transformData [Morningside S of Lawrence: 4/
 test('ReportCountSummary24hDetailed#generateCsv [Morningside S of Lawrence: 4/2156283]', () => {
   const reportInstance = new ReportCountSummary24hDetailed();
 
-  const count = {
-    date: DateTime.fromSQL('2019-03-07 00:00:00'),
+  const countDate = DateTime.fromObject({ year: 2019, month: 3, day: 7 });
+  const study = {
+    endDate: countDate,
     locationDesc: 'MORNINGSIDE AVE N/B S OF LAWRENCE AVE',
+    startDate: countDate,
     type: { name: 'SPEED' },
   };
-  const countDate = DateTime.fromObject({ year: 2018, month: 1, day: 1 });
   const counts = [{
     arteryCode: 42,
     date: countDate,
@@ -66,8 +106,8 @@ test('ReportCountSummary24hDetailed#generateCsv [Morningside S of Lawrence: 4/21
   }]]);
   const studyData = new Map([[17, countData_4_2156283]]);
 
-  const transformedData = reportInstance.transformData(count, { arteries, counts, studyData });
+  const transformedData = reportInstance.transformData(study, { arteries, counts, studyData });
   expect(() => {
-    reportInstance.generateCsv(count, transformedData);
+    reportInstance.generateCsv(study, transformedData);
   }).not.toThrow();
 });

--- a/tests/jest/unit/reports/data/transformedData_COUNT_SUMMARY_24H_4_2156283_empty.json
+++ b/tests/jest/unit/reports/data/transformedData_COUNT_SUMMARY_24H_4_2156283_empty.json
@@ -1,0 +1,73 @@
+[
+  {
+    "title": "MORNINGSIDE AVE",
+    "directionGroups": [
+      {
+        "title": "Northbound",
+        "counts": [
+          {
+            "location":"MORNINGSIDE AVE N/B S OF LAWRENCE AVE",
+            "category": "Speed / Volume ATR",
+            "stationCode": 2946,
+            "arteryCode": 2946,
+            "date": "2019-03-07 00:00:00.000",
+            "dayOfWeek": "Thu",
+            "amPeak": {
+              "indices": [0, 1, 2, 3],
+              "sum": 0,
+              "timeRange": {
+                "start": "2019-03-07 00:00:00.000",
+                "end": "2019-03-07 01:00:00.000"
+              }
+            },
+            "pmPeak": {
+              "indices": [48, 49, 50, 51],
+              "sum": 0,
+              "timeRange": {
+                "start": "2019-03-07 12:00:00.000",
+                "end": "2019-03-07 13:00:00.000"
+              }
+            },
+            "offPeak": {
+              "indices": [4, 5, 6, 7],
+              "sum": 0,
+              "timeRange": {
+                "start": "2019-03-07 01:00:00.000",
+                "end": "2019-03-07 02:00:00.000"
+              }
+            },
+            "total": 0
+          }
+        ],
+        "totals": {
+          "sum": {
+            "amPeak": 0,
+            "pmPeak": 0,
+            "offPeak": 0,
+            "total": 0
+          },
+          "avg": {
+            "amPeak": 0,
+            "pmPeak": 0,
+            "offPeak": 0,
+            "total": 0
+          }
+        }
+      }
+    ],
+    "totals": {
+      "sum": {
+        "amPeak": 0,
+        "pmPeak": 0,
+        "offPeak": 0,
+        "total": 0
+      },
+      "avg": {
+        "amPeak": 0,
+        "pmPeak": 0,
+        "offPeak": 0,
+        "total": 0
+      }
+    }
+  }
+]


### PR DESCRIPTION
# Issue Addressed
This PR closes #343 .

# Description
We fix a bug where the 24-hour detailed and summary reports were assuming counts have at least one data point - this is almost always true, but only almost!

# Tests
Added empty dataset tests for these two report types, ran them to repro failures, ran them after fixes to verify that fixes address the bug.  Quickly double-checked that we're not making this assumption in other report types.
