### PR TITLE
Airflow job to generate routing views 

### DIFF
--- a/scripts/airflow/dags/routing_index.py
+++ b/scripts/airflow/dags/routing_index.py
@@ -1,0 +1,19 @@
+"""
+routing_index
+
+Build any necessary views and indexes to support routing-related features in MOVE, such
+as corridor interpolation for multi-location selection.
+"""
+# pylint: disable=pointless-statement
+from datetime import datetime
+
+from airflow_utils import create_dag, create_bash_task_nested
+
+START_DATE = datetime(2020, 6, 23)
+SCHEDULE_INTERVAL = '30 6 * * 6'
+DAG = create_dag(__file__, __doc__, START_DATE, SCHEDULE_INTERVAL)
+
+TRANSFORM_CENTRELINE_VERTICES = create_bash_task_nested(DAG, 'transform_centreline_vertices')
+TRANSFORM_CENTRELINE_EDGES = create_bash_task_nested(DAG, 'transform_centreline_edges')
+
+TRANSFORM_CENTRELINE_VERTICES >> TRANSFORM_CENTRELINE_EDGES

--- a/scripts/airflow/tasks/dev_data/create_schemas.sql
+++ b/scripts/airflow/tasks/dev_data/create_schemas.sql
@@ -2,10 +2,12 @@ drop schema if exists collisions cascade;
 drop schema if exists counts cascade;
 drop schema if exists gis cascade;
 drop schema if exists location_search cascade;
+drop schema if exists routing cascade;
 drop schema if exists "TRAFFIC" cascade;
 
 create schema collisions;
 create schema counts;
 create schema gis;
 create schema location_search;
+create schema routing;
 create schema "TRAFFIC";

--- a/scripts/airflow/tasks/dev_data/dump_dev_data.sh
+++ b/scripts/airflow/tasks/dev_data/dump_dev_data.sh
@@ -157,12 +157,21 @@ mkdir -p /data/dev_data
   # shellcheck disable=SC2046
   env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t location_search.traffic_signal -x --no-owner --clean --if-exists --schema-only
 
+  # shellcheck disable=SC2046
+  env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t routing.centreline_vertices -x --no-owner --clean --if-exists --schema-only
+  # shellcheck disable=SC2046
+  env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t routing.centreline_edges -x --no-owner --clean --if-exists --schema-only
+
+
   #
   # refresh data for view definitions
   #
 
   echo 'REFRESH MATERIALIZED VIEW location_search.centreline_intersection;'
   echo 'REFRESH MATERIALIZED VIEW location_search.traffic_signal;'
+
+  echo 'REFRESH MATERIALIZED VIEW routing.centreline_vertices;'
+  echo 'REFRESH MATERIALIZED VIEW routing.centreline_edges;'
 } > "${FLASHCROW_DEV_DATA}"
 
 # compress to reduce copying bandwidth

--- a/scripts/airflow/tasks/routing_index/transform_centreline_edges.sh
+++ b/scripts/airflow/tasks/routing_index/transform_centreline_edges.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+GIT_ROOT=/home/ec2-user/flashcrow
+TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
+
+# shellcheck disable=SC2046
+env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 < "${TASKS_ROOT}/routing_index/transform_centreline_edges.sql"

--- a/scripts/airflow/tasks/routing_index/transform_centreline_edges.sql
+++ b/scripts/airflow/tasks/routing_index/transform_centreline_edges.sql
@@ -1,0 +1,22 @@
+CREATE SCHEMA IF NOT EXISTS routing;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS routing.centreline_edges AS (
+  SELECT
+    geo_id::int AS id,
+    fnode::int AS source,
+    tnode::int AS target,
+    ST_Length(ST_Transform(c.geom, 2952)) AS cost,
+    -1 AS reverse_cost,
+    ST_X(vf.geom) AS x1,
+    ST_Y(vf.geom) AS y1,
+    ST_X(vt.geom) AS x2,
+    ST_Y(vt.geom) AS y2
+  FROM gis.centreline c
+  JOIN routing.centreline_vertices vf ON c.fnode = vf.id
+  JOIN routing.centreline_vertices vt ON c.tnode = vt.id
+);
+CREATE UNIQUE INDEX IF NOT EXISTS centreline_edges_id ON routing.centreline_edges (id);
+CREATE INDEX IF NOT EXISTS centreline_edges_source ON routing.centreline_edges (source);
+CREATE INDEX IF NOT EXISTS centreline_edges_target ON routing.centreline_edges (target);
+
+REFRESH MATERIALIZED VIEW routing.centreline_edges;

--- a/scripts/airflow/tasks/routing_index/transform_centreline_vertices.sh
+++ b/scripts/airflow/tasks/routing_index/transform_centreline_vertices.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+GIT_ROOT=/home/ec2-user/flashcrow
+TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
+
+# shellcheck disable=SC2046
+env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 < "${TASKS_ROOT}/routing_index/transform_centreline_vertices.sql"

--- a/scripts/airflow/tasks/routing_index/transform_centreline_vertices.sql
+++ b/scripts/airflow/tasks/routing_index/transform_centreline_vertices.sql
@@ -1,0 +1,16 @@
+CREATE SCHEMA IF NOT EXISTS routing;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS routing.centreline_vertices AS (
+  SELECT
+    int_id AS id,
+    ST_Transform(
+      MODE() WITHIN GROUP (ORDER BY geom),
+      2952
+    ) AS geom
+  FROM gis.centreline_intersection
+  GROUP BY int_id
+);
+CREATE UNIQUE INDEX IF NOT EXISTS centreline_vertices_id ON routing.centreline_vertices (id);
+CREATE INDEX IF NOT EXISTS centreline_vertices_geom ON counts.centreline_intersection USING GIST (geom);
+
+REFRESH MATERIALIZED VIEW routing.centreline_vertices;

--- a/scripts/deployment/rds/createReadOnlyUser.sql
+++ b/scripts/deployment/rds/createReadOnlyUser.sql
@@ -45,6 +45,11 @@ GRANT SELECT ON public.geography_columns TO :username;
 GRANT SELECT ON public.geometry_columns TO :username;
 GRANT SELECT ON public.spatial_ref_sys TO :username;
 
+GRANT USAGE ON SCHEMA routing TO :username;
+GRANT SELECT ON ALL TABLES IN SCHEMA routing TO :username;
+ALTER DEFAULT PRIVILEGES IN SCHEMA routing
+	GRANT SELECT ON TABLES TO :username;
+
 GRANT USAGE ON SCHEMA volume TO :username;
 GRANT SELECT ON ALL TABLES IN SCHEMA volume TO :username;
 ALTER DEFAULT PRIVILEGES IN SCHEMA volume


### PR DESCRIPTION
# Issue Addressed
This PR closes #504 .

# Description
We introduce `routing_index`, a DAG that produces two views `routing.centreline_vertices` and `routing.centreline_edges` for use with `pgrouting` functions `pgr_dijkstra` and `pgr_astar`.

# Tests
Ran DAG via Airflow UI.  Loaded in local dev environment.  Tested `pgrouting` queries on these views in both AWS and local dev environments.
