### PR TITLE
Multi-location selection in map

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -236,6 +236,8 @@ MapZoom.init({
 MapZoom.MIN = MapZoom.LEVEL_3.minzoom;
 MapZoom.MAX = MapZoom.LEVEL_1.maxzoomSource;
 
+const MAX_LOCATIONS = 5;
+
 const ORG_NAME = 'Transportation Services';
 
 /**
@@ -630,6 +632,10 @@ RoadSegmentType.init({
     featureCode: 201700,
     description: 'Laneway',
   },
+  PENDING: {
+    featureCode: 201800,
+    description: 'Pending',
+  },
 });
 
 const SearchKeys = {
@@ -1019,6 +1025,7 @@ const Constants = {
   LocationMode,
   LocationSearchType,
   MapZoom,
+  MAX_LOCATIONS,
   ORG_NAME,
   PageOrientation,
   PageSize,
@@ -1058,6 +1065,7 @@ export {
   LocationMode,
   LocationSearchType,
   MapZoom,
+  MAX_LOCATIONS,
   ORG_NAME,
   PageOrientation,
   PageSize,

--- a/lib/geo/GeoStyle.js
+++ b/lib/geo/GeoStyle.js
@@ -385,10 +385,10 @@ class GeoStyle {
     return STYLE_BASE_MAP_LIGHT;
   }
 
-  static getNonSymbolLayers({ aerial, dark, layers: { collisions, counts, volume } }) {
+  static getNonSymbolLayers({ aerial, dark, layers: { collisions, studies, volume } }) {
     if (aerial) {
       let paint = {};
-      if (collisions || counts || volume) {
+      if (collisions || studies || volume) {
         paint = {
           'raster-brightness-min': 0.2,
           'raster-opacity': 0.8,

--- a/lib/geo/GeoStyle.js
+++ b/lib/geo/GeoStyle.js
@@ -242,7 +242,6 @@ function injectSources(style) {
   addDynamicTileSource(style, 'studies:5', MapZoom.LEVEL_2, MapZoom.LEVEL_1);
   addDynamicTileSource(style, 'studies:10', MapZoom.LEVEL_2, MapZoom.LEVEL_1);
   addGeoJsonSource(style, 'locations');
-  addGeoJsonSource(style, 'active');
 }
 
 injectSources(STYLE_BASE_MAP_DARK);
@@ -439,6 +438,27 @@ class GeoStyle {
         },
       }),
       {
+        id: 'locations-midblocks',
+        source: 'locations',
+        filter: ['==', ['get', 'centrelineType'], CentrelineType.SEGMENT],
+        type: 'line',
+        layout: {
+          'line-cap': 'round',
+          'line-sort-key': ['get', 'aadt'],
+        },
+        paint: {
+          'line-color': '#54a1e5',
+          'line-opacity': 0.5,
+          'line-width': [
+            'interpolate',
+            ['linear'],
+            ['zoom'],
+            MapZoom.LEVEL_3.minzoom, 2,
+            MapZoom.LEVEL_2.minzoom, lineWidth,
+          ],
+        },
+      },
+      {
         id: 'midblocksCasing',
         source: 'midblocks',
         'source-layer': 'midblocks',
@@ -451,6 +471,33 @@ class GeoStyle {
           'line-width': 1,
         },
       },
+      {
+        id: 'locations-midblocksCasing',
+        source: 'locations',
+        filter: ['==', ['get', 'centrelineType'], CentrelineType.SEGMENT],
+        type: 'line',
+        minzoom: MapZoom.LEVEL_2.minzoom,
+        maxzoom: MapZoom.LEVEL_1.maxzoomSource + 1,
+        paint: {
+          'line-color': '#19608c',
+          'line-gap-width': lineWidth,
+          'line-width': 1,
+        },
+      },
+      {
+        id: 'active-midblocksCasing',
+        source: 'midblocks',
+        'source-layer': 'midblocks',
+        filter: ['in', ['get', 'centrelineId'], ['literal', []]],
+        type: 'line',
+        minzoom: MapZoom.LEVEL_2.minzoom,
+        maxzoom: MapZoom.LEVEL_1.maxzoomSource + 1,
+        paint: {
+          'line-color': '#404040',
+          'line-gap-width': lineWidth,
+          'line-width': 1,
+        },
+      },
       getLayer(baseStyle, 'intersections', 'circle', {
         paint: {
           'circle-color': COLOR_CENTRELINE_GREY,
@@ -459,6 +506,33 @@ class GeoStyle {
           'circle-radius': 6,
         },
       }),
+      {
+        id: 'locations-intersections',
+        source: 'locations',
+        filter: ['==', ['get', 'centrelineType'], CentrelineType.INTERSECTION],
+        type: 'circle',
+        paint: {
+          'circle-color': '#54a1e5',
+          'circle-opacity': 0.5,
+          'circle-stroke-color': '#19608c',
+          'circle-stroke-width': 1,
+          'circle-radius': 6,
+        },
+      },
+      {
+        id: 'active-intersections',
+        source: 'intersections',
+        'source-layer': 'intersections',
+        filter: ['in', ['get', 'centrelineId'], ['literal', []]],
+        type: 'circle',
+        paint: {
+          'circle-color': '#54a1e5',
+          'circle-opacity': 0,
+          'circle-stroke-color': '#404040',
+          'circle-stroke-width': 1,
+          'circle-radius': 6,
+        },
+      },
     ];
   }
 
@@ -666,90 +740,10 @@ class GeoStyle {
     return LAYERS_SYMBOL_LIGHT;
   }
 
-  static getInteractionLayers({ layers: { volume } }) {
-    const lineWidth = aadtScaledFeature(volume, WIDTH_VOLUME_LOW, aadtScaleLineWidth);
-    return [
-      {
-        id: 'locations-midblocks',
-        source: 'locations',
-        filter: ['==', ['get', 'centrelineType'], CentrelineType.SEGMENT],
-        type: 'line',
-        layout: {
-          'line-cap': 'round',
-          'line-sort-key': ['get', 'aadt'],
-        },
-        paint: {
-          'line-color': '#54a1e5',
-          'line-opacity': 0.5,
-          'line-width': [
-            'interpolate',
-            ['linear'],
-            ['zoom'],
-            MapZoom.LEVEL_3.minzoom, 2,
-            MapZoom.LEVEL_2.minzoom, lineWidth,
-          ],
-        },
-      },
-      {
-        id: 'locations-midblocksCasing',
-        source: 'locations',
-        filter: ['==', ['get', 'centrelineType'], CentrelineType.SEGMENT],
-        type: 'line',
-        minzoom: MapZoom.LEVEL_2.minzoom,
-        maxzoom: MapZoom.LEVEL_1.maxzoomSource + 1,
-        paint: {
-          'line-color': '#19608c',
-          'line-gap-width': lineWidth,
-          'line-width': 1,
-        },
-      },
-      {
-        id: 'locations-intersections',
-        source: 'locations',
-        filter: ['==', ['get', 'centrelineType'], CentrelineType.INTERSECTION],
-        type: 'circle',
-        paint: {
-          'circle-color': '#54a1e5',
-          'circle-opacity': 0.5,
-          'circle-stroke-color': '#19608c',
-          'circle-stroke-width': 1,
-          'circle-radius': 6,
-        },
-      },
-      {
-        id: 'active-midblocksCasing',
-        source: 'active',
-        filter: ['==', ['get', 'centrelineType'], CentrelineType.SEGMENT],
-        type: 'line',
-        minzoom: MapZoom.LEVEL_2.minzoom,
-        maxzoom: MapZoom.LEVEL_1.maxzoomSource + 1,
-        paint: {
-          'line-color': '#404040',
-          'line-gap-width': lineWidth,
-          'line-width': 1,
-        },
-      },
-      {
-        id: 'active-intersections',
-        source: 'active',
-        filter: ['==', ['get', 'centrelineType'], CentrelineType.INTERSECTION],
-        type: 'circle',
-        paint: {
-          'circle-color': '#54a1e5',
-          'circle-opacity': 0,
-          'circle-stroke-color': '#404040',
-          'circle-stroke-width': 1,
-          'circle-radius': 6,
-        },
-      },
-    ];
-  }
-
   static get(options) {
     const baseStyle = GeoStyle.getBaseStyle(options);
     const nonSymbolLayers = GeoStyle.getNonSymbolLayers(options);
     const featureLayers = GeoStyle.getFeatureLayers(options, baseStyle);
-    const interactionLayers = GeoStyle.getInteractionLayers(options);
     const symbolLayers = GeoStyle.getSymbolLayers(options);
 
     const style = {
@@ -759,7 +753,6 @@ class GeoStyle {
     style.layers = [
       ...nonSymbolLayers,
       ...featureLayers,
-      ...interactionLayers,
       ...symbolLayers,
     ];
 

--- a/lib/geo/GeoStyle.js
+++ b/lib/geo/GeoStyle.js
@@ -242,6 +242,7 @@ function injectSources(style) {
   addDynamicTileSource(style, 'studies:5', MapZoom.LEVEL_2, MapZoom.LEVEL_1);
   addDynamicTileSource(style, 'studies:10', MapZoom.LEVEL_2, MapZoom.LEVEL_1);
   addGeoJsonSource(style, 'locations');
+  addGeoJsonSource(style, 'active');
 }
 
 injectSources(STYLE_BASE_MAP_DARK);
@@ -268,29 +269,6 @@ const COLOR_VOLUME_HIGH = '#14796c';
 const WIDTH_VOLUME_LOW = 3;
 const WIDTH_VOLUME_MED = 5;
 const WIDTH_VOLUME_HIGH = 8;
-
-/**
- * Produces a Mapbox GL style expression that changes the resulting value when a feature
- * is hovered over or selected.
- *
- * Note that this depends on two pieces of feature state, `selected` and `hover`.  These
- * states must be set within a Vue component by `Map#setFeatureState` in response to
- * user interactions.
- *
- * @param {*} base - Mapbox GL style expression, used when feature is neither hovered over
- * nor selected
- * @param {*} hovered - Mapbox GL style expression, used when feature is hovered over
- * @param {*} selected - Mapbox GL style expression, used when feature is selected
- * @returns {*} Mapbox GL style expression that responds to selected and hovered states
- */
-function interactionAttr(base, hovered, selected) {
-  return [
-    'case',
-    ['boolean', ['feature-state', 'selected'], false], selected,
-    ['boolean', ['feature-state', 'hover'], false], hovered,
-    base,
-  ];
-}
 
 /**
  * Produces a "factory function" that can be used to build three-step scales for different
@@ -468,7 +446,7 @@ class GeoStyle {
         minzoom: MapZoom.LEVEL_2.minzoom,
         maxzoom: MapZoom.LEVEL_1.maxzoomSource + 1,
         paint: {
-          'line-color': interactionAttr('#ffffff', '#404040', '#404040'),
+          'line-color': '#ffffff',
           'line-gap-width': lineWidth,
           'line-width': 1,
         },
@@ -476,7 +454,7 @@ class GeoStyle {
       getLayer(baseStyle, 'intersections', 'circle', {
         paint: {
           'circle-color': COLOR_CENTRELINE_GREY,
-          'circle-stroke-color': interactionAttr('#ffffff', '#404040', '#404040'),
+          'circle-stroke-color': '#ffffff',
           'circle-stroke-width': 1,
           'circle-radius': 6,
         },
@@ -688,7 +666,7 @@ class GeoStyle {
     return LAYERS_SYMBOL_LIGHT;
   }
 
-  static getLocationsLayers({ layers: { volume } }) {
+  static getInteractionLayers({ layers: { volume } }) {
     const lineWidth = aadtScaledFeature(volume, WIDTH_VOLUME_LOW, aadtScaleLineWidth);
     return [
       {
@@ -738,6 +716,32 @@ class GeoStyle {
           'circle-radius': 6,
         },
       },
+      {
+        id: 'active-midblocksCasing',
+        source: 'active',
+        filter: ['==', ['get', 'centrelineType'], CentrelineType.SEGMENT],
+        type: 'line',
+        minzoom: MapZoom.LEVEL_2.minzoom,
+        maxzoom: MapZoom.LEVEL_1.maxzoomSource + 1,
+        paint: {
+          'line-color': '#404040',
+          'line-gap-width': lineWidth,
+          'line-width': 1,
+        },
+      },
+      {
+        id: 'active-intersections',
+        source: 'active',
+        filter: ['==', ['get', 'centrelineType'], CentrelineType.INTERSECTION],
+        type: 'circle',
+        paint: {
+          'circle-color': '#54a1e5',
+          'circle-opacity': 0,
+          'circle-stroke-color': '#404040',
+          'circle-stroke-width': 1,
+          'circle-radius': 6,
+        },
+      },
     ];
   }
 
@@ -745,8 +749,8 @@ class GeoStyle {
     const baseStyle = GeoStyle.getBaseStyle(options);
     const nonSymbolLayers = GeoStyle.getNonSymbolLayers(options);
     const featureLayers = GeoStyle.getFeatureLayers(options, baseStyle);
+    const interactionLayers = GeoStyle.getInteractionLayers(options);
     const symbolLayers = GeoStyle.getSymbolLayers(options);
-    const locationsLayers = GeoStyle.getLocationsLayers(options);
 
     const style = {
       ...baseStyle,
@@ -755,8 +759,8 @@ class GeoStyle {
     style.layers = [
       ...nonSymbolLayers,
       ...featureLayers,
+      ...interactionLayers,
       ...symbolLayers,
-      ...locationsLayers,
     ];
 
     return style;

--- a/lib/geo/GeoStyle.js
+++ b/lib/geo/GeoStyle.js
@@ -1,4 +1,4 @@
-import { MapZoom, RoadSegmentType } from '@/lib/Constants';
+import { CentrelineType, MapZoom, RoadSegmentType } from '@/lib/Constants';
 import rootStyleDark from '@/lib/geo/theme/dark/root.json';
 import metadataDark from '@/lib/geo/theme/dark/metadata.json';
 import rootStyleLight from '@/lib/geo/theme/light/root.json';
@@ -196,6 +196,27 @@ function addDynamicTileSource(style, id, minLevel, maxLevel) {
   };
 }
 
+/*
+ * Vector sources refer to URLs, and can be reloaded from those URLs when `GeoStyle` map
+ * options change.  To achieve the same thing with GeoJSON, we need to maintain a single
+ * data reference that is shared between all base styles.
+ */
+const CACHE_GEOJSON = {};
+
+function addGeoJsonSource(style, id) {
+  if (!Object.prototype.hasOwnProperty.call(CACHE_GEOJSON, id)) {
+    CACHE_GEOJSON[id] = {
+      type: 'FeatureCollection',
+      features: [],
+    };
+  }
+  /* eslint-disable-next-line no-param-reassign */
+  style.sources[id] = {
+    type: 'geojson',
+    data: CACHE_GEOJSON[id],
+  };
+}
+
 function injectSources(style) {
   // SOURCES
   addTippecanoeSource(style, 'collisionsLevel3:1', MapZoom.LEVEL_3, MapZoom.LEVEL_3, 2);
@@ -220,6 +241,7 @@ function injectSources(style) {
   addDynamicTileSource(style, 'studies:3', MapZoom.LEVEL_2, MapZoom.LEVEL_1);
   addDynamicTileSource(style, 'studies:5', MapZoom.LEVEL_2, MapZoom.LEVEL_1);
   addDynamicTileSource(style, 'studies:10', MapZoom.LEVEL_2, MapZoom.LEVEL_1);
+  addGeoJsonSource(style, 'locations');
 }
 
 injectSources(STYLE_BASE_MAP_DARK);
@@ -349,6 +371,8 @@ function aadtScaledFeature(volume, defaultValue, aadtScale) {
     ],
   ];
 }
+
+// MAIN CLASS
 
 function getLayer(style, id, type, options) {
   const source = style.sources[id];
@@ -664,11 +688,65 @@ class GeoStyle {
     return LAYERS_SYMBOL_LIGHT;
   }
 
+  static getLocationsLayers({ layers: { volume } }) {
+    const lineWidth = aadtScaledFeature(volume, WIDTH_VOLUME_LOW, aadtScaleLineWidth);
+    return [
+      {
+        id: 'locations-midblocks',
+        source: 'locations',
+        filter: ['==', ['get', 'centrelineType'], CentrelineType.SEGMENT],
+        type: 'line',
+        layout: {
+          'line-cap': 'round',
+          'line-sort-key': ['get', 'aadt'],
+        },
+        paint: {
+          'line-color': '#54a1e5',
+          'line-opacity': 0.5,
+          'line-width': [
+            'interpolate',
+            ['linear'],
+            ['zoom'],
+            MapZoom.LEVEL_3.minzoom, 2,
+            MapZoom.LEVEL_2.minzoom, lineWidth,
+          ],
+        },
+      },
+      {
+        id: 'locations-midblocksCasing',
+        source: 'locations',
+        filter: ['==', ['get', 'centrelineType'], CentrelineType.SEGMENT],
+        type: 'line',
+        minzoom: MapZoom.LEVEL_2.minzoom,
+        maxzoom: MapZoom.LEVEL_1.maxzoomSource + 1,
+        paint: {
+          'line-color': '#19608c',
+          'line-gap-width': lineWidth,
+          'line-width': 1,
+        },
+      },
+      {
+        id: 'locations-intersections',
+        source: 'locations',
+        filter: ['==', ['get', 'centrelineType'], CentrelineType.INTERSECTION],
+        type: 'circle',
+        paint: {
+          'circle-color': '#54a1e5',
+          'circle-opacity': 0.5,
+          'circle-stroke-color': '#19608c',
+          'circle-stroke-width': 1,
+          'circle-radius': 6,
+        },
+      },
+    ];
+  }
+
   static get(options) {
     const baseStyle = GeoStyle.getBaseStyle(options);
     const nonSymbolLayers = GeoStyle.getNonSymbolLayers(options);
     const featureLayers = GeoStyle.getFeatureLayers(options, baseStyle);
     const symbolLayers = GeoStyle.getSymbolLayers(options);
+    const locationsLayers = GeoStyle.getLocationsLayers(options);
 
     const style = {
       ...baseStyle,
@@ -678,9 +756,14 @@ class GeoStyle {
       ...nonSymbolLayers,
       ...featureLayers,
       ...symbolLayers,
+      ...locationsLayers,
     ];
 
     return style;
+  }
+
+  static setData(id, data) {
+    CACHE_GEOJSON[id] = data;
   }
 }
 

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -158,7 +158,7 @@ export default {
     return {
       aerial: false,
       coordinates: null,
-      // used to add slight debounce delay (250ms) to hovered popup
+      // used to add slight debounce delay (200ms) to hovered popup
       featureKeyHoveredPopup: null,
       // keeps track of which feature we are currently hovering over
       hoveredFeature: null,
@@ -359,7 +359,7 @@ export default {
     },
     hoveredFeature: debounce(function watchHoveredFeature() {
       this.featureKeyHoveredPopup = this.featureKeyHovered;
-    }, 250),
+    }, 200),
     mapStyle() {
       this.map.setStyle(this.mapStyle);
     },
@@ -409,7 +409,12 @@ export default {
             });
           }
         });
