### PR TITLE
Fix tabulation overflow and null values

### DIFF
--- a/lib/reports/ReportCollisionTabulation.js
+++ b/lib/reports/ReportCollisionTabulation.js
@@ -11,7 +11,7 @@ class CollisionDimension {
     event,
     fn,
     nullValue = null,
-    otherDescriptionFn = () => 'Other',
+    otherDescriptionFn = values => `${values.length} other values`,
   }) {
     this.description = description;
     this.entries = entries;
@@ -225,6 +225,7 @@ class ReportCollisionTabulation extends ReportBaseCrash {
         }
         return null;
       },
+      otherDescriptionFn: values => `${values.length} other actions`,
     });
 
     const drivcondEntries = this.getCollisionFactorEntries('drivcond');
@@ -239,6 +240,7 @@ class ReportCollisionTabulation extends ReportBaseCrash {
         return null;
       },
       nullValue: 0,
+      otherDescriptionFn: values => `${values.length} other conditions`,
     });
 
     const impactypeEntries = this.getCollisionFactorEntries('impactype');
@@ -247,6 +249,7 @@ class ReportCollisionTabulation extends ReportBaseCrash {
       entries: impactypeEntries,
       event: false,
       fn: ({ impactype }) => impactype,
+      otherDescriptionFn: values => `${values.length} other impact types`,
     });
 
     const initdirEntries = this.getCollisionFactorEntries('initdir');
@@ -285,6 +288,7 @@ class ReportCollisionTabulation extends ReportBaseCrash {
       entries: invtypeEntries,
       event: false,
       fn: (event, { invtype }) => invtype,
+      otherDescriptionFn: values => `${values.length} other categories`,
     });
 
     const manoeuverEntries = this.getCollisionFactorEntries('manoeuver');
@@ -299,6 +303,7 @@ class ReportCollisionTabulation extends ReportBaseCrash {
         return null;
       },
       nullValue: 0,
+      otherDescriptionFn: values => `${values.length} other manoeuvers`,
     });
   }
 
@@ -359,12 +364,18 @@ class ReportCollisionTabulation extends ReportBaseCrash {
           const shade = i % 2 === 1;
           return [
             { value: description, style: { br: true, shade } },
-            ...orderedTable[i].map(value => ({ value, style: { shade } })),
+            ...orderedTable[i].map((value, j) => ({
+              value,
+              style: { bl: j === nx, shade },
+            })),
           ];
         }),
         [
           { value: 'Total', style: { bold: true, br: true, bt: true } },
-          ...orderedTable[ny].map(value => ({ value, style: { bold: true, bt: true } })),
+          ...orderedTable[ny].map((value, j) => ({
+            value,
+            style: { bold: true, bl: j === nx, bt: true },
+          })),
         ],
       ],
     };

--- a/lib/reports/ReportCollisionTabulation.js
+++ b/lib/reports/ReportCollisionTabulation.js
@@ -1,7 +1,6 @@
 /* eslint-disable class-methods-use-this */
 import ArrayUtils from '@/lib/ArrayUtils';
 import { ReportBlock, ReportType, SortDirection } from '@/lib/Constants';
-import ArrayStats from '@/lib/math/ArrayStats';
 import ReportBaseCrash from '@/lib/reports/ReportBaseCrash';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 
@@ -11,17 +10,18 @@ class CollisionDimension {
     entries,
     event,
     fn,
-    nullEntry = [null, 'Unknown'],
+    nullValue = null,
+    otherDescriptionFn = () => 'Other',
   }) {
     this.description = description;
     this.entries = entries;
     this.event = event;
     this.fn = fn;
-    const [nullValue, nullDescription] = nullEntry;
     this.nullValue = nullValue;
     if (!this.entries.has(this.nullValue)) {
-      this.entries.set(this.nullValue, { description: nullDescription });
+      this.entries.set(this.nullValue, { description: 'Unknown' });
     }
+    this.otherDescriptionFn = otherDescriptionFn;
   }
 }
 
