### PR TITLE
Backend implementation of corridor interpolation 

### DIFF
--- a/lib/ArrayUtils.js
+++ b/lib/ArrayUtils.js
@@ -218,6 +218,36 @@ class ArrayUtils {
     });
     return groups;
   }
+
+  /**
+   * Similar to the UNIX utility `uniq` and lodash's `_.sortedUniq`, returns `xs` with
+   * consecutive similar values removed.  Two values `x1`, `x2` are similar iff
+   * `key(x1) === key(x2)`.
+   *
+   * Note that this does not handle non-consecutive similar values.
+   *
+   * @param {Array} xs
+   * @param {ComparisonKey} key
+   * @see https://lodash.com/docs/4.17.15#sortedUniq
+   */
+  static consecutiveUniqBy(xs, key) {
+    const n = xs.length;
+    if (n === 0) {
+      return [];
+    }
+    let x = xs[0];
+    const xsConsecutiveUniq = [x];
+    let kPrev = key(x);
+    for (let i = 1; i < n; i++) {
+      x = xs[i];
+      const k = key(x);
+      if (k !== kPrev) {
+        xsConsecutiveUniq.push(x);
+        kPrev = k;
+      }
+    }
+    return xsConsecutiveUniq;
+  }
 }
 
 export default ArrayUtils;

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -87,6 +87,16 @@ async function getLocationByCentreline(feature) {
   return location;
 }
 
