### PR TITLE
Gh506 toggle arterycode search support

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -183,6 +183,17 @@ HttpStatus.init({
 });
 
 /**
+ * Location search types, corresponding to different types of entities to search over in
+ * {@link LocationController.getLocationSuggestions}.
+ */
+class LocationSearchType extends Enum {}
+LocationSearchType.init([
+  'ARTERY',
+  'INTERSECTION',
+  'SIGNAL',
+]);
+
+/**
  * Map zoom hierarchy.  These are divided into three "levels", corresponding to zoom level
  * ranges in which different features make sense:
  *
@@ -992,6 +1003,7 @@ const Constants = {
   CollisionRoadSurfaceCondition,
   FeatureCode,
   HttpStatus,
+  LocationSearchType,
   MapZoom,
   ORG_NAME,
   PageOrientation,
@@ -1029,6 +1041,7 @@ export {
   CollisionRoadSurfaceCondition,
   FeatureCode,
   HttpStatus,
+  LocationSearchType,
   MapZoom,
   ORG_NAME,
   PageOrientation,

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -105,12 +105,16 @@ async function getLocationByFeature(feature) {
   return locationsMap.get(key);
 }
 
-async function getLocationSuggestions(query) {
+async function getLocationSuggestions(query, filters) {
   if (query.length < 3) {
     return [];
   }
   const options = {
-    data: { limit: 10, q: query },
+    data: {
+      limit: 10,
+      q: query,
+      ...filters,
+    },
   };
   return apiClient.fetch('/location/suggest', options);
 }

--- a/lib/controller/LocationController.js
+++ b/lib/controller/LocationController.js
@@ -1,8 +1,7 @@
-import Joi from '@/lib/model/Joi';
-
+import { CentrelineType, LocationSearchType } from '@/lib/Constants';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import LocationSearchDAO from '@/lib/db/LocationSearchDAO';
-import { CentrelineType } from '@/lib/Constants';
+import Joi from '@/lib/model/Joi';
 
 /**
  * Utilities for location suggestions and lookups.
@@ -27,19 +26,22 @@ LocationController.push({
     auth: { mode: 'try' },
     validate: {
       query: {
-        q: Joi.string().min(3).required(),
         limit: Joi
           .number()
           .integer()
           .positive()
           .max(100)
           .required(),
+        q: Joi.string().min(3).required(),
+        types: Joi.array().items(
+          Joi.enum().ofType(LocationSearchType),
+        ).default(null),
       },
     },
   },
   handler: async (request) => {
-    const { limit, q } = request.query;
-    return LocationSearchDAO.getSuggestions(q, limit);
+    const { limit, q, types } = request.query;
+    return LocationSearchDAO.getSuggestions(types, q, limit);
   },
 });
 

--- a/lib/db/LocationSearchDAO.js
+++ b/lib/db/LocationSearchDAO.js
@@ -1,3 +1,4 @@
+import { LocationSearchType } from '@/lib/Constants';
 import db from '@/lib/db/db';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import { intersectionToFeature } from '@/lib/model/helpers/NormalizeUtils';
@@ -200,8 +201,21 @@ WHERE ts.px = $(px)`;
     return rows.map(intersectionToFeature);
   }
 
-  static async getSuggestions(query, limit) {
+  /**
+   * Main entry point to location search.
+   *
+   * @param {Array<LocationSearchType>?} types - types of entities to search over
+   * @param {string} query - textual query for search
+   * @param {number} limit - maximum number of results to return
+   * @returns {Array} ranked array of results matching the query if any, up to
+   * `limit` results; best match first
+   */
+  static async getSuggestions(types, query, limit) {
     const queryNormalized = query.trim();
+    let typesNormalized = types;
+    if (typesNormalized === null) {
+      typesNormalized = LocationSearchType.enumValues;
+    }
 
     const match = REGEX_SPECIAL_TERM.exec(queryNormalized);
     if (match !== null) {
@@ -211,16 +225,21 @@ WHERE ts.px = $(px)`;
       }
 
       const termPrefix = match[1];
-      if (TERMS_ARTERY.some(term => term.startsWith(termPrefix))) {
+      if (typesNormalized.includes(LocationSearchType.ARTERY)
+        && TERMS_ARTERY.some(term => term.startsWith(termPrefix))) {
         return LocationSearchDAO.arterySuggestions(value);
       }
-      if (TERMS_SIGNAL.some(term => term.startsWith(termPrefix))) {
+      if (typesNormalized.includes(LocationSearchType.SIGNAL)
+        && TERMS_SIGNAL.some(term => term.startsWith(termPrefix))) {
         return LocationSearchDAO.trafficSignalSuggestions(value);
       }
       return [];
     }
 
-    return LocationSearchDAO.intersectionSuggestions(query, limit);
+    if (typesNormalized.includes(LocationSearchType.INTERSECTION)) {
+      return LocationSearchDAO.intersectionSuggestions(query, limit);
+    }
+    return [];
   }
 }
 

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -25,10 +25,28 @@
           {{ aerial ? 'Map' : 'Aerial' }}
         </FcButton>
       </div>
-      <div
-        v-if="location !== null"
-        class="pane-map-navigate">
+      <div class="pane-map-navigate">
         <v-tooltip
+          left
+          :z-index="100">
+          <template v-slot:activator="{ on }">
+            <FcButton
+              :aria-label="tooltipLocationMulti"
+              class="pa-0"
+              :class="{
+                primary: locationMulti,
+                'white--text': locationMulti,
+              }"
+              type="fab-text"
+              @click="setLocationMulti(!locationMulti)"
+              v-on="on">
+              <v-icon class="display-2">mdi-map-marker-multiple</v-icon>
+            </FcButton>
+          </template>
+          <span>{{tooltipLocationMulti}}</span>
+        </v-tooltip>
+        <v-tooltip
+          v-if="location !== null"
           left
           :z-index="100">
           <template v-slot:activator="{ on }">
@@ -187,7 +205,18 @@ export default {
       }
       return !this.drawerOpen || !featureMatchesRoute;
     },
-    ...mapState(['drawerOpen', 'legendOptions', 'location']),
+    tooltipLocationMulti() {
+      if (this.locationMulti) {
+        return 'Stop selecting multiple locations';
+      }
+      return 'Select multiple locations';
+    },
+    ...mapState([
+      'drawerOpen',
+      'legendOptions',
+      'location',
+      'locationMulti',
+    ]),
   },
   created() {
     this.map = null;
@@ -543,7 +572,12 @@ export default {
           .addTo(this.map);
       }
     },
-    ...mapMutations(['setDrawerOpen', 'setLegendOptions', 'setLocation']),
+    ...mapMutations([
+      'setDrawerOpen',
+      'setLegendOptions',
+      'setLocation',
+      'setLocationMulti',
+    ]),
   },
 };
 </script>
@@ -584,7 +618,9 @@ export default {
     right: 20px;
     z-index: var(--z-index-controls);
     & > .fc-button {
+      display: block;
       height: 32px;
+      margin-top: 8px;
       min-width: 30px;
       width: 30px;
     }

--- a/web/components/inputs/FcSearchBarLocation.vue
+++ b/web/components/inputs/FcSearchBarLocation.vue
@@ -67,6 +67,7 @@
 <script>
 import { mapMutations, mapState } from 'vuex';
 
+import { LocationSearchType } from '@/lib/Constants';
 import { debounce } from '@/lib/FunctionUtils';
 import { getLocationSuggestions } from '@/lib/api/WebApi';
 import FcButton from '@/web/components/inputs/FcButton.vue';
@@ -98,7 +99,7 @@ export default {
         this.setLocation(internalLocation);
       },
     },
-    ...mapState(['location']),
+    ...mapState(['location', 'locationMulti']),
   },
   /*
    * To understand the following watchers, imagine a state machine:
@@ -162,7 +163,7 @@ export default {
          * the location watcher to move us into 1b.
          */
         this.loading = true;
-        this.items = await getLocationSuggestions(this.query);
+        await this.actionSearch();
         this.loading = false;
       }
       /*
@@ -178,6 +179,17 @@ export default {
        */
       this.query = null;
       this.setLocation(null);
+    },
+    async actionSearch() {
+      const { locationMulti, query } = this;
+      const filters = {};
+      if (locationMulti) {
+        filters.types = [
+          LocationSearchType.INTERSECTION,
+          LocationSearchType.SIGNAL,
+        ];
+      }
+      this.items = await getLocationSuggestions(query, filters);
     },
     ...mapMutations(['setLocation']),
   },

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -38,6 +38,7 @@ export default new Vuex.Store({
     backViewRequest: { name: 'requestsTrack' },
     // LOCATION
     location: null,
+    locationMulti: false,
     legendOptions: {
       datesFrom: 3,
       layers: {
@@ -103,6 +104,9 @@ export default new Vuex.Store({
     // LOCATION
     setLocation(state, location) {
       Vue.set(state, 'location', location);
+    },
+    setLocationMulti(state, locationMulti) {
+      Vue.set(state, 'locationMulti', locationMulti);
     },
     setLegendOptions(state, legendOptions) {
       Vue.set(state, 'legendOptions', legendOptions);


### PR DESCRIPTION
# Issue Addressed
This PR closes #506 .

# Description
We introduce the multi-location toggle button in `FcPaneMap`, which now toggles a `locationMulti` flag in our `vuex` store.  We also add a parameter `types` to `GET /location/suggest`, which allows the caller to specify that a location search should only include specific entity types (e.g. arterycodes, signals, intersections).

This was originally intended to simplify the implementation of corridor interpolation in #510 , but #506 identifies a possible way forward there that includes midblock routing.

# Tests
Tested in frontend, and inspected `vuex` state in developer tools to verify that `locationMulti` is being toggled as expected.
