### PR TITLE
Add sticky "in development" message at top of MOVE interface

### DIFF
--- a/web/App.vue
+++ b/web/App.vue
@@ -29,9 +29,12 @@
     </v-navigation-drawer>
     <v-main>
       <v-container
-        class="fill-height pa-0"
+        class="d-flex fill-height flex-column pa-0"
         fluid>
-        <router-view></router-view>
+        <FcDashboardNavInDevelopment />
+        <div class="flex-grow-1" style="width: 100%;">
+          <router-view></router-view>
+        </div>
       </v-container>
     </v-main>
   </v-app>
@@ -43,20 +46,25 @@ import { mapMutations, mapState } from 'vuex';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import '@/web/css/main.scss';
 
+import FcDialogAlertInDevelopment from
+  '@/web/components/dialogs/FcDialogAlertInDevelopment.vue';
 import FcDialogAlertStudyRequestUrgent from
   '@/web/components/dialogs/FcDialogAlertStudyRequestUrgent.vue';
 import FcDialogConfirmUnauthorized from
   '@/web/components/dialogs/FcDialogConfirmUnauthorized.vue';
-import FcDashboardNavBrand from '@/web/components/nav/FcDashboardNavBrand.vue';
 import FcDashboardNav from '@/web/components/nav/FcDashboardNav.vue';
+import FcDashboardNavBrand from '@/web/components/nav/FcDashboardNavBrand.vue';
+import FcDashboardNavInDevelopment from '@/web/components/nav/FcDashboardNavInDevelopment.vue';
 import FcDashboardNavUser from '@/web/components/nav/FcDashboardNavUser.vue';
 
 export default {
   name: 'App',
   components: {
-    FcDashboardNavBrand,
     FcDashboardNav,
+    FcDashboardNavBrand,
+    FcDashboardNavInDevelopment,
     FcDashboardNavUser,
+    FcDialogAlertInDevelopment,
     FcDialogAlertStudyRequestUrgent,
     FcDialogConfirmUnauthorized,
   },

--- a/web/components/dialogs/FcDialogAlertInDevelopment.vue
+++ b/web/components/dialogs/FcDialogAlertInDevelopment.vue
@@ -1,0 +1,37 @@
+<template>
+  <FcDialogAlert
+    v-model="internalValue"
+    title="MOVE's In Development!">
+    <div class="body-1">
+      <p>
+        Right now, we’re building a big new feature and releasing it here piece by piece.
+        We expect parts of the application to break.  We’re hoping to have a more stable
+        version of MOVE out soon that you can use without things breaking.  In the meantime,
+        please bear with us!
+      </p>
+
+      <p>
+        We do our best to make MOVE available on weekdays from 8:30am–6:00pm, but we can’t
+        guarantee this while we are still building the application.
+      </p>
+
+      <p>
+        If you have questions, please reach out to the MOVE Team at
+        <a href="mailto:move-team@toronto.ca">move-team@toronto.ca</a>.
+      </p>
+    </div>
+  </FcDialogAlert>
+</template>
+
+<script>
+import FcDialogAlert from '@/web/components/dialogs/FcDialogAlert.vue';
+import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+
+export default {
+  name: 'FcDialogAlertInDevelopment',
+  mixins: [FcMixinVModelProxy(Boolean)],
+  components: {
+    FcDialogAlert,
+  },
+};
+</script>

--- a/web/components/nav/FcDashboardNavInDevelopment.vue
+++ b/web/components/nav/FcDashboardNavInDevelopment.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="fc-dashboard-nav-in-development align-center d-flex px-5 py-2 warning lighten-3">
+    <div class="headline">
+      This is a development version of MOVE. You may experience unexpected downtime
+      and bugs at this time!
+    </div>
+    <v-spacer></v-spacer>
+    <FcButton
+      class="mr-2"
+      dense
+      type="secondary"
+      @click="actionLearnMore">
+      <v-icon left>mdi-information</v-icon>
+      Learn More
+    </FcButton>
+    <FcButton
+      type="secondary"
+      @click="actionContactUs">
+      <v-icon left>mdi-email-send</v-icon>
+      Contact Us
+    </FcButton>
+  </div>
+</template>
+
+<script>
+import { mapMutations } from 'vuex';
+
+import FcButton from '@/web/components/inputs/FcButton.vue';
+
+export default {
+  name: 'FcDashboardNavInDevelopment',
+  components: {
+    FcButton,
+  },
+  methods: {
+    actionContactUs() {
+      const url = 'mailto:move-team@toronto.ca';
+      window.open(url, '_blank');
+    },
+    actionLearnMore() {
+      this.setDialog({
+        dialog: 'AlertInDevelopment',
+        dialogData: {},
+      });
+    },
+    ...mapMutations(['setDialog']),
+  },
+};
+</script>
+
+<style lang="scss">
+.fc-dashboard-nav-in-development {
+  width: 100%;
+}
+</style>


### PR DESCRIPTION
# Issue Addressed
This PR closes #536 .

# Description
We add a sticky "in development" message bar at top.  This bar provides two actions: "Learn More", which opens a dialog that tells the user more about our development plans, and "Contact Us" to send an email to the MOVE Team address.

# Tests
Tested quickly in frontend on a variety of frontend routes.
