### PR TITLE
Cleanup prj_volume from dev dataset

### DIFF
--- a/scripts/airflow/tasks/dev_data/create_schemas.sql
+++ b/scripts/airflow/tasks/dev_data/create_schemas.sql
@@ -2,12 +2,10 @@ drop schema if exists collisions cascade;
 drop schema if exists counts cascade;
 drop schema if exists gis cascade;
 drop schema if exists location_search cascade;
-drop schema if exists prj_volume cascade;
 drop schema if exists "TRAFFIC" cascade;
 
 create schema collisions;
 create schema counts;
 create schema gis;
 create schema location_search;
-create schema prj_volume;
 create schema "TRAFFIC";

--- a/scripts/airflow/tasks/dev_data/dump_dev_data.sh
+++ b/scripts/airflow/tasks/dev_data/dump_dev_data.sh
@@ -29,9 +29,6 @@ mkdir -p /data/dev_data
   env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t flashcrow_dev_data.gis_school -x --no-owner --clean --if-exists --schema-only | sed "s/flashcrow_dev_data.gis_school/gis.school/g"
 
   # shellcheck disable=SC2046
-  env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t flashcrow_dev_data.prj_volume_artery_centreline -x --no-owner --clean --if-exists --schema-only | sed "s/flashcrow_dev_data.prj_volume_artery_centreline/prj_volume.artery_centreline/g"
-
-  # shellcheck disable=SC2046
   env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t flashcrow_dev_data.traffic_category -x --no-owner --clean --if-exists --schema-only | sed 's/flashcrow_dev_data.traffic_category/"TRAFFIC"."CATEGORY"/g'
   # shellcheck disable=SC2046
   env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t flashcrow_dev_data.traffic_arterydata -x --no-owner --clean --if-exists --schema-only | sed 's/flashcrow_dev_data.traffic_arterydata/"TRAFFIC"."ARTERYDATA"/g'
@@ -60,11 +57,6 @@ mkdir -p /data/dev_data
   echo 'COPY gis.school FROM stdin;'
   # shellcheck disable=SC2046
   env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -c "COPY (SELECT * FROM gis.school) TO stdout (FORMAT text, ENCODING 'UTF-8')"
-  echo '\.'
-
-  echo 'COPY prj_volume.artery_centreline FROM stdin;'
-  # shellcheck disable=SC2046
-  env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -c "COPY (SELECT * FROM prj_volume.artery_centreline) TO stdout (FORMAT text, ENCODING 'UTF-8')"
   echo '\.'
 
   echo 'COPY "TRAFFIC"."CATEGORY" FROM stdin;'

--- a/scripts/airflow/tasks/dev_data/sample_dev_data.sql
+++ b/scripts/airflow/tasks/dev_data/sample_dev_data.sql
@@ -9,8 +9,6 @@ drop table if exists flashcrow_dev_data.gis_centreline_intersection;
 drop table if exists flashcrow_dev_data.gis_hospital;
 drop table if exists flashcrow_dev_data.gis_school;
 
-drop table if exists flashcrow_dev_data.prj_volume_artery_centreline;
-
 drop table if exists flashcrow_dev_data.traffic_arterydata;
 drop table if exists flashcrow_dev_data.traffic_category;
 
@@ -20,8 +18,6 @@ create table flashcrow_dev_data.gis_centreline (like gis.centreline including in
 create table flashcrow_dev_data.gis_centreline_intersection (like gis.centreline_intersection including indexes);
 create table flashcrow_dev_data.gis_hospital (like gis.hospital including indexes);
 create table flashcrow_dev_data.gis_school (like gis.school including indexes);
-
-create table flashcrow_dev_data.prj_volume_artery_centreline (like prj_volume.artery_centreline including indexes);
 
 create table flashcrow_dev_data.traffic_arterydata (like "TRAFFIC"."ARTERYDATA" including indexes);
 create table flashcrow_dev_data.traffic_category (like "TRAFFIC"."CATEGORY" including indexes);

--- a/scripts/airflow/tasks/dev_data/sample_dev_data.sql
+++ b/scripts/airflow/tasks/dev_data/sample_dev_data.sql
@@ -39,7 +39,7 @@ drop table if exists flashcrow_dev_data.traffic_cnt_det;
 
 create table flashcrow_dev_data.collisions_events (like collisions.events including indexes);
 insert into flashcrow_dev_data.collisions_events
-  select * from collisions.events tablesample bernoulli (18)
+  select * from collisions.events tablesample bernoulli (10)
   where accdate >= '2009-01-01';
 insert into flashcrow_dev_data.collisions_events
   select t.* from collisions.events as t
@@ -64,15 +64,15 @@ insert into flashcrow_dev_data.collisions_involved
 
 create table flashcrow_dev_data.counts_studies (like counts.studies including indexes);
 insert into flashcrow_dev_data.counts_studies
-  select * from counts.studies tablesample bernoulli (0.5)
+  select * from counts.studies tablesample bernoulli (0.25)
   where start_date >= '2009-01-01'
   and "CATEGORY_ID" = 2;
 insert into flashcrow_dev_data.counts_studies
-  select * from counts.studies tablesample bernoulli (1)
+  select * from counts.studies tablesample bernoulli (0.5)
   where start_date >= '2009-01-01'
   and "CATEGORY_ID" = 6;
 insert into flashcrow_dev_data.counts_studies
-  select * from counts.studies tablesample bernoulli (5)
+  select * from counts.studies tablesample bernoulli (2)
   where start_date >= '2009-01-01'
   and "CATEGORY_ID" not in (2, 6);
 insert into flashcrow_dev_data.counts_studies


### PR DESCRIPTION
# Issue Addressed
This PR makes progress on #483 .

# Description
We remove `prj_volume` from the dev dataset, and reduce sampling percentages for collisions and counts to get a smaller dataset for faster test setup.

# Tests
Ran `dev_data` DAG, loaded into local dev environment, ran tests with dev dataset.
