### PR TITLE
Add square "includes" pins in MULTI (view) location selection mode

### DIFF
--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -209,6 +209,7 @@ export default {
     ...mapState([
       'locationMode',
       'locations',
+      'locationsIndex',
       'locationsSelection',
       'locationsEdit',
       'locationsEditIndex',

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -11,13 +11,13 @@
             v-model="locationsEditSelection.locations[i]"
             :location-index="i"
             :selected="i === locationsEditIndex"
-            @focus="setLocationEditIndex(i)"
+            @focus="setLocationsEditIndex(i)"
             @location-remove="actionRemove" />
           <FcInputLocationSearch
             v-if="!locationsEditFull"
             v-model="locationToAdd"
             :location-index="-1"
-            @focus="setLocationEditIndex(-1)"
+            @focus="setLocationsEditIndex(-1)"
             @location-add="addLocationEdit" />
         </div>
         <v-messages
@@ -40,14 +40,10 @@
     <div
       v-else
       class="flex-grow-1 flex-shrink-1">
-      <div class="fc-input-location-search-wrapper elevation-2">
-        <FcInputLocationSearch
-          v-for="(_, i) in locationsSelection.locations"
-          :key="i"
-          v-model="locationsSelection.locations[i]"
-          :location-index="i"
-          readonly />
-      </div>
+      <FcDisplayLocationMulti
+        :locations="locations"
+        :locations-index="locationsIndex"
+        :locations-selection="locationsSelection" />
     </div>
     <div class="flex-grow-0 flex-shrink-0">
       <h1
@@ -129,11 +125,13 @@ import {
 import { getLocationsWaypointIndices } from '@/lib/geo/CentrelineUtils';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcInputLocationSearch from '@/web/components/inputs/FcInputLocationSearch.vue';
+import FcDisplayLocationMulti from '@/web/components/location/FcDisplayLocationMulti.vue';
 
 export default {
   name: 'FcSelectorMultiLocation',
   components: {
     FcButton,
+    FcDisplayLocationMulti,
     FcInputLocationSearch,
   },
   data() {
@@ -237,7 +235,7 @@ export default {
   },
   methods: {
     actionRemove(i) {
-      this.setLocationEditIndex(-1);
+      this.setLocationsEditIndex(-1);
       this.removeLocationEdit(i);
     },
     actionViewData() {
@@ -254,7 +252,7 @@ export default {
       'removeLocationEdit',
       'saveLocationsEdit',
       'setLocationEdit',
-      'setLocationEditIndex',
+      'setLocationsEditIndex',
       'setLocationEditSelectionType',
       'setLocationMode',
     ]),

--- a/web/components/location/FcDisplayLocationMulti.vue
+++ b/web/components/location/FcDisplayLocationMulti.vue
@@ -1,0 +1,100 @@
+<template>
+  <div class="fc-input-location-search-wrapper elevation-2">
+    <div
+      v-for="(_, i) in locationsSelection.locations"
+      :key="i"
+      class="fc-input-location-search">
+      <v-text-field
+        v-model="locationsSelection.locations[i].description"
+        autocomplete="off"
+        dense
+        flat
+        hide-details
+        readonly
+        solo>
+        <template v-slot:append>
+          <FcIconLocationMulti
+            :location-index="i"
+            :selected="locationsIndex === waypointLocationsIndices[i]" />
+          <template v-if="intersectionsByWaypoint[i].length > 0">
+            <span class="pl-1">&#x2022;</span>
+            <template v-if="intersectionsByWaypoint[i].length <= 3">
+              <FcIconLocationMulti
+                v-for="j in intersectionsByWaypoint[i]"
+                :key="'icon_' + i + '_' + j"
+                class="ml-1"
+                :location-index="-1"
+                :selected="locationsIndex === j" />
+            </template>
+            <template v-else>
+              <FcIconLocationMulti
+                class="ml-1"
+                :location-index="-1"
+                :selected="intersectionsByWaypoint[i].includes(locationsIndex)" />
+              <span class="pl-1 secondary--text subtitle-2">
+                <span v-if="intersectionsByWaypoint[i].includes(locationsIndex)">
+                  {{intersectionsByWaypoint[i].indexOf(locationsIndex)}} /
+                  {{intersectionsByWaypoint[i].length}}
+                </span>
+                <span v-else>&times; {{intersectionsByWaypoint[i].length}}</span>
+              </span>
+            </template>
+          </template>
+        </template>
+      </v-text-field>
+    </div>
+  </div>
+</template>
+
+<script>
+import { CentrelineType } from '@/lib/Constants';
+import { getLocationsWaypointIndices } from '@/lib/geo/CentrelineUtils';
+import FcIconLocationMulti from '@/web/components/location/FcIconLocationMulti.vue';
+
+export default {
+  name: 'FcDisplayLocationMulti',
+  components: {
+    FcIconLocationMulti,
+  },
+  props: {
+    locations: Array,
+    locationsIndex: Number,
+    locationsSelection: Object,
+  },
+  computed: {
+    intersectionsByWaypoint() {
+      let intersections = [];
+      const intersectionsByWaypoint = [];
+      this.locations.forEach(({ centrelineType }, i) => {
+        const waypointIndices = this.locationsWaypointIndices[i];
+        if (waypointIndices.length === 0) {
+          if (centrelineType === CentrelineType.INTERSECTION) {
+            intersections.push(i);
+          }
+        } else {
+          waypointIndices.forEach(() => {
+            intersectionsByWaypoint.push(intersections);
+            intersections = [];
+          });
+        }
+      });
+      return intersectionsByWaypoint;
+    },
+    locationsWaypointIndices() {
+      return getLocationsWaypointIndices(
+        this.locations,
+        this.locationsSelection.locations,
+      );
+    },
+    waypointLocationsIndices() {
+      const waypointLocationsIndices = [];
+      this.locationsWaypointIndices.forEach((waypointIndices, i) => {
+        waypointIndices.forEach(() => {
+          waypointLocationsIndices.push(i);
+        });
+      });
+      return waypointLocationsIndices;
+    },
+  },
+};
+</script>

--- a/web/components/location/FcIconLocationMulti.vue
+++ b/web/components/location/FcIconLocationMulti.vue
@@ -3,6 +3,7 @@
     class="fc-icon-location-multi">
     <img :src="src" :alt="alt" />
     <div
+      v-if="locationIndex !== -1"
       class="subtitle-2"
       :class="{
         'primary--text': selected,
@@ -17,7 +18,7 @@ export default {
   props: {
     locationIndex: {
       type: Number,
-      default: null,
+      default: -1,
     },
     selected: {
       type: Boolean,
@@ -26,10 +27,19 @@ export default {
   },
   computed: {
     alt() {
+      if (this.locationIndex === -1) {
+        return 'Included intersection between locations';
+      }
       const i = this.locationIndex + 1;
       return `Location #${i}`;
     },
     src() {
+      if (this.locationIndex === -1) {
+        if (this.selected) {
+          return '/icons/map/location-multi-corridor-selected.svg';
+        }
+        return '/icons/map/location-multi-corridor.svg';
+      }
       if (this.selected) {
         return '/icons/map/location-multi-small-selected.svg';
       }

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -49,6 +49,7 @@ export default new Vuex.Store({
     backViewRequest: { name: 'requestsTrack' },
     // LOCATION
     locations: [],
+    locationsIndex: -1,
     locationsSelection: {
       locations: [],
       selectionType: LocationSelectionType.POINTS,
@@ -213,7 +214,7 @@ export default new Vuex.Store({
     setLocationEditSelectionType(state, selectionType) {
       Vue.set(state.locationsEditSelection, 'selectionType', selectionType);
     },
-    setLocationEditIndex(state, locationsEditIndex) {
+    setLocationsEditIndex(state, locationsEditIndex) {
       Vue.set(state, 'locationsEditIndex', locationsEditIndex);
     },
     setLocationMode(state, locationMode) {
@@ -242,6 +243,9 @@ export default new Vuex.Store({
       } else {
         Vue.set(state, 'locationMode', LocationMode.SINGLE);
       }
+    },
+    setLocationsIndex(state, locationsIndex) {
+      Vue.set(state, 'locationsIndex', locationsIndex);
     },
     setLocationsSelection(state, locationsSelection) {
       const { locations, selectionType } = locationsSelection;


### PR DESCRIPTION
# Issue Addressed
This PR closes #511 .

# Description
When `locationMode === LocationMode.MULTI`, we now use a new component `FcDisplayLocationMulti` instead of `FcInputLocationSearch` to show the current location selection state.  This new component displays waypoint markers _and_ "includes" markers for intersections in between those waypoints.

Although we haven't yet built any multi-location user flows that page through locations in `MULTI` mode (such as in View Data designs), `FcDisplayLocationMulti` does provide this functionality, so that we can use it when needed.  This is powered by `CentrelineUtils.getLocationsWaypointIndices`, which we use to help determine both how many markers to show and whether those markers should be selected or not.

# Tests
Tested quickly in frontend: both corridor and non-corridor modes; both long and short corridors; adjacent features.
