### PR TITLE
Support clearing location search bar

### DIFF
--- a/web/App.vue
+++ b/web/App.vue
@@ -27,13 +27,13 @@
         <FcDashboardNavUser />
       </template>
     </v-navigation-drawer>
-    <v-content>
+    <v-main>
       <v-container
         class="fill-height pa-0"
         fluid>
         <router-view></router-view>
       </v-container>
-    </v-content>
+    </v-main>
   </v-app>
 </template>
 

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -324,6 +324,12 @@ export default {
     },
     location(location, locationPrev) {
       if (location === null) {
+        /*
+         * Normally `this.loading = true` is paired with `this.loading = false` after some
+         * asynchronous operation.  In this case, however, we're using it to hide the View Data
+         * drawer contents to prevent errors after clearing `FcSearchBarLocation`.  This is OK,
+         * as the next line jumps to View Map which destroys this drawer component anyways.
+         */
         this.loading = true;
         this.$router.push({
           name: 'viewData',

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -324,6 +324,7 @@ export default {
     },
     location(location, locationPrev) {
       if (location === null) {
+        this.loading = true;
         this.$router.push({
           name: 'viewData',
         });

--- a/web/components/FcDrawerViewRequest.vue
+++ b/web/components/FcDrawerViewRequest.vue
@@ -9,10 +9,18 @@
       </FcButton>
       <h1 class="flex-grow-1 headline text-center">
         <span>
-          {{title}}:
+          Request #{{$route.params.id}}:
         </span>
-        <span class="font-weight-regular">
-          {{subtitle}}
+        <v-progress-circular
+          v-if="loading"
+          color="primary"
+          indeterminate
+          :size="20"
+          :width="2" />
+        <span
+          v-else
+          class="font-weight-regular">
+          {{studyRequestLocation.description}}
         </span>
       </h1>
       <FcButton
@@ -118,6 +126,7 @@ export default {
       studyRequest: null,
       studyRequestChanges: [],
       studyRequestComments: [],
+      studyRequestLocation: null,
       studyRequestUsers: new Map(),
     };
   },
@@ -193,16 +202,6 @@ export default {
         return 'View Data';
       }
       return 'Requests';
-    },
-    subtitle() {
-      if (this.location === null) {
-        return '';
-      }
-      return this.location.description;
-    },
-    title() {
-      const { id } = this.$route.params;
-      return `Request #${id}`;
     },
     ...mapState(['auth', 'backViewRequest', 'location']),
   },
@@ -282,6 +281,7 @@ export default {
       this.studyRequest = studyRequest;
       this.studyRequestChanges = studyRequestChanges;
       this.studyRequestComments = studyRequestComments;
+      this.studyRequestLocation = studyRequestLocation;
       this.studyRequestUsers = studyRequestUsers;
       this.setLocation(studyRequestLocation);
     },

--- a/web/components/FcPaneMapPopup.vue
+++ b/web/components/FcPaneMapPopup.vue
@@ -22,8 +22,8 @@
       <v-card-actions v-if="!loading && featureSelectable">
         <FcButton
           type="tertiary"
-          @click="actionViewData">
-          View Data
+          @click="actionSelected">
+          {{textActionSelected}}
         </FcButton>
       </v-card-actions>
     </v-card>
@@ -300,6 +300,13 @@ export default {
     layerId() {
       return this.feature.layer.id;
     },
+    textActionSelected() {
+      const { name } = this.$route;
+      if (name === 'requestStudyEdit' || name === 'requestStudyNew') {
+        return 'Set Study Location';
+      }
+      return 'View Data';
+    },
     title() {
       if (this.layerId === 'collisionsLevel2' || this.layerId === 'collisionsLevel1') {
         const { injury } = this.feature.properties;
@@ -364,6 +371,20 @@ export default {
     this.popup.remove();
   },
   methods: {
+    actionSelected() {
+      const { name } = this.$route;
+      if (name === 'requestStudyEdit' || name === 'requestStudyNew') {
+        this.actionSetStudyLocation();
+      } else {
+        this.actionViewData();
+      }
+    },
+    async actionSetStudyLocation() {
+      const { centrelineId, centrelineType } = this.feature.properties;
+      const feature = { centrelineId, centrelineType };
+      const location = await getLocationByFeature(feature);
+      this.setLocation(location);
+    },
     actionViewData() {
       if (this.$route.name === 'viewDataAtLocation') {
         this.setDrawerOpen(true);

--- a/web/components/inputs/FcSearchBarLocation.vue
+++ b/web/components/inputs/FcSearchBarLocation.vue
@@ -1,5 +1,23 @@
 <template>
   <div class="fc-search-bar-location-wrapper">
+    <FcDialogConfirm
+      v-model="showConfirmClear"
+      textCancel="Cancel"
+      textOk="Clear"
+      title="Clear Location"
+      @action-ok="actionClear">
+      <span class="body-1">
+        <span v-if="$route.name === 'requestStudyEdit'">
+
+        </span>
+        <span v-else-if="$route.name === 'requestStudyNew'">
+
+        </span>
+        <span v-else-if="$route.name === 'requestStudyView'">
+
+        </span>
+      </span>
+    </FcDialogConfirm>
     <v-tooltip
       v-if="collapseSearchBar"
       right
@@ -19,7 +37,6 @@
     <v-autocomplete
       v-else
       v-model="internalLocation"
-      append-icon="mdi-magnify"
       class="fc-search-bar-location elevation-2"
       dense
       hide-details
@@ -32,6 +49,24 @@
       return-object
       :search-input.sync="query"
       solo>
+      <template v-slot:append>
+        <v-tooltip
+          v-if="location !== null"
+          right>
+          <template v-slot:activator="{ on }">
+            <FcButton
+              aria-label="Clear Location"
+              type="icon"
+              @click="onClickClear"
+              v-on="on">
+              <v-icon>mdi-close-circle</v-icon>
+            </FcButton>
+          </template>
+          <span>Clear Location</span>
+        </v-tooltip>
+        <v-divider vertical />
+        <v-icon right>mdi-magnify</v-icon>
+      </template>
       <template v-slot:item="{ attrs, item, on, parent }">
         <v-list-item
           v-bind="attrs"
@@ -52,12 +87,14 @@ import { mapMutations, mapState } from 'vuex';
 
 import { debounce } from '@/lib/FunctionUtils';
 import { getLocationSuggestions } from '@/lib/api/WebApi';
+import FcDialogConfirm from '@/web/components/dialogs/FcDialogConfirm.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 
 export default {
   name: 'FcSearchBarLocation',
   components: {
     FcButton,
+    FcDialogConfirm,
   },
   data() {
     return {
@@ -65,6 +102,7 @@ export default {
       key: null,
       loading: false,
       query: null,
+      showConfirmClear: false,
     };
   },
   computed: {
@@ -78,7 +116,11 @@ export default {
         return this.location;
       },
       set(internalLocation) {
-        this.setLocation(internalLocation);
+        if (internalLocation !== undefined) {
+          this.setLocation(internalLocation);
+          return;
+        }
+        console.log('clear');
       },
     },
     ...mapState(['location']),
@@ -154,6 +196,18 @@ export default {
     }, 250),
   },
   methods: {
+    actionClear() {
+      this.query = null;
+      this.setLocation(null);
+    },
+    onClickClear() {
+      const { name } = this.$route;
+      if (name === 'viewData' || name === 'viewDataAtLocation') {
+        this.actionClear();
+      } else {
+        this.showConfirmClear = true;
+      }
+    },
     ...mapMutations(['setLocation']),
   },
 };

--- a/web/components/inputs/FcSearchBarLocation.vue
+++ b/web/components/inputs/FcSearchBarLocation.vue
@@ -95,11 +95,7 @@ export default {
         return this.location;
       },
       set(internalLocation) {
-        if (internalLocation !== undefined) {
-          this.setLocation(internalLocation);
-          return;
-        }
-        console.log('clear');
+        this.setLocation(internalLocation);
       },
     },
     ...mapState(['location']),

--- a/web/components/inputs/FcSearchBarLocation.vue
+++ b/web/components/inputs/FcSearchBarLocation.vue
@@ -1,23 +1,5 @@
 <template>
   <div class="fc-search-bar-location-wrapper">
-    <FcDialogConfirm
-      v-model="showConfirmClear"
-      textCancel="Cancel"
-      textOk="Clear"
-      title="Clear Location"
-      @action-ok="actionClear">
-      <span class="body-1">
-        <span v-if="$route.name === 'requestStudyEdit'">
-
-        </span>
-        <span v-else-if="$route.name === 'requestStudyNew'">
-
-        </span>
-        <span v-else-if="$route.name === 'requestStudyView'">
-
-        </span>
-      </span>
-    </FcDialogConfirm>
     <v-tooltip
       v-if="collapseSearchBar"
       right
@@ -57,7 +39,7 @@
             <FcButton
               aria-label="Clear Location"
               type="icon"
-              @click="onClickClear"
+              @click="actionClear"
               v-on="on">
               <v-icon>mdi-close-circle</v-icon>
             </FcButton>
@@ -87,14 +69,12 @@ import { mapMutations, mapState } from 'vuex';
 
 import { debounce } from '@/lib/FunctionUtils';
 import { getLocationSuggestions } from '@/lib/api/WebApi';
-import FcDialogConfirm from '@/web/components/dialogs/FcDialogConfirm.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 
 export default {
   name: 'FcSearchBarLocation',
   components: {
     FcButton,
-    FcDialogConfirm,
   },
   data() {
     return {
@@ -102,7 +82,6 @@ export default {
       key: null,
       loading: false,
       query: null,
-      showConfirmClear: false,
     };
   },
   computed: {
@@ -197,16 +176,12 @@ export default {
   },
   methods: {
     actionClear() {
+      /*
+       * 1b -> 1a -> 2a.  The debounce delay of 250ms on the `query` watcher is more than
+       * enough so that, by the time it fires, we're already in 2a.
+       */
       this.query = null;
       this.setLocation(null);
-    },
-    onClickClear() {
-      const { name } = this.$route;
-      if (name === 'viewData' || name === 'viewDataAtLocation') {
-        this.actionClear();
-      } else {
-        this.showConfirmClear = true;
-      }
     },
     ...mapMutations(['setLocation']),
   },


### PR DESCRIPTION
# Issue Addressed
This PR closes #445 .

# Description
We add a custom clear button to `FcLocationSearchBar` that integrates with our `vuex` setup for selected location.  We also update study request-related flows to ensure that clearing the location search bar does not disrupt / break user flows.

# Tests
Tested View Map, View Data, Request Study, Edit Request, and View Request with these changes.  Also tested View Reports (both collisions and study) to ensure that these were not broken by changes to `FcPaneMapPopup`.
