### PR TITLE
Integrate corridor interpolation with frontend

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -559,30 +559,6 @@ RoadIntersectionType.init({
     featureCode: 501700,
     description: 'Laneway Intersection',
   },
-  RAILWAY: {
-    featureCode: 502000,
-    description: 'Railway Intersection',
-  },
-  PEDESTRIAN: {
-    featureCode: 504000,
-    description: 'Pedestrian Intersection',
-  },
-  CUL_DE_SAC: {
-    featureCode: 509100,
-    description: 'Cul de sac Intersection',
-  },
-  PSUEDO: {
-    featureCode: 509200,
-    description: 'Psuedo Intersection',
-  },
-  UTILITY: {
-    featureCode: 509300,
-    description: 'Utility Intersection',
-  },
-  RIVER: {
-    featureCode: 509400,
-    description: 'River Intersection',
-  },
 });
 
 /**
@@ -647,6 +623,11 @@ RoadSegmentType.init({
     description: 'Pending',
   },
 });
+
+const FEATURE_CODES_INTERSECTION = RoadIntersectionType.enumValues
+  .map(({ featureCode }) => featureCode);
+const FEATURE_CODES_SEGMENT = RoadSegmentType.enumValues
+  .map(({ featureCode }) => featureCode);
 
 const SearchKeys = {
   Requests: {
@@ -1031,6 +1012,8 @@ const Constants = {
   CollisionEmphasisArea,
   CollisionRoadSurfaceCondition,
   FeatureCode,
+  FEATURE_CODES_INTERSECTION,
+  FEATURE_CODES_SEGMENT,
   HttpStatus,
   LocationMode,
   LocationSearchType,
@@ -1072,6 +1055,8 @@ export {
   CollisionEmphasisArea,
   CollisionRoadSurfaceCondition,
   FeatureCode,
+  FEATURE_CODES_INTERSECTION,
+  FEATURE_CODES_SEGMENT,
   HttpStatus,
   LocationMode,
   LocationSearchType,

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -207,6 +207,16 @@ LocationSearchType.init([
 ]);
 
 /**
+ * Location selection types, used to distinguish corridor and non-corridor selections when
+ * navigating between location-based components.
+ */
+class LocationSelectionType extends Enum {}
+LocationSelectionType.init([
+  'CORRIDOR',
+  'POINTS',
+]);
+
+/**
  * Map zoom hierarchy.  These are divided into three "levels", corresponding to zoom level
  * ranges in which different features make sense:
  *
@@ -1024,6 +1034,7 @@ const Constants = {
   HttpStatus,
   LocationMode,
   LocationSearchType,
+  LocationSelectionType,
   MapZoom,
   MAX_LOCATIONS,
   ORG_NAME,
@@ -1064,6 +1075,7 @@ export {
   HttpStatus,
   LocationMode,
   LocationSearchType,
+  LocationSelectionType,
   MapZoom,
   MAX_LOCATIONS,
   ORG_NAME,

--- a/lib/controller/LocationController.js
+++ b/lib/controller/LocationController.js
@@ -1,6 +1,11 @@
 import Boom from '@hapi/boom';
 
-import { CentrelineType, LocationSearchType } from '@/lib/Constants';
+import {
+  CentrelineType,
+  FEATURE_CODES_INTERSECTION,
+  FEATURE_CODES_SEGMENT,
+  LocationSearchType,
+} from '@/lib/Constants';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import LocationSearchDAO from '@/lib/db/LocationSearchDAO';
 import RoutingDAO from '@/lib/db/RoutingDAO';
@@ -8,6 +13,15 @@ import CompositeId from '@/lib/io/CompositeId';
 import Joi from '@/lib/model/Joi';
 import CentrelineLocation from '@/lib/model/helpers/CentrelineLocation';
 import CentrelineSelection from '@/lib/model/helpers/CentrelineSelection';
+
+function filterLocations(locations) {
+  return locations.filter(({ centrelineType, featureCode }) => {
+    if (centrelineType === CentrelineType.INTERSECTION) {
+      return FEATURE_CODES_INTERSECTION.includes(featureCode);
+    }
+    return FEATURE_CODES_SEGMENT.includes(featureCode);
+  });
+}
 
 /**
  * Utilities for location suggestions and lookups.
@@ -50,7 +64,8 @@ LocationController.push({
   },
   handler: async (request) => {
     const { limit, q, types } = request.query;
-    return LocationSearchDAO.getSuggestions(types, q, limit);
+    const locations = await LocationSearchDAO.getSuggestions(types, q, limit);
+    return filterLocations(locations);
   },
 });
 
@@ -128,7 +143,8 @@ LocationController.push({
   },
   handler: async (request) => {
     const { s1: features } = request.query;
-    return CentrelineDAO.byFeatures(features);
+    const locations = await CentrelineDAO.byFeatures(features);
+    return filterLocations(locations);
   },
 });
 
@@ -158,7 +174,8 @@ LocationController.push({
     if (corridor === null) {
       return Boom.notFound('no corridor found on the given location selection');
     }
-    return CentrelineDAO.byFeatures(corridor);
+    const locations = await CentrelineDAO.byFeatures(corridor);
+    return filterLocations(locations);
   },
 });
 

--- a/lib/geo/GeoStyle.js
+++ b/lib/geo/GeoStyle.js
@@ -758,15 +758,27 @@ class GeoStyle {
             'case',
             ['get', 'multi'], [
               'case',
-              ['get', 'selected'], 'location-multi-selected',
-              'location-multi',
+              ['==', ['get', 'locationIndex'], -1], [
+                'case',
+                ['get', 'selected'], 'location-multi-corridor-selected',
+                'location-multi-corridor',
+              ],
+              [
+                'case',
+                ['get', 'selected'], 'location-multi-selected',
+                'location-multi',
+              ],
             ],
             'location-single',
           ],
           'text-allow-overlap': true,
           'text-field': [
             'case',
-            ['get', 'multi'], ['to-string', ['+', ['get', 'locationIndex'], 1]],
+            ['get', 'multi'], [
+              'case',
+              ['==', ['get', 'locationIndex'], -1], '',
+              ['to-string', ['+', ['get', 'locationIndex'], 1]],
+            ],
             '',
           ],
           'text-font': [

--- a/lib/model/helpers/CentrelineLocation.js
+++ b/lib/model/helpers/CentrelineLocation.js
@@ -1,4 +1,4 @@
-import { CentrelineType, RoadIntersectionType, RoadSegmentType } from '@/lib/Constants';
+import { CentrelineType } from '@/lib/Constants';
 import Joi from '@/lib/model/Joi';
 import CentrelineFeature from '@/lib/model/helpers/CentrelineFeature';
 import {
@@ -8,24 +8,10 @@ import {
   Point,
 } from '@/lib/model/helpers/GeoJson';
 
-const FEATURE_CODES_INTERSECTION = RoadIntersectionType.enumValues.map(
-  ({ featureCode }) => featureCode,
-);
-const FEATURE_CODES_SEGMENT = RoadSegmentType.enumValues.map(
-  ({ featureCode }) => featureCode,
-);
-
 export default {
   ...CentrelineFeature,
   description: Joi.string().allow(null),
-  featureCode: Joi.number().when(
-    'centrelineType',
-    {
-      is: CentrelineType.INTERSECTION,
-      then: Joi.valid(...FEATURE_CODES_INTERSECTION),
-      otherwise: Joi.valid(...FEATURE_CODES_SEGMENT),
-    },
-  ),
+  featureCode: Joi.number().allow(null),
   geom: Joi.any().when(
     'centrelineType',
     {

--- a/lib/model/helpers/CentrelineLocation.js
+++ b/lib/model/helpers/CentrelineLocation.js
@@ -1,4 +1,8 @@
-import { CentrelineType } from '@/lib/Constants';
+import {
+  CentrelineType,
+  FEATURE_CODES_INTERSECTION,
+  FEATURE_CODES_SEGMENT,
+} from '@/lib/Constants';
 import Joi from '@/lib/model/Joi';
 import CentrelineFeature from '@/lib/model/helpers/CentrelineFeature';
 import {
@@ -11,7 +15,14 @@ import {
 export default {
   ...CentrelineFeature,
   description: Joi.string().allow(null),
-  featureCode: Joi.number().allow(null),
+  featureCode: Joi.number().when(
+    'centrelineType',
+    {
+      is: CentrelineType.INTERSECTION,
+      then: Joi.valid(...FEATURE_CODES_INTERSECTION),
+      otherwise: Joi.valid(...FEATURE_CODES_SEGMENT),
+    },
+  ),
   geom: Joi.any().when(
     'centrelineType',
     {

--- a/tests/jest/api/RestApi.spec.js
+++ b/tests/jest/api/RestApi.spec.js
@@ -65,7 +65,7 @@ test('LocationController.getLocationSuggestions', async () => {
     q: 'Danforth and Main',
     limit: 3,
   };
-  const response = await client.fetch('/location/suggest', { data });
+  const response = await client.fetch('/locations/suggest', { data });
   expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
   expect(response.result.length).toBe(3);
   expectSuggestionsContain(response.result, 13460034);
@@ -73,29 +73,26 @@ test('LocationController.getLocationSuggestions', async () => {
 
 test('LocationController.getLocationsByCentreline', async () => {
   // empty list of features
-  let data = {
-    centrelineId: [],
-    centrelineType: [],
-  };
-  let response = await client.fetch('/location/centreline', { data });
-  expect(response.statusCode).toBe(HttpStatus.BAD_REQUEST.statusCode);
-
-  // invalid feature
-  data = {
-    centrelineId: [-1],
-    centrelineType: [-1],
-  };
-  response = await client.fetch('/location/centreline', { data });
-  expect(response.statusCode).toBe(HttpStatus.BAD_REQUEST.statusCode);
+  let features = [];
+  let s1 = CompositeId.encode(features);
+  let data = { s1 };
+  let response = await client.fetch('/locations/byCentreline', { data });
+  expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
+  expect(response.result).toEqual([]);
 
   // valid multi-fetch
-  data = {
-    centrelineId: [30000549, 111569],
-    centrelineType: [CentrelineType.INTERSECTION, CentrelineType.SEGMENT],
-  };
-  response = await client.fetch('/location/centreline', { data });
+  features = [
+    { centrelineId: 13447240, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 111569, centrelineType: CentrelineType.SEGMENT },
+  ];
+  s1 = CompositeId.encode(features);
+  data = { s1 };
+  response = await client.fetch('/locations/byCentreline', { data });
   expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
-  expect(response.result.size).toBe(2);
+  expect(response.result.length).toEqual(features.length);
+  response.result.forEach(({ centrelineId, centrelineType }, i) => {
+    expect({ centrelineId, centrelineType }).toEqual(features[i]);
+  });
 });
 
 function expectNumPerCategoryStudy(actual, expected) {

--- a/tests/jest/unit/geo/CentrelineUtils.spec.js
+++ b/tests/jest/unit/geo/CentrelineUtils.spec.js
@@ -23,13 +23,13 @@ test('CentrelineUtils.getLocationFeatureType', () => {
 
   location = {
     centrelineType: CentrelineType.INTERSECTION,
-    featureCode: RoadIntersectionType.PEDESTRIAN.featureCode,
+    featureCode: RoadIntersectionType.LANEWAY.featureCode,
   };
-  expect(getLocationFeatureType(location)).toBe(RoadIntersectionType.PEDESTRIAN);
+  expect(getLocationFeatureType(location)).toBe(RoadIntersectionType.LANEWAY);
 
   location = {
     centrelineType: -1,
-    featureCode: RoadIntersectionType.PEDESTRIAN.featureCode,
+    featureCode: RoadIntersectionType.LANEWAY.featureCode,
   };
   expect(() => {
     getLocationFeatureType(location);

--- a/web/components/FcDrawerRequestStudy.vue
+++ b/web/components/FcDrawerRequestStudy.vue
@@ -251,13 +251,13 @@ export default {
           name: 'requestStudyView',
           params: { id },
         });
-      } else if (this.location === null) {
+      } else if (this.locations.length === 0) {
         this.$router.push({ name: 'viewData' });
       } else {
-        const { centrelineId, centrelineType } = this.location;
+        const s1 = CompositeId.encode(this.locations);
         this.$router.push({
           name: 'viewDataAtLocation',
-          params: { centrelineId, centrelineType },
+          params: { s1 },
         });
       }
     },

--- a/web/components/FcDrawerRequestStudy.vue
+++ b/web/components/FcDrawerRequestStudy.vue
@@ -101,7 +101,6 @@ import {
   REQUEST_STUDY_REQUIRES_LOCATION,
   REQUEST_STUDY_TIME_TO_FULFILL,
 } from '@/lib/i18n/Strings';
-import CompositeId from '@/lib/io/CompositeId';
 import DateTime from '@/lib/time/DateTime';
 import ValidationsStudyRequest from '@/lib/validation/ValidationsStudyRequest';
 import FcDetailsStudyRequest from '@/web/components/FcDetailsStudyRequest.vue';
@@ -190,10 +189,10 @@ export default {
     },
     routeFinish() {
       if (this.isCreate) {
-        const s1 = CompositeId.encode(this.locations);
+        const params = this.locationsRouteParams;
         return {
           name: 'viewDataAtLocation',
-          params: { s1 },
+          params,
         };
       }
       if (this.studyRequest === null) {
@@ -219,7 +218,7 @@ export default {
       return `Edit Request #${id}`;
     },
     ...mapState(['locations', 'now']),
-    ...mapGetters(['location']),
+    ...mapGetters(['location', 'locationsEmpty', 'locationsRouteParams']),
   },
   watch: {
     estimatedDeliveryDate() {
@@ -251,13 +250,13 @@ export default {
           name: 'requestStudyView',
           params: { id },
         });
-      } else if (this.locations.length === 0) {
+      } else if (this.locationsEmpty) {
         this.$router.push({ name: 'viewData' });
       } else {
-        const s1 = CompositeId.encode(this.locations);
+        const params = this.locationsRouteParams;
         this.$router.push({
           name: 'viewDataAtLocation',
-          params: { s1 },
+          params,
         });
       }
     },

--- a/web/components/FcDrawerViewRequest.vue
+++ b/web/components/FcDrawerViewRequest.vue
@@ -99,11 +99,15 @@
 </template>
 
 <script>
-import { mapActions, mapMutations, mapState } from 'vuex';
+import {
+  mapActions,
+  mapGetters,
+  mapMutations,
+  mapState,
+} from 'vuex';
 
 import { AuthScope, StudyRequestStatus } from '@/lib/Constants';
 import { getStudyRequest } from '@/lib/api/WebApi';
-import CompositeId from '@/lib/io/CompositeId';
 import FcCommentsStudyRequest from '@/web/components/FcCommentsStudyRequest.vue';
 import FcSummaryStudyRequest from '@/web/components/FcSummaryStudyRequest.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
@@ -205,6 +209,7 @@ export default {
       return 'Requests';
     },
     ...mapState(['auth', 'backViewRequest', 'locations']),
+    ...mapGetters(['locationsEmpty', 'locationsRouteParams']),
   },
   methods: {
     async actionAcceptChanges() {
@@ -257,13 +262,13 @@ export default {
       await this.updateMoreActions();
     },
     actionViewData() {
-      if (this.locations.length === 0) {
+      if (this.locationsEmpty) {
         return;
       }
-      const s1 = CompositeId.encode(this.locations);
+      const params = this.locationsRouteParams;
       const route = {
         name: 'viewDataAtLocation',
-        params: { s1 },
+        params,
       };
       this.$router.push(route);
     },

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -249,7 +249,7 @@ export default {
         properties.multi = multi;
         if (multi) {
           properties.locationIndex = i;
-          properties.selected = i === this.locationEditIndex;
+          properties.selected = i === this.locationsEditIndex;
         }
         return { type: 'Feature', geometry, properties };
       });
@@ -297,7 +297,7 @@ export default {
     ...mapState([
       'drawerOpen',
       'legendOptions',
-      'locationEditIndex',
+      'locationsEditIndex',
       'locationMode',
       'locations',
       'locationsEdit',

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -301,6 +301,8 @@ export default {
       'locationMode',
       'locations',
       'locationsEdit',
+      'locationsEditSelection',
+      'locationsSelection',
     ]),
   },
   created() {

--- a/web/components/FcPaneMapPopup.vue
+++ b/web/components/FcPaneMapPopup.vue
@@ -35,7 +35,12 @@
 import mapboxgl from 'mapbox-gl/dist/mapbox-gl';
 import { mapMutations, mapState } from 'vuex';
 
-import { CentrelineType, LocationMode, MAX_LOCATIONS } from '@/lib/Constants';
+import {
+  CentrelineType,
+  LocationMode,
+  LocationSelectionType,
+  MAX_LOCATIONS,
+} from '@/lib/Constants';
 import { formatCountLocationDescription } from '@/lib/StringFormatters';
 import {
   getCollisionByCollisionId,
@@ -446,7 +451,7 @@ export default {
       const s1 = CompositeId.encode([feature]);
       this.$router.push({
         name: 'viewDataAtLocation',
-        params: { s1 },
+        params: { s1, selectionType: LocationSelectionType.POINTS },
       });
     },
     createPopup() {

--- a/web/components/FcPaneMapPopup.vue
+++ b/web/components/FcPaneMapPopup.vue
@@ -300,7 +300,8 @@ export default {
         if (this.featureLocationsEditIndex !== -1) {
           return false;
         }
-        return this.locationsEditIndex === -1 && this.locationsEdit.length >= MAX_LOCATIONS;
+        return this.locationsEditIndex === -1
+          && this.locationsEditSelection.locations.length >= MAX_LOCATIONS;
       }
       return false;
     },
@@ -313,7 +314,7 @@ export default {
         return false;
       }
       const { centrelineId, centrelineType } = this.feature.properties;
-      return this.locationsEdit.findIndex(
+      return this.locationsEditSelection.locations.findIndex(
         location => location.centrelineType === centrelineType
           && location.centrelineId === centrelineId,
       );
@@ -385,7 +386,11 @@ export default {
       }
       return null;
     },
-    ...mapState(['locationsEditIndex', 'locationMode', 'locationsEdit']),
+    ...mapState([
+      'locationsEditIndex',
+      'locationsEditSelection',
+      'locationMode',
+    ]),
   },
   watch: {
     coordinates() {

--- a/web/components/FcPaneMapPopup.vue
+++ b/web/components/FcPaneMapPopup.vue
@@ -33,13 +33,12 @@
 
 <script>
 import mapboxgl from 'mapbox-gl/dist/mapbox-gl';
-import { mapMutations, mapState } from 'vuex';
+import { mapGetters, mapMutations, mapState } from 'vuex';
 
 import {
   CentrelineType,
   LocationMode,
   LocationSelectionType,
-  MAX_LOCATIONS,
 } from '@/lib/Constants';
 import { formatCountLocationDescription } from '@/lib/StringFormatters';
 import {
@@ -300,8 +299,7 @@ export default {
         if (this.featureLocationsEditIndex !== -1) {
           return false;
         }
-        return this.locationsEditIndex === -1
-          && this.locationsEditSelection.locations.length >= MAX_LOCATIONS;
+        return this.locationsEditIndex === -1 && this.locationsEditFull;
       }
       return false;
     },
@@ -391,6 +389,7 @@ export default {
       'locationsEditSelection',
       'locationMode',
     ]),
+    ...mapGetters(['locationsEditFull']),
   },
   watch: {
     coordinates() {

--- a/web/components/FcPaneMapPopup.vue
+++ b/web/components/FcPaneMapPopup.vue
@@ -295,7 +295,7 @@ export default {
         if (this.featureLocationsEditIndex !== -1) {
           return false;
         }
-        return this.locationEditIndex === -1 && this.locationsEdit.length >= MAX_LOCATIONS;
+        return this.locationsEditIndex === -1 && this.locationsEdit.length >= MAX_LOCATIONS;
       }
       return false;
     },
@@ -334,10 +334,10 @@ export default {
         if (this.featureLocationsEditIndex !== -1) {
           return `Remove Location #${this.featureLocationsEditIndex + 1}`;
         }
-        if (this.locationEditIndex === -1) {
+        if (this.locationsEditIndex === -1) {
           return 'Add Location';
         }
-        return `Set Location #${this.locationEditIndex + 1}`;
+        return `Set Location #${this.locationsEditIndex + 1}`;
       }
       return 'View Data';
     },
@@ -380,7 +380,7 @@ export default {
       }
       return null;
     },
-    ...mapState(['locationEditIndex', 'locationMode', 'locationsEdit']),
+    ...mapState(['locationsEditIndex', 'locationMode', 'locationsEdit']),
   },
   watch: {
     coordinates() {

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -65,7 +65,7 @@
       <div class="d-flex align-center">
         <template v-if="locationMode === LocationMode.MULTI_EDIT">
           <v-checkbox
-            v-model="locationsEditSelection.corridor"
+            v-model="internalCorridor"
             class="fc-multi-location-corridor mt-0"
             hide-details
             label="Include intersections and midblocks between locations" />
@@ -119,7 +119,12 @@ import {
   mapState,
 } from 'vuex';
 
-import { centrelineKey, LocationMode, MAX_LOCATIONS } from '@/lib/Constants';
+import {
+  centrelineKey,
+  LocationMode,
+  LocationSelectionType,
+  MAX_LOCATIONS,
+} from '@/lib/Constants';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcInputLocationSearch from '@/web/components/inputs/FcInputLocationSearch.vue';
 
@@ -143,6 +148,18 @@ export default {
         return this.locationsEditDescription;
       }
       return this.locationsDescription;
+    },
+    internalCorridor: {
+      get() {
+        return this.locationsEditSelection.selectionType === LocationSelectionType.CORRIDOR;
+      },
+      set(corridor) {
+        if (corridor) {
+          this.setLocationEditSelectionType(LocationSelectionType.CORRIDOR);
+        } else {
+          this.setLocationEditSelectionType(LocationSelectionType.POINTS);
+        }
+      },
     },
     locationsEditKeys() {
       const keyCounter = new Map();
@@ -177,10 +194,14 @@ export default {
     ]),
   },
   watch: {
-    async locationsEditSelection() {
-      this.loading = true;
-      await this.syncLocationsEdit();
-      this.loading = false;
+    locationsEditSelection: {
+      deep: true,
+      async handler() {
+        console.log('syncing...');
+        this.loading = true;
+        await this.syncLocationsEdit();
+        this.loading = false;
+      },
     },
   },
   methods: {
@@ -203,6 +224,7 @@ export default {
       'saveLocationsEdit',
       'setLocationEdit',
       'setLocationEditIndex',
+      'setLocationEditSelectionType',
       'setLocationMode',
     ]),
   },

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -54,7 +54,7 @@
         class="display-3 mb-4"
         :title="description">
         <span
-          v-if="locationsSelection.locations.length === 0"
+          v-if="locationsEmpty"
           class="secondary--text">
           No locations selected
         </span>
@@ -78,7 +78,7 @@
             Cancel
           </FcButton>
           <FcButton
-            :disabled="loading || locationsEditSelection.locations.length === 0"
+            :disabled="loading || locationsEmpty"
             :loading="loading"
             type="secondary"
             @click="saveLocationsEdit">
@@ -112,11 +112,14 @@
 </template>
 
 <script>
-import { mapActions, mapMutations, mapState } from 'vuex';
+import {
+  mapActions,
+  mapGetters,
+  mapMutations,
+  mapState,
+} from 'vuex';
 
 import { centrelineKey, LocationMode, MAX_LOCATIONS } from '@/lib/Constants';
-import { getLocationsDescription } from '@/lib/geo/CentrelineUtils';
-import CompositeId from '@/lib/io/CompositeId';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcInputLocationSearch from '@/web/components/inputs/FcInputLocationSearch.vue';
 
@@ -136,7 +139,10 @@ export default {
   },
   computed: {
     description() {
-      return getLocationsDescription(this.locationsEditSelection.features);
+      if (this.locationMode === LocationMode.MULTI_EDIT) {
+        return this.locationsEditDescription;
+      }
+      return this.locationsDescription;
     },
     locationsEditKeys() {
       const keyCounter = new Map();
@@ -161,7 +167,13 @@ export default {
       'locationMode',
       'locations',
       'locationsEdit',
+      'locationsEditIndex',
       'locationsEditSelection',
+    ]),
+    ...mapGetters([
+      'locationsDescription',
+      'locationsEditDescription',
+      'locationsEmpty',
     ]),
   },
   watch: {
@@ -177,10 +189,10 @@ export default {
       this.removeLocationEdit(i);
     },
     actionViewData() {
-      const s1 = CompositeId.encode(this.locations);
+      const params = this.locationsRouteParams;
       this.$router.push({
         name: 'viewDataAtLocation',
-        params: { s1 },
+        params,
       });
     },
     ...mapActions(['syncLocationsEdit']),

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -183,6 +183,7 @@ export default {
     ...mapState([
       'locationMode',
       'locations',
+      'locationsSelection',
       'locationsEdit',
       'locationsEditIndex',
       'locationsEditSelection',

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -197,7 +197,6 @@ export default {
     locationsEditSelection: {
       deep: true,
       async handler() {
-        console.log('syncing...');
         this.loading = true;
         await this.syncLocationsEdit();
         this.loading = false;

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -14,7 +14,7 @@
             @focus="setLocationEditIndex(i)"
             @location-remove="actionRemove" />
           <FcInputLocationSearch
-            v-if="locationsEditSelection.locations.length < MAX_LOCATIONS"
+            v-if="!locationsEditFull"
             v-model="locationToAdd"
             :location-index="-1"
             @focus="setLocationEditIndex(-1)"
@@ -139,7 +139,6 @@ export default {
       loading: false,
       LocationMode,
       locationToAdd: null,
-      MAX_LOCATIONS,
     };
   },
   computed: {
@@ -174,8 +173,7 @@ export default {
       });
     },
     messagesMaxLocations() {
-      if (this.locationMode !== LocationMode.MULTI_EDIT
-        || this.locationsEditSelection.locations.length < MAX_LOCATIONS) {
+      if (this.locationMode !== LocationMode.MULTI_EDIT || !this.locationsEditFull) {
         return [];
       }
       return [`Maximum of ${MAX_LOCATIONS} selected locations.`];
@@ -191,6 +189,7 @@ export default {
     ...mapGetters([
       'locationsDescription',
       'locationsEditDescription',
+      'locationsEditFull',
       'locationsEmpty',
     ]),
   },

--- a/web/components/inputs/FcSelectorSingleLocation.vue
+++ b/web/components/inputs/FcSelectorSingleLocation.vue
@@ -24,8 +24,9 @@
 </template>
 
 <script>
-import { mapMutations, mapState } from 'vuex';
+import { mapGetters, mapMutations } from 'vuex';
 
+import { LocationSelectionType } from '@/lib/Constants';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcInputLocationSearch from '@/web/components/inputs/FcInputLocationSearch.vue';
 
@@ -43,23 +44,24 @@ export default {
     },
     internalLocation: {
       get() {
-        if (this.locations.length === 0) {
-          return null;
-        }
-        return this.locations[0];
+        return this.location;
       },
       set(internalLocation) {
-        if (internalLocation === null) {
-          this.setLocations([]);
-        } else {
-          this.setLocations([internalLocation]);
+        const locations = [];
+        if (internalLocation !== null) {
+          locations.push(internalLocation);
         }
+        this.setLocations(locations);
+        this.setLocationsSelection({
+          locations,
+          selectionType: LocationSelectionType.POINTS,
+        });
       },
     },
-    ...mapState(['locations']),
+    ...mapGetters(['location']),
   },
   methods: {
-    ...mapMutations(['setLocations']),
+    ...mapMutations(['setLocations', 'setLocationsSelection']),
   },
 };
 </script>

--- a/web/components/nav/FcDashboardNav.vue
+++ b/web/components/nav/FcDashboardNav.vue
@@ -23,9 +23,8 @@
 </template>
 
 <script>
-import { mapState } from 'vuex';
+import { mapGetters } from 'vuex';
 
-import CompositeId from '@/lib/io/CompositeId';
 import FcDashboardNavItem from '@/web/components/nav/FcDashboardNavItem.vue';
 
 export default {
@@ -35,16 +34,16 @@ export default {
   },
   computed: {
     toViewMap() {
-      if (this.locations.length === 0) {
+      if (this.locationsEmpty) {
         return { name: 'viewData' };
       }
-      const s1 = CompositeId.encode(this.locations);
+      const params = this.locationsRouteParams;
       return {
         name: 'viewDataAtLocation',
-        params: { s1 },
+        params,
       };
     },
-    ...mapState(['locations']),
+    ...mapGetters(['locationsEmpty', 'locationsRouteParams']),
   },
 };
 </script>

--- a/web/router.js
+++ b/web/router.js
@@ -81,7 +81,7 @@ const router = new Router({
           next();
         },
       }, {
-        path: '/view/location/:s1/:corridor',
+        path: '/view/location/:s1/:selectionTypeName',
         name: 'viewDataAtLocation',
         meta: {
           auth: { mode: 'try' },
@@ -94,7 +94,7 @@ const router = new Router({
           next();
         },
       }, {
-        path: '/view/location/:s1/:corridor/reports/collision',
+        path: '/view/location/:s1/:selectionTypeName/reports/collision',
         name: 'viewCollisionReportsAtLocation',
         meta: {
           auth: { mode: 'try' },
@@ -107,7 +107,7 @@ const router = new Router({
           next();
         },
       }, {
-        path: '/view/location/:s1/:corridor/reports/:studyTypeName',
+        path: '/view/location/:s1/:selectionTypeName/reports/:studyTypeName',
         name: 'viewStudyReportsAtLocation',
         meta: {
           auth: { mode: 'try' },

--- a/web/router.js
+++ b/web/router.js
@@ -81,7 +81,7 @@ const router = new Router({
           next();
         },
       }, {
-        path: '/view/location/:s1',
+        path: '/view/location/:s1/:corridor',
         name: 'viewDataAtLocation',
         meta: {
           auth: { mode: 'try' },
@@ -94,7 +94,7 @@ const router = new Router({
           next();
         },
       }, {
-        path: '/view/location/:s1/reports/collision',
+        path: '/view/location/:s1/:corridor/reports/collision',
         name: 'viewCollisionReportsAtLocation',
         meta: {
           auth: { mode: 'try' },
@@ -107,7 +107,7 @@ const router = new Router({
           next();
         },
       }, {
-        path: '/view/location/:s1/reports/:studyTypeName',
+        path: '/view/location/:s1/:corridor/reports/:studyTypeName',
         name: 'viewStudyReportsAtLocation',
         meta: {
           auth: { mode: 'try' },

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -116,9 +116,6 @@ export default new Vuex.Store({
       const s1 = CompositeId.encode(locations);
       return { s1, selectionTypeName: selectionType.name };
     },
-    s1(state) {
-      return CompositeId.encode(state.locationsSelection.locations);
-    },
   },
   mutations: {
     // AUTH / HELPERS STATE
@@ -283,7 +280,7 @@ export default new Vuex.Store({
       commit('setLocations', locationsNext);
     },
     async syncLocationsEdit({ commit, state }) {
-      const { locationsEditSelection: { locations, selectionType } } = state;
+      const { locations, selectionType } = state.locationsEditSelection;
       let locationsEdit = locations;
       if (selectionType === LocationSelectionType.CORRIDOR) {
         locationsEdit = await getLocationsByCorridor(locations);

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -1,7 +1,11 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 
-import { LocationMode, LocationSelectionType } from '@/lib/Constants';
+import {
+  LocationMode,
+  LocationSelectionType,
+  MAX_LOCATIONS,
+} from '@/lib/Constants';
 import {
   getAuth,
   getLocationsByCentreline,
@@ -108,13 +112,28 @@ export default new Vuex.Store({
       const { locations } = state.locationsEditSelection;
       return getLocationsDescription(locations);
     },
+    locationsEditFull(state) {
+      return state.locationsEditSelection.locations.length >= MAX_LOCATIONS;
+    },
     locationsEmpty(state) {
       return state.locationsSelection.locations.length === 0;
+    },
+    locationsForMode(state) {
+      if (state.locationMode === LocationMode.MULTI_EDIT) {
+        return state.locationsEdit;
+      }
+      return state.locations;
     },
     locationsRouteParams(state) {
       const { locations, selectionType } = state.locationsSelection;
       const s1 = CompositeId.encode(locations);
       return { s1, selectionTypeName: selectionType.name };
+    },
+    locationsSelectionForMode(state) {
+      if (state.locationMode === LocationMode.MULTI_EDIT) {
+        return state.locationsEditSelection;
+      }
+      return state.locationsSelection;
     },
   },
   mutations: {


### PR DESCRIPTION
# Issue Addressed
This PR closes #510 .

# Description
We add new selection states `locationsSelection` / `locationsEditSelection` alongside `locations` / `locationsEdit`.  These selection states store the user's selected locations, as well as a `selectionType` that identifies whether this is a corridor or non-corridor selection.

In `MULTI_EDIT` mode, when the user updates the `selectionType` or the list of selected locations, we call a new action `syncLocationsEdit` that updates `locationsEdit`.  In non-corridor mode, it just copies the selected locations to `locationsEdit`; in corridor mode, it additionally makes a request to our routing API, then copies the resulting corridor to `locationsEdit`.

We also provide a new action `initLocations`, which initializes `locations` and `locationsSelection` from frontend route params.

Note that these changes do _not_ affect REST API endpoints for fetching collision / study data: the intent is that we can pass `CompositeId.encode(locations)` to these endpoints, so that from their point of view a corridor is just another set of centreline features to fetch data over.

# Tests
Tested the View Map and multi-location selection flows in frontend, including toggling the corridor checkbox on and off.

There is still a known issue where `routing.centreline_vertices` and `routing.centreline_edges` contain _all_ centreline features, including ones of types not captured in `RoadIntersectionType` / `RoadSegmentType`.  We'll need to think about what the right approach there is.