-        const cameraOptions = this.map.cameraForBounds(bounds, { padding: 40 });
+
+        // zoom to bounding box
+        const cameraOptions = this.map.cameraForBounds(bounds, {
+          maxZoom: MapZoom.LEVEL_1.minzoom,
+          padding: 64,
+        });
         cameraOptions.zoom = Math.max(this.map.getZoom(), cameraOptions.zoom);
         this.map.easeTo(cameraOptions);
       } else if (locationsPrev.length === 0) {
@@ -506,7 +511,7 @@ export default {
     },
     onMapMove: debounce(function onMapMove() {
       this.updateCoordinates();
-    }, 250),
+    }, 1000),
     openGoogleMaps() {
       if (this.coordinates === null) {
         return;

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -365,6 +365,15 @@ export default {
     }, 200),
     mapStyle() {
       this.map.setStyle(this.mapStyle);
+      this.updateLocationsLayers();
+      this.map.setFilter(
+        'active-intersections',
+        ['in', ['get', 'centrelineId'], ['literal', this.centrelineActiveIntersections]],
+      );
+      this.map.setFilter(
+        'active-midblocksCasing',
+        ['in', ['get', 'centrelineId'], ['literal', this.centrelineActiveMidblocks]],
+      );
     },
     locations(locations, locationsPrev) {
       this.easeToLocations(locations, locationsPrev);

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -222,7 +222,10 @@ export default {
       },
     },
     locationsGeoJson() {
-      const features = this.locations.map(
+      const featureLocations = this.locationMode === LocationMode.MULTI_EDIT
+        ? this.locationsEdit
+        : this.locations;
+      const features = featureLocations.map(
         ({ geom: geometry, ...properties }) => ({ type: 'Feature', geometry, properties }),
       );
       return {

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -183,7 +183,8 @@ export default {
       const { relatedTarget: $relatedTarget } = e;
       if ($relatedTarget !== null) {
         const $list = $relatedTarget.closest('.fc-list-location-suggestions');
-        if ($list === this.$refs.listLocationSuggestions.$el) {
+        if (this.$refs.listLocationSuggestions !== undefined
+          && $list === this.$refs.listLocationSuggestions.$el) {
           return;
         }
       }

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -183,6 +183,12 @@ export default {
       const { relatedTarget: $relatedTarget } = e;
       if ($relatedTarget !== null) {
         const $list = $relatedTarget.closest('.fc-list-location-suggestions');
+        /*
+         * From the [lifecycle diagram](https://vuejs.org/v2/guide/instance.html#Lifecycle-Diagram),
+         * child components are created after the parent.  Until the `<v-list>` component is
+         * created, `this.$refs.listLocationSuggestions` is undefined, and since `blur` can
+         * trigger pretty early on in the lifecycle we check for that here.
+         */
         if (this.$refs.listLocationSuggestions !== undefined
           && $list === this.$refs.listLocationSuggestions.$el) {
           return;

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -3,6 +3,8 @@
     <v-menu
       v-model="showLocationSuggestions"
       ref="menuLocationSuggestions"
+      :attach="$el"
+      :close-on-click="false"
       :close-on-content-click="false"
       :offset-y="true"
       :open-on-click="false">
@@ -17,7 +19,7 @@
           :loading="loading"
           solo
           v-bind="$attrs"
-          @blur="hasFocus = false"
+          @blur="actionBlur"
           @focus="actionFocus"
           @input="actionInput"
           v-on="onMenu">
@@ -45,7 +47,9 @@
           </template>
         </v-text-field>
       </template>
-      <v-list>
+      <v-list
+        ref="listLocationSuggestions"
+        class="fc-list-location-suggestions">
         <v-list-item
           v-for="(location, i) in locationSuggestions"
           :key="i"
@@ -109,17 +113,10 @@ export default {
     hasLocationToAddIndex() {
       return this.locationIndex === -1;
     },
-    showLocationSuggestions: {
-      get() {
-        return this.hasFocus
-          && this.locationSuggestions.length > 0
-          && this.state === LocationSearchState.SUGGESTIONS_RECEIVED;
-      },
-      set(showLocationSuggestions) {
-        if (!showLocationSuggestions) {
-          this.hasFocus = false;
-        }
-      },
+    showLocationSuggestions() {
+      return this.hasFocus
+        && this.locationSuggestions.length > 0
+        && this.state === LocationSearchState.SUGGESTIONS_RECEIVED;
     },
   },
   watch: {
@@ -169,6 +166,28 @@ export default {
       this.locationSuggestions = [];
       this.query = null;
       this.state = LocationSearchState.VALUE_EMPTY;
+      if (this.hasLocationIndex && !this.hasLocationToAddIndex) {
+        this.$emit('location-remove', this.locationIndex);
+      }
+    },
+    actionBlur(e) {
+      /*
+       * Clicking a location suggestion in the dropdown triggers a blur event.  However, if
+       * we set `this.hasFocus = false` immediately, the dropdown disappears before the `@click`
+       * handler is processed.
+       *
+       * By detecting this case here, we allow the state transition to
+       * `LocationSearchState.VALUE_SELECTED` within `actionSelect` to hide the dropdown instead,
+       * after the `@click` handler is processed.
+       */
+      const { relatedTarget: $relatedTarget } = e;
+      if ($relatedTarget !== null) {
+        const $list = $relatedTarget.closest('.fc-list-location-suggestions');
+        if ($list === this.$refs.listLocationSuggestions.$el) {
+          return;
+        }
+      }
+      this.hasFocus = false;
     },
     actionFocus() {
       this.hasFocus = true;

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -10,7 +10,8 @@
             :key="locationsEditKeys[i]"
             v-model="locationsEdit[i]"
             :location-index="i"
-            @focus="setLocationEditIndex(i)" />
+            @focus="setLocationEditIndex(i)"
+            @location-remove="removeLocationEdit" />
           <FcInputLocationSearch
             v-if="locations.length < 5"
             v-model="locationToAdd"

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -11,9 +11,9 @@
             v-model="locationsEdit[i]"
             :location-index="i"
             @focus="setLocationEditIndex(i)"
-            @location-remove="removeLocationEdit" />
+            @location-remove="actionRemove" />
           <FcInputLocationSearch
-            v-if="locations.length < 5"
+            v-if="locations.length < MAX_LOCATIONS"
             v-model="locationToAdd"
             :location-index="-1"
             @focus="setLocationEditIndex(-1)"
@@ -113,7 +113,7 @@
 <script>
 import { mapMutations, mapState } from 'vuex';
 
-import { centrelineKey, LocationMode } from '@/lib/Constants';
+import { centrelineKey, LocationMode, MAX_LOCATIONS } from '@/lib/Constants';
 import { getLocationsDescription } from '@/lib/geo/CentrelineUtils';
 import CompositeId from '@/lib/io/CompositeId';
 import FcButton from '@/web/components/inputs/FcButton.vue';
@@ -131,6 +131,7 @@ export default {
       locationIndexActive: -1,
       LocationMode,
       locationToAdd: null,
+      MAX_LOCATIONS,
     };
   },
   computed: {
@@ -150,17 +151,21 @@ export default {
       });
     },
     messagesMaxLocations() {
-      if (this.locations.length < 5) {
+      if (this.locations.length < MAX_LOCATIONS) {
         return [];
       }
       if (this.locationMode !== LocationMode.MULTI_EDIT) {
         return [];
       }
-      return ['Maximum of 5 selected locations.'];
+      return [`Maximum of ${MAX_LOCATIONS} selected locations.`];
     },
     ...mapState(['locations', 'locationsEdit', 'locationMode']),
   },
   methods: {
+    actionRemove(i) {
+      this.setLocationEditIndex(-1);
+      this.removeLocationEdit(i);
+    },
     actionViewData() {
       const s1 = CompositeId.encode(this.locations);
       this.$router.push({

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -13,7 +13,7 @@
             @focus="setLocationEditIndex(i)"
             @location-remove="actionRemove" />
           <FcInputLocationSearch
-            v-if="locations.length < MAX_LOCATIONS"
+            v-if="locationsEdit.length < MAX_LOCATIONS"
             v-model="locationToAdd"
             :location-index="-1"
             @focus="setLocationEditIndex(-1)"
@@ -151,10 +151,8 @@ export default {
       });
     },
     messagesMaxLocations() {
-      if (this.locations.length < MAX_LOCATIONS) {
-        return [];
-      }
-      if (this.locationMode !== LocationMode.MULTI_EDIT) {
+      if (this.locationMode !== LocationMode.MULTI_EDIT
+        || this.locationsEdit.length < MAX_LOCATIONS) {
         return [];
       }
       return [`Maximum of ${MAX_LOCATIONS} selected locations.`];

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -139,7 +139,7 @@ export default new Vuex.Store({
       state.locationsEdit.splice(i, 1);
     },
     saveLocationsEdit(state) {
-      Vue.set(state, 'locations', state.locationsEdit);
+      Vue.set(state, 'locations', [...state.locationsEdit]);
       Vue.set(state, 'locationsEdit', []);
       if (state.locations.length > 1) {
         Vue.set(state, 'locationMode', LocationMode.MULTI);
@@ -162,7 +162,7 @@ export default new Vuex.Store({
       if (locationMode === LocationMode.SINGLE && state.locations.length > 1) {
         Vue.set(state, 'locations', state.locations.slice(0, 1));
       } else if (locationMode === LocationMode.MULTI_EDIT) {
-        Vue.set(state, 'locationsEdit', state.locations);
+        Vue.set(state, 'locationsEdit', [...state.locations]);
       }
     },
     setLocations(state, locations) {

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -167,6 +167,11 @@ export default new Vuex.Store({
     },
     setLocations(state, locations) {
       Vue.set(state, 'locations', locations);
+      if (state.locations.length > 1) {
+        Vue.set(state, 'locationMode', LocationMode.MULTI);
+      } else {
+        Vue.set(state, 'locationMode', LocationMode.SINGLE);
+      }
     },
     setLegendOptions(state, legendOptions) {
       Vue.set(state, 'legendOptions', legendOptions);


### PR DESCRIPTION
# Issue Addressed
This PR closes #508 .

# Description
We update `FcPaneMap` to handle multi-location selections by adding new `locations` and `active` centreline layers.  `locations` layers are backed by a GeoJSON source that is updated to match the `locations` state from `vuex`, while `active` layers use Mapbox GL [filter expressions](https://docs.mapbox.com/mapbox-gl-js/example/query-similar-features/) to reflect hover / click interactions with individual map features.

As part of this, we also sever the connection between the selected location and hovered / selected features on the map - these must now be set separately.  We also refactor `easeToLocation` into the new `easeToLocations`, which builds a bounding box on multiple features before zooming.

Finally, we resolve an interaction bug with blur / focus states in `FcInputLocationSearch`.

# Tests
Quick manual testing in frontend.