+async function getLocationsByCorridor(features) {
+  if (features.length === 0) {
+    return [];
+  }
+  const s1 = CompositeId.encode(features);
+  const data = { s1 };
+  const options = { data };
+  return apiClient.fetch('/locations/byCorridor', options);
+}
+
 async function getLocationSuggestions(query, filters) {
   if (query.length < 3) {
     return [];
@@ -382,6 +392,7 @@ const WebApi = {
   getCollisionsByCentrelineTotal,
   getLocationByCentreline,
   getLocationsByCentreline,
+  getLocationsByCorridor,
   getLocationSuggestions,
   getPoiByCentrelineSummary,
   getReport,
@@ -411,6 +422,7 @@ export {
   getCollisionsByCentrelineTotal,
   getLocationByCentreline,
   getLocationsByCentreline,
+  getLocationsByCorridor,
   getLocationSuggestions,
   getPoiByCentrelineSummary,
   getReport,

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -17,6 +17,7 @@ import StudyRequestChange from '@/lib/model/StudyRequestChange';
 import StudyRequestComment from '@/lib/model/StudyRequestComment';
 import SuccessResponse from '@/lib/model/SuccessResponse';
 import User from '@/lib/model/User';
+import CentrelineLocation from '@/lib/model/helpers/CentrelineLocation';
 
 const apiClient = new BackendClient('/api');
 const reporterClient = new BackendClient('/reporter');
@@ -78,7 +79,9 @@ async function getLocationsByCentreline(features) {
   const s1 = CompositeId.encode(features);
   const data = { s1 };
   const options = { data };
-  return apiClient.fetch('/locations/byCentreline', options);
+  const locations = await apiClient.fetch('/locations/byCentreline', options);
+  const locationsSchema = Joi.array().items(CentrelineLocation);
+  return locationsSchema.validateAsync(locations);
 }
 
 async function getLocationByCentreline(feature) {
@@ -94,7 +97,9 @@ async function getLocationsByCorridor(features) {
   const s1 = CompositeId.encode(features);
   const data = { s1 };
   const options = { data };
-  return apiClient.fetch('/locations/byCorridor', options);
+  const locations = await apiClient.fetch('/locations/byCorridor', options);
+  const locationsSchema = Joi.array().items(CentrelineLocation);
+  return locationsSchema.validateAsync(locations);
 }
 
 async function getLocationSuggestions(query, filters) {
@@ -108,7 +113,9 @@ async function getLocationSuggestions(query, filters) {
       ...filters,
     },
   };
-  return apiClient.fetch('/locations/suggest', options);
+  const locations = await apiClient.fetch('/locations/suggest', options);
+  const locationsSchema = Joi.array().items(CentrelineLocation);
+  return locationsSchema.validateAsync(locations);
 }
 
 async function getPoiByCentrelineSummary(feature) {

--- a/lib/controller/LocationController.js
+++ b/lib/controller/LocationController.js
@@ -1,8 +1,12 @@
+import Boom from '@hapi/boom';
+
 import { CentrelineType, LocationSearchType } from '@/lib/Constants';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import LocationSearchDAO from '@/lib/db/LocationSearchDAO';
+import RoutingDAO from '@/lib/db/RoutingDAO';
 import CompositeId from '@/lib/io/CompositeId';
 import Joi from '@/lib/model/Joi';
+import CentrelineLocation from '@/lib/model/helpers/CentrelineLocation';
 import CentrelineSelection from '@/lib/model/helpers/CentrelineSelection';
 
 /**
@@ -26,6 +30,9 @@ LocationController.push({
   path: '/locations/suggest',
   options: {
     auth: { mode: 'try' },
+    response: {
+      schema: Joi.array().items(CentrelineLocation),
+    },
     validate: {
       query: {
         limit: Joi
@@ -112,6 +119,9 @@ LocationController.push({
   path: '/locations/byCentreline',
   options: {
     auth: { mode: 'try' },
+    response: {
+      schema: Joi.array().items(CentrelineLocation),
+    },
     validate: {
       query: CentrelineSelection,
     },
@@ -119,6 +129,36 @@ LocationController.push({
   handler: async (request) => {
     const { s1: features } = request.query;
     return CentrelineDAO.byFeatures(features);
+  },
+});
+
+/**
+ * Fetch centreline locations that make up a corridor connecting the features in the given
+ * centreline selection.
+ *
+ * @memberof LocationController
+ * @name getLocationsByCorridor
+ * @type {Hapi.ServerRoute}
+ */
+LocationController.push({
+  method: 'GET',
+  path: '/locations/byCorridor',
+  options: {
+    auth: { mode: 'try' },
+    response: {
+      schema: Joi.array().items(CentrelineLocation),
+    },
+    validate: {
+      query: CentrelineSelection,
+    },
+  },
+  handler: async (request) => {
+    const { s1: features } = request.query;
+    const corridor = await RoutingDAO.routeCorridor(features);
+    if (corridor === null) {
+      return Boom.notFound('no corridor found on the given location selection');
+    }
+    return CentrelineDAO.byFeatures(corridor);
   },
 });
 

--- a/lib/db/LocationSearchDAO.js
+++ b/lib/db/LocationSearchDAO.js
@@ -116,10 +116,9 @@ LIMIT $(limit);`;
      * Although we don't currently surface the score anywhere in the frontend, we preserve
      * them in the results in case they prove helpful eventually.
      */
-    const intersectionsExact = rowsExact.map(({ score, ...intersection }) => ({
-      score,
-      ...intersectionToFeature(intersection),
-    }));
+    const intersectionsExact = rowsExact.map(
+      ({ score, ...intersection }) => intersectionToFeature(intersection),
+    );
 
     /*
      * If we have enough results, stop; otherwise, continue to approximate matching and
@@ -170,10 +169,9 @@ LIMIT $(limitApprox);`;
       limitApprox,
       query,
     });
-    const intersectionsApprox = rowsApprox.map(({ score, ...intersection }) => ({
-      score,
-      ...intersectionToFeature(intersection),
-    }));
+    const intersectionsApprox = rowsApprox.map(
+      ({ score, ...intersection }) => intersectionToFeature(intersection),
+    );
     return intersectionsExact.concat(intersectionsApprox);
   }
 

--- a/lib/db/RoutingDAO.js
+++ b/lib/db/RoutingDAO.js
@@ -1,0 +1,269 @@
+import ArrayUtils from '@/lib/ArrayUtils';
+import { centrelineKey, CentrelineType } from '@/lib/Constants';
+import db from '@/lib/db/db';
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
+
+/**
+ * @typedef {Object} IntersectionRoutingResult
+ * @property {number} cost - total cost of the route
+ * @property {Array<CentrelineFeature>} route - list of features representing the route
+ */
+
+/**
+ * @typedef {Object} FeatureRoutingResult
+ * @property {number} next - next intersection to continue routing from
+ * @property {Array<CentrelineFeature>} route - list of feature representing the route
+ */
+
+/**
+ * Data access layer for centreline routing.  This was originally added to support corridor
+ * interpolation for multi-location selections.
+ *
+ * A route is a (possibly empty) sequence of alternating intersections and midblocks connecting
+ * zero or more waypoint features.  Although in general any set of two or more waypoints will
+ * have many such routes connecting them, this class always looks for the single "best" route
+ * using shortest-path algorithms available in the `pgrouting` extension.
+ *
+ * Note that these methods return routes as a sequence of {@link CentrelineFeature} objects.  If
+ * you need the entire location metadata, use {@link CentrelineDAO.byFeatures} to resolve the
+ * resulting features to locations.
+ */
+class RoutingDAO {
+  /**
+   *
+   * @param {number} intersectionFrom - intersection to route from
+   * @param {number} intersectionTo - intersection to route to
+   * @returns {IntersectionRoutingResult?} best route between `intersectionFrom` and
+   * `intersectionTo`, excluding `intersectionFrom` but including `intersectionTo`,
+   * or `null` if no such route exists
+   */
+  static async routeIntersections(intersectionFrom, intersectionTo) {
+    if (intersectionFrom === intersectionTo) {
+      return [];
+    }
+    const sqlVertices = `
+SELECT ST_X(geom) AS x, ST_Y(geom) AS y
+FROM routing.centreline_vertices
+WHERE id IN (:intersectionFrom, :intersectionTo)`;
+    const rowsVertices = await db.manyOrNone(sqlVertices, { intersectionFrom, intersectionTo });
+    if (rowsVertices.length !== 2) {
+      return null;
+    }
+    let [{ x: xmin, y: ymin }, { x: xmax, y: ymax }] = rowsVertices;
+    if (xmin > xmax) {
+      const temp = xmin;
+      xmin = xmax;
+      xmax = temp;
+    }
+    if (ymin > ymax) {
+      const temp = ymin;
+      ymin = ymax;
+      ymax = temp;
+    }
+
+    const sqlRouting = `
+SELECT node, edge, agg_cost AS "aggCost"
+FROM pgr_astar(
+  'WITH vertices AS (
+    SELECT id
+    FROM routing.centreline_vertices
+    WHERE ST_DWithin(
+      geom,
+      ST_MakeEnvelope(${xmin}, ${ymin}, ${xmax}, ${ymax}, 2952),
+      500
+    )
+  )
+  SELECT e.*
+  FROM routing.centreline_edges e
+  JOIN vertices vs ON e.source = vs.id
+  JOIN vertices vt ON e.target = vt.id',
+  :intersectionFrom,
+  :intersectionTo,
+  FALSE
+)
+ORDER BY seq ASC, path_seq ASC`;
+    const rowsRouting = await db.manyOrNone(sqlRouting, { intersectionFrom, intersectionTo });
+    if (rowsRouting.length === 0) {
+      /*
+       * As per [documentation](https://docs.pgrouting.org/2.4/en/pgr_aStar.html#pgr-astar),
+       * `pgr_astar` returns the empty set if no route could be found.
+       */
+      return null;
+    }
+
+    const route = [];
+    rowsRouting.forEach(({ node, edge }, i) => {
+      if (edge !== -1) {
+        route.push({
+          centrelineType: CentrelineType.SEGMENT,
+          centrelineId: edge,
+        });
+      }
+      if (i > 0) {
+        route.push({
+          centrelineType: CentrelineType.INTERSECTION,
+          centrelineId: node,
+        });
+      }
+    });
+    const cost = rowsRouting[rowsRouting.length - 1].aggCost;
+    return { cost, route };
+  }
+
+  /**
+   *
+   * @param {CentrelineFeature} feature
+   * @returns {Array<number>} if `feature` is an intersection, its ID; otherwise,
+   * the intersection IDs of the two midblock endpoints
+   */
+  static async getRoutableIntersections(feature) {
+    const { centrelineId, centrelineType } = feature;
+    if (centrelineType === CentrelineType.INTERSECTION) {
+      return [centrelineId];
+    }
+    const intersections = await CentrelineDAO.intersectionsIncidentTo(centrelineId);
+    return intersections.map(intersection => intersection.centrelineId);
+  }
+
+  /**
+   *
+   * @param {Array<number>} intersections - array of intersections of length 1 or 2
+   * @param {number} intersection - one of the intersections
+   * @returns {number} if `intersections.length === 2`, the other intersection; otherwise,
+   * `intersection` itself (so that we can continue routing if only one intersection was
+   * found for whatever reason)
+   */
+  static getOtherIntersection(intersections, intersection) {
+    if (intersections.length === 2 && intersection === intersections[0]) {
+      return intersections[1];
+    }
+    return intersections[0];
+  }
+
+  /**
+   *
+   * @param {CentrelineFeature} featureFrom - feature to route from
+   * @param {CentrelineFeature} featureTo - feature to route to
+   * @returns {FeatureRoutingResult?} best route between `featureFrom` and
+   * `featureTo`, excluding `featureFrom` but including `featureTo`, or `null`
+   * if no such route exists
+   */
+  static async routeFeatures(featureFrom, featureTo) {
+    // 1. route all pairs of intersections
+    const [intersectionsFrom, intersectionsTo] = await Promise.all([
+      RoutingDAO.getRoutableIntersections(featureFrom),
+      RoutingDAO.getRoutableIntersections(featureTo),
+    ]);
+    if (intersectionsFrom.length === 0 || intersectionsTo.length === 0) {
+      return null;
+    }
+    const intersectionPairs = [];
+    intersectionsFrom.forEach((intersectionFrom) => {
+      intersectionsTo.forEach((intersectionTo) => {
+        intersectionPairs.push([intersectionFrom, intersectionTo]);
+      });
+    });
+    const results = await Promise.all(intersectionPairs.map(
+      ([intersectionFrom, intersectionTo]) => RoutingDAO.routeIntersections(
+        intersectionFrom,
+        intersectionTo,
+      ),
+    ));
+
+    // 2. identify best route among all pairs
+    const bestResultIndex = ArrayUtils.getMinIndexBy(
+      results,
+      result => (result === null ? Infinity : result.cost),
+    );
+    const bestResult = results[bestResultIndex];
+    if (bestResult === null) {
+      return null;
+    }
+    const { route: bestRoute } = bestResult;
+    const [intersectionFrom, intersectionTo] = intersectionPairs[bestResultIndex];
+
+    // 3. build result
+    const isIntersectionFrom = featureFrom.centrelineType === CentrelineType.INTERSECTION;
+    const isIntersectionTo = featureTo.centrelineType === CentrelineType.INTERSECTION;
+    if (isIntersectionFrom) {
+      if (isIntersectionTo) {
+        // 3a. from intersection to intersection
+        return { next: featureTo, route: bestRoute };
+      }
+      /*
+       * 3b. from intersection to midblock - in this case, we've routed to one of the endpoints
+       * of `toFeature`.  We need to add `toFeature` to that route, and return its other endpoint
+       * as the next feature to continue routing from.
+       */
+      const route = [...bestRoute, featureTo];
+      const next = RoutingDAO.getOtherIntersection(intersectionsTo, intersectionTo);
+      return { next, route };
+    }
+    const routeFrom = {
+      centrelineId: intersectionFrom,
+      centrelineType: CentrelineType.INTERSECTION,
+    };
+    if (isIntersectionTo) {
+      /*
+       * 3c. from midblock to intersection - in this case, we've routed from one of the endpoints
+       * of `fromFeature`.  We need to add that endpoint to the beginning of the route.
+       */
+      const route = [routeFrom, ...bestRoute];
+      return { next: featureTo, route };
+    }
+    /*
+     * 3d. from midblock to midblock - here both of the additional requirements in 3b and 3c
+     * apply.
+     */
+    const route = [routeFrom, ...bestRoute, featureTo];
+    const next = RoutingDAO.getOtherIntersection(intersectionsTo, intersectionTo);
+    return { next, route };
+  }
+
+  /**
+   * Returns a corridor on the given waypoint features.  Note that this makes at least `n - 1`
+   * calls (and possibly as many as `2n` calls) to `pgr_astar`, which can be expensive for
+   * large waypoint sets or over waypoints that are far apart.  Furthermore, these calls
+   * are not parallelized - we sequentially route over each consecutive pair of features,
+   * using the information of previous calls to help resolve routes that involve midblock
+   * waypoints.
+   *
+   * For these reasons, user-facing APIs that call this method should consider placing
+   * limitations on use (e.g. size of input set, distance covered, rate limiting, etc.)
+   *
+   * A corridor over the waypoint features exists if and only if all such `pgr_astar` calls
+   * return a valid route.  This method does not attempt to route "partial" corridors.
+   *
+   * @param {Array<CentrelineFeature>} features - waypoints to connect with corridor
+   * @returns {Array<CentrelineFeature>?} corridor connecting waypoints, or `null` if no such
+   * corridor exists
+   */
+  static async corridorByFeatures(features) {
+    const n = features.length;
+    if (n < 2) {
+      return features;
+    }
+    let featureFrom = features[0];
+    const corridor = [featureFrom];
+    for (let i = 1; i < n; i++) {
+      const featureTo = features[i];
+      /* eslint-disable-next-line no-await-in-loop */
+      const result = await RoutingDAO.fromFeatureToFeature(featureFrom, featureTo);
+      if (result === null) {
+        return null;
+      }
+      const { route, next } = result;
+      featureFrom = {
+        centrelineId: next,
+        centrelineType: CentrelineType.INTERSECTION,
+      };
+      corridor.push(...route);
+      if (i < n - 1 && centrelineKey(featureFrom) !== centrelineKey(featureTo)) {
+        corridor.push(featureFrom);
+      }
+    }
+    return corridor;
+  }
+}
+
+export default RoutingDAO;

--- a/lib/db/RoutingDAO.js
+++ b/lib/db/RoutingDAO.js
@@ -1,5 +1,5 @@
 import ArrayUtils from '@/lib/ArrayUtils';
-import { centrelineKey, CentrelineType } from '@/lib/Constants';
+import { CentrelineType } from '@/lib/Constants';
 import db from '@/lib/db/db';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 
@@ -11,8 +11,8 @@ import CentrelineDAO from '@/lib/db/CentrelineDAO';
 
 /**
  * @typedef {Object} FeatureRoutingResult
- * @property {number} next - next intersection to continue routing from
- * @property {Array<CentrelineFeature>} route - list of feature representing the route
+ * @property {CentrelineFeature} next - next feature to continue routing from
+ * @property {Array<CentrelineFeature>} route - list of features representing the route
  */
 
 /**
@@ -149,6 +149,11 @@ ORDER BY seq ASC, path_seq ASC`;
    * if no such route exists
    */
   static async routeFeatures(featureFrom, featureTo) {
+    if (featureFrom.centrelineType === featureTo.centrelineType
+        && featureFrom.centrelineId === featureTo.centrelineId) {
+      return { next: featureTo, route: [] };
+    }
+
     // 1. route all pairs of intersections
     const [intersectionsFrom, intersectionsTo] = await Promise.all([
       RoutingDAO.getRoutableIntersections(featureFrom),
@@ -196,7 +201,8 @@ ORDER BY seq ASC, path_seq ASC`;
        * as the next feature to continue routing from.
        */
       const route = [...bestRoute, featureTo];
-      const next = RoutingDAO.getOtherIntersection(intersectionsTo, intersectionTo);
+      let next = RoutingDAO.getOtherIntersection(intersectionsTo, intersectionTo);
+      next = { centrelineId: next, centrelineType: CentrelineType.INTERSECTION };
       return { next, route };
     }
     const routeFrom = {
@@ -216,7 +222,8 @@ ORDER BY seq ASC, path_seq ASC`;
      * apply.
      */
     const route = [routeFrom, ...bestRoute, featureTo];
-    const next = RoutingDAO.getOtherIntersection(intersectionsTo, intersectionTo);
+    let next = RoutingDAO.getOtherIntersection(intersectionsTo, intersectionTo);
+    next = { centrelineId: next, centrelineType: CentrelineType.INTERSECTION };
     return { next, route };
   }
 
@@ -253,12 +260,12 @@ ORDER BY seq ASC, path_seq ASC`;
         return null;
       }
       const { route, next } = result;
-      featureFrom = {
-        centrelineId: next,
-        centrelineType: CentrelineType.INTERSECTION,
-      };
+      featureFrom = next;
       corridor.push(...route);
-      if (i < n - 1 && centrelineKey(featureFrom) !== centrelineKey(featureTo)) {
+      if (i < n - 1 && (
+        featureFrom.centrelineType !== featureTo.centrelineType
+        || featureFrom.centrelineId !== featureTo.centrelineId
+      )) {
         corridor.push(featureFrom);
       }
     }

--- a/lib/db/RoutingDAO.js
+++ b/lib/db/RoutingDAO.js
@@ -39,12 +39,12 @@ class RoutingDAO {
    */
   static async routeIntersections(intersectionFrom, intersectionTo) {
     if (intersectionFrom === intersectionTo) {
-      return [];
+      return { cost: 0, route: [] };
     }
     const sqlVertices = `
 SELECT ST_X(geom) AS x, ST_Y(geom) AS y
 FROM routing.centreline_vertices
-WHERE id IN (:intersectionFrom, :intersectionTo)`;
+WHERE id IN ($(intersectionFrom), $(intersectionTo))`;
     const rowsVertices = await db.manyOrNone(sqlVertices, { intersectionFrom, intersectionTo });
     if (rowsVertices.length !== 2) {
       return null;
@@ -77,8 +77,8 @@ FROM pgr_astar(
   FROM routing.centreline_edges e
   JOIN vertices vs ON e.source = vs.id
   JOIN vertices vt ON e.target = vt.id',
-  :intersectionFrom,
-  :intersectionTo,
+  $(intersectionFrom),
+  $(intersectionTo),
   FALSE
 )
 ORDER BY seq ASC, path_seq ASC`;
@@ -93,16 +93,16 @@ ORDER BY seq ASC, path_seq ASC`;
 
     const route = [];
     rowsRouting.forEach(({ node, edge }, i) => {
-      if (edge !== -1) {
-        route.push({
-          centrelineType: CentrelineType.SEGMENT,
-          centrelineId: edge,
-        });
-      }
       if (i > 0) {
         route.push({
           centrelineType: CentrelineType.INTERSECTION,
           centrelineId: node,
+        });
+      }
+      if (edge !== -1) {
+        route.push({
+          centrelineType: CentrelineType.SEGMENT,
+          centrelineId: edge,
         });
       }
     });

--- a/lib/db/RoutingDAO.js
+++ b/lib/db/RoutingDAO.js
@@ -1,5 +1,5 @@
 import ArrayUtils from '@/lib/ArrayUtils';
-import { CentrelineType } from '@/lib/Constants';
+import { centrelineKey, CentrelineType } from '@/lib/Constants';
 import db from '@/lib/db/db';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 
@@ -245,17 +245,21 @@ ORDER BY seq ASC, path_seq ASC`;
    * @returns {Array<CentrelineFeature>?} corridor connecting waypoints, or `null` if no such
    * corridor exists
    */
-  static async corridorByFeatures(features) {
-    const n = features.length;
+  static async routeCorridor(features) {
+    const featuresConsecutiveUniq = ArrayUtils.consecutiveUniqBy(
+      features,
+      ({ centrelineId, centrelineType }) => centrelineKey(centrelineType, centrelineId),
+    );
+    const n = featuresConsecutiveUniq.length;
     if (n < 2) {
-      return features;
+      return featuresConsecutiveUniq;
     }
-    let featureFrom = features[0];
+    let featureFrom = featuresConsecutiveUniq[0];
     const corridor = [featureFrom];
     for (let i = 1; i < n; i++) {
-      const featureTo = features[i];
+      const featureTo = featuresConsecutiveUniq[i];
       /* eslint-disable-next-line no-await-in-loop */
-      const result = await RoutingDAO.fromFeatureToFeature(featureFrom, featureTo);
+      const result = await RoutingDAO.routeFeatures(featureFrom, featureTo);
       if (result === null) {
         return null;
       }

--- a/lib/db/RoutingDAO.js
+++ b/lib/db/RoutingDAO.js
@@ -33,19 +33,15 @@ class RoutingDAO {
    *
    * @param {number} intersectionFrom - intersection to route from
    * @param {number} intersectionTo - intersection to route to
-   * @returns {IntersectionRoutingResult?} best route between `intersectionFrom` and
-   * `intersectionTo`, excluding `intersectionFrom` but including `intersectionTo`,
-   * or `null` if no such route exists
+   * @returns {Object?} bounding box on the locations of `intersectionFrom`, `intersectionTo`
+   * or `null` if one or both intersections do not exist
    */
-  static async routeIntersections(intersectionFrom, intersectionTo) {
-    if (intersectionFrom === intersectionTo) {
-      return { cost: 0, route: [] };
-    }
-    const sqlVertices = `
+  static async getIntersectionsBoundingBox(intersectionFrom, intersectionTo) {
+    const sql = `
 SELECT ST_X(geom) AS x, ST_Y(geom) AS y
 FROM routing.centreline_vertices
 WHERE id IN ($(intersectionFrom), $(intersectionTo))`;
-    const rowsVertices = await db.manyOrNone(sqlVertices, { intersectionFrom, intersectionTo });
+    const rowsVertices = await db.manyOrNone(sql, { intersectionFrom, intersectionTo });
     if (rowsVertices.length !== 2) {
       return null;
     }
@@ -60,8 +56,38 @@ WHERE id IN ($(intersectionFrom), $(intersectionTo))`;
       ymin = ymax;
       ymax = temp;
     }
+    return {
+      xmin,
+      ymin,
+      xmax,
+      ymax,
+    };
+  }
 
-    const sqlRouting = `
+  /**
+   *
+   * @param {number} intersectionFrom - intersection to route from
+   * @param {number} intersectionTo - intersection to route to
+   * @returns {IntersectionRoutingResult?} best route between `intersectionFrom` and
+   * `intersectionTo`, excluding `intersectionFrom` but including `intersectionTo`,
+   * or `null` if no such route exists
+   */
+  static async routeIntersections(intersectionFrom, intersectionTo) {
+    if (intersectionFrom === intersectionTo) {
+      return { cost: 0, route: [] };
+    }
+    const bbox = await RoutingDAO.getIntersectionsBoundingBox(intersectionFrom, intersectionTo);
+    if (bbox === null) {
+      return null;
+    }
+    const {
+      xmin,
+      ymin,
+      xmax,
+      ymax,
+    } = bbox;
+
+    const sql = `
 SELECT node, edge, agg_cost AS "aggCost"
 FROM pgr_astar(
   'WITH vertices AS (
@@ -82,7 +108,7 @@ FROM pgr_astar(
   FALSE
 )
 ORDER BY seq ASC, path_seq ASC`;
-    const rowsRouting = await db.manyOrNone(sqlRouting, { intersectionFrom, intersectionTo });
+    const rowsRouting = await db.manyOrNone(sql, { intersectionFrom, intersectionTo });
     if (rowsRouting.length === 0) {
       /*
        * As per [documentation](https://docs.pgrouting.org/2.4/en/pgr_aStar.html#pgr-astar),

--- a/lib/model/helpers/CentrelineFeature.js
+++ b/lib/model/helpers/CentrelineFeature.js
@@ -1,6 +1,24 @@
 import { CentrelineType } from '@/lib/Constants';
 import Joi from '@/lib/model/Joi';
 
+/**
+ * Centreline feature, used throughout MOVE to look up centreline locations (usually
+ * with the help of {@link CentrelineDAO} or {@link LocationController}).
+ *
+ * A "feature" is essentially a key to a centreline location.  It consists of two fields:
+ * a type (intersection or midblock segment) and an ID.  For intersections, this ID is equal to
+ * the value of `gis.centreline_intersection.int_id` for the corresponding location.  For
+ * midblocks, it is equal to the value of `gis.centreline.geo_id`.
+ *
+ * Features can be encoded into a {@link CompositeId}, which is then used to help build URLs
+ * (either for frontend routes or REST API calls) that must look up information about one or
+ * more locations at once.
+ *
+ * @typedef {Object} CentrelineFeature
+ * @property {number} centrelineId - ID of corresponding location
+ * @property {number} centrelineType - type of corresponding location
+ */
+
 export default {
   centrelineId: Joi.number().integer().positive().required(),
   centrelineType: Joi.number().valid(

--- a/lib/model/helpers/CentrelineLocation.js
+++ b/lib/model/helpers/CentrelineLocation.js
@@ -1,0 +1,40 @@
+import { CentrelineType, RoadIntersectionType, RoadSegmentType } from '@/lib/Constants';
+import Joi from '@/lib/model/Joi';
+import CentrelineFeature from '@/lib/model/helpers/CentrelineFeature';
+import {
+  Lat,
+  LineString,
+  Lng,
+  Point,
+} from '@/lib/model/helpers/GeoJson';
+
+const FEATURE_CODES_INTERSECTION = RoadIntersectionType.enumValues.map(
+  ({ featureCode }) => featureCode,
+);
+const FEATURE_CODES_SEGMENT = RoadSegmentType.enumValues.map(
+  ({ featureCode }) => featureCode,
+);
+
+export default {
+  ...CentrelineFeature,
+  description: Joi.string().allow(null),
+  featureCode: Joi.number().when(
+    'centrelineType',
+    {
+      is: CentrelineType.INTERSECTION,
+      then: Joi.valid(...FEATURE_CODES_INTERSECTION),
+      otherwise: Joi.valid(...FEATURE_CODES_SEGMENT),
+    },
+  ),
+  geom: Joi.any().when(
+    'centrelineType',
+    {
+      is: CentrelineType.INTERSECTION,
+      then: Point.required(),
+      otherwise: LineString.required(),
+    },
+  ),
+  lat: Lat.required(),
+  lng: Lng.required(),
+  roadId: Joi.number().allow(null),
+};

--- a/lib/model/helpers/GeoJson.js
+++ b/lib/model/helpers/GeoJson.js
@@ -1,11 +1,35 @@
 import Joi from '@/lib/model/Joi';
 
-export default {
-  Point: Joi.object().keys({
-    type: Joi.string().valid('Point').required(),
-    coordinates: Joi.array().length(2).ordered(
-      Joi.number().min(-180).max(180).required(),
-      Joi.number().min(-90).max(90).required(),
-    ).required(),
-  }),
+const Lng = Joi.number().min(-180).max(180);
+const Lat = Joi.number().min(-90).max(90);
+
+const LngLat = Joi.array().length(2).ordered(Lng.required(), Lat.required());
+
+const LineString = Joi.object().keys({
+  type: Joi.string().valid('LineString').required(),
+  coordinates: Joi.array().items(
+    LngLat.required(),
+  ).required(),
+});
+
+const Point = Joi.object().keys({
+  type: Joi.string().valid('Point').required(),
+  coordinates: LngLat.required(),
+});
+
+const GeoJson = {
+  Lat,
+  LineString,
+  Lng,
+  LngLat,
+  Point,
+};
+
+export {
+  GeoJson as default,
+  Lat,
+  LineString,
+  Lng,
+  LngLat,
+  Point,
 };

--- a/scripts/dev/provision-db-vagrant.sql
+++ b/scripts/dev/provision-db-vagrant.sql
@@ -8,4 +8,5 @@ create extension fuzzystrmatch;
 create extension postgis_tiger_geocoder;
 create extension postgis_topology;
 create extension pg_trgm;
+create extension pgrouting;
 set search_path=public,tiger;

--- a/tests/jest/db/ArteryDAO.spec.js
+++ b/tests/jest/db/ArteryDAO.spec.js
@@ -1,5 +1,10 @@
 import { CardinalDirection, CentrelineType } from '@/lib/Constants';
+import db from '@/lib/db/db';
 import ArteryDAO from '@/lib/db/ArteryDAO';
+
+afterAll(() => {
+  db.$pool.end();
+});
 
 test('ArteryDAO.getApproachDirection', async () => {
   expect(ArteryDAO.getApproachDirection('')).toBe(null);

--- a/tests/jest/db/CategoryDAO.spec.js
+++ b/tests/jest/db/CategoryDAO.spec.js
@@ -1,6 +1,11 @@
 import { StudyType } from '@/lib/Constants';
+import db from '@/lib/db/db';
 import CategoryDAO from '@/lib/db/CategoryDAO';
 import Category from '@/lib/model/Category';
+
+afterAll(() => {
+  db.$pool.end();
+});
 
 test('CategoryDAO', async () => {
   expect(CategoryDAO.isInited()).toBe(false);

--- a/tests/jest/db/CentrelineDAO.spec.js
+++ b/tests/jest/db/CentrelineDAO.spec.js
@@ -1,6 +1,11 @@
 import { CentrelineType } from '@/lib/Constants';
+import db from '@/lib/db/db';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import { InvalidCentrelineTypeError } from '@/lib/error/MoveErrors';
+
+afterAll(() => {
+  db.$pool.end();
+});
 
 test('CentrelineDAO.byFeature', async () => {
   // intersection

--- a/tests/jest/db/CollisionFactorDAO.spec.js
+++ b/tests/jest/db/CollisionFactorDAO.spec.js
@@ -1,4 +1,9 @@
+import db from '@/lib/db/db';
 import CollisionFactorDAO from '@/lib/db/CollisionFactorDAO';
+
+afterAll(() => {
+  db.$pool.end();
+});
 
 test('CollisionFactorDAO', async () => {
   expect(CollisionFactorDAO.isInited()).toBe(false);

--- a/tests/jest/db/CountDAO.spec.js
+++ b/tests/jest/db/CountDAO.spec.js
@@ -1,6 +1,11 @@
 import { StudyType } from '@/lib/Constants';
+import db from '@/lib/db/db';
 import CountDAO from '@/lib/db/CountDAO';
 import DateTime from '@/lib/time/DateTime';
+
+afterAll(() => {
+  db.$pool.end();
+});
 
 test('CountDAO.byStudy', async () => {
   // TMC: single-day, single-arterycode

--- a/tests/jest/db/RoutingDAO.spec.js
+++ b/tests/jest/db/RoutingDAO.spec.js
@@ -1,3 +1,4 @@
+import { CentrelineType } from '@/lib/Constants';
 import db from '@/lib/db/db';
 import RoutingDAO from '@/lib/db/RoutingDAO';
 
@@ -9,4 +10,72 @@ test('RoutingDAO.getOtherIntersection', () => {
   expect(RoutingDAO.getOtherIntersection([6, 17], 6)).toEqual(17);
   expect(RoutingDAO.getOtherIntersection([6, 17], 17)).toEqual(6);
   expect(RoutingDAO.getOtherIntersection([42], 42)).toEqual(42);
+});
+
+test('RoutingDAO.getRoutableIntersections', async () => {
+  let feature = {
+    centrelineId: 13452850,
+    centrelineType: CentrelineType.INTERSECTION,
+  };
+  let intersections = await RoutingDAO.getRoutableIntersections(feature);
+  expect(intersections).toEqual([13452850]);
+
+  feature = {
+    centrelineId: 444525,
+    centrelineType: CentrelineType.SEGMENT,
+  };
+  intersections = await RoutingDAO.getRoutableIntersections(feature);
+  expect(intersections).toEqual([13454566, 13454601]);
+});
+
+test('RoutingDAO.routeIntersections', async () => {
+  // routing with non-existent intersection(s): should return null
+  let intersectionFrom = 13456414;
+  let intersectionTo = -1;
+  let result = await RoutingDAO.routeIntersections(intersectionFrom, intersectionTo);
+  expect(result).toBeNull();
+
+  intersectionFrom = -1;
+  intersectionTo = 13456414;
+  result = await RoutingDAO.routeIntersections(intersectionFrom, intersectionTo);
+  expect(result).toBeNull();
+
+  // route to self: should be empty with zero cost
+  intersectionFrom = 13456414;
+  intersectionTo = 13456414;
+  result = await RoutingDAO.routeIntersections(intersectionFrom, intersectionTo);
+  expect(result).toEqual({ cost: 0, route: [] });
+
+  // routing to neighbour
+  intersectionFrom = 13456414;
+  intersectionTo = 13456067;
+  result = await RoutingDAO.routeIntersections(intersectionFrom, intersectionTo);
+  const { cost } = result;
+  expect(cost).toBeGreaterThan(0);
+  expect(result.route).toEqual([
+    { centrelineId: 3304786, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13456067, centrelineType: CentrelineType.INTERSECTION },
+  ]);
+
+  // reverse route
+  intersectionFrom = 13456067;
+  intersectionTo = 13456414;
+  result = await RoutingDAO.routeIntersections(intersectionFrom, intersectionTo);
+  expect(result.cost).toEqual(cost);
+  expect(result.route).toEqual([
+    { centrelineId: 3304786, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13456414, centrelineType: CentrelineType.INTERSECTION },
+  ]);
+
+  // routing two steps away
+  intersectionFrom = 13456414;
+  intersectionTo = 13455700;
+  result = await RoutingDAO.routeIntersections(intersectionFrom, intersectionTo);
+  expect(result.cost).toBeGreaterThan(cost);
+  expect(result.route).toEqual([
+    { centrelineId: 3304786, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13456067, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 445623, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13455700, centrelineType: CentrelineType.INTERSECTION },
+  ]);
 });

--- a/tests/jest/db/RoutingDAO.spec.js
+++ b/tests/jest/db/RoutingDAO.spec.js
@@ -200,3 +200,124 @@ test('RoutingDAO.routeFeatures', async () => {
     ],
   });
 });
+
+test('RoutingDAO.routeCorridor', async () => {
+  // length 0
+  let features = [];
+  let corridor = await RoutingDAO.routeCorridor(features);
+  expect(corridor).toEqual([]);
+
+  // length 1
+  features = [
+    { centrelineId: 13456414, centrelineType: CentrelineType.INTERSECTION },
+  ];
+  corridor = await RoutingDAO.routeCorridor(features);
+  expect(corridor).toEqual(features);
+
+  // length 2, duplicate point
+  features = [
+    { centrelineId: 13456414, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 13456414, centrelineType: CentrelineType.INTERSECTION },
+  ];
+  corridor = await RoutingDAO.routeCorridor(features);
+  expect(corridor).toEqual([features[0]]);
+
+  // length 2, point to nearby midblock
+  features = [
+    { centrelineId: 13456067, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 444912, centrelineType: CentrelineType.SEGMENT },
+  ];
+  corridor = await RoutingDAO.routeCorridor(features);
+  expect(corridor).toEqual([
+    features[0],
+    { centrelineId: 445623, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13455700, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 445346, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13455359, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 445100, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13455130, centrelineType: CentrelineType.INTERSECTION },
+    features[1],
+  ]);
+
+  // length > 2, Don Mills from Overlea / Gateway to Eglinton in several steps
+  features = [
+    { centrelineId: 13456414, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 13455700, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 445346, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 444912, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13454752, centrelineType: CentrelineType.INTERSECTION },
+  ];
+  corridor = await RoutingDAO.routeCorridor(features);
+  expect(corridor).toEqual([
+    features[0],
+    { centrelineId: 3304786, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13456067, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 445623, centrelineType: CentrelineType.SEGMENT },
+    features[1],
+    features[2],
+    { centrelineId: 13455359, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 445100, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13455130, centrelineType: CentrelineType.INTERSECTION },
+    features[3],
+    { centrelineId: 13454835, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 444715, centrelineType: CentrelineType.SEGMENT },
+    features[4],
+  ]);
+
+  // length > 2, same corridor with duplicates
+  features = [
+    { centrelineId: 13456414, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 13455700, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 13455700, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 445346, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 444912, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 444912, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13454752, centrelineType: CentrelineType.INTERSECTION },
+  ];
+  corridor = await RoutingDAO.routeCorridor(features);
+  expect(corridor).toEqual([
+    features[0],
+    { centrelineId: 3304786, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13456067, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 445623, centrelineType: CentrelineType.SEGMENT },
+    features[1],
+    features[3],
+    { centrelineId: 13455359, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 445100, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13455130, centrelineType: CentrelineType.INTERSECTION },
+    features[4],
+    { centrelineId: 13454835, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 444715, centrelineType: CentrelineType.SEGMENT },
+    features[6],
+  ]);
+
+  // length > 2, Don Mills from Overlea / Gateway to Eglinton with backtracking
+  features = [
+    { centrelineId: 13456414, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 13455700, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 13456067, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 445346, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 444912, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13454752, centrelineType: CentrelineType.INTERSECTION },
+  ];
+  corridor = await RoutingDAO.routeCorridor(features);
+  expect(corridor).toEqual([
+    features[0],
+    { centrelineId: 3304786, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13456067, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 445623, centrelineType: CentrelineType.SEGMENT },
+    features[1],
+    { centrelineId: 445623, centrelineType: CentrelineType.SEGMENT },
+    features[2],
+    { centrelineId: 445623, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13455700, centrelineType: CentrelineType.INTERSECTION },
+    features[3],
+    { centrelineId: 13455359, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 445100, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13455130, centrelineType: CentrelineType.INTERSECTION },
+    features[4],
+    { centrelineId: 13454835, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 444715, centrelineType: CentrelineType.SEGMENT },
+    features[5],
+  ]);
+});

--- a/tests/jest/db/RoutingDAO.spec.js
+++ b/tests/jest/db/RoutingDAO.spec.js
@@ -1,0 +1,12 @@
+import db from '@/lib/db/db';
+import RoutingDAO from '@/lib/db/RoutingDAO';
+
+afterAll(() => {
+  db.$pool.end();
+});
+
+test('RoutingDAO.getOtherIntersection', () => {
+  expect(RoutingDAO.getOtherIntersection([6, 17], 6)).toEqual(17);
+  expect(RoutingDAO.getOtherIntersection([6, 17], 17)).toEqual(6);
+  expect(RoutingDAO.getOtherIntersection([42], 42)).toEqual(42);
+});

--- a/tests/jest/db/StudyDataDAO.spec.js
+++ b/tests/jest/db/StudyDataDAO.spec.js
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 import path from 'path';
 
+import db from '@/lib/db/db';
 import StudyDAO from '@/lib/db/StudyDAO';
 import StudyDataDAO from '@/lib/db/StudyDataDAO';
 import { loadJsonSync } from '@/lib/test/TestDataLoader';
@@ -11,6 +12,10 @@ const countData_4_1415698 = loadJsonSync(
 const countData_5_26177 = loadJsonSync(
   path.resolve(__dirname, './data/countData_5_26177.json'),
 );
+
+afterAll(() => {
+  db.$pool.end();
+});
 
 test('StudyDataDAO', async () => {
   // TMC

--- a/tests/jest/db/StudyRequestChangeDAO.spec.js
+++ b/tests/jest/db/StudyRequestChangeDAO.spec.js
@@ -6,12 +6,17 @@ import {
   StudyRequestStatus,
   StudyType,
 } from '@/lib/Constants';
+import db from '@/lib/db/db';
 import StudyRequestDAO from '@/lib/db/StudyRequestDAO';
 import StudyRequestChangeDAO from '@/lib/db/StudyRequestChangeDAO';
 import UserDAO from '@/lib/db/UserDAO';
 import StudyRequestChange from '@/lib/model/StudyRequestChange';
 import { generateUser } from '@/lib/test/random/UserGenerator';
 import DateTime from '@/lib/time/DateTime';
+
+afterAll(() => {
+  db.$pool.end();
+});
 
 test('StudyRequestChangeDAO', async () => {
   await expect(StudyRequestChangeDAO.byId(-1)).resolves.toBeNull();

--- a/tests/jest/db/StudyRequestCommentDAO.spec.js
+++ b/tests/jest/db/StudyRequestCommentDAO.spec.js
@@ -5,12 +5,17 @@ import {
   StudyRequestReason,
   StudyType,
 } from '@/lib/Constants';
+import db from '@/lib/db/db';
 import StudyRequestDAO from '@/lib/db/StudyRequestDAO';
 import StudyRequestCommentDAO from '@/lib/db/StudyRequestCommentDAO';
 import UserDAO from '@/lib/db/UserDAO';
 import StudyRequestComment from '@/lib/model/StudyRequestComment';
 import { generateUser } from '@/lib/test/random/UserGenerator';
 import DateTime from '@/lib/time/DateTime';
+
+afterAll(() => {
+  db.$pool.end();
+});
 
 test('StudyRequestCommentDAO', async () => {
   await expect(StudyRequestCommentDAO.byId(-1)).resolves.toBeNull();

--- a/tests/jest/db/UserDAO.spec.js
+++ b/tests/jest/db/UserDAO.spec.js
@@ -1,4 +1,5 @@
 import { AuthScope } from '@/lib/Constants';
+import db from '@/lib/db/db';
 import UserDAO from '@/lib/db/UserDAO';
 import {
   generateEmail,
@@ -6,6 +7,10 @@ import {
   generateUniqueName,
   generateUser,
 } from '@/lib/test/random/UserGenerator';
+
+afterAll(() => {
+  db.$pool.end();
+});
 
 test('UserDAO', async () => {
   const transientUser1 = generateUser();

--- a/tests/jest/unit/ArrayUtils.spec.js
+++ b/tests/jest/unit/ArrayUtils.spec.js
@@ -218,3 +218,29 @@ test('ArrayUtils.groupBy()', () => {
     [2, 5, 8],
   ]);
 });
+
+test('ArrayUtils.consecutiveUniqBy', () => {
+  let xs = [];
+  let xsConsecutiveUniq = ArrayUtils.consecutiveUniqBy(xs, x => x);
+  expect(xsConsecutiveUniq).toEqual([]);
+
+  xs = [3];
+  xsConsecutiveUniq = ArrayUtils.consecutiveUniqBy(xs, x => x);
+  expect(xsConsecutiveUniq).toEqual([3]);
+
+  xs = [3, 3];
+  xsConsecutiveUniq = ArrayUtils.consecutiveUniqBy(xs, x => x);
+  expect(xsConsecutiveUniq).toEqual([3]);
+
+  xs = [3, 3, 1, 1, 1, 2];
+  xsConsecutiveUniq = ArrayUtils.consecutiveUniqBy(xs, x => x);
+  expect(xsConsecutiveUniq).toEqual([3, 1, 2]);
+
+  xs = [3, 3, 1, 1, 1, 2, 2];
+  xsConsecutiveUniq = ArrayUtils.consecutiveUniqBy(xs, x => x);
+  expect(xsConsecutiveUniq).toEqual([3, 1, 2]);
+
+  xs = [3, 3, 1, 1, 3, 1, 2, 2];
+  xsConsecutiveUniq = ArrayUtils.consecutiveUniqBy(xs, x => x);
+  expect(xsConsecutiveUniq).toEqual([3, 1, 3, 1, 2]);
+});


### PR DESCRIPTION
# Issue Addressed
This PR makes significant progress on #510 .

# Description
We introduce `RoutingDAO` to deal with routing corridors to connect multi-location selections, using `pgrouting` (thanks @jovenc @chmnata and others for your excellent notes here from previous BDITTO work!)  We also add tests for routing methods in `RoutingDAO.spec.js`.

We then add a new endpoint, `LocationController.getLocationsByCorridor`, that accepts a `CentrelineSelection` and returns a `CentrelineLocation` array representing a corridor on the waypoints in that selection.

# Tests
Pre-commit tests, `npm run test:test-db`, `npm run test:test-api`.