@@ -58,26 +58,79 @@ class CrossTabulation {
   }
 
   getOrderX() {
-    return ArrayUtils.sortBy(
-      Array.from(this.dimX.entries.keys()),
-      (x) => {
-        if (x === this.dimX.nullValue) {
-          // show null value at right
-          return Infinity;
-        }
-        return x;
-      },
-    );
+    const { entries, nullValue } = this.dimX;
+    const keys = Array.from(entries.keys());
+    const keysNoNull = keys.filter(x => x !== nullValue);
+    const orderX = ArrayUtils.sortBy(keysNoNull, x => x);
+    orderX.push(nullValue);
+    return orderX;
   }
 
-  getOrderY(sortY) {
-    const keyY = sortY ? y => this.table.get(y).total : y => y;
-    const dirY = sortY ? SortDirection.DESC : SortDirection.ASC;
-    return ArrayUtils.sortBy(
-      Array.from(this.dimY.entries.keys()),
-      keyY,
-      dirY,
-    );
+  getOrderY({
+    hideNull = false,
+    hideOther = false,
+    limit = 10,
+    sortByTotal = true,
+    sortDirection = SortDirection.DESC,
+  }) {
+    const { entries, nullValue } = this.dimY;
+    const keys = Array.from(entries.keys());
+    const keysNoNull = keys.filter(y => y !== nullValue);
+    let sortKey;
+    if (sortByTotal) {
+      sortKey = y => this.table.get(y).total;
+    } else {
+      sortKey = y => y;
+    }
+    const orderY = ArrayUtils.sortBy(keysNoNull, sortKey, sortDirection);
+    const n = hideNull ? keysNoNull.length : keys.length;
+    if (n <= limit) {
+      if (!hideNull) {
+        orderY.push(nullValue);
+      }
+      return orderY;
+    }
+    const hasNull = this.table.get(nullValue).total > 0;
+    if (!hideNull && hasNull) {
+      const orderYRest = orderY.slice(limit - 2);
+      const orderYLimit = orderY.slice(0, limit - 2);
+      orderYLimit.push(nullValue);
+      if (!hideOther) {
+        orderYLimit.push(orderYRest);
+      }
+      return orderYLimit;
+    }
+    const orderYRest = orderY.slice(limit - 1);
+    const orderYLimit = orderY.slice(0, limit - 1);
+    if (!hideOther) {
+      orderYLimit.push(orderYRest);
+    }
+    return orderYLimit;
+  }
+
+  getOrderedTable(orderX, orderY) {
+    const nx = orderX.length;
+    const ny = orderY.length;
+    const orderedTable = orderY.map((y) => {
+      const row = new Array(nx + 1).fill(0);
+      const ys = Array.isArray(y) ? y : [y];
+      ys.forEach((yy) => {
+        const { total, values } = this.table.get(yy);
+        orderX.forEach((x, j) => {
+          row[j] += values.get(x);
+        });
+        row[nx] += total;
+      });
+      return row;
+    });
+    const rowTotals = new Array(nx + 1).fill(0);
+    for (let i = 0; i < ny; i++) {
+      for (let j = 0; j <= nx; j++) {
+        rowTotals[j] += orderedTable[i][j];
+      }
+    }
+    orderedTable.push(rowTotals);
+    return orderedTable;
   }
 }
 
@@ -185,6 +238,7 @@ class ReportCollisionTabulation extends ReportBaseCrash {
         }
         return null;
       },
+      nullValue: 0,
     });
 
     const impactypeEntries = this.getCollisionFactorEntries('impactype');
@@ -206,6 +260,7 @@ class ReportCollisionTabulation extends ReportBaseCrash {
         }
         return null;
       },
+      nullValue: 0,
     });
 
     const injuryEntries = this.getCollisionFactorEntries('injury');
@@ -243,6 +298,7 @@ class ReportCollisionTabulation extends ReportBaseCrash {
         }
         return null;
       },
+      nullValue: 0,
     });
   }
 
@@ -270,25 +326,13 @@ class ReportCollisionTabulation extends ReportBaseCrash {
     return crossTabulation;
   }
 
