### PR TITLE
Improved validation in Request Study

### DIFF
--- a/lib/validation/ValidationsStudyRequest.js
+++ b/lib/validation/ValidationsStudyRequest.js
@@ -29,6 +29,7 @@ function numConsecutiveDaysOfWeek(daysOfWeek) {
 const ValidationsStudyRequest = {
   studyRequest: {
     ccEmails: {
+      requiredIfUrgent: requiredIf(({ urgent }) => urgent),
       $each: {
         required,
         torontoInternal(ccEmail) {

--- a/web/components/FcDetailsStudyRequest.vue
+++ b/web/components/FcDetailsStudyRequest.vue
@@ -120,8 +120,8 @@
               :error-messages="errorMessagesDueDate"
               label="Due Date"
               :max="maxDueDate"
-              :messages="[REQUEST_STUDY_PROVIDE_URGENT_DUE_DATE.text]"
-              :min="minDueDate">
+              :min="minDueDate"
+              :success="!v.dueDate.$invalid">
             </FcDatePicker>
           </v-col>
         </v-row>
@@ -136,7 +136,8 @@
             v-model="v.ccEmails.$model"
             :error-messages="errorMessagesCcEmails"
             label="Staff Email"
-            :messages="[OPTIONAL.text]" />
+            :messages="messagesCcEmails"
+            :success="internalValue.urgent && !v.ccEmails.$invalid" />
         </v-col>
       </v-row>
     </div>
@@ -151,6 +152,7 @@
         no-resize
         outlined
         rows="4"
+        :success="internalValue.urgent && !v.urgentReason.$invalid"
         @blur="v.urgentReason.$touch()"></v-textarea>
     </div>
   </section>
@@ -208,6 +210,9 @@ export default {
   computed: {
     errorMessagesCcEmails() {
       const errors = [];
+      if (!this.v.ccEmails.requiredIfUrgent) {
+        errors.push('Please provide an additional point of contact for this urgent request.');
+      }
       this.internalValue.ccEmails.forEach((_, i) => {
         if (!this.v.ccEmails.$each[i].$dirty) {
           return;
@@ -308,6 +313,13 @@ export default {
       }
       return null;
     },
+    messagesCcEmails() {
+      const { urgent } = this.internalValue;
+      if (urgent) {
+        return [];
+      }
+      return [OPTIONAL.text];
+    },
     messagesDaysOfWeek() {
       const { duration, studyType } = this.internalValue;
       if (studyType.automatic) {
@@ -329,7 +341,7 @@ export default {
     messagesUrgentReason() {
       const { urgent } = this.internalValue;
       if (urgent) {
-        return [REQUEST_STUDY_PROVIDE_URGENT_REASON.text];
+        return [];
       }
       return [OPTIONAL.text];
     },

--- a/web/components/FcDrawerRequestStudy.vue
+++ b/web/components/FcDrawerRequestStudy.vue
@@ -62,6 +62,7 @@
         <FcDetailsStudyRequest
           v-model="studyRequest"
           class="pr-5"
+          :is-create="isCreate"
           :v="$v.studyRequest" />
 
         <section
@@ -99,6 +100,7 @@ import {
   REQUEST_STUDY_REQUIRES_LOCATION,
   REQUEST_STUDY_TIME_TO_FULFILL,
 } from '@/lib/i18n/Strings';
+import DateTime from '@/lib/time/DateTime';
 import ValidationsStudyRequest from '@/lib/validation/ValidationsStudyRequest';
 import FcDetailsStudyRequest from '@/web/components/FcDetailsStudyRequest.vue';
 import FcDialogConfirm from '@/web/components/dialogs/FcDialogConfirm.vue';
@@ -164,15 +166,16 @@ export default {
         return null;
       }
       const { dueDate, urgent } = studyRequest;
+      if (dueDate === null) {
+        return null;
+      }
       if (urgent) {
         return dueDate;
       }
-      const oneWeekBeforeDueDate = dueDate.minus({ weeks: 1 });
-      const twoMonthsOut = now.plus({ months: 2 });
-      if (oneWeekBeforeDueDate.valueOf() < twoMonthsOut.valueOf()) {
-        return twoMonthsOut;
-      }
-      return oneWeekBeforeDueDate;
+      return DateTime.max(
+        dueDate.minus({ weeks: 1 }),
+        now.plus({ months: 2 }),
+      );
     },
     isCreate() {
       return this.$route.name === 'requestStudyNew';

--- a/web/components/inputs/FcDatePicker.vue
+++ b/web/components/inputs/FcDatePicker.vue
@@ -16,6 +16,7 @@
           v-bind="$attrs"
           @blur="resetValueFormatted"
           @input="updateValueFormatted"
+          @click:append="showMenu = !showMenu"
           v-on="on"></v-text-field>
       </template>
       <v-date-picker

--- a/web/components/inputs/FcInputTextArray.vue
+++ b/web/components/inputs/FcInputTextArray.vue
@@ -2,11 +2,11 @@
   <v-combobox
     v-model="internalValue"
     append-icon="mdi-plus"
-    chips
     deletable-chips
     dense
     multiple
     outlined
+    small-chips
     v-bind="$attrs"></v-combobox>
 </template>
 


### PR DESCRIPTION
# Issue Addressed
This PR closes #447 .

# Description
We update Request Study so that marking a request urgent instantly flags due date, CC emails, and urgent reason as required fields, rather than waiting for the user to interact with them.  We also add a success state on these fields for urgent requests.

`FcInputTextArray` and `FcDatePicker` receive some small visual / interaction tweaks in the process.

# Tests
Tested in the browser for both Request Study and Edit Request, and checked that created / edited requests are successfully saved (i.e. pass both frontend and backend validation checks).