### PR TITLE
Stub out multi-location selection box

### DIFF
--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="fc-drawer-view-data d-flex flex-column">
     <div class="flex-grow-0 flex-shrink-0 pa-5">
-      <FcSearchBarLocation />
+      <FcSelectorSingleLocation />
     </div>
     <section class="flex-grow-1 flex-shrink-1 overflow-y-auto">
       <v-progress-linear
@@ -224,7 +224,7 @@ import FcDataTableStudies from '@/web/components/FcDataTableStudies.vue';
 import FcDialogCollisionFilters from '@/web/components/dialogs/FcDialogCollisionFilters.vue';
 import FcDialogStudyFilters from '@/web/components/dialogs/FcDialogStudyFilters.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
-import FcSearchBarLocation from '@/web/components/inputs/FcSearchBarLocation.vue';
+import FcSelectorSingleLocation from '@/web/components/inputs/FcSelectorSingleLocation.vue';
 import FcMixinAuthScope from '@/web/mixins/FcMixinAuthScope';
 import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
 
@@ -240,7 +240,7 @@ export default {
     FcDataTableStudies,
     FcDialogCollisionFilters,
     FcDialogStudyFilters,
-    FcSearchBarLocation,
+    FcSelectorSingleLocation,
   },
   data() {
     return {
@@ -327,7 +327,7 @@ export default {
         /*
          * Normally `this.loading = true` is paired with `this.loading = false` after some
          * asynchronous operation.  In this case, however, we're using it to hide the View Data
-         * drawer contents to prevent errors after clearing `FcSearchBarLocation`.  This is OK,
+         * drawer contents to prevent errors after clearing `FcSelectorSingleLocation`.  This is OK,
          * as the next line jumps to View Map which destroys this drawer component anyways.
          */
         this.loading = true;

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -594,7 +594,7 @@ export default {
     width: 100%;
     z-index: var(--z-index-controls);
   }
-  & > .fc-search-bar-location-wrapper {
+  & > .fc-search-bar-location {
     left: 20px;
     top: 20px;
     position: absolute;

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -8,8 +8,16 @@
           :active="loading"
           indeterminate />
       </div>
-      <FcSearchBarLocation
-        v-if="!drawerOpen" />
+      <div
+        class="pane-map-location-search"
+        v-if="!drawerOpen">
+        <FcSelectorMultiLocation
+          v-if="locationMulti"
+          class="elevation-2" />
+        <FcSelectorSingleLocation
+          v-else
+          class="mt-5 ml-5" />
+      </div>
       <FcPaneMapLegend
         v-model="internalLegendOptions" />
       <div class="pane-map-mode">
@@ -90,7 +98,8 @@ import GeoStyle from '@/lib/geo/GeoStyle';
 import FcPaneMapPopup from '@/web/components/FcPaneMapPopup.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcPaneMapLegend from '@/web/components/inputs/FcPaneMapLegend.vue';
-import FcSearchBarLocation from '@/web/components/inputs/FcSearchBarLocation.vue';
+import FcSelectorMultiLocation from '@/web/components/inputs/FcSelectorMultiLocation.vue';
+import FcSelectorSingleLocation from '@/web/components/inputs/FcSelectorSingleLocation.vue';
 
 const BOUNDS_TORONTO = new mapboxgl.LngLatBounds(
   new mapboxgl.LngLat(-79.639264937, 43.580995995),
@@ -128,7 +137,8 @@ export default {
     FcButton,
     FcPaneMapLegend,
     FcPaneMapPopup,
-    FcSearchBarLocation,
+    FcSelectorMultiLocation,
+    FcSelectorSingleLocation,
   },
   provide() {
     const self = this;
@@ -594,10 +604,10 @@ export default {
     width: 100%;
     z-index: var(--z-index-controls);
   }
-  & > .fc-search-bar-location {
-    left: 20px;
-    top: 20px;
+  & > .pane-map-location-search {
+    left: 0;
     position: absolute;
+    top: 0;
     z-index: var(--z-index-controls);
   }
   & > .fc-pane-map-legend {

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -1,0 +1,172 @@
+<template>
+  <v-autocomplete
+    v-model="internalValue"
+    class="fc-input-location-search"
+    dense
+    hide-details
+    hide-no-data
+    :items="items"
+    item-text="description"
+    label="Search"
+    :loading="loading"
+    no-filter
+    return-object
+    :search-input.sync="query"
+    solo>
+    <template v-slot:append>
+      <v-tooltip
+        v-if="internalValue !== null"
+        right>
+        <template v-slot:activator="{ on }">
+          <FcButton
+            aria-label="Clear Location"
+            type="icon"
+            @click="actionClear"
+            v-on="on">
+            <v-icon left>mdi-close-circle</v-icon>
+          </FcButton>
+        </template>
+        <span>Clear Location</span>
+      </v-tooltip>
+      <v-divider vertical />
+      <v-icon right>mdi-magnify</v-icon>
+    </template>
+    <template v-slot:item="{ attrs, item, on, parent }">
+      <v-list-item
+        v-bind="attrs"
+        v-on="on">
+        <v-list-item-content>
+          <v-list-item-title>
+            <span>{{item[parent.itemText]}}</span>
+          </v-list-item-title>
+        </v-list-item-content>
+      </v-list-item>
+    </template>
+  </v-autocomplete>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+
+import { LocationSearchType } from '@/lib/Constants';
+import { debounce } from '@/lib/FunctionUtils';
+import { getLocationSuggestions } from '@/lib/api/WebApi';
+import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+
+export default {
+  name: 'FcInputLocationSearch',
+  mixins: [FcMixinVModelProxy(Object)],
+  data() {
+    return {
+      items: [],
+      loading: false,
+      query: null,
+    };
+  },
+  computed: {
+    ...mapState(['locationMulti']),
+  },
+  /*
+   * To understand the following watchers, imagine a state machine:
+   *
+   * 1. selected location...
+   *   a. empty query
+   *   b. query that matches location
+   *   c. query that doesn't match location
+   * 2. no selected location...
+   *   a. empty query
+   *   b. non-empty query
+   *
+   * Transitions between these are explained below.
+   */
+  watch: {
+    internalValue: {
+      handler() {
+        if (this.internalValue !== null) {
+          /*
+           * 1c -> 1b: the user just selected a location, either via the autocomplete
+           * dropdown or via map interaction.  We need to update the search bar to match.
+           */
+          this.query = this.internalValue.description;
+        }
+      },
+      immediate: true,
+    },
+    query: debounce(async function processQuery() {
+      if (this.internalValue !== null) {
+        if (this.query === null) {
+          /*
+           * 1a -> 1b: a new search bar instance was just loaded, and we already have a
+           * selected location.  We need to update the search bar to match.
+           *
+           * While setting a value in its own watcher is unusual, we can avoid infinite
+           * recursion by moving through the state machine.
+           */
+          this.query = this.internalValue.description;
+          return;
+        }
+        if (this.query === this.internalValue.description) {
+          /*
+           * 1b: `<v-autocomplete>` gets confused if the list of items doesn't contain
+           * the `v-model` value, so we make a special items list with the selected
+           * location to un-confuse it.
+           */
+          this.items = [this.internalValue];
+          return;
+        }
+        /*
+         * 1c: we already have a selected location, but the user is currently typing
+         * a new query...
+         */
+      }
+      if (this.query !== null) {
+        /*
+         * 1c / 2b: the user is currently typing a query.  We need to fetch suggested
+         * locations for that query.
+         *
+         * Once the user selects a suggested location, `location` is updated, triggering
+         * the location watcher to move us into 1b.
+         */
+        this.loading = true;
+        await this.actionSearch();
+        this.loading = false;
+      }
+      /*
+       * 2a: there is no selected location, and no query to search for.  Do nothing.
+       */
+    }, 250),
+  },
+  methods: {
+    actionClear() {
+      /*
+       * 1b -> 1a -> 2a.  The debounce delay of 250ms on the `query` watcher is more than
+       * enough so that, by the time it fires, we're already in 2a.
+       */
+      this.query = null;
+      this.internalValue = null;
+    },
+    async actionSearch() {
+      const { locationMulti, query } = this;
+      const filters = {};
+      if (locationMulti) {
+        filters.types = [
+          LocationSearchType.INTERSECTION,
+          LocationSearchType.SIGNAL,
+        ];
+      }
+      this.items = await getLocationSuggestions(query, filters);
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+.fc-input-location-search {
+  &.v-select .v-input__append-inner .v-input__icon--append .v-icon {
+    margin-top: 0;
+  }
+  &.v-select.v-select--is-menu-active .v-input__icon--append .v-icon {
+    transform: none;
+  }
+}
+</style>

--- a/web/components/inputs/FcSearchBarLocation.vue
+++ b/web/components/inputs/FcSearchBarLocation.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fc-search-bar-location-wrapper">
+  <div class="fc-search-bar-location">
     <v-tooltip
       v-if="collapseSearchBar"
       right
@@ -16,74 +16,24 @@
       </template>
       <span>Search for new location</span>
     </v-tooltip>
-    <v-autocomplete
+    <FcInputLocationSearch
       v-else
       v-model="internalLocation"
-      class="fc-search-bar-location elevation-2"
-      dense
-      hide-details
-      hide-no-data
-      :items="items"
-      item-text="description"
-      label="Search"
-      :loading="loading"
-      no-filter
-      return-object
-      :search-input.sync="query"
-      solo>
-      <template v-slot:append>
-        <v-tooltip
-          v-if="location !== null"
-          right>
-          <template v-slot:activator="{ on }">
-            <FcButton
-              aria-label="Clear Location"
-              type="icon"
-              @click="actionClear"
-              v-on="on">
-              <v-icon>mdi-close-circle</v-icon>
-            </FcButton>
-          </template>
-          <span>Clear Location</span>
-        </v-tooltip>
-        <v-divider vertical />
-        <v-icon right>mdi-magnify</v-icon>
-      </template>
-      <template v-slot:item="{ attrs, item, on, parent }">
-        <v-list-item
-          v-bind="attrs"
-          v-on="on">
-          <v-list-item-content>
-            <v-list-item-title>
-              <span>{{item[parent.itemText]}}</span>
-            </v-list-item-title>
-          </v-list-item-content>
-        </v-list-item>
-      </template>
-    </v-autocomplete>
+      class="elevation-2" />
   </div>
 </template>
 
 <script>
 import { mapMutations, mapState } from 'vuex';
 
-import { LocationSearchType } from '@/lib/Constants';
-import { debounce } from '@/lib/FunctionUtils';
-import { getLocationSuggestions } from '@/lib/api/WebApi';
 import FcButton from '@/web/components/inputs/FcButton.vue';
+import FcInputLocationSearch from '@/web/components/inputs/FcInputLocationSearch.vue';
 
 export default {
   name: 'FcSearchBarLocation',
   components: {
     FcButton,
-  },
-  data() {
-    return {
-      items: [],
-      key: null,
-      loading: false,
-      query: null,
-    };
+    FcInputLocationSearch,
   },
   computed: {
     collapseSearchBar() {
@@ -99,113 +49,18 @@ export default {
         this.setLocation(internalLocation);
       },
     },
-    ...mapState(['location', 'locationMulti']),
-  },
-  /*
-   * To understand the following watchers, imagine a state machine:
-   *
-   * 1. selected location...
-   *   a. empty query
-   *   b. query that matches location
-   *   c. query that doesn't match location
-   * 2. no selected location...
-   *   a. empty query
-   *   b. non-empty query
-   *
-   * Transitions between these are explained below.
-   */
-  watch: {
-    location: {
-      handler() {
-        if (this.location !== null) {
-          /*
-           * 1c -> 1b: the user just selected a location, either via the autocomplete
-           * dropdown or via map interaction.  We need to update the search bar to match.
-           */
-          this.query = this.location.description;
-        }
-      },
-      immediate: true,
-    },
-    query: debounce(async function processQuery() {
-      if (this.location !== null) {
-        if (this.query === null) {
-          /*
-           * 1a -> 1b: a new search bar instance was just loaded, and we already have a
-           * selected location.  We need to update the search bar to match.
-           *
-           * While setting a value in its own watcher is unusual, we can avoid infinite
-           * recursion by moving through the state machine.
-           */
-          this.query = this.location.description;
-          return;
-        }
-        if (this.query === this.location.description) {
-          /*
-           * 1b: `<v-autocomplete>` gets confused if the list of items doesn't contain
-           * the `v-model` value, so we make a special items list with the selected
-           * location to un-confuse it.
-           */
-          this.items = [this.location];
-          return;
-        }
-        /*
-         * 1c: we already have a selected location, but the user is currently typing
-         * a new query...
-         */
-      }
-      if (this.query !== null) {
-        /*
-         * 1c / 2b: the user is currently typing a query.  We need to fetch suggested
-         * locations for that query.
-         *
-         * Once the user selects a suggested location, `location` is updated, triggering
-         * the location watcher to move us into 1b.
-         */
-        this.loading = true;
-        await this.actionSearch();
-        this.loading = false;
-      }
-      /*
-       * 2a: there is no selected location, and no query to search for.  Do nothing.
-       */
-    }, 250),
+    ...mapState(['location']),
   },
   methods: {
-    actionClear() {
-      /*
-       * 1b -> 1a -> 2a.  The debounce delay of 250ms on the `query` watcher is more than
-       * enough so that, by the time it fires, we're already in 2a.
-       */
-      this.query = null;
-      this.setLocation(null);
-    },
-    async actionSearch() {
-      const { locationMulti, query } = this;
-      const filters = {};
-      if (locationMulti) {
-        filters.types = [
-          LocationSearchType.INTERSECTION,
-          LocationSearchType.SIGNAL,
-        ];
-      }
-      this.items = await getLocationSuggestions(query, filters);
-    },
     ...mapMutations(['setLocation']),
   },
 };
 </script>
 
 <style lang="scss">
-.fc-search-bar-location-wrapper {
-  & > .fc-search-bar-location {
+.fc-search-bar-location {
+  & > .fc-input-location-search {
     width: 392px;
-    &.v-select .v-input__append-inner .v-input__icon--append .v-icon {
-      margin-top: 0;
-    }
-    &.v-select.v-select--is-menu-active .v-input__icon--append .v-icon {
-      transform: none;
-    }
   }
 
   & > button.fc-button.v-btn.fc-search-bar-open {

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -1,0 +1,131 @@
+<template>
+  <div class="fc-selector-multi-location d-flex flex-column pa-5 shading">
+    <div class="align-start d-flex flex-grow-1 flex-shrink-1">
+      <div class="fc-input-location-search-wrapper elevation-2">
+        <FcInputLocationSearch
+          v-for="(_, i) in locations"
+          :key="'search_' + i"
+          v-model="locations[i]"
+          :location-index="i" />
+        <FcInputLocationSearch
+          v-if="locations.length < 5"
+          v-model="locationToAdd"
+          :location-index="-1"
+          @location-add="actionAddLocation" />
+      </div>
+      <div class="ml-2">
+        <div
+          v-for="(_, i) in locations"
+          :key="'remove_' + i"
+          class="fc-input-location-search-remove">
+          <FcButton
+            type="icon"
+            @click="actionRemoveLocation(i)">
+            <v-icon>mdi-close</v-icon>
+          </FcButton>
+        </div>
+      </div>
+    </div>
+    <div class="flex-grow-0 flex-shrink-0">
+      <h1
+        class="display-3 mb-4"
+        :title="description">
+        <span
+          v-if="locations.length === 0"
+          class="secondary--text">
+          No locations selected
+        </span>
+        <span v-else>
+          {{description}}
+        </span>
+      </h1>
+      <div class="d-flex align-center">
+        <v-checkbox
+          v-model="corridor"
+          class="fc-multi-location-corridor mt-0"
+          hide-details
+          label="Include intersections and midblocks between locations" />
+        <v-spacer></v-spacer>
+        <FcButton
+          type="tertiary">
+          Cancel
+        </FcButton>
+        <FcButton
+          :disabled="locations.length === 0"
+          type="secondary">
+          Done
+        </FcButton>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import FcButton from '@/web/components/inputs/FcButton.vue';
+import FcInputLocationSearch from '@/web/components/inputs/FcInputLocationSearch.vue';
+
+export default {
+  name: 'FcSelectorMultiLocation',
+  components: {
+    FcButton,
+    FcInputLocationSearch,
+  },
+  data() {
+    return {
+      corridor: false,
+      locationToAdd: null,
+      locations: [],
+    };
+  },
+  computed: {
+    description() {
+      const n = this.locations.length;
+      if (n === 0) {
+        return null;
+      }
+      const [{ description }] = this.locations;
+      if (n === 1) {
+        return description;
+      }
+      if (n === 2) {
+        return `${description} + 1 location`;
+      }
+      return `${description} + ${n - 1} locations`;
+    },
+  },
+  methods: {
+    actionAddLocation(location) {
+      this.locations.push(location);
+    },
+    actionRemoveLocation(i) {
+      this.locations.splice(i, 1);
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+.fc-selector-multi-location {
+  border-radius: 8px;
+  height: 387px;
+  width: 664px;
+
+  & .fc-input-location-search-wrapper {
+    width: 472px;
+    & > .fc-input-location-search {
+      &:not(:first-child) {
+        border-top: 1px solid var(--v-border-base);
+      }
+    }
+  }
+  & .fc-input-location-search-remove {
+    height: 39px;
+  }
+
+  & .fc-multi-location-corridor {
+    & .v-label {
+      font-size: 0.875rem;
+    }
+  }
+}
+</style>

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -47,12 +47,14 @@
           label="Include intersections and midblocks between locations" />
         <v-spacer></v-spacer>
         <FcButton
-          type="tertiary">
+          type="tertiary"
+          @click="setLocationMulti(false)">
           Cancel
         </FcButton>
         <FcButton
           :disabled="locations.length === 0"
-          type="secondary">
+          type="secondary"
+          @click="comingSoon">
           Done
         </FcButton>
       </div>
@@ -61,6 +63,8 @@
 </template>
 
 <script>
+import { mapMutations } from 'vuex';
+
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcInputLocationSearch from '@/web/components/inputs/FcInputLocationSearch.vue';
 
@@ -100,6 +104,11 @@ export default {
     actionRemoveLocation(i) {
       this.locations.splice(i, 1);
     },
+    comingSoon() {
+      /* eslint-disable-next-line no-alert */
+      window.alert('Coming Soon');
+    },
+    ...mapMutations(['setLocationMulti']),
   },
 };
 </script>

--- a/web/components/inputs/FcSelectorSingleLocation.vue
+++ b/web/components/inputs/FcSelectorSingleLocation.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fc-search-bar-location">
+  <div class="fc-selector-single-location">
     <v-tooltip
       v-if="collapseSearchBar"
       right
@@ -30,7 +30,7 @@ import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcInputLocationSearch from '@/web/components/inputs/FcInputLocationSearch.vue';
 
 export default {
-  name: 'FcSearchBarLocation',
+  name: 'FcSelectorSingleLocation',
   components: {
     FcButton,
     FcInputLocationSearch,
@@ -58,7 +58,7 @@ export default {
 </script>
 
 <style lang="scss">
-.fc-search-bar-location {
+.fc-selector-single-location {
   & > .fc-input-location-search {
     width: 392px;
   }


### PR DESCRIPTION
# Issue Addressed
This PR makes significant progress on #407 .

# Description
We introduce `FcSelectorMultiLocation` and rename `FcSearchBarLocation` to `FcSelectorSingleLocation`.  This new multi-location selection component currently does not tie into `vuex` state, except to revert to single-location mode when the "Cancel" button is clicked.

Internally, the multi-location selection component handles adding new locations (up to 5) to the selection via a series of stacked `FcInputLocationSearch` bars.  It also supports removing those locations.  These bars are not yet integrated with the map.

# Tests
Tested both single-location and multi-location flows quickly in frontend.  (Testing will get more stringent as we proceed through this large set of changes.)