-  getTableOptions(crossTabulation, dimX, dimY, options) {
-    const {
-      limit = 10,
-      sortY = true,
-    } = options;
+  getTableOptions(crossTabulation, options) {
+    const { dimX, dimY } = crossTabulation;
     const orderX = crossTabulation.getOrderX();
-    const orderY = crossTabulation.getOrderY(sortY);
-    const { table } = crossTabulation;
-    const orderYLimit = limit === null ? orderY : orderY.slice(0, limit);
+    const orderY = crossTabulation.getOrderY(options);
+    const orderedTable = crossTabulation.getOrderedTable(orderX, orderY);
     const nx = orderX.length;
-
-    const orderXTotals = orderX.map(
-      x => ArrayStats.sum(
-        orderY.map(y => table.get(y).values.get(x)),
-      ),
-    );
-    const orderYTotal = ArrayStats.sum(
-      orderY.map(y => table.get(y).total),
-    );
+    const ny = orderY.length;
 
     return {
       columnStyles: [
@@ -305,20 +349,22 @@ class ReportCollisionTabulation extends ReportBaseCrash {
         })),
       ],
       body: [
-        ...orderYLimit.map((y, i) => {
-          const { description } = dimY.entries.get(y);
-          const { total, values } = table.get(y);
+        ...orderY.map((y, i) => {
+          let description;
+          if (Array.isArray(y)) {
+            description = dimY.otherDescriptionFn(y);
+          } else {
+            description = dimY.entries.get(y).description;
+          }
           const shade = i % 2 === 1;
           return [
             { value: description, style: { br: true, shade } },
-            ...orderX.map(x => ({ value: values.get(x), style: { shade } })),
-            { value: total, style: { bl: true, shade } },
+            ...orderedTable[i].map(value => ({ value, style: { shade } })),
           ];
         }),
         [
           { value: 'Total', style: { bold: true, br: true, bt: true } },
-          ...orderXTotals.map(value => ({ value, style: { bold: true, bt: true } })),
-          { value: orderYTotal, style: { bold: true, bl: true, bt: true } },
+          ...orderedTable[ny].map(value => ({ value, style: { bold: true, bt: true } })),
         ],
       ],
     };
@@ -326,12 +372,12 @@ class ReportCollisionTabulation extends ReportBaseCrash {
 
   getEventTableOptions(collisions, dimX, dimY, options = {}) {
     const crossTabulation = this.getEventCrossTabulation(collisions, dimX, dimY);
-    return this.getTableOptions(crossTabulation, dimX, dimY, options);
+    return this.getTableOptions(crossTabulation, options);
   }
 
   getInvolvedTableOptions(collisions, dimX, dimY, options = {}) {
     const crossTabulation = this.getInvolvedCrossTabulation(collisions, dimX, dimY);
-    return this.getTableOptions(crossTabulation, dimX, dimY, options);
+    return this.getTableOptions(crossTabulation, options);
   }
 
   static getDimAccdateEntries(collisions) {
@@ -393,6 +439,10 @@ class ReportCollisionTabulation extends ReportBaseCrash {
       entries,
       event: true,
       fn: ({ accdate }) => accdate.year,
+      otherDescriptionFn: (values) => {
+        const [yearEnd] = values;
+        return `${yearEnd} or earlier`;
+      },
     });
   }
 
@@ -463,7 +513,7 @@ class ReportCollisionTabulation extends ReportBaseCrash {
             collisions,
             this.dimInjuryEvent,
             dimAccdateYear,
-            { limit: null, sortY: false },
+            { limit: 11, sortByTotal: false },
           ),
         },
         {
@@ -472,7 +522,13 @@ class ReportCollisionTabulation extends ReportBaseCrash {
             collisions,
             this.dimInjuryEvent,
             this.dimAccdateMonth,
-            { limit: 12, sortY: false },
+            {
+              hideNull: true,
+              hideOther: true,
+              limit: 12,
+              sortByTotal: false,
+              sortDirection: SortDirection.ASC,
+            },
           ),
         },
       ],

--- a/lib/reports/ReportCollisionTabulation.js
+++ b/lib/reports/ReportCollisionTabulation.js
@@ -5,29 +5,151 @@ import ArrayStats from '@/lib/math/ArrayStats';
 import ReportBaseCrash from '@/lib/reports/ReportBaseCrash';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 
