### PR TITLE
Limit routing edges table to more major features

### DIFF
--- a/scripts/airflow/tasks/routing_index/transform_centreline_edges.sql
+++ b/scripts/airflow/tasks/routing_index/transform_centreline_edges.sql
@@ -14,6 +14,7 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS routing.centreline_edges AS (
   FROM gis.centreline c
   JOIN routing.centreline_vertices vf ON c.fnode = vf.id
   JOIN routing.centreline_vertices vt ON c.tnode = vt.id
+  WHERE c.fcode <= 201800
 );
 CREATE UNIQUE INDEX IF NOT EXISTS centreline_edges_id ON routing.centreline_edges (id);
 CREATE INDEX IF NOT EXISTS centreline_edges_source ON routing.centreline_edges (source);


### PR DESCRIPTION
# Issue Addressed
This PR makes progress on #528 , as part of addressing review comments on #510 .

# Description
We prevent routing corridors along trails and other minor edge features like access / utility roads by removing these from `routing.centreline_edges`.

# Tests
Ran `routing_index` and `dev_data` DAGs, loaded new dev dataset, tested it out.
