### PR TITLE
Gh520 bitstream limits

### DIFF
--- a/lib/io/BitStream.js
+++ b/lib/io/BitStream.js
@@ -84,6 +84,9 @@ class BitStream {
     const bitIndexPrev = this.bitIndex;
     this.seek(0);
     const cs = [];
+    const mod = this.bitLength % 6;
+    const cMod = BitStream.CHARS_BASE_64[mod];
+    cs.push(cMod);
     while (this.bitIndex < this.bitLength) {
       const rest = Math.min(this.bitLength - this.bitIndex, 6);
       const value = this.read(rest);
@@ -91,9 +94,7 @@ class BitStream {
       cs.push(c);
     }
     this.seek(bitIndexPrev);
-    const len = this.bitLength.toString(16);
-    const b64 = cs.join('');
-    return `${len}:${b64}`;
+    return cs.join('');
   }
 
   static base64Index(ord) {
@@ -120,27 +121,26 @@ class BitStream {
    * @param {string} str - string to deserialize
    */
   static fromString(str) {
-    const parts = str.split(':');
-    if (parts.length !== 2) {
-      throw new BitStreamSerializationError(`invalid structure: ${str}`);
+    const n = str.length - 1;
+    if (n < 0) {
+      throw new BitStreamSerializationError('expected bitLength % 6, got empty string');
     }
-    const [len, b64] = parts;
-    const match = BitStream.REGEX_LEN.exec(len);
-    if (match === null) {
-      throw new BitStreamSerializationError(`invalid bit length: ${len}`);
+    const ordMod = str.charCodeAt(0);
+    const mod = BitStream.base64Index(ordMod);
+    if (mod >= 6) {
+      throw new BitStreamSerializationError(`expected bitLength % 6, got ${ordMod}`);
     }
 
-    const bitLength = parseInt(len, 16);
+    let bitLength = n * 6;
+    if (mod !== 0) {
+      bitLength -= 6 - mod;
+    }
     const numBytes = Math.ceil(bitLength / 8);
     const bytes = new Uint8Array(numBytes);
     const bitStream = new BitStream(bytes);
-    const n = Math.ceil(bitLength / 6);
-    if (b64.length !== n) {
-      throw new BitStreamSerializationError(`expected ${n} characters, got ${b64.length}`);
-    }
     for (let i = 0; i < n; i++) {
-      const c = b64.charCodeAt(i);
-      const value = BitStream.base64Index(c);
+      const ord = str.charCodeAt(i + 1);
+      const value = BitStream.base64Index(ord);
       const rest = Math.min(bitLength - i * 6, 6);
       bitStream.write(rest, value);
     }
@@ -151,6 +151,5 @@ class BitStream {
   }
 }
 BitStream.CHARS_BASE_64 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
-BitStream.REGEX_LEN = /^[0-9a-f]+$/;
 
 export default BitStream;

--- a/lib/io/CompositeId.js
+++ b/lib/io/CompositeId.js
@@ -65,6 +65,9 @@ class CompositeId {
 
   static encode(features) {
     const n = features.length;
+    if (n > CompositeId.MAX_FEATURES) {
+      throw new InvalidCompositeIdError('maximum number of features exceeded');
+    }
     const numBytes = Math.ceil(n * CompositeId.BITS_PER_FEATURE / 8);
     const bytes = new Uint8Array(numBytes);
     const bitStream = new BitStream(bytes);

--- a/lib/io/CompositeId.js
+++ b/lib/io/CompositeId.js
@@ -20,6 +20,9 @@ import BitStream from '@/lib/io/BitStream';
  */
 class CompositeId {
   static decode(compositeId) {
+    if (compositeId.length > CompositeId.MAX_LENGTH) {
+      throw new InvalidCompositeIdError('maximum length exceeded');
+    }
     const typeSeparatorIndex = compositeId.indexOf(':');
     if (typeSeparatorIndex === -1) {
       throw new InvalidCompositeIdError(`invalid structure: ${compositeId}`);
@@ -78,5 +81,17 @@ class CompositeId {
   }
 }
 CompositeId.BITS_PER_FEATURE = 30;
+CompositeId.MAX_FEATURES = 100;
+/**
+ * Maximum length of an encoded `CompositeId`.  This corresponds to a prefix of 4 characters
+ * (i.e. `"s1:${mod}"`) followed by `CompositeId.BITS_PER_FEATURE / 6` characters for each of
+ * `CompositeId.MAX_FEATURES` features.
+ *
+ * The use of `Math.ceil` allows this to handle feature bit lengths that aren't aligned to base
+ * 64 characters.
+ */
+CompositeId.MAX_LENGTH = 4 + Math.ceil(
+  CompositeId.MAX_FEATURES * CompositeId.BITS_PER_FEATURE / 6,
+);
 
 export default CompositeId;

--- a/tests/jest/unit/io/BitStream.spec.js
+++ b/tests/jest/unit/io/BitStream.spec.js
@@ -211,15 +211,11 @@ test('BitStream [invalid serialization]', () => {
   }).toThrow(BitStreamSerializationError);
 
   expect(() => {
-    BitStream.fromString('blargl:');
+    BitStream.fromString('A+%&@*@%');
   }).toThrow(BitStreamSerializationError);
 
   expect(() => {
-    BitStream.fromString('3f:+%&@*@%');
-  }).toThrow(BitStreamSerializationError);
-
-  expect(() => {
-    BitStream.fromString('1e:AAAA');
+    BitStream.fromString('QAAA');
   }).toThrow(BitStreamSerializationError);
 });
 

--- a/tests/jest/unit/io/CompositeId.spec.js
+++ b/tests/jest/unit/io/CompositeId.spec.js
@@ -29,6 +29,23 @@ test('CompositeId [invalid IDs]', () => {
   }).toThrow(InvalidCompositeIdError);
 });
 
+test('CompositeId [length limit]', () => {
+  const parts = ['s1:A'];
+  for (let i = 0; i < CompositeId.MAX_FEATURES; i++) {
+    parts.push('CAAAA');
+  }
+  let compositeId = parts.join('');
+  expect(() => {
+    CompositeId.decode(compositeId);
+  }).not.toThrow(InvalidCompositeIdError);
+
+  parts.push('CAAAA');
+  compositeId = parts.join('');
+  expect(() => {
+    CompositeId.decode(compositeId);
+  }).toThrow(InvalidCompositeIdError);
+});
+
 test('CompositeId [empty feature set]', () => {
   const compositeId = CompositeId.encode([]);
   expect(CompositeId.decode(compositeId)).toEqual([]);

--- a/tests/jest/unit/io/CompositeId.spec.js
+++ b/tests/jest/unit/io/CompositeId.spec.js
@@ -17,11 +17,7 @@ test('CompositeId [invalid IDs]', () => {
   }).toThrow(InvalidCompositeIdError);
 
   expect(() => {
-    CompositeId.decode('s1:blargl');
-  }).toThrow(InvalidCompositeIdError);
-
-  expect(() => {
-    CompositeId.decode('s1:blargl:');
+    CompositeId.decode('s1:QAAA');
   }).toThrow(InvalidCompositeIdError);
 
   expect(() => {
@@ -29,11 +25,7 @@ test('CompositeId [invalid IDs]', () => {
   }).toThrow(InvalidCompositeIdError);
 
   expect(() => {
-    CompositeId.decode('s1:1e:AAAA');
-  }).toThrow(InvalidCompositeIdError);
-
-  expect(() => {
-    CompositeId.decode('s1:1e:AAAAA');
+    CompositeId.decode('s1:AAAAAA');
   }).toThrow(InvalidCompositeIdError);
 });
 

--- a/tests/jest/unit/io/CompositeId.spec.js
+++ b/tests/jest/unit/io/CompositeId.spec.js
@@ -3,6 +3,15 @@ import Random from '@/lib/Random';
 import { InvalidCompositeIdError } from '@/lib/error/MoveErrors';
 import CompositeId from '@/lib/io/CompositeId';
 
+function generateCompositeIdFeature() {
+  const centrelineId = Random.range(1, 0x20000000);
+  const centrelineType = Random.choice([
+    CentrelineType.SEGMENT,
+    CentrelineType.INTERSECTION,
+  ]);
+  return { centrelineId, centrelineType };
+}
+
 test('CompositeId [invalid IDs]', () => {
   expect(() => {
     CompositeId.decode('');
@@ -29,7 +38,7 @@ test('CompositeId [invalid IDs]', () => {
   }).toThrow(InvalidCompositeIdError);
 });
 
-test('CompositeId [length limit]', () => {
+test('CompositeId [length limit decode]', () => {
   const parts = ['s1:A'];
   for (let i = 0; i < CompositeId.MAX_FEATURES; i++) {
     parts.push('CAAAA');
@@ -43,6 +52,24 @@ test('CompositeId [length limit]', () => {
   compositeId = parts.join('');
   expect(() => {
     CompositeId.decode(compositeId);
+  }).toThrow(InvalidCompositeIdError);
+});
+
+test('CompositeId [length limit encode]', () => {
+  const features = [];
+  let feature;
+  for (let i = 0; i < CompositeId.MAX_FEATURES; i++) {
+    feature = generateCompositeIdFeature();
+    features.push(feature);
+  }
+  expect(() => {
+    CompositeId.encode(features);
+  }).not.toThrow(InvalidCompositeIdError);
+
+  feature = generateCompositeIdFeature();
+  features.push(feature);
+  expect(() => {
+    CompositeId.encode(features);
   }).toThrow(InvalidCompositeIdError);
 });
 
@@ -82,12 +109,8 @@ test('CompositeId [fuzz test encode / decode]', () => {
     const n = Random.range(1, 20);
     const features = [];
     for (let j = 0; j < n; j++) {
-      const centrelineId = Random.range(1, 0x20000000);
-      const centrelineType = Random.choice([
-        CentrelineType.SEGMENT,
-        CentrelineType.INTERSECTION,
-      ]);
-      features.push({ centrelineId, centrelineType });
+      const feature = generateCompositeIdFeature();
+      features.push(feature);
     }
     const compositeId = CompositeId.encode(features);
     expect(CompositeId.decode(compositeId)).toEqual(features);

--- a/tests/jest/unit/model/Joi.spec.js
+++ b/tests/jest/unit/model/Joi.spec.js
@@ -24,26 +24,26 @@ CssColor.init(cssColorValues);
 class NotAnEnum {}
 
 test('Joi.compositeId', () => {
-  let compositeId = 's1:0:';
+  let compositeId = 's1:A';
   let result = Joi.compositeId().ofType('s1').validate(compositeId);
   expect(result.error).toBeUndefined();
   expect(result.value).toEqual([]);
 
-  compositeId = 's1:1e:AAAAA';
+  compositeId = 's1:AAAAAA';
   result = Joi.compositeId().ofType('s1').validate(compositeId);
   expect(result.error).not.toBeUndefined();
 
-  compositeId = 's1:1e:CAAAA';
+  compositeId = 's1:ACAAAA';
   result = Joi.compositeId().ofType('s1').validate(compositeId);
   expect(result.error).toBeUndefined();
   expect(result.value).toEqual([
     { centrelineId: 1, centrelineType: CentrelineType.INTERSECTION },
   ]);
 
-  compositeId = 's2:0:';
+  compositeId = 's2:A';
   result = Joi.compositeId().ofType('s1').validate(compositeId);
   expect(result.error).not.toBeUndefined();
-  compositeId = 's1:0';
+  compositeId = 's1:';
   result = Joi.compositeId().ofType('s1').validate(compositeId);
   expect(result.error).not.toBeUndefined();
   compositeId = 's1';


### PR DESCRIPTION
# Issue Addressed
This PR closes #520 .

# Description
We change the format of `BitStream` to `${mod}${b64}`, where `${mod}` is a single base-64 character representing `bitLength % 6` and `${b64}` contains base-64-encoded bits as before.  We also impose a limit, `CompositeId.MAX_LENGTH`, on the size of a `CompositeId`-encoded string.

# Tests
Ran `BitStream` and `CompositeId` tests via `jest`.