+class CollisionDimension {
+  constructor({
+    description,
+    entries,
+    event,
+    fn,
+    nullEntry = [null, 'Unknown'],
+  }) {
+    this.description = description;
+    this.entries = entries;
+    this.event = event;
+    this.fn = fn;
+    const [nullValue, nullDescription] = nullEntry;
+    this.nullValue = nullValue;
+    if (!this.entries.has(this.nullValue)) {
+      this.entries.set(this.nullValue, { description: nullDescription });
+    }
+  }
+}
+
+class CrossTabulation {
+  constructor(dimX, dimY) {
+    this.dimX = dimX;
+    this.dimY = dimY;
+    this.table = new Map();
+    this.total = 0;
+    this.dimY.entries.forEach((valueY, y) => {
+      const values = new Map();
+      this.dimX.entries.forEach((valueX, x) => {
+        values.set(x, 0);
+      });
+      this.table.set(y, { total: 0, values });
+    });
+  }
+
+  incr(x0, y0) {
+    let y = y0;
+    if (y === null || !this.table.has(y)) {
+      y = this.dimY.nullValue;
+    }
+    const tableY = this.table.get(y);
+
+    let x = x0;
+    if (x === null || !tableY.values.has(x)) {
+      x = this.dimX.nullValue;
+    }
+    const valueX = tableY.values.get(x);
+    this.total += 1;
+    tableY.total += 1;
+    tableY.values.set(x, valueX + 1);
+  }
+
+  getOrderX() {
+    return ArrayUtils.sortBy(
+      Array.from(this.dimX.entries.keys()),
+      (x) => {
+        if (x === this.dimX.nullValue) {
+          // show null value at right
+          return Infinity;
+        }
+        return x;
+      },
+    );
+  }
+
+  getOrderY(sortY) {
+    const keyY = sortY ? y => this.table.get(y).total : y => y;
+    const dirY = sortY ? SortDirection.DESC : SortDirection.ASC;
+    return ArrayUtils.sortBy(
+      Array.from(this.dimY.entries.keys()),
+      keyY,
+      dirY,
+    );
+  }
+}
+
+class EventCrossTabulation extends CrossTabulation {
+  constructor(dimX, dimY) {
+    super(dimX, dimY);
+    if (!dimX.event || !dimY.event) {
+      throw new Error('expected event-level dimensions!');
+    }
+  }
+
+  tabulate(collisions) {
+    collisions.forEach((event) => {
+      const x = this.dimX.fn(event);
+      const y = this.dimY.fn(event);
+      this.incr(x, y);
+    });
+  }
+}
+
+class InvolvedCrossTabulation extends CrossTabulation {
+  constructor(dimX, dimY) {
+    super(dimX, dimY);
+    if (dimX.event || dimY.event) {
+      throw new Error('expected involved-level dimensions!');
+    }
+  }
+
+  tabulate(collisions) {
+    collisions.forEach(({ involved, ...event }) => {
+      involved.forEach((person) => {
+        const x = this.dimX.fn(event, person);
+        const y = this.dimY.fn(event, person);
+        this.incr(x, y);
+      });
+    });
+  }
+}
+
 class ReportCollisionTabulation extends ReportBaseCrash {
+  constructor() {
+    super();
+    // TODO: proper initialization system for report modules
+    this.initedDims = false;
+  }
+
   type() {
     return ReportType.COLLISION_TABULATION;
   }
 
   initDims() {
-    this.dimAccdateMonth = {
+    this.initedDims = true;
+
+    this.dimAccdateMonth = new CollisionDimension({
       description: 'Month of Collision',
       entries: new Map(
         TimeFormatters.MONTHS_OF_YEAR.map(
           (month, i) => [i + 1, { description: month }],
         ),
       ),
+      event: true,
       fn: ({ accdate }) => accdate.month,
-    };
+    });
 
-    this.dimAge = {
+    this.dimAge = new CollisionDimension({
       description: 'Age Group',
       entries: new Map([
         [0, { description: 'School Child' }],
         [1, { description: 'Adult' }],
         [2, { description: 'Older Adult' }],
       ]),
+      event: false,
       fn: (event, { olderAdult, schoolChild }) => {
         if (olderAdult) {
           return 2;
@@ -37,88 +159,98 @@ class ReportCollisionTabulation extends ReportBaseCrash {
         }
         return 1;
       },
-    };
+    });
 
     const drivactEntries = this.getCollisionFactorEntries('drivact');
-    this.dimDrivact = {
+    this.dimDrivact = new CollisionDimension({
       description: 'Driver Action',
       entries: drivactEntries,
+      event: false,
       fn: (event, { drivact, invtype }) => {
         if (invtype === 1 || invtype === 6 || invtype === 18) {
           return drivact;
         }
         return null;
       },
-    };
+    });
 
     const drivcondEntries = this.getCollisionFactorEntries('drivcond');
-    this.dimDrivcond = {
+    this.dimDrivcond = new CollisionDimension({
       description: 'Driver Condition',
       entries: drivcondEntries,
+      event: false,
       fn: (event, { drivcond, invtype }) => {
         if (invtype === 1 || invtype === 6 || invtype === 18) {
           return drivcond;
         }
         return null;
       },
-    };
+    });
 
     const impactypeEntries = this.getCollisionFactorEntries('impactype');
-    this.dimImpactype = {
+    this.dimImpactype = new CollisionDimension({
       description: 'Initial Impact Type',
       entries: impactypeEntries,
+      event: false,
       fn: ({ impactype }) => impactype,
-    };
+    });
 
     const initdirEntries = this.getCollisionFactorEntries('initdir');
-    this.dimInitdir = {
+    this.dimInitdir = new CollisionDimension({
       description: 'Initial Direction of Driver',
       entries: initdirEntries,
+      event: false,
       fn: (event, { initdir, invtype }) => {
         if (invtype === 1 || invtype === 6 || invtype === 18) {
           return initdir;
         }
         return null;
       },
-    };
+    });
 
     const injuryEntries = this.getCollisionFactorEntries('injury');
-    this.dimInjury = {
+    this.dimInjury = new CollisionDimension({
       description: 'Severity of Injury',
       entries: injuryEntries,
+      event: false,
       fn: (event, { injury }) => injury,
-    };
-    this.dimInjuryEvent = {
+    });
+    this.dimInjuryEvent = new CollisionDimension({
       description: 'Severity of Injury',
       entries: injuryEntries,
+      event: true,
       fn: ({ involved }) => Math.max(
         ...involved.map(({ injury }) => injury),
       ),
-    };
+    });
 
     const invtypeEntries = this.getCollisionFactorEntries('invtype');
-    this.dimInvtype = {
+    this.dimInvtype = new CollisionDimension({
       description: 'Category of Person',
       entries: invtypeEntries,
+      event: false,
       fn: (event, { invtype }) => invtype,
-    };
+    });
 
     const manoeuverEntries = this.getCollisionFactorEntries('manoeuver');
-    this.dimManoeuver = {
+    this.dimManoeuver = new CollisionDimension({
       description: 'Manoeuver',
       entries: manoeuverEntries,
+      event: false,
       fn: (event, { invtype, manoeuver }) => {
         if (invtype === 1 || invtype === 6 || invtype === 18) {
           return manoeuver;
         }
         return null;
       },
-    };
+    });
   }
 
   async fetchRawData(location, filters) {
     const rawData = await super.fetchRawData(location, filters);
-    this.initDims();
+    if (!this.initedDims) {
+      this.initDims();
+    }
     return rawData;
   }
 
@@ -126,88 +258,26 @@ class ReportCollisionTabulation extends ReportBaseCrash {
     return rawData;
   }
 
-  static getEmptyCrossTabulation(dimX, dimY) {
-    const table = new Map();
-    dimY.entries.forEach((valueY, y) => {
-      const values = new Map();
-      dimX.entries.forEach((valueX, x) => {
-        values.set(x, 0);
-      });
-      values.set(null, 0);
-      table.set(y, { total: 0, values });
-    });
-    return table;
+  getEventCrossTabulation(collisions, dimX, dimY) {
+    const crossTabulation = new EventCrossTabulation(dimX, dimY);
+    crossTabulation.tabulate(collisions);
+    return crossTabulation;
   }
 
-  static incrCrossTabulation(table, x, y) {
-    // TODO: handle null values
-    if (y === null) {
-      return;
-    }
-    const tableY = table.get(y);
-    if (tableY === undefined) {
-      return;
-    }
-    tableY.total += 1;
-
-    if (x === null) {
-      return;
-    }
-    const valueX = tableY.values.get(x);
-    if (valueX === undefined) {
-      return;
-    }
-    tableY.values.set(x, valueX + 1);
-  }
-
-  static getDimOrders(table, dimX, dimY, options) {
-    const {
-      sortY = true,
-    } = options;
-    const orderX = ArrayUtils.sortBy(
-      Array.from(dimX.entries.keys()),
-      x => x,
-    );
-    const keyY = sortY ? y => table.get(y).total : y => y;
-    const dirY = sortY ? SortDirection.DESC : SortDirection.ASC;
-    const orderY = ArrayUtils.sortBy(
-      Array.from(dimY.entries.keys()),
-      keyY,
-      dirY,
-    );
-    return { orderX, orderY };
-  }
-
-  getEventCrossTabulation(collisions, dimX, dimY, options) {
-    const table = ReportCollisionTabulation.getEmptyCrossTabulation(dimX, dimY);
-    collisions.forEach((event) => {
-      const x = dimX.fn(event);
-      const y = dimY.fn(event);
-      ReportCollisionTabulation.incrCrossTabulation(table, x, y);
-    });
-    const { orderX, orderY } = ReportCollisionTabulation.getDimOrders(table, dimX, dimY, options);
-    return { orderX, orderY, table };
-  }
-
-  getInvolvedCrossTabulation(collisions, dimX, dimY, options) {
-    const table = ReportCollisionTabulation.getEmptyCrossTabulation(dimX, dimY);
-    collisions.forEach(({ involved, ...event }) => {
-      involved.forEach((person) => {
-        const x = dimX.fn(event, person);
-        const y = dimY.fn(event, person);
-        ReportCollisionTabulation.incrCrossTabulation(table, x, y);
-      });
-    });
-    const { orderX, orderY } = ReportCollisionTabulation.getDimOrders(table, dimX, dimY, options);
-    return { orderX, orderY, table };
+  getInvolvedCrossTabulation(collisions, dimX, dimY) {
+    const crossTabulation = new InvolvedCrossTabulation(dimX, dimY);
+    crossTabulation.tabulate(collisions);
+    return crossTabulation;
   }
 
   getTableOptions(crossTabulation, dimX, dimY, options) {
     const {
       limit = 10,
+      sortY = true,
     } = options;
-
-    const { orderX, orderY, table } = crossTabulation;
+    const orderX = crossTabulation.getOrderX();
+    const orderY = crossTabulation.getOrderY(sortY);
+    const { table } = crossTabulation;
     const orderYLimit = limit === null ? orderY : orderY.slice(0, limit);
     const nx = orderX.length;
 
@@ -255,12 +325,12 @@ class ReportCollisionTabulation extends ReportBaseCrash {
   }
 
   getEventTableOptions(collisions, dimX, dimY, options = {}) {
-    const crossTabulation = this.getEventCrossTabulation(collisions, dimX, dimY, options);
+    const crossTabulation = this.getEventCrossTabulation(collisions, dimX, dimY);
     return this.getTableOptions(crossTabulation, dimX, dimY, options);
   }
 
   getInvolvedTableOptions(collisions, dimX, dimY, options = {}) {
-    const crossTabulation = this.getInvolvedCrossTabulation(collisions, dimX, dimY, options);
+    const crossTabulation = this.getInvolvedCrossTabulation(collisions, dimX, dimY);
     return this.getTableOptions(crossTabulation, dimX, dimY, options);
   }
 
@@ -318,11 +388,12 @@ class ReportCollisionTabulation extends ReportBaseCrash {
 
   static getDimAccdateYear(collisions) {
     const entries = ReportCollisionTabulation.getDimAccdateEntries(collisions);
-    return {
+    return new CollisionDimension({
       description: 'Year of Collision',
       entries,
+      event: true,
       fn: ({ accdate }) => accdate.year,
-    };
+    });
   }
 
   generateLayoutContent(location, { collisions, collisionSummary }) {


### PR DESCRIPTION
# Issue Addressed
This PR closes #468 and #469 .

# Description
We refactor `ReportCollisionTabulation` to provide `CollisionDimension` and `CrossTabulation`, two utility classes for handling cross-tabulations across a pair of dimensions.  `CollisionDimension` provides several configurable options for handling null values and "other" buckets upon truncation.  `CrossTabulation` handles building a table across two dimensions, using those configurable options from `CollisionDimension` to address null and truncated values.

# Tests
Ran several reports in the frontend.  (Due to the DAO dependency in `ReportBaseCrash`, we don't yet have unit tests on CRASH reports.)