### PR TITLE
Multi-location state in vuex store

### DIFF
--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -47,8 +47,8 @@ async function getCollisionByCollisionId(collisionId) {
   return CollisionEvent.read.validateAsync(collision);
 }
 
-async function getCollisionsByCentreline(feature, filters) {
-  const s1 = CompositeId.encode([feature]);
+async function getCollisionsByCentreline(features, filters) {
+  const s1 = CompositeId.encode(features);
   const data = { s1, ...filters };
   const options = { data };
   const collisions = await apiClient.fetch('/collisions/byCentreline', options);
@@ -56,27 +56,27 @@ async function getCollisionsByCentreline(feature, filters) {
   return collisionsSchema.validateAsync(collisions);
 }
 
-async function getCollisionsByCentrelineSummary(feature, filters) {
-  const s1 = CompositeId.encode([feature]);
+async function getCollisionsByCentrelineSummary(features, filters) {
+  const s1 = CompositeId.encode(features);
   const data = { s1, ...filters };
   const options = { data };
   return apiClient.fetch('/collisions/byCentreline/summary', options);
 }
 
-async function getCollisionsByCentrelineTotal(feature) {
-  const s1 = CompositeId.encode([feature]);
+async function getCollisionsByCentrelineTotal(features) {
+  const s1 = CompositeId.encode(features);
   const data = { s1 };
   const options = { data };
   const { total } = await apiClient.fetch('/collisions/byCentreline/total', options);
   return total;
 }
 
-async function getLocationsByFeature(centrelineTypesAndIds) {
-  if (centrelineTypesAndIds.length === 0) {
+async function getLocationsByFeature(features) {
+  if (features.length === 0) {
     return new Map();
   }
-  const centrelineIds = centrelineTypesAndIds.map(({ centrelineId: id }) => id);
-  const centrelineTypes = centrelineTypesAndIds.map(({ centrelineType: type }) => type);
+  const centrelineIds = features.map(({ centrelineId: id }) => id);
+  const centrelineTypes = features.map(({ centrelineType: type }) => type);
   const options = {
     data: {
       centrelineId: centrelineIds,
@@ -164,8 +164,8 @@ async function getReportWeb(type, id, reportParameters) {
   };
 }
 
-async function getStudiesByCentreline(feature, studyType, filters, pagination) {
-  const s1 = CompositeId.encode([feature]);
+async function getStudiesByCentreline(features, studyType, filters, pagination) {
+  const s1 = CompositeId.encode(features);
   const data = { s1, ...filters, ...pagination };
   const options = { data };
   const studies = await apiClient.fetch('/studies/byCentreline', options);
@@ -173,8 +173,8 @@ async function getStudiesByCentreline(feature, studyType, filters, pagination) {
   return studiesSchema.validateAsync(studies);
 }
 
-async function getStudiesByCentrelineSummary(feature, filters) {
-  const s1 = CompositeId.encode([feature]);
+async function getStudiesByCentrelineSummary(features, filters) {
+  const s1 = CompositeId.encode(features);
   const data = { s1, ...filters };
   const options = { data };
   const studySummary = await apiClient.fetch('/studies/byCentreline/summary', options);
@@ -188,8 +188,8 @@ async function getStudiesByCentrelineSummary(feature, filters) {
   return studySummarySchema.validateAsync(studySummary);
 }
 
-async function getStudiesByCentrelineTotal(feature) {
-  const s1 = CompositeId.encode([feature]);
+async function getStudiesByCentrelineTotal(features) {
+  const s1 = CompositeId.encode(features);
   const data = { s1 };
   const options = { data };
   const { total } = await apiClient.fetch('/studies/byCentreline/total', options);
@@ -270,20 +270,20 @@ async function getStudyRequests() {
   studyRequests = await studyRequestsSchema.validateAsync(studyRequests);
 
   const centrelineKeys = new Set();
-  const centrelineIdsAndTypes = [];
-  let ids = new Set();
+  const features = [];
+  let userIds = new Set();
   studyRequests.forEach(({ centrelineId, centrelineType, userId }) => {
     const key = centrelineKey(centrelineId, centrelineType);
     if (!centrelineKeys.has(key)) {
       centrelineKeys.add(key);
-      centrelineIdsAndTypes.push({ centrelineId, centrelineType });
+      features.push({ centrelineId, centrelineType });
     }
-    ids.add(userId);
+    userIds.add(userId);
   });
-  ids = Array.from(ids);
+  userIds = Array.from(userIds);
 
-  const promiseLocations = getLocationsByFeature(centrelineIdsAndTypes);
-  const promiseUsers = getUsersByIds(ids);
+  const promiseLocations = getLocationsByFeature(features);
+  const promiseUsers = getUsersByIds(userIds);
   const [
     studyRequestLocations,
     studyRequestUsers,
@@ -296,8 +296,8 @@ async function getStudyRequests() {
   };
 }
 
-async function getStudyRequestsByCentrelinePending(feature) {
-  const s1 = CompositeId.encode([feature]);
+async function getStudyRequestsByCentrelinePending(features) {
+  const s1 = CompositeId.encode(features);
   const data = { s1 };
   const options = { data };
   const studyRequests = await apiClient.fetch('/requests/study/byCentreline/pending', options);

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -71,31 +71,20 @@ async function getCollisionsByCentrelineTotal(features) {
   return total;
 }
 
-async function getLocationsByFeature(features) {
+async function getLocationsByCentreline(features) {
   if (features.length === 0) {
-    return new Map();
+    return [];
   }
-  const centrelineIds = features.map(({ centrelineId: id }) => id);
-  const centrelineTypes = features.map(({ centrelineType: type }) => type);
-  const options = {
-    data: {
-      centrelineId: centrelineIds,
-      centrelineType: centrelineTypes,
-    },
-  };
-  const locations = await apiClient.fetch('/location/centreline', options);
-  return new Map(locations);
+  const s1 = CompositeId.encode(features);
+  const data = { s1 };
+  const options = { data };
+  return apiClient.fetch('/locations/byCentreline', options);
 }
 
-async function getLocationByFeature(feature) {
-  const locationsMap = await getLocationsByFeature([feature]);
-  const { centrelineId, centrelineType } = feature;
-  const key = centrelineKey(centrelineType, centrelineId);
-  if (!locationsMap.has(key)) {
-    // TODO: better error handling here
-    throw new Error('not found!');
-  }
-  return locationsMap.get(key);
+async function getLocationByCentreline(feature) {
+  const locations = await getLocationsByCentreline([feature]);
+  const [location] = locations;
+  return location;
 }
 
 async function getLocationSuggestions(query, filters) {
@@ -109,7 +98,7 @@ async function getLocationSuggestions(query, filters) {
       ...filters,
     },
   };
-  return apiClient.fetch('/location/suggest', options);
+  return apiClient.fetch('/locations/suggest', options);
 }
 
 async function getPoiByCentrelineSummary(feature) {
@@ -250,7 +239,7 @@ async function getStudyRequest(id) {
     studyRequestLocation,
     studyRequestUsers,
   ] = await Promise.all([
-    getLocationByFeature({ centrelineId, centrelineType }),
+    getLocationByCentreline({ centrelineId, centrelineType }),
     getUsersByIds(ids),
   ]);
 
@@ -282,7 +271,7 @@ async function getStudyRequests() {
   });
   userIds = Array.from(userIds);
 
-  const promiseLocations = getLocationsByFeature(features);
+  const promiseLocations = getLocationsByCentreline(features);
   const promiseUsers = getUsersByIds(userIds);
   const [
     studyRequestLocations,
@@ -391,8 +380,8 @@ const WebApi = {
   getCollisionsByCentreline,
   getCollisionsByCentrelineSummary,
   getCollisionsByCentrelineTotal,
-  getLocationByFeature,
-  getLocationsByFeature,
+  getLocationByCentreline,
+  getLocationsByCentreline,
   getLocationSuggestions,
   getPoiByCentrelineSummary,
   getReport,
@@ -420,8 +409,8 @@ export {
   getCollisionsByCentreline,
   getCollisionsByCentrelineSummary,
   getCollisionsByCentrelineTotal,
-  getLocationByFeature,
-  getLocationsByFeature,
+  getLocationByCentreline,
+  getLocationsByCentreline,
   getLocationSuggestions,
   getPoiByCentrelineSummary,
   getReport,

--- a/lib/controller/LocationController.js
+++ b/lib/controller/LocationController.js
@@ -23,7 +23,7 @@ const LocationController = [];
  */
 LocationController.push({
   method: 'GET',
-  path: '/location/suggest',
+  path: '/locations/suggest',
   options: {
     auth: { mode: 'try' },
     validate: {
@@ -58,7 +58,7 @@ LocationController.push({
  */
 LocationController.push({
   method: 'GET',
-  path: '/location/compositeId',
+  path: '/locations/compositeId',
   options: {
     auth: { mode: 'try' },
     response: {
@@ -101,51 +101,24 @@ LocationController.push({
 });
 
 /**
- * Fetch centreline features for the given centreline IDs and types.  `centrelineId` and
- * `centrelineType` are arrays of the same length such that each pair
- * `(centrelineType[i], centrelineId[i])` defines a single feature to lookup.
+ * Fetch centreline locations for the features in the given centreline selection.
  *
  * @memberof LocationController
- * @name getLocationsByFeature
+ * @name getLocationsByCentreline
  * @type {Hapi.ServerRoute}
  */
 LocationController.push({
   method: 'GET',
-  path: '/location/centreline',
+  path: '/locations/byCentreline',
   options: {
     auth: { mode: 'try' },
     validate: {
-      query: {
-        centrelineId: Joi.array().single().items(
-          Joi.number().integer().positive().required(),
-        ).required(),
-        centrelineType: Joi
-          .array()
-          .single()
-          .items(
-            Joi.number().valid(
-              CentrelineType.SEGMENT,
-              CentrelineType.INTERSECTION,
-            ),
-          )
-          .length(Joi.ref('centrelineId.length'))
-          .required(),
-      },
+      query: CentrelineSelection,
     },
   },
   handler: async (request) => {
-    const {
-      centrelineId,
-      centrelineType,
-    } = request.query;
-    const n = centrelineId.length;
-    const centrelineIdsAndTypes = new Array(n)
-      .fill()
-      .map((_, i) => ({
-        centrelineId: centrelineId[i],
-        centrelineType: centrelineType[i],
-      }));
-    return CentrelineDAO.byIdsAndTypes(centrelineIdsAndTypes);
+    const { s1: features } = request.query;
+    return CentrelineDAO.byFeatures(features);
   },
 });
 

--- a/lib/db/CentrelineDAO.js
+++ b/lib/db/CentrelineDAO.js
@@ -85,20 +85,16 @@ SELECT DISTINCT ON (int_id)
 
   // COMBINED METHODS
 
-  static async byIdAndType(centrelineId, centrelineType) {
-    const centrelineIdsAndTypes = [{ centrelineId, centrelineType }];
-    const features = await CentrelineDAO.byIdsAndTypes(centrelineIdsAndTypes);
-    const key = centrelineKey(centrelineType, centrelineId);
-    if (features.has(key)) {
-      return features.get(key);
-    }
-    return null;
+  static async byFeature(feature) {
+    const locations = await CentrelineDAO.byFeatures([feature]);
+    const [location] = locations;
+    return location;
   }
 
-  static async byIdsAndTypes(centrelineIdsAndTypes) {
+  static async byFeatures(features) {
     const segmentIds = new Set();
     const intersectionIds = new Set();
-    centrelineIdsAndTypes.forEach(({ centrelineId, centrelineType }) => {
+    features.forEach(({ centrelineId, centrelineType }) => {
       if (centrelineType === CentrelineType.SEGMENT) {
         segmentIds.add(centrelineId);
       } else if (centrelineType === CentrelineType.INTERSECTION) {
@@ -111,18 +107,25 @@ SELECT DISTINCT ON (int_id)
       CentrelineDAO.segmentsByIds([...segmentIds]),
       CentrelineDAO.intersectionsByIds([...intersectionIds]),
     ]);
-    const features = new Map();
+    const locationMap = new Map();
     rowsSegments.forEach((segment) => {
       const { centrelineId } = segment;
       const key = centrelineKey(CentrelineType.SEGMENT, centrelineId);
-      features.set(key, segment);
+      locationMap.set(key, segment);
     });
     rowsIntersections.forEach((intersection) => {
       const { centrelineId } = intersection;
       const key = centrelineKey(CentrelineType.INTERSECTION, centrelineId);
-      features.set(key, intersection);
+      locationMap.set(key, intersection);
     });
-    return features;
+    return features.map(({ centrelineId, centrelineType }) => {
+      const key = centrelineKey(centrelineType, centrelineId);
+      const location = locationMap.get(key);
+      if (location === undefined) {
+        return null;
+      }
+      return location;
+    });
   }
 
   /**

--- a/lib/db/LocationSearchDAO.js
+++ b/lib/db/LocationSearchDAO.js
@@ -40,8 +40,9 @@ WHERE arterycode = $(arterycode)`;
       return [];
     }
     const { centrelineId, centrelineType } = row;
-    const feature = await CentrelineDAO.byIdAndType(centrelineId, centrelineType);
-    return [feature];
+    const feature = { centrelineId, centrelineType };
+    const location = await CentrelineDAO.byFeature(feature);
+    return [location];
   }
 
   /**

--- a/lib/email/EmailStudyRequestConfirmation.js
+++ b/lib/email/EmailStudyRequestConfirmation.js
@@ -34,7 +34,8 @@ class EmailStudyRequestConfirmation extends EmailBase {
 
   async init() {
     const { centrelineId, centrelineType } = this.studyRequest;
-    this.location = await CentrelineDAO.byIdAndType(centrelineId, centrelineType);
+    const feature = { centrelineId, centrelineType };
+    this.location = await CentrelineDAO.byFeature(feature);
   }
 
   getRecipients() {

--- a/lib/geo/CentrelineUtils.js
+++ b/lib/geo/CentrelineUtils.js
@@ -22,11 +22,28 @@ function getLocationFeatureType(location) {
   throw new InvalidCentrelineTypeError(centrelineType);
 }
 
+function getLocationsDescription(locations) {
+  const n = locations.length;
+  if (n === 0) {
+    return null;
+  }
+  const [{ description }] = locations;
+  if (n === 1) {
+    return description;
+  }
+  if (n === 2) {
+    return `${description} + 1 location`;
+  }
+  return `${description} + ${n - 1} locations`;
+}
+
 const CentrelineUtils = {
   getLocationFeatureType,
+  getLocationsDescription,
 };
 
 export {
   CentrelineUtils as default,
   getLocationFeatureType,
+  getLocationsDescription,
 };

--- a/lib/io/CompositeId.js
+++ b/lib/io/CompositeId.js
@@ -16,7 +16,7 @@ import BitStream from '@/lib/io/BitStream';
  * packed representation of the individual object IDs.  Note that the `CompositeId`
  * does not contain objects, but only ID references to those objects.  It is intended
  * to be used with methods and/or REST API requests that resolve those ID references
- * to their full objects, such as `WebApi.getLocationsByFeature`.
+ * to their full objects, such as `WebApi.getLocationsByCentreline`.
  */
 class CompositeId {
   static decode(compositeId) {

--- a/lib/reports/ReportBaseCrash.js
+++ b/lib/reports/ReportBaseCrash.js
@@ -4,7 +4,6 @@ import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import CollisionDAO from '@/lib/db/CollisionDAO';
 import CollisionFactorDAO from '@/lib/db/CollisionFactorDAO';
 import {
-  InvalidCentrelineTypeError,
   InvalidCompositeIdError,
   InvalidReportIdError,
 } from '@/lib/error/MoveErrors';
@@ -33,9 +32,6 @@ class ReportBaseCrash extends ReportBase {
       const locations = await CentrelineDAO.byFeatures(features);
       return Array.from(locations.values());
     } catch (err) {
-      if (err instanceof InvalidCentrelineTypeError) {
-        throw new InvalidReportIdError(s1);
-      }
       if (err instanceof InvalidCompositeIdError) {
         throw new InvalidReportIdError(s1);
       }

--- a/lib/reports/ReportBaseCrash.js
+++ b/lib/reports/ReportBaseCrash.js
@@ -5,8 +5,10 @@ import CollisionDAO from '@/lib/db/CollisionDAO';
 import CollisionFactorDAO from '@/lib/db/CollisionFactorDAO';
 import {
   InvalidCentrelineTypeError,
+  InvalidCompositeIdError,
   InvalidReportIdError,
 } from '@/lib/error/MoveErrors';
+import CompositeId from '@/lib/io/CompositeId';
 import ReportBase from '@/lib/reports/ReportBase';
 
 /**
@@ -19,58 +21,35 @@ class ReportBaseCrash extends ReportBase {
   }
 
   /**
-   * Parses an ID in the format `{centrelineType}/{centrelineId}`, and returns it
-   * as a location from {@link CentrelineDAO} for further processing.
+   * Parses a `CompositeId`, and returns it as an array of centreline locations from
+   * {@link CentrelineDAO} for further processing.
    *
-   * @param {string} rawId - ID to parse
+   * @param {string} s1 - `CompositeId` to parse
    * @throws {InvalidReportIdError}
    */
-  async parseId(rawId) {
-    const parts = rawId.split('/');
-    if (parts.length !== 2) {
-      throw new InvalidReportIdError(rawId);
-    }
-
-    let centrelineType = parts.shift();
-    centrelineType = parseInt(centrelineType, 10);
-    if (Number.isNaN(centrelineType)) {
-      throw new InvalidReportIdError(rawId);
-    }
-
-    let centrelineId = parts.shift();
-    centrelineId = parseInt(centrelineId, 10);
-    if (Number.isNaN(centrelineId)) {
-      throw new InvalidReportIdError(rawId);
-    }
-
+  async parseId(s1) {
     try {
-      const location = await CentrelineDAO.byIdAndType(centrelineId, centrelineType);
-      if (location === null) {
-        throw new InvalidReportIdError(rawId);
-      }
-      return location;
+      const features = CompositeId.decode(s1);
+      const locations = await CentrelineDAO.byIdsAndTypes(features);
+      return Array.from(locations.values());
     } catch (err) {
       if (err instanceof InvalidCentrelineTypeError) {
-        throw new InvalidReportIdError(rawId);
+        throw new InvalidReportIdError(s1);
+      }
+      if (err instanceof InvalidCompositeIdError) {
+        throw new InvalidReportIdError(s1);
       }
       throw err;
     }
   }
 
-  async fetchRawData(location, filters) {
+  async fetchRawData(features, collisionQuery) {
     if (this.collisionFactors === null) {
       this.collisionFactors = await CollisionFactorDAO.all();
     }
-
-    const { centrelineId, centrelineType } = location;
-    const collisionQuery = {
-      centrelineId,
-      centrelineType,
-      ...filters,
-    };
     const [collisions, collisionSummary] = await Promise.all([
-      CollisionDAO.byCentreline(collisionQuery),
-      CollisionDAO.byCentrelineSummary(collisionQuery),
+      CollisionDAO.byCentreline(features, collisionQuery),
+      CollisionDAO.byCentrelineSummary(features, collisionQuery),
     ]);
     return { collisions, collisionSummary };
   }

--- a/lib/reports/ReportBaseCrash.js
+++ b/lib/reports/ReportBaseCrash.js
@@ -30,7 +30,7 @@ class ReportBaseCrash extends ReportBase {
   async parseId(s1) {
     try {
       const features = CompositeId.decode(s1);
-      const locations = await CentrelineDAO.byIdsAndTypes(features);
+      const locations = await CentrelineDAO.byFeatures(features);
       return Array.from(locations.values());
     } catch (err) {
       if (err instanceof InvalidCentrelineTypeError) {

--- a/lib/reports/ReportBaseFlowDirectional.js
+++ b/lib/reports/ReportBaseFlowDirectional.js
@@ -360,8 +360,9 @@ class ReportBaseFlowDirectional extends ReportBaseFlow {
      * We start by identifying the segments incident on the intersection under study.
      */
     const { centrelineId, centrelineType } = study;
+    const feature = { centrelineId, centrelineType };
     const [intersection, segments] = await Promise.all([
-      CentrelineDAO.byIdAndType(centrelineId, centrelineType),
+      CentrelineDAO.byFeature(feature),
       CentrelineDAO.featuresIncidentTo(centrelineType, centrelineId),
     ]);
 

--- a/tests/jest/api/RestApi.spec.js
+++ b/tests/jest/api/RestApi.spec.js
@@ -71,7 +71,7 @@ test('LocationController.getLocationSuggestions', async () => {
   expectSuggestionsContain(response.result, 13460034);
 });
 
-test('LocationController.getLocationsByFeature', async () => {
+test('LocationController.getLocationsByCentreline', async () => {
   // empty list of features
   let data = {
     centrelineId: [],

--- a/tests/jest/unit/reports/format/MovePdfGenerator.spec.js
+++ b/tests/jest/unit/reports/format/MovePdfGenerator.spec.js
@@ -92,7 +92,7 @@ function setup_5_38661() {
   }];
   const studyData = new Map([[38661, countData_5_38661]]);
   StudyDataDAO.byStudy.mockResolvedValue({ counts, studyData });
-  CentrelineDAO.byIdAndType.mockResolvedValue({
+  CentrelineDAO.byFeature.mockResolvedValue({
     geom: {
       type: 'Point',
       coordinates: [-79.343625497, 43.70747321],

--- a/web/components/FcDrawerRequestStudy.vue
+++ b/web/components/FcDrawerRequestStudy.vue
@@ -100,6 +100,7 @@ import {
   REQUEST_STUDY_REQUIRES_LOCATION,
   REQUEST_STUDY_TIME_TO_FULFILL,
 } from '@/lib/i18n/Strings';
+import CompositeId from '@/lib/io/CompositeId';
 import DateTime from '@/lib/time/DateTime';
 import ValidationsStudyRequest from '@/lib/validation/ValidationsStudyRequest';
 import FcDetailsStudyRequest from '@/web/components/FcDetailsStudyRequest.vue';
@@ -188,10 +189,11 @@ export default {
     },
     routeFinish() {
       if (this.isCreate) {
-        const { centrelineId, centrelineType } = this.location;
+        const features = [this.location];
+        const s1 = CompositeId.encode(features);
         return {
           name: 'viewDataAtLocation',
-          params: { centrelineId, centrelineType },
+          params: { s1 },
         };
       }
       if (this.studyRequest === null) {

--- a/web/components/FcDrawerRequestStudy.vue
+++ b/web/components/FcDrawerRequestStudy.vue
@@ -187,10 +187,15 @@ export default {
       }
       return 'View Data';
     },
+    location() {
+      if (this.locations.length === 0) {
+        return null;
+      }
+      return this.locations[0];
+    },
     routeFinish() {
       if (this.isCreate) {
-        const features = [this.location];
-        const s1 = CompositeId.encode(features);
+        const s1 = CompositeId.encode(this.locations);
         return {
           name: 'viewDataAtLocation',
           params: { s1 },
@@ -218,7 +223,7 @@ export default {
       const { id } = this.$route.params;
       return `Edit Request #${id}`;
     },
-    ...mapState(['location', 'now']),
+    ...mapState(['locations', 'now']),
   },
   watch: {
     estimatedDeliveryDate() {
@@ -280,7 +285,7 @@ export default {
         studyRequestLocation = result.studyRequestLocation;
       }
       this.studyRequest = studyRequest;
-      this.setLocation(studyRequestLocation);
+      this.setLocations([studyRequestLocation]);
       this.updateStudyRequestLocation();
     },
     updateStudyRequestLocation() {
@@ -308,7 +313,7 @@ export default {
       this.$v.studyRequest.centrelineType.$touch();
       this.$v.studyRequest.geom.$touch();
     },
-    ...mapMutations(['setLocation']),
+    ...mapMutations(['setLocations']),
     ...mapActions(['saveStudyRequest']),
   },
 };

--- a/web/components/FcDrawerRequestStudy.vue
+++ b/web/components/FcDrawerRequestStudy.vue
@@ -91,6 +91,7 @@
 <script>
 import {
   mapActions,
+  mapGetters,
   mapMutations,
   mapState,
 } from 'vuex';
@@ -187,12 +188,6 @@ export default {
       }
       return 'View Data';
     },
-    location() {
-      if (this.locations.length === 0) {
-        return null;
-      }
-      return this.locations[0];
-    },
     routeFinish() {
       if (this.isCreate) {
         const s1 = CompositeId.encode(this.locations);
@@ -224,6 +219,7 @@ export default {
       return `Edit Request #${id}`;
     },
     ...mapState(['locations', 'now']),
+    ...mapGetters(['location']),
   },
   watch: {
     estimatedDeliveryDate() {

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -110,6 +110,7 @@ import {
   getReport,
   getReportWeb,
 } from '@/lib/api/WebApi';
+import CompositeId from '@/lib/io/CompositeId';
 import FcDialogConfirm from '@/web/components/dialogs/FcDialogConfirm.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcReport from '@/web/components/reports/FcReport.vue';
@@ -179,11 +180,11 @@ export default {
       next();
       return;
     }
-    const { centrelineId, centrelineType } = from.params;
+    const { s1 } = from.params;
     const { name } = to;
     if (name === 'viewDataAtLocation') {
-      const { centrelineId: nextCentrelineId, centrelineType: nextCentrelineType } = to.params;
-      if (centrelineType === nextCentrelineType && centrelineId === nextCentrelineId) {
+      const { s1: s1Next } = to.params;
+      if (s1 === s1Next) {
         next();
         return;
       }
@@ -213,16 +214,17 @@ export default {
       this.$router.push(this.nextRoute);
     },
     actionNavigateBack() {
-      const { centrelineId, centrelineType } = this.$route.params;
+      const { s1 } = this.$route.params;
       this.$router.push({
         name: 'viewDataAtLocation',
-        params: { centrelineId, centrelineType },
+        params: { s1 },
       });
     },
     async loadAsyncForRoute(to) {
-      const { centrelineId, centrelineType } = to.params;
+      const { s1 } = to.params;
+      const features = CompositeId.decode(s1);
       const tasks = [
-        getLocationByFeature({ centrelineId, centrelineType }),
+        getLocationByFeature(features[0]),
       ];
       const [location] = await Promise.all(tasks);
       this.updateReportLayout();
@@ -241,9 +243,8 @@ export default {
       }
       this.loadingReportLayout = true;
 
-      const { centrelineId, centrelineType } = this.$route.params;
-      const id = `${centrelineType}/${centrelineId}`;
-      const reportLayout = await getReportWeb(activeReportType, id, filterParamsCollision);
+      const { s1 } = this.$route.params;
+      const reportLayout = await getReportWeb(activeReportType, s1, filterParamsCollision);
       this.reportLayout = reportLayout;
 
       this.loadingReportLayout = false;

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -226,8 +226,7 @@ export default {
       this.updateReportLayout();
       if (s1 !== s1Next) {
         const features = CompositeId.decode(s1Next);
-        const locationMap = await getLocationsByCentreline(features);
-        const locations = Array.from(locationMap.values());
+        const locations = await getLocationsByCentreline(features);
         this.setLocations(locations);
       }
     },

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -106,7 +106,7 @@ import { mapGetters, mapMutations, mapState } from 'vuex';
 
 import { ReportFormat, ReportType } from '@/lib/Constants';
 import {
-  getLocationsByFeature,
+  getLocationsByCentreline,
   getReport,
   getReportWeb,
 } from '@/lib/api/WebApi';
@@ -226,7 +226,7 @@ export default {
       this.updateReportLayout();
       if (s1 !== s1Next) {
         const features = CompositeId.decode(s1Next);
-        const locationMap = await getLocationsByFeature(features);
+        const locationMap = await getLocationsByCentreline(features);
         const locations = Array.from(locationMap.values());
         this.setLocations(locations);
       }

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -211,7 +211,7 @@ import { AuthScope } from '@/lib/Constants';
 import {
   getCollisionsByCentrelineSummary,
   getCollisionsByCentrelineTotal,
-  getLocationsByFeature,
+  getLocationsByCentreline,
   getPoiByCentrelineSummary,
   getStudiesByCentrelineSummary,
   getStudiesByCentrelineTotal,
@@ -403,7 +403,7 @@ export default {
 
       const { s1 } = this;
       if (s1 !== s1Next) {
-        const locationMap = await getLocationsByFeature(features);
+        const locationMap = await getLocationsByCentreline(features);
         const locations = Array.from(locationMap.values());
         this.setLocations(locations);
       }

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -217,6 +217,7 @@ import {
   getStudiesByCentrelineTotal,
   getStudyRequestsByCentrelinePending,
 } from '@/lib/api/WebApi';
+import CompositeId from '@/lib/io/CompositeId';
 import DateTime from '@/lib/time/DateTime';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 import FcDataTableCollisions from '@/web/components/FcDataTableCollisions.vue';
@@ -367,41 +368,33 @@ export default {
       this.$router.push({ name: 'requestStudyNew' });
     },
     actionShowReportsCollision() {
-      const { centrelineId, centrelineType } = this.$route.params;
-      const params = {
-        centrelineId,
-        centrelineType,
-      };
+      const { s1 } = this.$route.params;
       this.$router.push({
         name: 'viewCollisionReportsAtLocation',
-        params,
+        params: { s1 },
       });
     },
     actionShowReportsStudy({ category: { studyType } }) {
-      const { centrelineId, centrelineType } = this.$route.params;
-      const params = {
-        centrelineId,
-        centrelineType,
-        studyTypeName: studyType.name,
-      };
+      const { s1 } = this.$route.params;
+      const params = { s1, studyTypeName: studyType.name };
       this.$router.push({
         name: 'viewStudyReportsAtLocation',
         params,
       });
     },
     async loadAsyncForRoute(to) {
-      const { centrelineId, centrelineType } = to.params;
-      const feature = { centrelineId, centrelineType };
+      const { s1 } = to.params;
+      const features = CompositeId.decode(s1);
       const tasks = [
-        getCollisionsByCentrelineSummary(feature, this.filterParamsCollision),
-        getCollisionsByCentrelineTotal(feature),
-        getLocationByFeature(feature),
-        getPoiByCentrelineSummary(feature),
-        getStudiesByCentrelineSummary(feature, this.filterParamsStudy),
-        getStudiesByCentrelineTotal(feature),
+        getCollisionsByCentrelineSummary(features, this.filterParamsCollision),
+        getCollisionsByCentrelineTotal(features),
+        getLocationByFeature(features[0]),
+        getPoiByCentrelineSummary(features[0]),
+        getStudiesByCentrelineSummary(features, this.filterParamsStudy),
+        getStudiesByCentrelineTotal(features),
       ];
       if (this.hasAuthScope(AuthScope.STUDY_REQUESTS)) {
-        tasks.push(getStudyRequestsByCentrelinePending({ centrelineId, centrelineType }));
+        tasks.push(getStudyRequestsByCentrelinePending(features));
       }
       const [
         collisionSummary,

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -403,8 +403,7 @@ export default {
 
       const { s1 } = this;
       if (s1 !== s1Next) {
-        const locationMap = await getLocationsByCentreline(features);
-        const locations = Array.from(locationMap.values());
+        const locations = await getLocationsByCentreline(features);
         this.setLocations(locations);
       }
     },

--- a/web/components/FcDrawerViewRequest.vue
+++ b/web/components/FcDrawerViewRequest.vue
@@ -204,7 +204,7 @@ export default {
       }
       return 'Requests';
     },
-    ...mapState(['auth', 'backViewRequest', 'location']),
+    ...mapState(['auth', 'backViewRequest', 'locations']),
   },
   methods: {
     async actionAcceptChanges() {
@@ -257,11 +257,10 @@ export default {
       await this.updateMoreActions();
     },
     actionViewData() {
-      if (this.location === null) {
+      if (this.locations.length === 0) {
         return;
       }
-      const features = [this.location];
-      const s1 = CompositeId.encode(features);
+      const s1 = CompositeId.encode(this.locations);
       const route = {
         name: 'viewDataAtLocation',
         params: { s1 },
@@ -285,7 +284,7 @@ export default {
       this.studyRequestComments = studyRequestComments;
       this.studyRequestLocation = studyRequestLocation;
       this.studyRequestUsers = studyRequestUsers;
-      this.setLocation(studyRequestLocation);
+      this.setLocations([studyRequestLocation]);
     },
     onAddComment({ studyRequest, studyRequestComment }) {
       this.studyRequest = studyRequest;
@@ -307,7 +306,7 @@ export default {
       }
       this.loadingMoreActions = false;
     },
-    ...mapMutations(['setLocation']),
+    ...mapMutations(['setLocations']),
     ...mapActions(['saveStudyRequest']),
   },
 };

--- a/web/components/FcDrawerViewRequest.vue
+++ b/web/components/FcDrawerViewRequest.vue
@@ -103,6 +103,7 @@ import { mapActions, mapMutations, mapState } from 'vuex';
 
 import { AuthScope, StudyRequestStatus } from '@/lib/Constants';
 import { getStudyRequest } from '@/lib/api/WebApi';
+import CompositeId from '@/lib/io/CompositeId';
 import FcCommentsStudyRequest from '@/web/components/FcCommentsStudyRequest.vue';
 import FcSummaryStudyRequest from '@/web/components/FcSummaryStudyRequest.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
@@ -259,10 +260,11 @@ export default {
       if (this.location === null) {
         return;
       }
-      const { centrelineId, centrelineType } = this.location;
+      const features = [this.location];
+      const s1 = CompositeId.encode(features);
       const route = {
         name: 'viewDataAtLocation',
-        params: { centrelineId, centrelineType },
+        params: { s1 },
       };
       this.$router.push(route);
     },

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -349,8 +349,7 @@ export default {
 
       const { s1 } = this;
       if (s1 !== s1Next) {
-        const locationMap = await getLocationsByCentreline(features);
-        const locations = Array.from(locationMap.values());
+        const locations = await getLocationsByCentreline(features);
         this.setLocations(locations);
       }
     },

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -148,7 +148,7 @@ import {
   StudyType,
 } from '@/lib/Constants';
 import {
-  getLocationsByFeature,
+  getLocationsByCentreline,
   getReport,
   getReportWeb,
   getStudiesByCentreline,
@@ -349,7 +349,7 @@ export default {
 
       const { s1 } = this;
       if (s1 !== s1Next) {
-        const locationMap = await getLocationsByFeature(features);
+        const locationMap = await getLocationsByCentreline(features);
         const locations = Array.from(locationMap.values());
         this.setLocations(locations);
       }

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -153,6 +153,7 @@ import {
   getReportWeb,
   getStudiesByCentreline,
 } from '@/lib/api/WebApi';
+import CompositeId from '@/lib/io/CompositeId';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 import FcDialogConfirm from '@/web/components/dialogs/FcDialogConfirm.vue';
 import FcDialogReportParameters from '@/web/components/dialogs/FcDialogReportParameters.vue';
@@ -293,11 +294,11 @@ export default {
       next();
       return;
     }
-    const { centrelineId, centrelineType } = from.params;
+    const { s1 } = from.params;
     const { name } = to;
     if (name === 'viewDataAtLocation') {
-      const { centrelineId: nextCentrelineId, centrelineType: nextCentrelineType } = to.params;
-      if (centrelineType === nextCentrelineType && centrelineId === nextCentrelineId) {
+      const { s1: s1Next } = to.params;
+      if (s1 === s1Next) {
         next();
         return;
       }
@@ -327,19 +328,20 @@ export default {
       this.$router.push(this.nextRoute);
     },
     actionNavigateBack() {
-      const { centrelineId, centrelineType } = this.$route.params;
+      const { s1 } = this.$route.params;
       this.$router.push({
         name: 'viewDataAtLocation',
-        params: { centrelineId, centrelineType },
+        params: { s1 },
       });
     },
     async loadAsyncForRoute(to) {
-      const { centrelineId, centrelineType, studyTypeName } = to.params;
+      const { s1, studyTypeName } = to.params;
+      const features = CompositeId.decode(s1);
       const studyType = StudyType.enumValueOf(studyTypeName);
       const tasks = [
-        getLocationByFeature({ centrelineId, centrelineType }),
+        getLocationByFeature(features[0]),
         getStudiesByCentreline(
-          { centrelineId, centrelineType },
+          features,
           studyType,
           this.filterParamsStudyReports,
           { limit: 10, offset: 0 },

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -185,6 +185,13 @@ export default {
         this.setLegendOptions(legendOptions);
       },
     },
+    location() {
+      const { locations } = this;
+      if (locations.length === 0) {
+        return null;
+      }
+      return locations[0];
+    },
     mapOptions() {
       const { aerial, legendOptions } = this;
       const { dark } = this.$vuetify.theme;
@@ -217,15 +224,15 @@ export default {
     },
     tooltipLocationMulti() {
       if (this.locationMulti) {
-        return 'Stop selecting multiple locations';
+        return 'Select single location';
       }
       return 'Select multiple locations';
     },
     ...mapState([
       'drawerOpen',
       'legendOptions',
-      'location',
       'locationMulti',
+      'locations',
     ]),
   },
   created() {
@@ -585,7 +592,6 @@ export default {
     ...mapMutations([
       'setDrawerOpen',
       'setLegendOptions',
-      'setLocation',
       'setLocationMulti',
     ]),
   },

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -90,7 +90,7 @@
 <script>
 import mapboxgl from 'mapbox-gl/dist/mapbox-gl';
 import Vue from 'vue';
-import { mapMutations, mapState } from 'vuex';
+import { mapGetters, mapMutations, mapState } from 'vuex';
 
 import { CentrelineType, MapZoom } from '@/lib/Constants';
 import { debounce } from '@/lib/FunctionUtils';
@@ -185,13 +185,6 @@ export default {
         this.setLegendOptions(legendOptions);
       },
     },
-    location() {
-      const { locations } = this;
-      if (locations.length === 0) {
-        return null;
-      }
-      return locations[0];
-    },
     mapOptions() {
       const { aerial, legendOptions } = this;
       const { dark } = this.$vuetify.theme;
@@ -232,8 +225,8 @@ export default {
       'drawerOpen',
       'legendOptions',
       'locationMulti',
-      'locations',
     ]),
+    ...mapGetters(['location']),
   },
   created() {
     this.map = null;

--- a/web/components/FcPaneMapPopup.vue
+++ b/web/components/FcPaneMapPopup.vue
@@ -38,7 +38,7 @@ import { CentrelineType } from '@/lib/Constants';
 import { formatCountLocationDescription } from '@/lib/StringFormatters';
 import {
   getCollisionByCollisionId,
-  getLocationByFeature,
+  getLocationByCentreline,
   getStudiesByCentrelineSummary,
 } from '@/lib/api/WebApi';
 import { getLocationFeatureType } from '@/lib/geo/CentrelineUtils';
@@ -107,7 +107,7 @@ function getCollisionIcon(feature, { involved }) {
 
 async function getCentrelineDetails(feature, centrelineType) {
   const { centrelineId } = feature.properties;
-  const location = await getLocationByFeature({ centrelineId, centrelineType });
+  const location = await getLocationByCentreline({ centrelineId, centrelineType });
   return { location };
 }
 
@@ -165,7 +165,7 @@ function getSchoolIcon() {
 async function getStudyDetails(feature) {
   const { centrelineId, centrelineType } = feature.properties;
   const tasks = [
-    getLocationByFeature({ centrelineId, centrelineType }),
+    getLocationByCentreline({ centrelineId, centrelineType }),
     getStudiesByCentrelineSummary([{ centrelineId, centrelineType }], {}),
   ];
   const [location, studySummary] = await Promise.all(tasks);
@@ -383,7 +383,7 @@ export default {
     async actionSetStudyLocation() {
       const { centrelineId, centrelineType } = this.feature.properties;
       const feature = { centrelineId, centrelineType };
-      const location = await getLocationByFeature(feature);
+      const location = await getLocationByCentreline(feature);
       this.setLocations([location]);
     },
     actionViewData() {
@@ -392,9 +392,9 @@ export default {
       }
 
       // open the view data window
-      const features = [this.feature.properties];
-      const s1 = CompositeId.encode(features);
-      console.log(s1);
+      const { centrelineId, centrelineType } = this.feature.properties;
+      const feature = { centrelineId, centrelineType };
+      const s1 = CompositeId.encode([feature]);
       this.$router.push({
         name: 'viewDataAtLocation',
         params: { s1 },

--- a/web/components/FcPaneMapPopup.vue
+++ b/web/components/FcPaneMapPopup.vue
@@ -384,7 +384,7 @@ export default {
       const { centrelineId, centrelineType } = this.feature.properties;
       const feature = { centrelineId, centrelineType };
       const location = await getLocationByFeature(feature);
-      this.setLocation(location);
+      this.setLocations([location]);
     },
     actionViewData() {
       if (this.$route.name === 'viewDataAtLocation') {
@@ -394,6 +394,7 @@ export default {
       // open the view data window
       const features = [this.feature.properties];
       const s1 = CompositeId.encode(features);
+      console.log(s1);
       this.$router.push({
         name: 'viewDataAtLocation',
         params: { s1 },
@@ -415,7 +416,7 @@ export default {
       this.featureDetails = await getFeatureDetails(this.layerId, this.feature);
       this.loading = false;
     },
-    ...mapMutations(['setDrawerOpen', 'setLocation']),
+    ...mapMutations(['setDrawerOpen', 'setLocations']),
   },
 };
 </script>

--- a/web/components/FcPaneMapPopup.vue
+++ b/web/components/FcPaneMapPopup.vue
@@ -43,6 +43,7 @@ import {
 } from '@/lib/api/WebApi';
 import { getLocationFeatureType } from '@/lib/geo/CentrelineUtils';
 import { getGeometryMidpoint } from '@/lib/geo/GeometryUtils';
+import CompositeId from '@/lib/io/CompositeId';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 
@@ -165,7 +166,7 @@ async function getStudyDetails(feature) {
   const { centrelineId, centrelineType } = feature.properties;
   const tasks = [
     getLocationByFeature({ centrelineId, centrelineType }),
-    getStudiesByCentrelineSummary({ centrelineId, centrelineType }, {}),
+    getStudiesByCentrelineSummary([{ centrelineId, centrelineType }], {}),
   ];
   const [location, studySummary] = await Promise.all(tasks);
   return { location, studySummary };
@@ -391,10 +392,11 @@ export default {
       }
 
       // open the view data window
-      const { centrelineId, centrelineType } = this.feature.properties;
+      const features = [this.feature.properties];
+      const s1 = CompositeId.encode(features);
       this.$router.push({
         name: 'viewDataAtLocation',
-        params: { centrelineId, centrelineType },
+        params: { s1 },
       });
     },
     createPopup() {

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -23,10 +23,11 @@
           <template v-slot:activator="{ on }">
             <FcButton
               aria-label="Clear Location"
+              class="mr-1"
               type="icon"
               @click="actionClear"
               v-on="on">
-              <v-icon left>mdi-close-circle</v-icon>
+              <v-icon>mdi-close-circle</v-icon>
             </FcButton>
           </template>
           <span>Clear Location</span>

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -65,6 +65,7 @@
 <script>
 import { mapMutations } from 'vuex';
 
+import { getLocationsDescription } from '@/lib/geo/CentrelineUtils';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcInputLocationSearch from '@/web/components/inputs/FcInputLocationSearch.vue';
 
@@ -83,18 +84,7 @@ export default {
   },
   computed: {
     description() {
-      const n = this.locations.length;
-      if (n === 0) {
-        return null;
-      }
-      const [{ description }] = this.locations;
-      if (n === 1) {
-        return description;
-      }
-      if (n === 2) {
-        return `${description} + 1 location`;
-      }
-      return `${description} + ${n - 1} locations`;
+      return getLocationsDescription(this.locations);
     },
   },
   methods: {

--- a/web/components/inputs/FcSelectorSingleLocation.vue
+++ b/web/components/inputs/FcSelectorSingleLocation.vue
@@ -43,16 +43,23 @@ export default {
     },
     internalLocation: {
       get() {
-        return this.location;
+        if (this.locations.length === 0) {
+          return null;
+        }
+        return this.locations[0];
       },
       set(internalLocation) {
-        this.setLocation(internalLocation);
+        if (internalLocation === null) {
+          this.setLocations([]);
+        } else {
+          this.setLocations([internalLocation]);
+        }
       },
     },
-    ...mapState(['location']),
+    ...mapState(['locations']),
   },
   methods: {
-    ...mapMutations(['setLocation']),
+    ...mapMutations(['setLocations']),
   },
 };
 </script>

--- a/web/components/nav/FcDashboardNav.vue
+++ b/web/components/nav/FcDashboardNav.vue
@@ -35,17 +35,16 @@ export default {
   },
   computed: {
     toViewMap() {
-      if (this.location === null) {
+      if (this.locations.length === 0) {
         return { name: 'viewData' };
       }
-      const features = [this.location];
-      const s1 = CompositeId.encode(features);
+      const s1 = CompositeId.encode(this.locations);
       return {
         name: 'viewDataAtLocation',
         params: { s1 },
       };
     },
-    ...mapState(['location']),
+    ...mapState(['locations']),
   },
 };
 </script>

--- a/web/components/nav/FcDashboardNav.vue
+++ b/web/components/nav/FcDashboardNav.vue
@@ -25,6 +25,7 @@
 <script>
 import { mapState } from 'vuex';
 
+import CompositeId from '@/lib/io/CompositeId';
 import FcDashboardNavItem from '@/web/components/nav/FcDashboardNavItem.vue';
 
 export default {
@@ -37,10 +38,11 @@ export default {
       if (this.location === null) {
         return { name: 'viewData' };
       }
-      const { centrelineId, centrelineType } = this.location;
+      const features = [this.location];
+      const s1 = CompositeId.encode(features);
       return {
         name: 'viewDataAtLocation',
-        params: { centrelineId, centrelineType },
+        params: { s1 },
       };
     },
     ...mapState(['location']),

--- a/web/router.js
+++ b/web/router.js
@@ -81,7 +81,7 @@ const router = new Router({
           next();
         },
       }, {
-        path: '/view/location/:centrelineType/:centrelineId',
+        path: '/view/location/:s1',
         name: 'viewDataAtLocation',
         meta: {
           auth: { mode: 'try' },
@@ -94,7 +94,7 @@ const router = new Router({
           next();
         },
       }, {
-        path: '/view/location/:centrelineType/:centrelineId/reports/collision',
+        path: '/view/location/:s1/reports/collision',
         name: 'viewCollisionReportsAtLocation',
         meta: {
           auth: { mode: 'try' },
@@ -107,7 +107,7 @@ const router = new Router({
           next();
         },
       }, {
-        path: '/view/location/:centrelineType/:centrelineId/reports/:studyTypeName',
+        path: '/view/location/:s1/reports/:studyTypeName',
         name: 'viewStudyReportsAtLocation',
         meta: {
           auth: { mode: 'try' },

--- a/web/store/LoginState.js
+++ b/web/store/LoginState.js
@@ -9,8 +9,8 @@ function restoreLoginState(next) {
   }
   window.sessionStorage.removeItem(STORAGE_KEY_LOGIN_STATE);
   try {
-    const { location, name, params } = JSON.parse(loginState);
-    store.commit('setLocation', location);
+    const { locations, name, params } = JSON.parse(loginState);
+    store.commit('setLocations', locations);
     next({ name, params });
     return true;
   } catch (err) {
@@ -22,9 +22,9 @@ function restoreLoginState(next) {
 }
 
 function saveLoginState(to) {
-  const { location } = store.state;
+  const { locations } = store.state;
   const { name, params = {} } = to;
-  const loginState = JSON.stringify({ location, name, params });
+  const loginState = JSON.stringify({ locations, name, params });
   window.sessionStorage.setItem(STORAGE_KEY_LOGIN_STATE, loginState);
 }
 

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -6,11 +6,15 @@ import {
   postStudyRequest,
   putStudyRequest,
 } from '@/lib/api/WebApi';
-import { getLocationFeatureType } from '@/lib/geo/CentrelineUtils';
+import {
+  getLocationFeatureType,
+  getLocationsDescription,
+} from '@/lib/geo/CentrelineUtils';
 import {
   REQUEST_STUDY_SUBMITTED,
   REQUEST_STUDY_UPDATED,
 } from '@/lib/i18n/Strings';
+import CompositeId from '@/lib/io/CompositeId';
 import DateTime from '@/lib/time/DateTime';
 import viewData from '@/web/store/modules/viewData';
 
@@ -37,7 +41,7 @@ export default new Vuex.Store({
     // NAVIGATION
     backViewRequest: { name: 'requestsTrack' },
     // LOCATION
-    location: null,
+    locations: [],
     locationMulti: false,
     legendOptions: {
       datesFrom: 3,
@@ -70,8 +74,17 @@ export default new Vuex.Store({
     },
     // LOCATION
     locationFeatureType(state) {
-      const { location } = state;
-      return getLocationFeatureType(location);
+      const { locations } = state;
+      if (locations.length === 0) {
+        return null;
+      }
+      return getLocationFeatureType(locations[0]);
+    },
+    locationsDescription(state) {
+      return getLocationsDescription(state.locations);
+    },
+    s1(state) {
+      return CompositeId.encode(state.locations);
     },
   },
   mutations: {
@@ -102,8 +115,8 @@ export default new Vuex.Store({
       Vue.set(state, 'backViewRequest', backViewRequest);
     },
     // LOCATION
-    setLocation(state, location) {
-      Vue.set(state, 'location', location);
+    setLocations(state, locations) {
+      Vue.set(state, 'locations', locations);
     },
     setLocationMulti(state, locationMulti) {
       Vue.set(state, 'locationMulti', locationMulti);

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -73,6 +73,13 @@ export default new Vuex.Store({
       return scope;
     },
     // LOCATION
+    location(state) {
+      const { locations } = state;
+      if (locations.length === 0) {
+        return null;
+      }
+      return locations[0];
+    },
     locationFeatureType(state) {
       const { locations } = state;
       if (locations.length === 0) {


### PR DESCRIPTION
# Issue Addressed
This PR closes #407 .

# Description
We change the way location selections are stored in `vuex` from a single location to an array of locations.  We then refactor a whole slew of callsites to use this new multi-location array: reading it from `state.locations`, writing it via the `setLocations` mutation, encoding it into a `CompositeId` for navigation between frontend routes, and passing that encoded `CompositeId` to REST API endpoints for multi-location data lookup in the backend.

The end result is that we can now largely roll the multi-location ball downhill, building UI changes into the framework already built up here and in previous PRs.  (There is still a substantial amount of work on those UI changes.)

# Tests
Tested several user flows in the frontend, including reporting flows.
