### PR TITLE
Side nav tweaks: View Request, reloading location in View Map

### DIFF
--- a/scripts/dev/Vagrantfile
+++ b/scripts/dev/Vagrantfile
@@ -30,12 +30,14 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider "virtualbox" do |v|
     # see https://stefanwrobel.com/how-to-make-vagrant-performance-not-suck
-    v.customize ["modifyvm", :id, "--memory", 2048]
+    v.customize ["modifyvm", :id, "--memory", 8192]
     # see https://www.mkwd.net/improve-vagrant-performance/
     v.cpus = 2
     v.customize ["modifyvm", :id, "--ioapic", "on"]
     # see https://serverfault.com/questions/453185/vagrant-virtualbox-dns-10-0-2-3-not-working
     v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+    # turn on host I/O cache
+    v.customize ["storagectl", :id, "--name", "SATA", "--hostiocache", "on"]
   end
 
   # 808x: SERVICES

--- a/web/App.vue
+++ b/web/App.vue
@@ -22,28 +22,7 @@
       <template v-slot:prepend>
         <FcDashboardNavBrand />
       </template>
-      <v-list
-        class="d-flex fill-height flex-column justify-center"
-        dense>
-        <FcDashboardNavItem
-          :active-route-names="[
-            'viewCollisionReportsAtLocation',
-            'viewDataAtLocation',
-            'viewStudyReportsAtLocation',
-          ]"
-          icon="map"
-          label="View Map"
-          :to="{ name: 'viewData' }" />
-        <FcDashboardNavItem
-          :active-route-names="[
-            'requestStudyEdit',
-            'requestStudyNew',
-            'requestStudyView',
-          ]"
-          icon="clipboard-list"
-          label="Track Requests"
-          :to="{ name: 'requestsTrack' }" />
-      </v-list>
+      <FcDashboardNav />
       <template v-slot:append>
         <FcDashboardNavUser />
       </template>
@@ -69,14 +48,14 @@ import FcDialogAlertStudyRequestUrgent from
 import FcDialogConfirmUnauthorized from
   '@/web/components/dialogs/FcDialogConfirmUnauthorized.vue';
 import FcDashboardNavBrand from '@/web/components/nav/FcDashboardNavBrand.vue';
-import FcDashboardNavItem from '@/web/components/nav/FcDashboardNavItem.vue';
+import FcDashboardNav from '@/web/components/nav/FcDashboardNav.vue';
 import FcDashboardNavUser from '@/web/components/nav/FcDashboardNavUser.vue';
 
 export default {
   name: 'App',
   components: {
     FcDashboardNavBrand,
-    FcDashboardNavItem,
+    FcDashboardNav,
     FcDashboardNavUser,
     FcDialogAlertStudyRequestUrgent,
     FcDialogConfirmUnauthorized,

--- a/web/components/nav/FcDashboardNav.vue
+++ b/web/components/nav/FcDashboardNav.vue
@@ -1,0 +1,49 @@
+<template>
+  <v-list
+    class="d-flex fill-height flex-column justify-center"
+    dense>
+    <FcDashboardNavItem
+      :active-route-names="[
+        'viewCollisionReportsAtLocation',
+        'viewDataAtLocation',
+        'viewStudyReportsAtLocation',
+      ]"
+      icon="map"
+      label="View Map"
+      :to="toViewMap" />
+    <FcDashboardNavItem
+      :active-route-names="[
+        'requestStudyEdit',
+        'requestStudyNew',
+      ]"
+      icon="clipboard-list"
+      label="Track Requests"
+      :to="{ name: 'requestsTrack' }" />
+  </v-list>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+
+import FcDashboardNavItem from '@/web/components/nav/FcDashboardNavItem.vue';
+
+export default {
+  name: 'FcDashboardNav',
+  components: {
+    FcDashboardNavItem,
+  },
+  computed: {
+    toViewMap() {
+      if (this.location === null) {
+        return { name: 'viewData' };
+      }
+      const { centrelineId, centrelineType } = this.location;
+      return {
+        name: 'viewDataAtLocation',
+        params: { centrelineId, centrelineType },
+      };
+    },
+    ...mapState(['location']),
+  },
+};
+</script>

--- a/web/components/nav/FcDashboardNavItem.vue
+++ b/web/components/nav/FcDashboardNavItem.vue
@@ -24,6 +24,8 @@
 </template>
 
 <script>
+import { mapState } from 'vuex';
+
 export default {
   name: 'FcDashboardNavItem',
   props: {
@@ -42,9 +44,18 @@ export default {
   computed: {
     isActive() {
       const { name } = this.$route;
-      const { name: toName } = this.to;
-      return name === toName || this.activeRouteNames.includes(name);
+      const { backViewRequest, to } = this;
+      const { name: backViewRequestName } = backViewRequest;
+      const { name: toName } = to;
+      if (name === toName) {
+        return true;
+      }
+      if (this.activeRouteNames.includes(name)) {
+        return true;
+      }
+      return name === 'requestStudyView' && backViewRequestName === toName;
     },
+    ...mapState(['backViewRequest']),
   },
 };
 </script>

--- a/web/main.js
+++ b/web/main.js
@@ -2,6 +2,7 @@ import { format } from 'd3-format';
 import Vue from 'vue';
 import Vuelidate from 'vuelidate';
 import Vuetify from 'vuetify/lib/framework';
+import en from 'vuetify/es5/locale/en';
 
 import App from '@/web/App.vue';
 import router from '@/web/router';
@@ -37,6 +38,10 @@ Vue.config.productionTip = false;
  * This offers us flexibility in developing a standard look-and-feel across the application.
  */
 const vuetify = new Vuetify({
+  lang: {
+    locales: { en },
+    current: 'en',
+  },
   theme: {
     options: {
       customProperties: true,


### PR DESCRIPTION
# Issue Addressed
This PR closes #446 .

# Description
We introduce `FcDashboardNav`, which provides a layer on top of `FcDashboardNavItem` that allows us a bit more control over handling the active state of those navigation items.

We then use this to dynamically change the `to` route of the View Map navigation item based on whether a location is selected, and to set the correct navigation item active in View Request based on the value of `backViewRequest`.

We also incorporate a couple of unrelated dev tooling tweaks: more VM memory, enable host I/O cache, only load English locale for Vuetify.

# Tests
Tested several flows manually in the browser.
