### PR TITLE
View / Edit modes for multi-location selector

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -182,6 +182,19 @@ HttpStatus.init({
   },
 });
 
+class LocationMode extends Enum {}
+LocationMode.init({
+  SINGLE: {
+    multi: false,
+  },
+  MULTI_EDIT: {
+    multi: true,
+  },
+  MULTI: {
+    multi: true,
+  },
+});
+
 /**
  * Location search types, corresponding to different types of entities to search over in
  * {@link LocationController.getLocationSuggestions}.
@@ -1003,6 +1016,7 @@ const Constants = {
   CollisionRoadSurfaceCondition,
   FeatureCode,
   HttpStatus,
+  LocationMode,
   LocationSearchType,
   MapZoom,
   ORG_NAME,
@@ -1041,6 +1055,7 @@ export {
   CollisionRoadSurfaceCondition,
   FeatureCode,
   HttpStatus,
+  LocationMode,
   LocationSearchType,
   MapZoom,
   ORG_NAME,

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -12,7 +12,7 @@
         class="pane-map-location-search"
         v-if="!drawerOpen">
         <FcSelectorMultiLocation
-          v-if="locationMulti"
+          v-if="locationMode.multi"
           class="elevation-2" />
         <FcSelectorSingleLocation
           v-else
@@ -39,19 +39,19 @@
           :z-index="100">
           <template v-slot:activator="{ on }">
             <FcButton
-              :aria-label="tooltipLocationMulti"
+              :aria-label="tooltipLocationMode"
               class="pa-0"
               :class="{
-                primary: locationMulti,
-                'white--text': locationMulti,
+                primary: locationMode.multi,
+                'white--text': locationMode.multi,
               }"
               type="fab-text"
-              @click="setLocationMulti(!locationMulti)"
+              @click="actionToggleLocationMode"
               v-on="on">
               <v-icon class="display-2">mdi-map-marker-multiple</v-icon>
             </FcButton>
           </template>
-          <span>{{tooltipLocationMulti}}</span>
+          <span>{{tooltipLocationMode}}</span>
         </v-tooltip>
         <v-tooltip
           v-if="location !== null"
@@ -92,7 +92,7 @@ import mapboxgl from 'mapbox-gl/dist/mapbox-gl';
 import Vue from 'vue';
 import { mapGetters, mapMutations, mapState } from 'vuex';
 
-import { CentrelineType, MapZoom } from '@/lib/Constants';
+import { CentrelineType, LocationMode, MapZoom } from '@/lib/Constants';
 import { debounce } from '@/lib/FunctionUtils';
 import GeoStyle from '@/lib/geo/GeoStyle';
 import FcPaneMapPopup from '@/web/components/FcPaneMapPopup.vue';
@@ -215,16 +215,16 @@ export default {
       }
       return !this.drawerOpen || !featureMatchesRoute;
     },
-    tooltipLocationMulti() {
-      if (this.locationMulti) {
-        return 'Select single location';
+    tooltipLocationMode() {
+      if (this.locationMode.multi) {
+        return 'Switch to single-location mode';
       }
-      return 'Select multiple locations';
+      return 'Add location';
     },
     ...mapState([
       'drawerOpen',
       'legendOptions',
-      'locationMulti',
+      'locationMode',
     ]),
     ...mapGetters(['location']),
   },
@@ -337,6 +337,13 @@ export default {
     },
   },
   methods: {
+    actionToggleLocationMode() {
+      if (this.locationMode === LocationMode.SINGLE) {
+        this.setLocationMode(LocationMode.MULTI_EDIT);
+      } else {
+        this.setLocationMode(LocationMode.SINGLE);
+      }
+    },
     clearHoveredFeature() {
       if (this.hoveredFeature !== null) {
         this.map.setFeatureState(this.hoveredFeature, { hover: false });
@@ -585,7 +592,7 @@ export default {
     ...mapMutations([
       'setDrawerOpen',
       'setLegendOptions',
-      'setLocationMulti',
+      'setLocationMode',
     ]),
   },
 };

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -16,8 +16,9 @@
           label="Choose location or click on the map"
           :loading="loading"
           solo
+          v-bind="$attrs"
           @blur="hasFocus = false"
-          @focus="hasFocus = true"
+          @focus="actionFocus"
           @input="actionInput"
           v-on="onMenu">
           <template v-slot:append>
@@ -169,8 +170,16 @@ export default {
       this.query = null;
       this.state = LocationSearchState.VALUE_EMPTY;
     },
+    actionFocus() {
+      this.hasFocus = true;
+      this.$emit('focus');
+    },
     actionInput() {
-      this.state = LocationSearchState.QUERY_TYPING;
+      if (this.query === '') {
+        this.actionClear();
+      } else {
+        this.state = LocationSearchState.QUERY_TYPING;
+      }
     },
     actionSelect(location) {
       this.internalValue = location;

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -3,7 +3,7 @@
     v-model="internalValue"
     class="fc-input-location-search"
     dense
-    :flat="locationMulti"
+    :flat="hasLocationIndex"
     hide-details
     hide-no-data
     :items="items"
@@ -13,9 +13,10 @@
     no-filter
     return-object
     :search-input.sync="query"
-    solo>
+    solo
+    v-on="$listeners">
     <template v-slot:append>
-      <span v-if="locationMulti">&nbsp;</span>
+      <span v-if="hasLocationIndex">&nbsp;</span>
       <template v-else>
         <v-tooltip
           v-if="internalValue !== null || query !== null"
@@ -76,10 +77,10 @@ export default {
     };
   },
   computed: {
-    locationMulti() {
+    hasLocationIndex() {
       return this.locationIndex !== null;
     },
-    locationToAddMulti() {
+    hasLocationToAddIndex() {
       return this.locationIndex === -1;
     },
   },
@@ -100,7 +101,7 @@ export default {
     internalValue: {
       handler() {
         if (this.internalValue !== null) {
-          if (this.locationToAddMulti) {
+          if (this.hasLocationToAddIndex) {
             /*
              * In this case, the user has just selected a location to be added to the
              * multi-location selection.  We need to pass that new location up, then

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -1,61 +1,80 @@
 <template>
-  <v-autocomplete
-    v-model="internalValue"
-    class="fc-input-location-search"
-    dense
-    :flat="hasLocationIndex"
-    hide-details
-    hide-no-data
-    :items="items"
-    item-text="description"
-    label="Choose location or click on the map"
-    :loading="loading"
-    no-filter
-    return-object
-    :search-input.sync="query"
-    solo
-    v-on="$listeners">
-    <template v-slot:append>
-      <span v-if="hasLocationIndex">&nbsp;</span>
-      <template v-else>
-        <v-tooltip
-          v-if="internalValue !== null || query !== null"
-          right>
-          <template v-slot:activator="{ on }">
-            <FcButton
-              aria-label="Clear Location"
-              class="mr-1"
-              type="icon"
-              @click="actionClear"
-              v-on="on">
-              <v-icon>mdi-close-circle</v-icon>
-            </FcButton>
+  <div class="fc-input-location-search">
+    <v-menu
+      v-model="showLocationSuggestions"
+      ref="menuLocationSuggestions"
+      :close-on-content-click="false"
+      :offset-y="true"
+      :open-on-click="false">
+      <template v-slot:activator="{ on: onMenu }">
+        <v-text-field
+          v-model="query"
+          autocomplete="off"
+          dense
+          :flat="hasLocationIndex"
+          hide-details
+          label="Choose location or click on the map"
+          :loading="loading"
+          solo
+          @blur="hasFocus = false"
+          @focus="hasFocus = true"
+          @input="actionInput"
+          v-on="onMenu">
+          <template v-slot:append>
+            <span v-if="hasLocationIndex">&nbsp;</span>
+            <template v-else>
+              <v-tooltip
+                v-if="internalValue !== null || query !== null"
+                right>
+                <template v-slot:activator="{ on: onTooltip }">
+                  <FcButton
+                    aria-label="Clear Location"
+                    class="mr-1"
+                    type="icon"
+                    @click="actionClear"
+                    v-on="onTooltip">
+                    <v-icon>mdi-close-circle</v-icon>
+                  </FcButton>
+                </template>
+                <span>Clear Location</span>
+              </v-tooltip>
+              <v-divider vertical />
+              <v-icon right>mdi-magnify</v-icon>
+            </template>
           </template>
-          <span>Clear Location</span>
-        </v-tooltip>
-        <v-divider vertical />
-        <v-icon right>mdi-magnify</v-icon>
+        </v-text-field>
       </template>
-    </template>
-    <template v-slot:item="{ attrs, item, on, parent }">
-      <v-list-item
-        v-bind="attrs"
-        v-on="on">
-        <v-list-item-content>
-          <v-list-item-title>
-            <span>{{item[parent.itemText]}}</span>
-          </v-list-item-title>
-        </v-list-item-content>
-      </v-list-item>
-    </template>
-  </v-autocomplete>
+      <v-list>
+        <v-list-item
+          v-for="(location, i) in locationSuggestions"
+          :key="i"
+          @click="actionSelect(location)">
+          <v-list-item-content>
+            <v-list-item-title>
+              <span>{{location.description}}</span>
+            </v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+      </v-list>
+    </v-menu>
+  </div>
 </template>
 
 <script>
+import { Enum } from '@/lib/ClassUtils';
 import { debounce } from '@/lib/FunctionUtils';
 import { getLocationSuggestions } from '@/lib/api/WebApi';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+
+class LocationSearchState extends Enum {}
+LocationSearchState.init([
+  'VALUE_EMPTY',
+  'QUERY_TYPING',
+  'QUERY_SENT',
+  'SUGGESTIONS_RECEIVED',
+  'VALUE_SELECTED',
+]);
 
 export default {
   name: 'FcInputLocationSearch',
@@ -70,10 +89,16 @@ export default {
     },
   },
   data() {
+    const query = this.value === null ? null : this.value.description;
+    const state = this.value === null
+      ? LocationSearchState.VALUE_EMPTY
+      : LocationSearchState.VALUE_SELECTED;
     return {
-      items: [],
+      hasFocus: false,
       loading: false,
-      query: null,
+      locationSuggestions: [],
+      query,
+      state,
     };
   },
   computed: {
@@ -83,97 +108,73 @@ export default {
     hasLocationToAddIndex() {
       return this.locationIndex === -1;
     },
-  },
-  /*
-   * To understand the following watchers, imagine a state machine:
-   *
-   * 1. selected location...
-   *   a. empty query
-   *   b. query that matches location
-   *   c. query that doesn't match location
-   * 2. no selected location...
-   *   a. empty query
-   *   b. non-empty query
-   *
-   * Transitions between these are explained below.
-   */
-  watch: {
-    internalValue: {
-      handler() {
-        if (this.internalValue !== null) {
-          if (this.hasLocationToAddIndex) {
-            /*
-             * In this case, the user has just selected a location to be added to the
-             * multi-location selection.  We need to pass that new location up, then
-             * clear the search bar state - the parent component can't clear it for us,
-             * and we're reusing the same search bar for the next new location.
-             */
-            this.$emit('location-add', this.internalValue);
-            this.actionClear();
-          } else {
-            /*
-             * 1c -> 1b: the user just selected a location, either via the autocomplete
-             * dropdown or via map interaction.  We need to update the search bar to match.
-             */
-            this.query = this.internalValue.description;
-          }
+    showLocationSuggestions: {
+      get() {
+        return this.hasFocus
+          && this.locationSuggestions.length > 0
+          && this.state === LocationSearchState.SUGGESTIONS_RECEIVED;
+      },
+      set(showLocationSuggestions) {
+        if (!showLocationSuggestions) {
+          this.hasFocus = false;
         }
       },
-      immediate: true,
     },
+  },
+  watch: {
     query: debounce(async function processQuery() {
-      if (this.internalValue !== null) {
-        if (this.query === null) {
+      if (this.state !== LocationSearchState.QUERY_TYPING) {
+        return;
+      }
+      this.loading = true;
+      this.state = LocationSearchState.QUERY_SENT;
+      const locationSuggestions = await getLocationSuggestions(this.query, {});
+      if (this.state !== LocationSearchState.QUERY_SENT) {
+        return;
+      }
+      this.locationSuggestions = locationSuggestions;
+      this.loading = false;
+      this.state = LocationSearchState.SUGGESTIONS_RECEIVED;
+    }, 200),
+    showLocationSuggestions() {
+      if (this.showLocationSuggestions) {
+        this.$refs.menuLocationSuggestions.$el.focus();
+      }
+    },
+    state() {
+      if (this.state === LocationSearchState.VALUE_SELECTED) {
+        if (this.hasLocationToAddIndex) {
           /*
-           * 1a -> 1b: a new search bar instance was just loaded, and we already have a
-           * selected location.  We need to update the search bar to match.
-           *
-           * While setting a value in its own watcher is unusual, we can avoid infinite
-           * recursion by moving through the state machine.
-           */
+            * In this case, the user has just selected a location to be added to the
+            * multi-location selection.  We need to pass that new location up, then
+            * clear the search bar state - the parent component can't clear it for us,
+            * and we're reusing the same search bar for the next new location.
+            */
+          this.$emit('location-add', this.internalValue);
+          this.actionClear();
+        } else {
+          /*
+            * The user just selected a location, either via the autocomplete dropdown or
+            * via map interaction.  We need to update the search bar to match.
+            */
           this.query = this.internalValue.description;
-          return;
         }
-        if (this.query === this.internalValue.description) {
-          /*
-           * 1b: `<v-autocomplete>` gets confused if the list of items doesn't contain
-           * the `v-model` value, so we make a special items list with the selected
-           * location to un-confuse it.
-           */
-          this.items = [this.internalValue];
-          return;
-        }
-        /*
-         * 1c: we already have a selected location, but the user is currently typing
-         * a new query...
-         */
       }
-      if (this.query !== null) {
-        /*
-         * 1c / 2b: the user is currently typing a query.  We need to fetch suggested
-         * locations for that query.
-         *
-         * Once the user selects a suggested location, `location` is updated, triggering
-         * the location watcher to move us into 1b.
-         */
-        this.loading = true;
-        this.items = await getLocationSuggestions(this.query, {});
-        this.loading = false;
-      }
-      /*
-       * 2a: there is no selected location, and no query to search for.  Do nothing.
-       */
-    }, 250),
+    },
   },
   methods: {
     actionClear() {
-      this.items = [];
-      /*
-       * 1b -> 1a -> 2a.  The debounce delay of 250ms on the `query` watcher is more than
-       * enough so that, by the time it fires, we're already in 2a.
-       */
-      this.query = null;
       this.internalValue = null;
+      this.locationSuggestions = [];
+      this.query = null;
+      this.state = LocationSearchState.VALUE_EMPTY;
+    },
+    actionInput() {
+      this.state = LocationSearchState.QUERY_TYPING;
+    },
+    actionSelect(location) {
+      this.internalValue = location;
+      this.state = LocationSearchState.VALUE_SELECTED;
     },
   },
 };

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -84,7 +84,6 @@
             View Data
           </FcButton>
           <FcButton
-            :disabled="locationsEdit.length === 0"
             type="secondary"
             @click="setLocationMode(LocationMode.MULTI_EDIT)">
             <v-icon left>mdi-circle-edit-outline</v-icon>

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -1,17 +1,18 @@
 <template>
   <div class="fc-selector-multi-location d-flex flex-column pa-5 shading">
-    <div class="align-start d-flex flex-grow-1 flex-shrink-1">
+    <div
+      v-if="locationMode === LocationMode.MULTI_EDIT"
+      class="align-start d-flex flex-grow-1 flex-shrink-1">
       <div>
         <div class="fc-input-location-search-wrapper elevation-2">
           <FcInputLocationSearch
             v-for="(_, i) in locationsEdit"
-            :key="locationKeys[i]"
+            :key="locationsEditKeys[i]"
             v-model="locationsEdit[i]"
             :location-index="i"
-            :readonly="locationMode !== LocationMode.MULTI_EDIT"
             @focus="setLocationEditIndex(i)" />
           <FcInputLocationSearch
-            v-if="locationMode === LocationMode.MULTI_EDIT && locations.length < 5"
+            v-if="locations.length < 5"
             v-model="locationToAdd"
             :location-index="-1"
             @focus="setLocationEditIndex(-1)"
@@ -21,9 +22,7 @@
           class="mt-2"
           :value="messagesMaxLocations"></v-messages>
       </div>
-      <div
-        v-if="locationMode === LocationMode.MULTI_EDIT"
-        class="ml-2">
+      <div class="ml-2">
         <div
           v-for="(_, i) in locations"
           :key="'remove_' + i"
@@ -34,6 +33,18 @@
             <v-icon>mdi-close</v-icon>
           </FcButton>
         </div>
+      </div>
+    </div>
+    <div
+      v-else
+      class="flex-grow-1 flex-shrink-1">
+      <div class="fc-input-location-search-wrapper elevation-2">
+        <FcInputLocationSearch
+          v-for="(_, i) in locations"
+          :key="i"
+          v-model="locations[i]"
+          :location-index="i"
+          readonly />
       </div>
     </div>
     <div class="flex-grow-0 flex-shrink-0">
@@ -50,21 +61,15 @@
         </span>
       </h1>
       <div class="d-flex align-center">
-        <v-checkbox
-          v-if="locationMode === LocationMode.MULTI_EDIT"
-          v-model="corridor"
-          class="fc-multi-location-corridor mt-0"
-          hide-details
-          label="Include intersections and midblocks between locations" />
-        <span
-          v-else-if="corridor"
-          class="secondary--text">
-          Includes intersections and midblocks between locations
-        </span>
-
-        <v-spacer></v-spacer>
-
         <template v-if="locationMode === LocationMode.MULTI_EDIT">
+          <v-checkbox
+            v-model="corridor"
+            class="fc-multi-location-corridor mt-0"
+            hide-details
+            label="Include intersections and midblocks between locations" />
+
+          <v-spacer></v-spacer>
+
           <FcButton
             type="tertiary"
             @click="cancelLocationsEdit">
@@ -78,6 +83,15 @@
           </FcButton>
         </template>
         <template v-else>
+
+          <span
+            v-if="corridor"
+            class="secondary--text">
+            Includes intersections and midblocks between locations
+          </span>
+
+          <v-spacer></v-spacer>
+
           <FcButton
             type="tertiary"
             @click="actionViewData">
@@ -122,9 +136,9 @@ export default {
     description() {
       return getLocationsDescription(this.locations);
     },
-    locationKeys() {
+    locationsEditKeys() {
       const keyCounter = new Map();
-      return this.locations.map(({ centrelineId, centrelineType }) => {
+      return this.locationsEdit.map(({ centrelineId, centrelineType }) => {
         const key = centrelineKey(centrelineType, centrelineId);
         let counter = 0;
         if (keyCounter.has(key)) {

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -1,17 +1,22 @@
 <template>
   <div class="fc-selector-multi-location d-flex flex-column pa-5 shading">
     <div class="align-start d-flex flex-grow-1 flex-shrink-1">
-      <div class="fc-input-location-search-wrapper elevation-2">
-        <FcInputLocationSearch
-          v-for="(_, i) in locations"
-          :key="'search_' + i"
-          v-model="locations[i]"
-          :location-index="i" />
-        <FcInputLocationSearch
-          v-if="locations.length < 5"
-          v-model="locationToAdd"
-          :location-index="-1"
-          @location-add="actionAddLocation" />
+      <div>
+        <div class="fc-input-location-search-wrapper elevation-2">
+          <FcInputLocationSearch
+            v-for="(_, i) in locations"
+            :key="locationKeys[i]"
+            v-model="locations[i]"
+            :location-index="i" />
+          <FcInputLocationSearch
+            v-if="locations.length < 5"
+            v-model="locationToAdd"
+            :location-index="-1"
+            @location-add="actionAddLocation" />
+        </div>
+        <v-messages
+          class="mt-2"
+          :value="messagesMaxLocations"></v-messages>
       </div>
       <div class="ml-2">
         <div
@@ -65,6 +70,7 @@
 <script>
 import { mapMutations } from 'vuex';
 
+import { centrelineKey } from '@/lib/Constants';
 import { getLocationsDescription } from '@/lib/geo/CentrelineUtils';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcInputLocationSearch from '@/web/components/inputs/FcInputLocationSearch.vue';
@@ -85,6 +91,24 @@ export default {
   computed: {
     description() {
       return getLocationsDescription(this.locations);
+    },
+    locationKeys() {
+      const keyCounter = new Map();
+      return this.locations.map(({ centrelineId, centrelineType }) => {
+        const key = centrelineKey(centrelineType, centrelineId);
+        let counter = 0;
+        if (keyCounter.has(key)) {
+          counter = keyCounter.get(key) + 1;
+        }
+        keyCounter.set(key, counter);
+        return `${key}_${counter}`;
+      });
+    },
+    messagesMaxLocations() {
+      if (this.locations.length < 5) {
+        return [];
+      }
+      return ['Maximum of 5 selected locations.'];
     },
   },
   methods: {

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 
+import { LocationMode } from '@/lib/Constants';
 import {
   getAuth,
   postStudyRequest,
@@ -42,7 +43,9 @@ export default new Vuex.Store({
     backViewRequest: { name: 'requestsTrack' },
     // LOCATION
     locations: [],
-    locationMulti: false,
+    locationsEdit: [],
+    locationEditIndex: -1,
+    locationMode: LocationMode.SINGLE,
     legendOptions: {
       datesFrom: 3,
       layers: {
@@ -122,11 +125,48 @@ export default new Vuex.Store({
       Vue.set(state, 'backViewRequest', backViewRequest);
     },
     // LOCATION
+    addLocationEdit(state, location) {
+      state.locationsEdit.push(location);
+    },
+    cancelLocationsEdit(state) {
+      if (state.locations.length > 1) {
+        Vue.set(state, 'locationMode', LocationMode.MULTI);
+      } else {
+        Vue.set(state, 'locationMode', LocationMode.SINGLE);
+      }
+    },
+    removeLocationEdit(state, i) {
+      state.locationsEdit.splice(i, 1);
+    },
+    saveLocationsEdit(state) {
+      Vue.set(state, 'locations', state.locationsEdit);
+      Vue.set(state, 'locationsEdit', []);
+      if (state.locations.length > 1) {
+        Vue.set(state, 'locationMode', LocationMode.MULTI);
+      } else {
+        Vue.set(state, 'locationMode', LocationMode.SINGLE);
+      }
+    },
+    setLocationEdit(state, location) {
+      if (state.locationEditIndex === -1) {
+        state.locationsEdit.push(location);
+      } else {
+        Vue.set(state.locationsEdit, state.locationEditIndex, location);
+      }
+    },
+    setLocationEditIndex(state, locationEditIndex) {
+      Vue.set(state, 'locationEditIndex', locationEditIndex);
+    },
+    setLocationMode(state, locationMode) {
+      Vue.set(state, 'locationMode', locationMode);
+      if (locationMode === LocationMode.SINGLE && state.locations.length > 1) {
+        Vue.set(state, 'locations', state.locations.slice(0, 1));
+      } else if (locationMode === LocationMode.MULTI_EDIT) {
+        Vue.set(state, 'locationsEdit', state.locations);
+      }
+    },
     setLocations(state, locations) {
       Vue.set(state, 'locations', locations);
-    },
-    setLocationMulti(state, locationMulti) {
-      Vue.set(state, 'locationMulti', locationMulti);
     },
     setLegendOptions(state, legendOptions) {
       Vue.set(state, 'legendOptions', legendOptions);


### PR DESCRIPTION
# Issue Addressed
This PR makes significant progress on #508 and #511 .

# Description
We update `FcSelectorMultiLocation` to work with both search bar and map interactions, and to properly navigate between View / Edit modes.  In the process, we update `FcInputLocationSearch` to use a state-machine-backed approach - several interaction issues came up in attempting to use the old `<v-autocomplete>`-based implementation in `FcSelectorMultiLocation`.

# Tests
Tested in frontend - will do a more stringent testing pass later on in the multi-location development cycle.
