### PR TITLE
View Data: finish detail view

### DIFF
--- a/lib/geo/GeoStyle.js
+++ b/lib/geo/GeoStyle.js
@@ -452,8 +452,11 @@ class GeoStyle {
           'line-sort-key': ['get', 'aadt'],
         },
         paint: {
-          'line-color': '#54a1e5',
-          'line-opacity': 0.5,
+          'line-color': [
+            'case',
+            ['get', 'selected'], '#ffffff',
+            '#19608c',
+          ],
           'line-width': [
             'interpolate',
             ['linear'],
@@ -484,7 +487,11 @@ class GeoStyle {
         minzoom: MapZoom.LEVEL_2.minzoom,
         maxzoom: MapZoom.LEVEL_1.maxzoomSource + 1,
         paint: {
-          'line-color': '#19608c',
+          'line-color': [
+            'case',
+            ['get', 'selected'], '#19608c',
+            '#ffffff',
+          ],
           'line-gap-width': lineWidth,
           'line-width': 1,
         },
@@ -517,9 +524,16 @@ class GeoStyle {
         filter: ['==', ['get', 'centrelineType'], CentrelineType.INTERSECTION],
         type: 'circle',
         paint: {
-          'circle-color': '#54a1e5',
-          'circle-opacity': 0.5,
-          'circle-stroke-color': '#19608c',
+          'circle-color': [
+            'case',
+            ['get', 'selected'], '#ffffff',
+            '#19608c',
+          ],
+          'circle-stroke-color': [
+            'case',
+            ['get', 'selected'], '#19608c',
+            '#ffffff',
+          ],
           'circle-stroke-width': 1,
           'circle-radius': 6,
         },

--- a/web/components/FcDataTableCollisions.vue
+++ b/web/components/FcDataTableCollisions.vue
@@ -1,42 +1,52 @@
 <template>
-  <FcDataTable
-    class="fc-data-table-collisions"
-    :columns="columns"
-    disable-sort
-    :loading="loading"
-    :items="[collisionSummary]">
-    <template v-slot:item.AMOUNT="{ item }">
-      <span>{{item.amount}}</span>
-    </template>
-    <template v-slot:item.KSI="{ item }">
-      <span>{{item.ksi}}</span>
-    </template>
-    <template v-slot:item.VALIDATED="{ item }">
-      <span>{{item.validated}}</span>
-    </template>
-    <template v-slot:header.VIEW_REPORT>
-      <span class="sr-only">Reports</span>
-    </template>
-    <template v-slot:item.VIEW_REPORT="{ item }">
+  <div class="align-end d-flex mb-5 mx-5">
+    <v-progress-linear
+      v-if="loading"
+      indeterminate />
+    <template v-else>
+      <div class="flex-grow-1 flex-shrink-1">
+        <div class="font-weight-regular title">
+          Amount
+        </div>
+        <div class="display-2 mt-2">
+          {{collisionSummary.amount}}
+        </div>
+      </div>
+      <div class="flex-grow-1 flex-shrink-1">
+        <div class="font-weight-regular title">
+          KSI
+        </div>
+        <div class="display-2 mt-2">
+          {{collisionSummary.ksi}}
+        </div>
+      </div>
+      <div class="flex-grow-0 flex-shrink-0 mr-12 pr-2">
+        <div class="font-weight-regular title">
+          Validated
+        </div>
+        <div class="display-2 mt-2">
+          {{collisionSummary.validated}}
+        </div>
+      </div>
       <FcButton
+        class="flex-grow-0 flex-shrink-0"
         type="tertiary"
-        :disabled="item.amount === 0"
+        :disabled="collisionSummary.amount === 0"
         @click="$emit('show-reports', item)">
         <span>View Reports</span>
       </FcButton>
     </template>
-  </FcDataTable>
+  </div>
 </template>
 
 <script>
-import FcDataTable from '@/web/components/FcDataTable.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 
 export default {
   name: 'FcDataTableCollisions',
   components: {
     FcButton,
-    FcDataTable,
+    // FcDataTable,
   },
   props: {
     collisionSummary: Object,

--- a/web/components/FcDataTableCollisions.vue
+++ b/web/components/FcDataTableCollisions.vue
@@ -46,7 +46,6 @@ export default {
   name: 'FcDataTableCollisions',
   components: {
     FcButton,
-    // FcDataTable,
   },
   props: {
     collisionSummary: Object,

--- a/web/components/FcDataTableStudies.vue
+++ b/web/components/FcDataTableStudies.vue
@@ -1,6 +1,6 @@
 <template>
   <FcDataTable
-    class="fc-data-table-studies"
+    class="fc-data-table-studies mx-1"
     :columns="columns"
     disable-sort
     :loading="loading"


### PR DESCRIPTION
# Issue Addressed
This PR closes #516 .

# Description
Previously, `FcPaneMap` only showed selected markers in `MULTI_EDIT` mode; we extend that to `MULTI` mode as well, and update the look-and-feel to use full fill as per design comments.

We also rework `FcDataTableCollisions` - this no longer uses `FcDataTable`, but now instead uses a simple `<div class="d-flex">`.

# Tests
Tested quickly in frontend.
