### PR TITLE
View Data: multi-location aggregate view

### DIFF
--- a/lib/MapUtils.js
+++ b/lib/MapUtils.js
@@ -1,0 +1,16 @@
+function setdefault(map, key, defaultValue) {
+  if (map.has(key)) {
+    return map.get(key);
+  }
+  map.set(key, defaultValue);
+  return defaultValue;
+}
+
+const MapUtils = {
+  setdefault,
+};
+
+export {
+  MapUtils as default,
+  setdefault,
+};

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -64,6 +64,13 @@ async function getCollisionsByCentrelineSummary(features, filters) {
   return apiClient.fetch('/collisions/byCentreline/summary', options);
 }
 
+async function getCollisionsByCentrelineSummaryPerLocation(features, filters) {
+  const s1 = CompositeId.encode(features);
+  const data = { s1, ...filters };
+  const options = { data };
+  return apiClient.fetch('/collisions/byCentreline/summaryPerLocation', options);
+}
+
 async function getCollisionsByCentrelineTotal(features) {
   const s1 = CompositeId.encode(features);
   const data = { s1 };
@@ -192,6 +199,28 @@ async function getStudiesByCentrelineSummary(features, filters) {
     }),
   );
   return studySummarySchema.validateAsync(studySummary);
+}
+
+async function getStudiesByCentrelineSummaryPerLocation(features, filters) {
+  const s1 = CompositeId.encode(features);
+  const data = { s1, ...filters };
+  const options = { data };
+  const studySummaryPerLocation = await apiClient.fetch(
+    '/studies/byCentreline/summaryPerLocation',
+    options,
+  );
+  const studySummaryPerLocationSchema = Joi.array().items(
+    Joi.object().keys({
+      category: Category.read,
+      perLocation: Joi.array().items(
+        Joi.object().keys({
+          mostRecent: Study.read.allow(null),
+          n: Joi.number().integer().min(0).required(),
+        }),
+      ),
+    }),
+  );
+  return studySummaryPerLocationSchema.validateAsync(studySummaryPerLocation);
 }
 
 async function getStudiesByCentrelineTotal(features) {
@@ -399,6 +428,7 @@ const WebApi = {
   getCollisionByCollisionId,
   getCollisionsByCentreline,
   getCollisionsByCentrelineSummary,
+  getCollisionsByCentrelineSummaryPerLocation,
   getCollisionsByCentrelineTotal,
   getLocationByCentreline,
   getLocationsByCentreline,
@@ -409,6 +439,7 @@ const WebApi = {
   getReportWeb,
   getStudiesByCentreline,
   getStudiesByCentrelineSummary,
+  getStudiesByCentrelineSummaryPerLocation,
   getStudiesByCentrelineTotal,
   getStudyRequest,
   getStudyRequests,
@@ -429,6 +460,7 @@ export {
   getCollisionByCollisionId,
   getCollisionsByCentreline,
   getCollisionsByCentrelineSummary,
+  getCollisionsByCentrelineSummaryPerLocation,
   getCollisionsByCentrelineTotal,
   getLocationByCentreline,
   getLocationsByCentreline,
@@ -439,6 +471,7 @@ export {
   getReportWeb,
   getStudiesByCentreline,
   getStudiesByCentrelineSummary,
+  getStudiesByCentrelineSummaryPerLocation,
   getStudiesByCentrelineTotal,
   getStudyRequest,
   getStudyRequests,

--- a/lib/controller/CollisionController.js
+++ b/lib/controller/CollisionController.js
@@ -102,6 +102,48 @@ CollisionController.push({
 });
 
 /**
+ * Fetch summary statistics on collisions matching the given query, broken down per location.
+ *
+ * This returns an array, one element per feature in the given `CentrelineSelection`, regardless
+ * of whether they have matching collisions, in the same order as they appear in that selection.
+ * Since selections can contain duplicate features (e.g. if a selected corridor loops back
+ * on itself), the sum of `amount` values in the response may exceed the total as determined using
+ * {@link CollisionController.getCollisionsByCentrelineTotal}.
+ *
+ * If consistency between summary and total stats is desired, you should either pass a
+ * `CentrelineSelection` containing unique features here, or post-process the result to only
+ * consider summary stats from unique features, or use the total endpoint to retrieve total stats
+ * as needed.
+ *
+ * @memberof CollisionController
+ * @name getCollisionsByCentrelineSummaryPerLocation
+ */
+CollisionController.push({
+  method: 'GET',
+  path: '/collisions/byCentreline/summaryPerLocation',
+  options: {
+    auth: { mode: 'try' },
+    response: {
+      schema: Joi.array().items({
+        amount: Joi.number().integer().min(0).required(),
+        ksi: Joi.number().integer().min(0).required(),
+        validated: Joi.number().integer().min(0).required(),
+      }),
+    },
+    validate: {
+      query: {
+        ...CentrelineSelection,
+        ...CollisionFilters,
+      },
+    },
+  },
+  handler: async (request) => {
+    const { s1: features, ...collisionQuery } = request.query;
+    return CollisionDAO.byCentrelineSummaryPerLocation(features, collisionQuery);
+  },
+});
+
+/**
  * Fetch total number of collisions at the given centreline feature, regardless of
  * active filters.
  *

--- a/lib/controller/StudyController.js
+++ b/lib/controller/StudyController.js
@@ -15,7 +15,7 @@ import CentrelineSelection from '@/lib/model/helpers/CentrelineSelection';
 const StudyController = [];
 
 /**
- * Fetch summary statistics on counts matching the given query.
+ * Fetch studies matching the given query.
  *
  * @memberof StudyController
  * @name getStudiesByCentreline
@@ -59,7 +59,10 @@ StudyController.push({
 });
 
 /**
- * Fetch summary statistics on counts matching the given query.
+ * Fetch summary statistics on studies matching the given query.
+ *
+ * This returns an array by category.  Only categories for which there is at least one matching
+ * study are represented in this array.
  *
  * @memberof StudyController
  * @name getStudiesByCentrelineSummary
@@ -90,6 +93,69 @@ StudyController.push({
       const { s1: features, ...studyQuery } = request.query;
       const studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);
       return studySummary;
+    } catch (err) {
+      return Boom.badRequest(err.message);
+    }
+  },
+});
+
+/**
+ * Fetch summary statistics on studies matching the given query, broken down per location.
+ *
+ * This returns an array of arrays, first by category and then by location.  Only categories for
+ * which there is at least one matching study are represented in this first-level array.
+ *
+ * These second-level arrays contain one element per feature in the given `CentrelineSelection`,
+ * regardless of whether they have matching studies of the first-level category, in the same order
+ * as they appear in that selection.  Since selections can contain duplicate features (e.g. if a
+ * selected corridor loops back on itself), the sum of `n` values in the response may exceed:
+ *
+ * - the total per category as determined using
+ *   {@link CollisionController.getCollisionsByCentrelineSummary};
+ * - the overall total as determined using
+ *   {@link CollisionController.getCollisionsByCentrelineTotal}.
+ *
+ * If consistency between summary and total stats is desired, you should either pass a
+ * `CentrelineSelection` containing unique features here, or post-process the result to only
+ * consider summary stats from unique features, or use those two endpoints to retrieve summary
+ * and total stats as needed.
+ *
+ * @memberof StudyController
+ * @name getStudiesByCentrelineSummaryPerLocation
+ */
+StudyController.push({
+  method: 'GET',
+  path: '/studies/byCentreline/summaryPerLocation',
+  options: {
+    auth: { mode: 'try' },
+    response: {
+      schema: Joi.array().items(
+        Joi.object().keys({
+          category: Category.read,
+          perLocation: Joi.array().items(
+            Joi.object().keys({
+              mostRecent: Study.read.allow(null),
+              n: Joi.number().integer().min(0).required(),
+            }),
+          ),
+        }),
+      ),
+    },
+    validate: {
+      query: {
+        ...CentrelineSelection,
+        ...StudyFilters,
+      },
+    },
+  },
+  handler: async (request) => {
+    try {
+      const { s1: features, ...studyQuery } = request.query;
+      const studySummaryPerLocation = await StudyDAO.byCentrelineSummaryPerLocation(
+        features,
+        studyQuery,
+      );
+      return studySummaryPerLocation;
     } catch (err) {
       return Boom.badRequest(err.message);
     }

--- a/lib/db/CentrelineDAO.js
+++ b/lib/db/CentrelineDAO.js
@@ -21,14 +21,16 @@ class CentrelineDAO {
     }
     const sql = `
 SELECT
-  CAST(geo_id AS INT),
-  lfn_id,
-  lf_name,
-  fcode,
-  ST_AsGeoJSON(ST_ClosestPoint(geom, ST_Centroid(geom)))::json AS "geomPoint",
-  ST_AsGeoJSON(ST_LineMerge(geom))::json AS geom
-  FROM gis.centreline
-  WHERE geo_id IN ($(centrelineIds:csv))`;
+  va.aadt,
+  CAST(gc.geo_id AS INT),
+  gc.lfn_id,
+  gc.lf_name,
+  gc.fcode,
+  ST_AsGeoJSON(ST_ClosestPoint(gc.geom, ST_Centroid(gc.geom)))::json AS "geomPoint",
+  ST_AsGeoJSON(ST_LineMerge(gc.geom))::json AS geom
+  FROM gis.centreline gc
+  LEFT JOIN volume.aadt va ON gc.geo_id = va.centreline_id
+  WHERE gc.geo_id IN ($(centrelineIds:csv))`;
     const rows = await db.manyOrNone(sql, { centrelineIds });
     return rows.map(segmentToFeature);
   }
@@ -36,14 +38,16 @@ SELECT
   static async segmentsIncidentTo(intersectionId) {
     const sql = `
 SELECT
-  CAST(geo_id AS INT),
-  lfn_id,
-  lf_name,
-  fcode,
-  ST_AsGeoJSON(ST_ClosestPoint(geom, ST_Centroid(geom)))::json AS "geomPoint",
-  ST_AsGeoJSON(ST_lineMerge(geom))::json AS geom
-  FROM gis.centreline
-  WHERE fnode = $(intersectionId) OR tnode = $(intersectionId)`;
+  va.aadt,
+  CAST(gc.geo_id AS INT),
+  gc.lfn_id,
+  gc.lf_name,
+  gc.fcode,
+  ST_AsGeoJSON(ST_ClosestPoint(gc.geom, ST_Centroid(gc.geom)))::json AS "geomPoint",
+  ST_AsGeoJSON(ST_lineMerge(gc.geom))::json AS geom
+  FROM gis.centreline gc
+  LEFT JOIN volume.aadt va ON gc.geo_id = va.centreline_id
+  WHERE gc.fnode = $(intersectionId) OR gc.tnode = $(intersectionId)`;
     const rows = await db.manyOrNone(sql, { intersectionId });
     return rows.map(segmentToFeature);
   }

--- a/lib/db/CollisionDAO.js
+++ b/lib/db/CollisionDAO.js
@@ -1,3 +1,4 @@
+import { centrelineKey } from '@/lib/Constants';
 import { formatCombinedStreet } from '@/lib/StringFormatters';
 import db from '@/lib/db/db';
 import { InvalidCollisionQueryError } from '@/lib/error/MoveErrors';
@@ -255,6 +256,37 @@ FROM collisions.events e
 JOIN collisions.events_centreline ec ON e.collision_id = ec.collision_id
 WHERE ${collisionFilters}`;
     return db.one(sql, params);
+  }
+
+  static async byCentrelineSummaryPerLocation(features, collisionQuery) {
+    const collisionQueryNormalized = normalizeCollisionQuery(collisionQuery);
+    const { filters, params } = getCollisionFilters(features, collisionQueryNormalized);
+    const collisionFilters = filters.join('\n  AND ');
+    const sql = `
+SELECT
+  ec.centreline_type AS "centrelineType",
+  ec.centreline_id AS "centrelineId",
+  COUNT(*) AS amount,
+  COUNT(*) FILTER (WHERE e.ksi) AS ksi,
+  COUNT(*) FILTER (WHERE e.changed IS NOT NULL) AS validated
+FROM collisions.events e
+JOIN collisions.events_centreline ec ON e.collision_id = ec.collision_id
+WHERE ${collisionFilters}
+GROUP BY ec.centreline_type, ec.centreline_id`;
+    const rows = await db.manyOrNone(sql, params);
+    const mapSummaryPerLocation = new Map(
+      rows.map(({ centrelineId, centrelineType, ...summary }) => {
+        const key = centrelineKey(centrelineType, centrelineId);
+        return [key, summary];
+      }),
+    );
+    return features.map(({ centrelineId, centrelineType }) => {
+      const key = centrelineKey(centrelineType, centrelineId);
+      if (mapSummaryPerLocation.has(key)) {
+        return mapSummaryPerLocation.get(key);
+      }
+      return { amount: 0, ksi: 0, validated: 0 };
+    });
   }
 
   static async byCentrelineTotal(features) {

--- a/lib/db/StudyDAO.js
+++ b/lib/db/StudyDAO.js
@@ -1,3 +1,5 @@
+import { centrelineKey } from '@/lib/Constants';
+import { setdefault } from '@/lib/MapUtils';
 import db from '@/lib/db/db';
 import CategoryDAO from '@/lib/db/CategoryDAO';
 import { InvalidStudyQueryError } from '@/lib/error/MoveErrors';
@@ -181,6 +183,88 @@ GROUP BY "CATEGORY_ID"`;
       const category = mostRecent.type;
       const n = mapNumPerCategory.get(category.id);
       return { category, mostRecent, n };
+    });
+  }
+
+  static async byCentrelineSummaryPerLocation(features, studyQuery) {
+    const studyQueryNormalized = normalizeStudyQuery(studyQuery);
+    const categories = await CategoryDAO.all();
+    const { filters, params } = getStudyFilters(features, studyQueryNormalized, categories);
+    const studyFilters = filters.join('\n  AND ');
+
+    const sqlMostRecent = `
+SELECT * FROM (
+  SELECT
+    ROW_NUMBER() OVER (
+      PARTITION BY "CATEGORY_ID", "centreline_type", "centreline_id"
+      ORDER BY start_date DESC
+    ) __row,
+    ${STUDIES_FIELDS}
+  WHERE ${studyFilters}
+) x
+WHERE x.__row = 1`;
+    const sqlNumPerCategory = `
+SELECT COUNT(*) AS n,
+"CATEGORY_ID",
+"centreline_type" AS "centrelineType",
+"centreline_id" AS "centrelineId"
+FROM counts.studies
+WHERE ${studyFilters}
+GROUP BY "CATEGORY_ID", "centreline_type", "centreline_id"`;
+
+    const [rowsMostRecent, rowsNumPerCategory] = await Promise.all([
+      db.manyOrNone(sqlMostRecent, params),
+      db.manyOrNone(sqlNumPerCategory, params),
+    ]);
+
+    const studies = await validateStudies(rowsMostRecent, categories);
+    const mapCategories = new Map();
+    const mapStudiesPerCategoryAndLocation = new Map();
+    studies.forEach((study) => {
+      const { centrelineId, centrelineType, type } = study;
+      const { id: categoryId } = type;
+      mapCategories.set(categoryId, type);
+
+      const mapStudiesPerLocation = setdefault(
+        mapStudiesPerCategoryAndLocation,
+        categoryId,
+        new Map(),
+      );
+      const key = centrelineKey(centrelineType, centrelineId);
+      mapStudiesPerLocation.set(key, study);
+    });
+
+    const mapNumPerCategoryAndLocation = new Map();
+    rowsNumPerCategory.forEach(({
+      CATEGORY_ID,
+      centrelineId,
+      centrelineType,
+      n,
+    }) => {
+      const mapNumPerLocation = setdefault(
+        mapNumPerCategoryAndLocation,
+        CATEGORY_ID,
+        new Map(),
+      );
+      const key = centrelineKey(centrelineType, centrelineId);
+      mapNumPerLocation.set(key, n);
+    });
+
+    const categoriesWithStudies = Array.from(mapCategories.values());
+    return categoriesWithStudies.map((category) => {
+      const { id: categoryId } = category;
+      const mapStudiesPerLocation = mapStudiesPerCategoryAndLocation.get(categoryId);
+      const mapNumPerLocation = mapNumPerCategoryAndLocation.get(categoryId);
+      const perLocation = features.map(({ centrelineId, centrelineType }) => {
+        const key = centrelineKey(centrelineType, centrelineId);
+        if (mapStudiesPerLocation.has(key)) {
+          const mostRecent = mapStudiesPerLocation.get(key);
+          const n = mapNumPerLocation.get(key);
+          return { mostRecent, n };
+        }
+        return { mostRecent: null, n: 0 };
+      });
+      return { category, perLocation };
     });
   }
 

--- a/lib/geo/CentrelineUtils.js
+++ b/lib/geo/CentrelineUtils.js
@@ -63,9 +63,24 @@ function getLocationsWaypointIndices(locations, waypoints) {
   });
 }
 
+function getLocationsIconProps(locations, waypoints) {
+  const locationsWaypointIndices = getLocationsWaypointIndices(locations, waypoints);
+  return locations.map(({ centrelineType }, i) => {
+    const midblock = centrelineType === CentrelineType.SEGMENT;
+    const waypointIndices = locationsWaypointIndices[i];
+    const n = waypointIndices.length;
+    if (n === 0) {
+      return { locationIndex: -1, midblock };
+    }
+    const locationIndex = waypointIndices[n - 1];
+    return { locationIndex, midblock };
+  });
+}
+
 const CentrelineUtils = {
   getLocationFeatureType,
   getLocationsDescription,
+  getLocationsIconProps,
   getLocationsWaypointIndices,
 };
 
@@ -73,5 +88,6 @@ export {
   CentrelineUtils as default,
   getLocationFeatureType,
   getLocationsDescription,
+  getLocationsIconProps,
   getLocationsWaypointIndices,
 };

--- a/lib/model/helpers/CentrelineLocation.js
+++ b/lib/model/helpers/CentrelineLocation.js
@@ -14,13 +14,21 @@ import {
 
 export default {
   ...CentrelineFeature,
-  description: Joi.string().allow(null),
+  aadt: Joi.any().when(
+    'centrelineType',
+    {
+      is: CentrelineType.INTERSECTION,
+      then: Joi.forbidden(),
+      otherwise: Joi.number().positive().allow(null).required(),
+    },
+  ),
+  description: Joi.string().allow(null).required(),
   featureCode: Joi.number().when(
     'centrelineType',
     {
       is: CentrelineType.INTERSECTION,
-      then: Joi.valid(...FEATURE_CODES_INTERSECTION),
-      otherwise: Joi.valid(...FEATURE_CODES_SEGMENT),
+      then: Joi.valid(...FEATURE_CODES_INTERSECTION).required(),
+      otherwise: Joi.valid(...FEATURE_CODES_SEGMENT).required(),
     },
   ),
   geom: Joi.any().when(
@@ -33,5 +41,12 @@ export default {
   ),
   lat: Lat.required(),
   lng: Lng.required(),
-  roadId: Joi.number().allow(null),
+  roadId: Joi.any().when(
+    'centrelineType',
+    {
+      is: CentrelineType.INTERSECTION,
+      then: Joi.forbidden(),
+      otherwise: Joi.number().allow(null),
+    },
+  ),
 };

--- a/lib/model/helpers/NormalizeUtils.js
+++ b/lib/model/helpers/NormalizeUtils.js
@@ -16,15 +16,11 @@ function intersectionToFeature({
     geom,
     lat,
     lng,
-    /*
-     * Only SEGMENT features have road IDs.  When using `roadId`, you should usually
-     * check `feature.centrelineType === CentrelineType.SEGMENT` first.
-     */
-    roadId: null,
   };
 }
 
 function segmentToFeature({
+  aadt,
   lf_name: description,
   fcode: featureCode,
   geo_id: geoId,
@@ -35,6 +31,14 @@ function segmentToFeature({
   const centrelineId = parseInt(geoId, 10);
   const [lng, lat] = geomPoint.coordinates;
   return {
+    /*
+     * Only SEGMENT features have AADT estimates.  When using `aadt`, you should usually
+     * check `location.centrelineType === CentrelineType.SEGMENT` first.  You should also
+     * check whether `location.aadt === null`, as AADT cannot be reliably estimated for all
+     * segments.  (For instance, newer roads have no historical data to base this off of,
+     * and some small laneways have insufficient data.)
+     */
+    aadt,
     centrelineId,
     centrelineType: CentrelineType.SEGMENT,
     description,
@@ -42,6 +46,10 @@ function segmentToFeature({
     geom,
     lat,
     lng,
+    /*
+     * Only SEGMENT features have road IDs.  When using `roadId`, you should usually
+     * check `location.centrelineType === CentrelineType.SEGMENT` first.
+     */
     roadId,
   };
 }

--- a/scripts/test/db/startup.sh
+++ b/scripts/test/db/startup.sh
@@ -45,7 +45,7 @@ fi
 # create ramdisk using diskutil
 echo "Creating ramdisk..."
 sudo mkdir ${RAMDISK_MOUNT_POINT}
-RAMDISK_DEVICE=$(sudo mount -t tmpfs -o size=1g tmpfs ${RAMDISK_MOUNT_POINT})
+RAMDISK_DEVICE=$(sudo mount -t tmpfs -o size=2g tmpfs ${RAMDISK_MOUNT_POINT})
 echo "$RAMDISK_DEVICE" | sudo tee ${RAMDISK_DEVICE_FILE}
 
 # give 'vagrant' user/group ownership of the RAM-disk folder.

--- a/tests/jest/db/CollisionDAO.spec.js
+++ b/tests/jest/db/CollisionDAO.spec.js
@@ -57,7 +57,7 @@ test('CollisionDAO.byCentrelineSummary', async () => {
   let features = [
     { centrelineId: 1142194, centrelineType: CentrelineType.SEGMENT },
   ];
-  let collisionQuery = {
+  const collisionQuery = {
     dateRangeEnd,
     dateRangeStart,
     daysOfWeek: null,
@@ -70,15 +70,61 @@ test('CollisionDAO.byCentrelineSummary', async () => {
   features = [
     { centrelineId: 13465434, centrelineType: CentrelineType.INTERSECTION },
   ];
-  collisionQuery = {
+  result = await CollisionDAO.byCentrelineSummary(features, collisionQuery);
+  expect(result).toEqual({ amount: 27, ksi: 1, validated: 16 });
+
+  features = [
+    { centrelineId: 1142194, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13465434, centrelineType: CentrelineType.INTERSECTION },
+  ];
+  result = await CollisionDAO.byCentrelineSummary(features, collisionQuery);
+  expect(result).toEqual({ amount: 58, ksi: 1, validated: 42 });
+});
+
+test('CollisionDAO.byCentrelineSummaryPerLocation', async () => {
+  const dateRangeStart = DateTime.fromObject({ year: 2017, month: 1, day: 1 });
+  const dateRangeEnd = DateTime.fromObject({ year: 2020, month: 1, day: 1 });
+
+  let features = [
+    { centrelineId: 1142194, centrelineType: CentrelineType.SEGMENT },
+  ];
+  const collisionQuery = {
     dateRangeEnd,
     dateRangeStart,
     daysOfWeek: null,
     emphasisAreas: null,
     roadSurfaceConditions: null,
   };
-  result = await CollisionDAO.byCentrelineSummary(features, collisionQuery);
-  expect(result).toEqual({ amount: 27, ksi: 1, validated: 16 });
+  let result = await CollisionDAO.byCentrelineSummaryPerLocation(features, collisionQuery);
+  expect(result).toEqual([{ amount: 31, ksi: 0, validated: 26 }]);
+
+  features = [
+    { centrelineId: 13465434, centrelineType: CentrelineType.INTERSECTION },
+  ];
+  result = await CollisionDAO.byCentrelineSummaryPerLocation(features, collisionQuery);
+  expect(result).toEqual([{ amount: 27, ksi: 1, validated: 16 }]);
+
+  features = [
+    { centrelineId: 1142194, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13465434, centrelineType: CentrelineType.INTERSECTION },
+  ];
+  result = await CollisionDAO.byCentrelineSummaryPerLocation(features, collisionQuery);
+  expect(result).toEqual([
+    { amount: 31, ksi: 0, validated: 26 },
+    { amount: 27, ksi: 1, validated: 16 },
+  ]);
+
+  features = [
+    { centrelineId: 1142194, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13465434, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 1142194, centrelineType: CentrelineType.SEGMENT },
+  ];
+  result = await CollisionDAO.byCentrelineSummaryPerLocation(features, collisionQuery);
+  expect(result).toEqual([
+    { amount: 31, ksi: 0, validated: 26 },
+    { amount: 27, ksi: 1, validated: 16 },
+    { amount: 31, ksi: 0, validated: 26 },
+  ]);
 });
 
 test('CollisionDAO.byCentrelineTotal', async () => {

--- a/tests/jest/unit/MapUtils.spec.js
+++ b/tests/jest/unit/MapUtils.spec.js
@@ -1,0 +1,20 @@
+import { setdefault } from '@/lib/MapUtils';
+
+test('MapUtils.setdefault', () => {
+  const map = new Map();
+
+  expect(setdefault(map, 'foo', 42)).toEqual(42);
+  expect(map.get('foo')).toEqual(42);
+
+  expect(setdefault(map, 'foo', 17)).toEqual(42);
+  expect(map.get('foo')).toEqual(42);
+
+  let bar = setdefault(map, 'bar', []);
+  expect(map.get('bar')).toEqual([]);
+  bar.push('a');
+
+  bar = setdefault(map, 'bar', []);
+  expect(map.get('bar')).toEqual(['a']);
+  bar.push('b');
+  expect(map.get('bar')).toEqual(['a', 'b']);
+});

--- a/tests/jest/unit/geo/CentrelineUtils.spec.js
+++ b/tests/jest/unit/geo/CentrelineUtils.spec.js
@@ -1,4 +1,3 @@
-
 import {
   CentrelineType,
   RoadIntersectionType,
@@ -8,6 +7,7 @@ import { InvalidCentrelineTypeError } from '@/lib/error/MoveErrors';
 import {
   getLocationFeatureType,
   getLocationsDescription,
+  getLocationsIconProps,
   getLocationsWaypointIndices,
 } from '@/lib/geo/CentrelineUtils';
 
@@ -61,6 +61,48 @@ test('CentrelineUtils.getLocationsDescription', () => {
     { description: 'Warden and Cataraqui Cres' },
   ];
   expect(getLocationsDescription(locations)).toEqual('Warden and St Clair + 2 locations');
+});
+
+test('CentrelineUtils.getLocationsIconProps', () => {
+  const waypoints = [
+    { centrelineId: 13456414, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 13455700, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 13455700, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 445346, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 444912, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 444912, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13454752, centrelineType: CentrelineType.INTERSECTION },
+  ];
+  const locations = [
+    waypoints[0],
+    { centrelineId: 3304786, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13456067, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 445623, centrelineType: CentrelineType.SEGMENT },
+    waypoints[1],
+    waypoints[3],
+    { centrelineId: 13455359, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 445100, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13455130, centrelineType: CentrelineType.INTERSECTION },
+    waypoints[4],
+    { centrelineId: 13454835, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 444715, centrelineType: CentrelineType.SEGMENT },
+    waypoints[6],
+  ];
+  expect(getLocationsIconProps(locations, waypoints)).toEqual([
+    { locationIndex: 0, midblock: false },
+    { locationIndex: -1, midblock: true },
+    { locationIndex: -1, midblock: false },
+    { locationIndex: -1, midblock: true },
+    { locationIndex: 2, midblock: false },
+    { locationIndex: 3, midblock: true },
+    { locationIndex: -1, midblock: false },
+    { locationIndex: -1, midblock: true },
+    { locationIndex: -1, midblock: false },
+    { locationIndex: 5, midblock: true },
+    { locationIndex: -1, midblock: false },
+    { locationIndex: -1, midblock: true },
+    { locationIndex: 6, midblock: false },
+  ]);
 });
 
 test('CentrelineUtils.getLocationsWaypointIndices', () => {

--- a/web/components/FcDataTableCollisions.vue
+++ b/web/components/FcDataTableCollisions.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="align-end d-flex mb-5 mx-5">
+  <div class="fc-data-table-collisions align-end d-flex mb-5 mx-5">
     <v-progress-linear
       v-if="loading"
       indeterminate />
@@ -30,7 +30,7 @@
           </span>
         </div>
       </div>
-      <div class="flex-grow-0 flex-shrink-0 mr-12 pr-2">
+      <div class="fc-collisions-validated flex-grow-0 flex-shrink-0 mr-8">
         <div class="font-weight-regular title">
           Validated
         </div>
@@ -77,3 +77,11 @@ export default {
   },
 };
 </script>
+
+<style lang="scss">
+.fc-data-table-collisions {
+  .fc-collisions-validated {
+    width: 120px;
+  }
+}
+</style>

--- a/web/components/FcDataTableCollisions.vue
+++ b/web/components/FcDataTableCollisions.vue
@@ -10,6 +10,11 @@
         </div>
         <div class="display-2 mt-2">
           {{collisionSummary.amount}}
+          <span
+            v-if="hasFiltersCollision"
+            class="font-weight-regular title">
+            / {{collisionSummaryUnfiltered.amount}}
+          </span>
         </div>
       </div>
       <div class="flex-grow-1 flex-shrink-1">
@@ -18,6 +23,11 @@
         </div>
         <div class="display-2 mt-2">
           {{collisionSummary.ksi}}
+          <span
+            v-if="hasFiltersCollision"
+            class="font-weight-regular title">
+            / {{collisionSummaryUnfiltered.ksi}}
+          </span>
         </div>
       </div>
       <div class="flex-grow-0 flex-shrink-0 mr-12 pr-2">
@@ -26,6 +36,11 @@
         </div>
         <div class="display-2 mt-2">
           {{collisionSummary.validated}}
+          <span
+            v-if="hasFiltersCollision"
+            class="font-weight-regular title">
+            / {{collisionSummaryUnfiltered.validated}}
+          </span>
         </div>
       </div>
       <FcButton
@@ -40,6 +55,8 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex';
+
 import FcButton from '@/web/components/inputs/FcButton.vue';
 
 export default {
@@ -49,42 +66,14 @@ export default {
   },
   props: {
     collisionSummary: Object,
+    collisionSummaryUnfiltered: Object,
     loading: {
       type: Boolean,
       default: false,
     },
   },
-  data() {
-    const columns = [{
-      value: 'AMOUNT',
-      text: 'Amount',
-    }, {
-      value: 'KSI',
-      text: 'KSI',
-    }, {
-      value: 'VALIDATED',
-      text: 'Validated',
-    }, {
-      align: 'end',
-      value: 'VIEW_REPORT',
-      text: ' ',
-    }];
-    return {
-      columns,
-    };
+  computed: {
+    ...mapGetters('viewData', ['hasFiltersCollision']),
   },
 };
 </script>
-
-<style lang="scss">
-.fc-data-table-collisions {
-  & th:first-child,
-  & td:first-child {
-    padding-left: 20px;
-  }
-  & th:last-child,
-  & td:last-child {
-    padding-right: 20px;
-  }
-}
-</style>

--- a/web/components/FcDataTableStudies.vue
+++ b/web/components/FcDataTableStudies.vue
@@ -1,5 +1,83 @@
 <template>
-  <FcDataTable
+  <div class="fc-data-table-studies">
+    <v-progress-linear
+      v-if="loading"
+      indeterminate />
+    <div
+      v-else-if="studySummaryUnfiltered.length === 0"
+      class="my-8 py-12 secondary--text text-center">
+      There are no studies for this location,<br>
+      please request a study if necessary
+    </div>
+    <div
+      v-else-if="studySummary.length === 0"
+      class="my-8 py-12 secondary--text text-center">
+      No studies match the active filters,<br>
+      clear one or more filters to see studies
+    </div>
+    <template v-else>
+      <div
+        v-for="item in items"
+        :key="item.category.id"
+        class="ml-5">
+        <div class="align-center d-flex mb-4 pr-5">
+          <div class="flex-grow-1 flex-shrink-1 font-weight-regular title">
+            <div v-if="item.category.studyType === null">
+              Unknown
+            </div>
+            <div v-else>
+              {{item.category.studyType.label}}
+            </div>
+            <div class="mt-2 secondary--text">
+              <span v-if="item.mostRecent === null">
+                No studies
+              </span>
+              <span v-else>
+                Most Recent
+                {{item.mostRecent.startDate | date}} ({{item.mostRecent.startDate | dayOfWeek}})
+                &#x2022;
+                <span v-if="item.mostRecent.duration !== null">
+                  {{item.mostRecent.duration | durationHuman}} ({{item.mostRecent.duration}} hrs)
+                </span>
+                <span
+                  v-else-if="item.mostRecent.hours !== null"
+                  :title="item.mostRecent.hours.hint">
+                  {{item.mostRecent.hours.description}}
+                </span>
+              </span>
+            </div>
+          </div>
+          <div class="fc-studies-n flex-grow-0 flex-shrink-0 mr-8">
+            <div class="display-2">
+              {{item.n}}
+              <span
+                v-if="hasFiltersStudy"
+                class="font-weight-regular title">
+                / {{item.nUnfiltered}}
+              </span>
+            </div>
+          </div>
+          <FcButton
+            class="flex-grow-0 flex-shrink-0"
+            v-if="item.category.studyType !== null"
+            type="tertiary"
+            @click="$emit('show-reports', item)">
+            <span>View Reports</span>
+          </FcButton>
+        </div>
+        <v-divider></v-divider>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex';
+
+import FcButton from '@/web/components/inputs/FcButton.vue';
+
+/*
+<FcDataTable
     class="fc-data-table-studies mx-1"
     :columns="columns"
     disable-sort
@@ -37,25 +115,15 @@
       <span class="sr-only">Reports</span>
     </template>
     <template v-slot:item.VIEW_REPORT="{ item }">
-      <FcButton
-        v-if="item.category.studyType !== null"
-        type="tertiary"
-        @click="$emit('show-reports', item)">
-        <span>View Reports</span>
-      </FcButton>
+
     </template>
   </FcDataTable>
-</template>
-
-<script>
-import FcDataTable from '@/web/components/FcDataTable.vue';
-import FcButton from '@/web/components/inputs/FcButton.vue';
+  */
 
 export default {
   name: 'FcDataTableStudies',
   components: {
     FcButton,
-    FcDataTable,
   },
   props: {
     loading: {
@@ -63,38 +131,32 @@ export default {
       default: false,
     },
     studySummary: Array,
+    studySummaryUnfiltered: Array,
   },
-  data() {
-    const columns = [{
-      value: 'STUDY_REPORTS',
-      text: 'Study Reports',
-    }, {
-      value: 'DATE',
-      text: 'Most Recent Date',
-    }, {
-      value: 'HOURS',
-      text: 'Most Recent Hours',
-    }, {
-      align: 'end',
-      value: 'VIEW_REPORT',
-      text: ' ',
-    }];
-    return {
-      columns,
-    };
+  computed: {
+    items() {
+      return this.studySummaryUnfiltered.map(({ category, n }) => {
+        let item = this.studySummary.find(
+          itemFiltered => itemFiltered.category.id === category.id,
+        );
+        if (item === undefined) {
+          item = { category, mostRecent: null, n: 0 };
+        }
+        return {
+          ...item,
+          nUnfiltered: n,
+        };
+      });
+    },
+    ...mapGetters('viewData', ['hasFiltersStudy']),
   },
 };
 </script>
 
 <style lang="scss">
 .fc-data-table-studies {
-  & th:first-child,
-  & td:first-child {
-    padding-left: 20px;
-  }
-  & th:last-child,
-  & td:last-child {
-    padding-right: 20px;
+  .fc-studies-n {
+    width: 120px;
   }
 }
 </style>

--- a/web/components/FcDataTableStudies.vue
+++ b/web/components/FcDataTableStudies.vue
@@ -76,50 +76,6 @@ import { mapGetters } from 'vuex';
 
 import FcButton from '@/web/components/inputs/FcButton.vue';
 
-/*
-<FcDataTable
-    class="fc-data-table-studies mx-1"
-    :columns="columns"
-    disable-sort
-    :loading="loading"
-    :items="studySummary">
-    <template v-slot:item.STUDY_REPORTS="{ item }">
-      <span v-if="item.category.studyType === null">
-        Unknown
-      </span>
-      <span v-else>
-        {{item.category.studyType.label}}
-      </span>
-      <span
-        v-if="item.n > 1"
-        class="secondary--text">
-        &#x2022; {{item.n}}
-      </span>
-    </template>
-    <template v-slot:item.DATE="{ item }">
-      <span>
-        {{item.mostRecent.startDate | date}} ({{item.mostRecent.startDate | dayOfWeek}})
-      </span>
-    </template>
-    <template v-slot:item.HOURS="{ item }">
-      <span v-if="item.mostRecent.duration !== null">
-        {{item.mostRecent.duration | durationHuman}} ({{item.mostRecent.duration}} hrs)
-      </span>
-      <span
-        v-else-if="item.mostRecent.hours !== null"
-        :title="item.mostRecent.hours.hint">
-        {{item.mostRecent.hours.description}}
-      </span>
-    </template>
-    <template v-slot:header.VIEW_REPORT>
-      <span class="sr-only">Reports</span>
-    </template>
-    <template v-slot:item.VIEW_REPORT="{ item }">
-
-    </template>
-  </FcDataTable>
-  */
-
 export default {
   name: 'FcDataTableStudies',
   components: {

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -48,7 +48,8 @@
           :location="locationActive" />
         <FcViewDataAggregate
           v-else
-          :locations="locations" />
+          :locations="locations"
+          :locations-selection="locationsSelection" />
       </template>
     </section>
   </div>

--- a/web/components/data/FcAggregateCollisions.vue
+++ b/web/components/data/FcAggregateCollisions.vue
@@ -9,16 +9,19 @@
         accordion
         flat
         focusable>
-        <v-expansion-panel class="fc-collisions-summary-per-location">
+        <v-expansion-panel
+          v-for="field in fields"
+          :key="field.name"
+          class="fc-collisions-summary-per-location">
           <v-expansion-panel-header class="pr-8">
-            <span class="body-1">Amount</span>
+            <span class="body-1">{{field.description}}</span>
             <v-spacer></v-spacer>
             <div class="display-1 flex-grow-0 flex-shrink-0 mr-5">
-              {{collisionSummary.amount}}
+              {{collisionSummary[field.name]}}
               <span
                 v-if="hasFiltersCollision"
-                class="font-weight-regular title">
-                / {{collisionSummaryUnfiltered.amount}}
+                class="body-1">
+                / {{collisionSummaryUnfiltered[field.name]}}
               </span>
             </div>
           </v-expansion-panel-header>
@@ -39,91 +42,11 @@
               </span>
               <v-spacer></v-spacer>
               <div class="display-1 flex-grow-0 flex-shrink-0 mr-5">
-                {{collisionSummaryPerLocation[i].amount}}
+                {{collisionSummaryPerLocation[i][field.name]}}
                 <span
                   v-if="hasFiltersCollision"
-                  class="font-weight-regular title">
-                  / {{collisionSummaryPerLocationUnfiltered[i].amount}}
-                </span>
-              </div>
-            </div>
-          </v-expansion-panel-content>
-        </v-expansion-panel>
-        <v-expansion-panel class="fc-collisions-summary-per-location">
-          <v-expansion-panel-header class="pr-8">
-            <span class="body-1">KSI</span>
-            <v-spacer></v-spacer>
-            <div class="display-1 flex-grow-0 flex-shrink-0 mr-5">
-              {{collisionSummary.ksi}}
-              <span
-                v-if="hasFiltersCollision"
-                class="font-weight-regular title">
-                / {{collisionSummaryUnfiltered.ksi}}
-              </span>
-            </div>
-          </v-expansion-panel-header>
-          <v-expansion-panel-content class="shading pt-1">
-            <div
-              v-for="(location, i) in locations"
-              :key="i"
-              class="d-flex pa-3 pr-8">
-              <FcIconLocationMulti v-bind="locationsIconProps[i]" />
-              <span
-                class="title"
-                :class="{
-                  'pl-4': locationsIconProps[i].midblock,
-                  'pl-5': !locationsIconProps[i].midblock,
-                  'font-weight-regular': locationsIconProps[i].locationIndex === -1,
-                }">
-                {{location.description}}
-              </span>
-              <v-spacer></v-spacer>
-              <div class="display-1 flex-grow-0 flex-shrink-0 mr-5">
-                {{collisionSummaryPerLocation[i].ksi}}
-                <span
-                  v-if="hasFiltersCollision"
-                  class="font-weight-regular title">
-                  / {{collisionSummaryPerLocationUnfiltered[i].ksi}}
-                </span>
-              </div>
-            </div>
-          </v-expansion-panel-content>
-        </v-expansion-panel>
-        <v-expansion-panel class="fc-collisions-summary-per-location">
-          <v-expansion-panel-header class="pr-8">
-            <span class="body-1">Validated</span>
-            <v-spacer></v-spacer>
-            <div class="display-1 flex-grow-0 flex-shrink-0 mr-5">
-              {{collisionSummary.validated}}
-              <span
-                v-if="hasFiltersCollision"
-                class="font-weight-regular title">
-                / {{collisionSummaryUnfiltered.validated}}
-              </span>
-            </div>
-          </v-expansion-panel-header>
-          <v-expansion-panel-content class="shading pt-1">
-            <div
-              v-for="(location, i) in locations"
-              :key="i"
-              class="d-flex pa-3 pr-8">
-              <FcIconLocationMulti v-bind="locationsIconProps[i]" />
-              <span
-                class="title"
-                :class="{
-                  'pl-4': locationsIconProps[i].midblock,
-                  'pl-5': !locationsIconProps[i].midblock,
-                  'font-weight-regular': locationsIconProps[i].locationIndex === -1,
-                }">
-                {{location.description}}
-              </span>
-              <v-spacer></v-spacer>
-              <div class="display-1 flex-grow-0 flex-shrink-0 mr-5">
-                {{collisionSummaryPerLocation[i].validated}}
-                <span
-                  v-if="hasFiltersCollision"
-                  class="font-weight-regular title">
-                  / {{collisionSummaryPerLocationUnfiltered[i].validated}}
+                  class="body-1">
+                  / {{collisionSummaryPerLocationUnfiltered[i][field.name]}}
                 </span>
               </div>
             </div>
@@ -147,8 +70,7 @@
 <script>
 import { mapGetters } from 'vuex';
 
-import { CentrelineType } from '@/lib/Constants';
-import { getLocationsWaypointIndices } from '@/lib/geo/CentrelineUtils';
+import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcIconLocationMulti from '@/web/components/location/FcIconLocationMulti.vue';
 
@@ -168,26 +90,20 @@ export default {
     locationsSelection: Object,
   },
   data() {
+    const fields = [
+      { description: 'Amount', name: 'amount' },
+      { description: 'KSI', name: 'ksi' },
+      { description: 'Validated', name: 'validated' },
+    ];
+
     return {
+      fields,
       indexOpen: null,
     };
   },
   computed: {
     locationsIconProps() {
-      const locationsWaypointIndices = getLocationsWaypointIndices(
-        this.locations,
-        this.locationsSelection.locations,
-      );
-      return this.locations.map(({ centrelineType }, i) => {
-        const midblock = centrelineType === CentrelineType.SEGMENT;
-        const waypointIndices = locationsWaypointIndices[i];
-        const n = waypointIndices.length;
-        if (n === 0) {
-          return { locationIndex: -1, midblock };
-        }
-        const locationIndex = waypointIndices[n - 1];
-        return { locationIndex, midblock };
-      });
+      return getLocationsIconProps(this.locations, this.locationsSelection.locations);
     },
     ...mapGetters('viewData', ['hasFiltersCollision']),
   },

--- a/web/components/data/FcAggregateCollisions.vue
+++ b/web/components/data/FcAggregateCollisions.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="fc-aggregate-collisions mb-5 mx-5">
+    <v-progress-linear
+      v-if="loading"
+      indeterminate />
+    <template v-else>
+      <h3>TODO: aggregate collisions</h3>
+    </template>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex';
+
+export default {
+  name: 'FcAggregateCollisions',
+  props: {
+    collisionSummaryPerLocation: Array,
+    collisionSummaryPerLocationUnfiltered: Array,
+    loading: Boolean,
+  },
+  computed: {
+    ...mapGetters('viewData', ['hasFiltersCollision']),
+  },
+};
+</script>

--- a/web/components/data/FcAggregateCollisions.vue
+++ b/web/components/data/FcAggregateCollisions.vue
@@ -17,14 +17,12 @@
           <v-expansion-panel-header class="pr-8">
             <span class="body-1">{{field.description}}</span>
             <v-spacer></v-spacer>
-            <div class="display-1 flex-grow-0 flex-shrink-0 mr-5">
-              {{collisionSummary[field.name]}}
-              <span
-                v-if="hasFiltersCollision"
-                class="body-1">
-                / {{collisionSummaryUnfiltered[field.name]}}
-              </span>
-            </div>
+            <FcTextSummaryFraction
+              :a="collisionSummary[field.name]"
+              :b="collisionSummaryUnfiltered[field.name]"
+              class="flex-grow-0 flex-shrink-0 mr-5"
+              :show-b="hasFiltersCollision"
+              small />
           </v-expansion-panel-header>
           <v-expansion-panel-content class="shading pt-1">
             <div
@@ -45,14 +43,12 @@
                 {{location.description}}
               </span>
               <v-spacer></v-spacer>
-              <div class="display-1 flex-grow-0 flex-shrink-0 mr-5">
-                {{collisionSummaryPerLocation[i][field.name]}}
-                <span
-                  v-if="hasFiltersCollision"
-                  class="body-1">
-                  / {{collisionSummaryPerLocationUnfiltered[i][field.name]}}
-                </span>
-              </div>
+              <FcTextSummaryFraction
+                :a="collisionSummaryPerLocation[i][field.name]"
+                :b="collisionSummaryPerLocationUnfiltered[i][field.name]"
+                class="flex-grow-0 flex-shrink-0 mr-5"
+                :show-b="hasFiltersCollision"
+                small />
             </div>
           </v-expansion-panel-content>
         </v-expansion-panel>
@@ -75,6 +71,7 @@
 import { mapGetters } from 'vuex';
 
 import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
+import FcTextSummaryFraction from '@/web/components/data/FcTextSummaryFraction.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcIconLocationMulti from '@/web/components/location/FcIconLocationMulti.vue';
 
@@ -83,6 +80,7 @@ export default {
   components: {
     FcButton,
     FcIconLocationMulti,
+    FcTextSummaryFraction,
   },
   props: {
     collisionSummary: Object,

--- a/web/components/data/FcAggregateCollisions.vue
+++ b/web/components/data/FcAggregateCollisions.vue
@@ -5,6 +5,7 @@
       indeterminate />
     <template v-else>
       <v-expansion-panels
+        v-model="indexOpen"
         accordion
         flat
         focusable>
@@ -21,10 +22,31 @@
               </span>
             </div>
           </v-expansion-panel-header>
-          <v-expansion-panel-content>
-            <p>
-            TODO: amount
-            </p>
+          <v-expansion-panel-content class="shading pt-1">
+            <div
+              v-for="(location, i) in locations"
+              :key="i"
+              class="d-flex pa-3 pr-8">
+              <FcIconLocationMulti v-bind="locationsIconProps[i]" />
+              <span
+                class="title"
+                :class="{
+                  'pl-4': locationsIconProps[i].midblock,
+                  'pl-5': !locationsIconProps[i].midblock,
+                  'font-weight-regular': locationsIconProps[i].locationIndex === -1,
+                }">
+                {{location.description}}
+              </span>
+              <v-spacer></v-spacer>
+              <div class="display-1 flex-grow-0 flex-shrink-0 mr-5">
+                {{collisionSummaryPerLocation[i].amount}}
+                <span
+                  v-if="hasFiltersCollision"
+                  class="font-weight-regular title">
+                  / {{collisionSummaryPerLocationUnfiltered[i].amount}}
+                </span>
+              </div>
+            </div>
           </v-expansion-panel-content>
         </v-expansion-panel>
         <v-expansion-panel class="fc-collisions-summary-per-location">
@@ -40,10 +62,31 @@
               </span>
             </div>
           </v-expansion-panel-header>
-          <v-expansion-panel-content>
-            <p>
-            TODO: KSI
-            </p>
+          <v-expansion-panel-content class="shading pt-1">
+            <div
+              v-for="(location, i) in locations"
+              :key="i"
+              class="d-flex pa-3 pr-8">
+              <FcIconLocationMulti v-bind="locationsIconProps[i]" />
+              <span
+                class="title"
+                :class="{
+                  'pl-4': locationsIconProps[i].midblock,
+                  'pl-5': !locationsIconProps[i].midblock,
+                  'font-weight-regular': locationsIconProps[i].locationIndex === -1,
+                }">
+                {{location.description}}
+              </span>
+              <v-spacer></v-spacer>
+              <div class="display-1 flex-grow-0 flex-shrink-0 mr-5">
+                {{collisionSummaryPerLocation[i].ksi}}
+                <span
+                  v-if="hasFiltersCollision"
+                  class="font-weight-regular title">
+                  / {{collisionSummaryPerLocationUnfiltered[i].ksi}}
+                </span>
+              </div>
+            </div>
           </v-expansion-panel-content>
         </v-expansion-panel>
         <v-expansion-panel class="fc-collisions-summary-per-location">
@@ -59,10 +102,31 @@
               </span>
             </div>
           </v-expansion-panel-header>
-          <v-expansion-panel-content>
-            <p>
-            TODO: validated
-            </p>
+          <v-expansion-panel-content class="shading pt-1">
+            <div
+              v-for="(location, i) in locations"
+              :key="i"
+              class="d-flex pa-3 pr-8">
+              <FcIconLocationMulti v-bind="locationsIconProps[i]" />
+              <span
+                class="title"
+                :class="{
+                  'pl-4': locationsIconProps[i].midblock,
+                  'pl-5': !locationsIconProps[i].midblock,
+                  'font-weight-regular': locationsIconProps[i].locationIndex === -1,
+                }">
+                {{location.description}}
+              </span>
+              <v-spacer></v-spacer>
+              <div class="display-1 flex-grow-0 flex-shrink-0 mr-5">
+                {{collisionSummaryPerLocation[i].validated}}
+                <span
+                  v-if="hasFiltersCollision"
+                  class="font-weight-regular title">
+                  / {{collisionSummaryPerLocationUnfiltered[i].validated}}
+                </span>
+              </div>
+            </div>
           </v-expansion-panel-content>
         </v-expansion-panel>
       </v-expansion-panels>
@@ -83,12 +147,16 @@
 <script>
 import { mapGetters } from 'vuex';
 
+import { CentrelineType } from '@/lib/Constants';
+import { getLocationsWaypointIndices } from '@/lib/geo/CentrelineUtils';
 import FcButton from '@/web/components/inputs/FcButton.vue';
+import FcIconLocationMulti from '@/web/components/location/FcIconLocationMulti.vue';
 
 export default {
   name: 'FcAggregateCollisions',
   components: {
     FcButton,
+    FcIconLocationMulti,
   },
   props: {
     collisionSummary: Object,
@@ -97,8 +165,30 @@ export default {
     collisionSummaryPerLocationUnfiltered: Array,
     loading: Boolean,
     locations: Array,
+    locationsSelection: Object,
+  },
+  data() {
+    return {
+      indexOpen: null,
+    };
   },
   computed: {
+    locationsIconProps() {
+      const locationsWaypointIndices = getLocationsWaypointIndices(
+        this.locations,
+        this.locationsSelection.locations,
+      );
+      return this.locations.map(({ centrelineType }, i) => {
+        const midblock = centrelineType === CentrelineType.SEGMENT;
+        const waypointIndices = locationsWaypointIndices[i];
+        const n = waypointIndices.length;
+        if (n === 0) {
+          return { locationIndex: -1, midblock };
+        }
+        const locationIndex = waypointIndices[n - 1];
+        return { locationIndex, midblock };
+      });
+    },
     ...mapGetters('viewData', ['hasFiltersCollision']),
   },
 };

--- a/web/components/data/FcAggregateCollisions.vue
+++ b/web/components/data/FcAggregateCollisions.vue
@@ -1,10 +1,81 @@
 <template>
-  <div class="fc-aggregate-collisions mb-5 mx-5">
+  <div class="fc-aggregate-collisions mb-5 ml-5">
     <v-progress-linear
       v-if="loading"
       indeterminate />
     <template v-else>
-      <h3>TODO: aggregate collisions</h3>
+      <v-expansion-panels
+        accordion
+        flat
+        focusable>
+        <v-expansion-panel class="fc-collisions-summary-per-location">
+          <v-expansion-panel-header class="pr-8">
+            <span class="body-1">Amount</span>
+            <v-spacer></v-spacer>
+            <div class="display-1 flex-grow-0 flex-shrink-0 mr-5">
+              {{collisionSummary.amount}}
+              <span
+                v-if="hasFiltersCollision"
+                class="font-weight-regular title">
+                / {{collisionSummaryUnfiltered.amount}}
+              </span>
+            </div>
+          </v-expansion-panel-header>
+          <v-expansion-panel-content>
+            <p>
+            TODO: amount
+            </p>
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+        <v-expansion-panel class="fc-collisions-summary-per-location">
+          <v-expansion-panel-header class="pr-8">
+            <span class="body-1">KSI</span>
+            <v-spacer></v-spacer>
+            <div class="display-1 flex-grow-0 flex-shrink-0 mr-5">
+              {{collisionSummary.ksi}}
+              <span
+                v-if="hasFiltersCollision"
+                class="font-weight-regular title">
+                / {{collisionSummaryUnfiltered.ksi}}
+              </span>
+            </div>
+          </v-expansion-panel-header>
+          <v-expansion-panel-content>
+            <p>
+            TODO: KSI
+            </p>
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+        <v-expansion-panel class="fc-collisions-summary-per-location">
+          <v-expansion-panel-header class="pr-8">
+            <span class="body-1">Validated</span>
+            <v-spacer></v-spacer>
+            <div class="display-1 flex-grow-0 flex-shrink-0 mr-5">
+              {{collisionSummary.validated}}
+              <span
+                v-if="hasFiltersCollision"
+                class="font-weight-regular title">
+                / {{collisionSummaryUnfiltered.validated}}
+              </span>
+            </div>
+          </v-expansion-panel-header>
+          <v-expansion-panel-content>
+            <p>
+            TODO: validated
+            </p>
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+      </v-expansion-panels>
+      <div class="d-flex mt-4 mr-5">
+        <v-spacer></v-spacer>
+        <FcButton
+          class="flex-grow-0 flex-shrink-0"
+          type="tertiary"
+          :disabled="collisionSummary.amount === 0"
+          @click="$emit('show-reports')">
+          <span>View Total Reports</span>
+        </FcButton>
+      </div>
     </template>
   </div>
 </template>
@@ -12,15 +83,31 @@
 <script>
 import { mapGetters } from 'vuex';
 
+import FcButton from '@/web/components/inputs/FcButton.vue';
+
 export default {
   name: 'FcAggregateCollisions',
+  components: {
+    FcButton,
+  },
   props: {
+    collisionSummary: Object,
+    collisionSummaryUnfiltered: Object,
     collisionSummaryPerLocation: Array,
     collisionSummaryPerLocationUnfiltered: Array,
     loading: Boolean,
+    locations: Array,
   },
   computed: {
     ...mapGetters('viewData', ['hasFiltersCollision']),
   },
 };
 </script>
+
+<style lang="scss">
+.fc-aggregate-collisions {
+  .fc-collisions-summary-per-location:not(:last-child) {
+    border-bottom: 1px solid var(--v-border-base);
+  }
+}
+</style>

--- a/web/components/data/FcAggregateCollisions.vue
+++ b/web/components/data/FcAggregateCollisions.vue
@@ -12,7 +12,8 @@
         <v-expansion-panel
           v-for="field in fields"
           :key="field.name"
-          class="fc-collisions-summary-per-location">
+          class="fc-collisions-summary-per-location"
+          :disabled="collisionSummary[field.name] === 0">
           <v-expansion-panel-header class="pr-8">
             <span class="body-1">{{field.description}}</span>
             <v-spacer></v-spacer>
@@ -29,7 +30,10 @@
             <div
               v-for="(location, i) in locations"
               :key="i"
-              class="d-flex pa-3 pr-8">
+              class="d-flex pa-3 pr-8"
+              :class="{
+                'data-empty': collisionSummaryPerLocation[i][field.name] === 0,
+              }">
               <FcIconLocationMulti v-bind="locationsIconProps[i]" />
               <span
                 class="title"
@@ -57,8 +61,8 @@
         <v-spacer></v-spacer>
         <FcButton
           class="flex-grow-0 flex-shrink-0"
-          type="tertiary"
           :disabled="collisionSummary.amount === 0"
+          type="tertiary"
           @click="$emit('show-reports')">
           <span>View Total Reports</span>
         </FcButton>
@@ -112,8 +116,11 @@ export default {
 
 <style lang="scss">
 .fc-aggregate-collisions {
-  .fc-collisions-summary-per-location:not(:last-child) {
+  & .fc-collisions-summary-per-location:not(:last-child) {
     border-bottom: 1px solid var(--v-border-base);
+  }
+  & .data-empty {
+    opacity: 0.37;
   }
 }
 </style>

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -30,14 +30,12 @@
               </div>
             </div>
             <v-spacer></v-spacer>
-            <div class="display-1 flex-grow-0 flex-shrink-0 mr-5">
-              {{item.n}}
-              <span
-                v-if="hasFiltersStudy"
-                class="body-1">
-                / {{item.nUnfiltered}}
-              </span>
-            </div>
+            <FcTextSummaryFraction
+              :a="item.n"
+              :b="item.nUnfiltered"
+              class="flex-grow-0 flex-shrink-0 mr-5"
+              :show-b="hasFiltersStudy"
+              small />
           </v-expansion-panel-header>
           <v-expansion-panel-content class="shading pt-1">
             <div
@@ -61,37 +59,20 @@
                   }">
                   {{location.description}}
                 </div>
-                <div
+                <FcTextMostRecent
                   v-if="itemsPerLocation[i][j].mostRecent !== null"
-                  class="mt-2 secondary--text">
-                  <span>
-                    Most Recent
-                    {{itemsPerLocation[i][j].mostRecent.startDate | date}}
-                    ({{itemsPerLocation[i][j].mostRecent.startDate | dayOfWeek}})
-                    &#x2022;
-                    <span v-if="itemsPerLocation[i][j].mostRecent.duration !== null">
-                      {{itemsPerLocation[i][j].mostRecent.duration | durationHuman}}
-                      ({{item.mostRecent.duration}} hrs)
-                    </span>
-                    <span
-                      v-else-if="itemsPerLocation[i][j].mostRecent.hours !== null"
-                      :title="itemsPerLocation[i][j].mostRecent.hours.hint">
-                      {{itemsPerLocation[i][j].mostRecent.hours.description}}
-                    </span>
-                  </span>
-                </div>
+                  class="mt-2"
+                  :study="itemsPerLocation[i][j].mostRecent" />
               </div>
               <v-spacer></v-spacer>
               <div class="display-1 flex-grow-0 flex-shrink-0 mr-5">
-                <div class="text-right">
-                  {{itemsPerLocation[i][j].n}}
-                  <span
-                    v-if="hasFiltersStudy"
-                    class="body-1">
-                    / {{itemsPerLocation[i][j].nUnfiltered}}
-                  </span>
-                </div>
-                <div v-if="itemsPerLocation[i][j].nUnfiltered > 0">
+                <FcTextSummaryFraction
+                  :a="itemsPerLocation[i][j].n"
+                  :b="itemsPerLocation[i][j].nUnfiltered"
+                  class="text-right"
+                  :show-b="hasFiltersStudy"
+                  small />
+                <div v-if="itemsPerLocation[i][j].n > 0">
                   <FcButton
                     class="mr-n4 mt-2"
                     type="tertiary"
@@ -112,6 +93,8 @@
 import { mapGetters } from 'vuex';
 
 import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
+import FcTextMostRecent from '@/web/components/data/FcTextMostRecent.vue';
+import FcTextSummaryFraction from '@/web/components/data/FcTextSummaryFraction.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcIconLocationMulti from '@/web/components/location/FcIconLocationMulti.vue';
 
@@ -120,6 +103,8 @@ export default {
   components: {
     FcButton,
     FcIconLocationMulti,
+    FcTextMostRecent,
+    FcTextSummaryFraction,
   },
   props: {
     studySummary: Array,

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -9,12 +9,6 @@
       There are no studies for these locations,<br>
       please request studies if necessary
     </div>
-    <div
-      v-else-if="studySummary.length === 0"
-      class="my-8 py-12 secondary--text text-center">
-      No studies match the active filters,<br>
-      clear one or more filters to see studies
-    </div>
     <template v-else>
       <v-expansion-panels
         v-model="indexOpen"

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -24,7 +24,8 @@
         <v-expansion-panel
           v-for="(item, i) in items"
           :key="i"
-          class="fc-studies-summary-per-location">
+          class="fc-studies-summary-per-location"
+          :disabled="item.n === 0">
           <v-expansion-panel-header class="pr-8">
             <div class="body-1">
               <div v-if="item.category.studyType === null">
@@ -48,7 +49,10 @@
             <div
               v-for="(location, j) in locations"
               :key="i + '_' + j"
-              class="d-flex pa-3 pr-8">
+              class="d-flex pa-3 pr-8"
+              :class="{
+                'data-empty': itemsPerLocation[i][j].mostRecent === null,
+              }">
               <FcIconLocationMulti v-bind="locationsIconProps[j]" />
               <div
                 class="body-1 flex-grow-1 flex-shrink-1"
@@ -63,11 +67,10 @@
                   }">
                   {{location.description}}
                 </div>
-                <div class="mt-2 secondary--text">
-                  <span v-if="itemsPerLocation[i][j].mostRecent === null">
-                    No studies
-                  </span>
-                  <span v-else>
+                <div
+                  v-if="itemsPerLocation[i][j].mostRecent !== null"
+                  class="mt-2 secondary--text">
+                  <span>
                     Most Recent
                     {{itemsPerLocation[i][j].mostRecent.startDate | date}}
                     ({{itemsPerLocation[i][j].mostRecent.startDate | dayOfWeek}})
@@ -86,12 +89,22 @@
               </div>
               <v-spacer></v-spacer>
               <div class="display-1 flex-grow-0 flex-shrink-0 mr-5">
-                {{itemsPerLocation[i][j].n}}
-                <span
-                  v-if="hasFiltersStudy"
-                  class="body-1">
-                  / {{itemsPerLocation[i][j].nUnfiltered}}
-                </span>
+                <div class="text-right">
+                  {{itemsPerLocation[i][j].n}}
+                  <span
+                    v-if="hasFiltersStudy"
+                    class="body-1">
+                    / {{itemsPerLocation[i][j].nUnfiltered}}
+                  </span>
+                </div>
+                <div v-if="itemsPerLocation[i][j].nUnfiltered > 0">
+                  <FcButton
+                    class="mr-n4 mt-2"
+                    type="tertiary"
+                    @click="$emit('show-reports', j)">
+                    <span>View Reports</span>
+                  </FcButton>
+                </div>
               </div>
             </div>
           </v-expansion-panel-content>
@@ -105,11 +118,13 @@
 import { mapGetters } from 'vuex';
 
 import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
+import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcIconLocationMulti from '@/web/components/location/FcIconLocationMulti.vue';
 
 export default {
   name: 'FcAggregateStudies',
   components: {
+    FcButton,
     FcIconLocationMulti,
   },
   props: {
@@ -146,12 +161,12 @@ export default {
         const itemPerLocation = this.studySummaryPerLocation.find(
           itemPerLocationFiltered => itemPerLocationFiltered.category.id === category.id,
         );
-        return perLocation.map(({ n }, i) => {
+        return perLocation.map(({ n }, j) => {
           if (itemPerLocation === undefined) {
             return { mostRecent: null, n: 0, nUnfiltered: n };
           }
           return {
-            ...itemPerLocation.perLocation[i],
+            ...itemPerLocation.perLocation[j],
             nUnfiltered: n,
           };
         });
@@ -167,8 +182,11 @@ export default {
 
 <style lang="scss">
 .fc-aggregate-studies {
-  .fc-studies-summary-per-location:not(:last-child) {
+  & .fc-studies-summary-per-location:not(:last-child) {
     border-bottom: 1px solid var(--v-border-base);
+  }
+  & .data-empty {
+    opacity: 0.37;
   }
 }
 </style>

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -1,21 +1,174 @@
 <template>
-  <div class="fc-aggregate-studies mb-5 mx-5">
+  <div class="fc-aggregate-studies mb-5 ml-5">
     <v-progress-linear
       v-if="loading"
       indeterminate />
+    <div
+      v-else-if="studySummaryUnfiltered.length === 0"
+      class="my-8 py-12 secondary--text text-center">
+      There are no studies for these locations,<br>
+      please request studies if necessary
+    </div>
+    <div
+      v-else-if="studySummary.length === 0"
+      class="my-8 py-12 secondary--text text-center">
+      No studies match the active filters,<br>
+      clear one or more filters to see studies
+    </div>
     <template v-else>
-      <h3>TODO: aggregate studies</h3>
+      <v-expansion-panels
+        v-model="indexOpen"
+        accordion
+        flat
+        focusable>
+        <v-expansion-panel
+          v-for="(item, i) in items"
+          :key="i"
+          class="fc-studies-summary-per-location">
+          <v-expansion-panel-header class="pr-8">
+            <div class="body-1">
+              <div v-if="item.category.studyType === null">
+                Unknown
+              </div>
+              <div v-else>
+                {{item.category.studyType.label}}
+              </div>
+            </div>
+            <v-spacer></v-spacer>
+            <div class="display-1 flex-grow-0 flex-shrink-0 mr-5">
+              {{item.n}}
+              <span
+                v-if="hasFiltersStudy"
+                class="body-1">
+                / {{item.nUnfiltered}}
+              </span>
+            </div>
+          </v-expansion-panel-header>
+          <v-expansion-panel-content class="shading pt-1">
+            <div
+              v-for="(location, j) in locations"
+              :key="i + '_' + j"
+              class="d-flex pa-3 pr-8">
+              <FcIconLocationMulti v-bind="locationsIconProps[j]" />
+              <div
+                class="body-1 flex-grow-1 flex-shrink-1"
+                :class="{
+                  'pl-4': locationsIconProps[j].midblock,
+                  'pl-5': !locationsIconProps[j].midblock,
+                }">
+                <div
+                  :class="{
+                    'body-1': locationsIconProps[j].locationIndex === -1,
+                    title: locationsIconProps[j].locationIndex !== -1,
+                  }">
+                  {{location.description}}
+                </div>
+                <div class="mt-2 secondary--text">
+                  <span v-if="itemsPerLocation[i][j].mostRecent === null">
+                    No studies
+                  </span>
+                  <span v-else>
+                    Most Recent
+                    {{itemsPerLocation[i][j].mostRecent.startDate | date}}
+                    ({{itemsPerLocation[i][j].mostRecent.startDate | dayOfWeek}})
+                    &#x2022;
+                    <span v-if="itemsPerLocation[i][j].mostRecent.duration !== null">
+                      {{itemsPerLocation[i][j].mostRecent.duration | durationHuman}}
+                      ({{item.mostRecent.duration}} hrs)
+                    </span>
+                    <span
+                      v-else-if="itemsPerLocation[i][j].mostRecent.hours !== null"
+                      :title="itemsPerLocation[i][j].mostRecent.hours.hint">
+                      {{itemsPerLocation[i][j].mostRecent.hours.description}}
+                    </span>
+                  </span>
+                </div>
+              </div>
+              <v-spacer></v-spacer>
+              <div class="display-1 flex-grow-0 flex-shrink-0 mr-5">
+                {{itemsPerLocation[i][j].n}}
+                <span
+                  v-if="hasFiltersStudy"
+                  class="body-1">
+                  / {{itemsPerLocation[i][j].nUnfiltered}}
+                </span>
+              </div>
+            </div>
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+      </v-expansion-panels>
     </template>
   </div>
 </template>
 
 <script>
+import { mapGetters } from 'vuex';
+
+import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
+import FcIconLocationMulti from '@/web/components/location/FcIconLocationMulti.vue';
+
 export default {
   name: 'FcAggregateStudies',
+  components: {
+    FcIconLocationMulti,
+  },
   props: {
-    loading: Boolean,
+    studySummary: Array,
+    studySummaryUnfiltered: Array,
     studySummaryPerLocation: Array,
     studySummaryPerLocationUnfiltered: Array,
+    loading: Boolean,
+    locations: Array,
+    locationsSelection: Object,
+  },
+  data() {
+    return {
+      indexOpen: null,
+    };
+  },
+  computed: {
+    items() {
+      return this.studySummaryUnfiltered.map(({ category, n }) => {
+        let item = this.studySummary.find(
+          itemFiltered => itemFiltered.category.id === category.id,
+        );
+        if (item === undefined) {
+          item = { category, mostRecent: null, n: 0 };
+        }
+        return {
+          ...item,
+          nUnfiltered: n,
+        };
+      });
+    },
+    itemsPerLocation() {
+      return this.studySummaryPerLocationUnfiltered.map(({ category, perLocation }) => {
+        const itemPerLocation = this.studySummaryPerLocation.find(
+          itemPerLocationFiltered => itemPerLocationFiltered.category.id === category.id,
+        );
+        return perLocation.map(({ n }, i) => {
+          if (itemPerLocation === undefined) {
+            return { mostRecent: null, n: 0, nUnfiltered: n };
+          }
+          return {
+            ...itemPerLocation.perLocation[i],
+            nUnfiltered: n,
+          };
+        });
+      });
+    },
+    locationsIconProps() {
+      return getLocationsIconProps(this.locations, this.locationsSelection.locations);
+    },
+    ...mapGetters('viewData', ['hasFiltersStudy']),
   },
 };
 </script>
+
+<style lang="scss">
+.fc-aggregate-studies {
+  .fc-studies-summary-per-location:not(:last-child) {
+    border-bottom: 1px solid var(--v-border-base);
+  }
+}
+</style>

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="fc-aggregate-studies mb-5 mx-5">
+    <v-progress-linear
+      v-if="loading"
+      indeterminate />
+    <template v-else>
+      <h3>TODO: aggregate studies</h3>
+    </template>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'FcAggregateStudies',
+  props: {
+    loading: Boolean,
+    studySummaryPerLocation: Array,
+    studySummaryPerLocationUnfiltered: Array,
+  },
+};
+</script>

--- a/web/components/data/FcDetailCollisions.vue
+++ b/web/components/data/FcDetailCollisions.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fc-data-table-collisions align-end d-flex mb-5 mx-5">
+  <div class="fc-detail-collisions align-end d-flex mb-5 mx-5">
     <v-progress-linear
       v-if="loading"
       indeterminate />
@@ -60,17 +60,14 @@ import { mapGetters } from 'vuex';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 
 export default {
-  name: 'FcDataTableCollisions',
+  name: 'FcDetailCollisions',
   components: {
     FcButton,
   },
   props: {
     collisionSummary: Object,
     collisionSummaryUnfiltered: Object,
-    loading: {
-      type: Boolean,
-      default: false,
-    },
+    loading: Boolean,
   },
   computed: {
     ...mapGetters('viewData', ['hasFiltersCollision']),
@@ -79,7 +76,7 @@ export default {
 </script>
 
 <style lang="scss">
-.fc-data-table-collisions {
+.fc-detail-collisions {
   .fc-collisions-validated {
     width: 120px;
   }

--- a/web/components/data/FcDetailCollisions.vue
+++ b/web/components/data/FcDetailCollisions.vue
@@ -5,40 +5,40 @@
       indeterminate />
     <template v-else>
       <div class="flex-grow-1 flex-shrink-1">
-        <div class="font-weight-regular title">
+        <div class="body-1">
           Amount
         </div>
         <div class="display-2 mt-2">
           {{collisionSummary.amount}}
           <span
             v-if="hasFiltersCollision"
-            class="font-weight-regular title">
+            class="body-1">
             / {{collisionSummaryUnfiltered.amount}}
           </span>
         </div>
       </div>
       <div class="flex-grow-1 flex-shrink-1">
-        <div class="font-weight-regular title">
+        <div class="body-1">
           KSI
         </div>
         <div class="display-2 mt-2">
           {{collisionSummary.ksi}}
           <span
             v-if="hasFiltersCollision"
-            class="font-weight-regular title">
+            class="body-1">
             / {{collisionSummaryUnfiltered.ksi}}
           </span>
         </div>
       </div>
       <div class="fc-collisions-validated flex-grow-0 flex-shrink-0 mr-8">
-        <div class="font-weight-regular title">
+        <div class="body-1">
           Validated
         </div>
         <div class="display-2 mt-2">
           {{collisionSummary.validated}}
           <span
             v-if="hasFiltersCollision"
-            class="font-weight-regular title">
+            class="body-1">
             / {{collisionSummaryUnfiltered.validated}}
           </span>
         </div>

--- a/web/components/data/FcDetailCollisions.vue
+++ b/web/components/data/FcDetailCollisions.vue
@@ -8,40 +8,31 @@
         <div class="body-1">
           Amount
         </div>
-        <div class="display-2 mt-2">
-          {{collisionSummary.amount}}
-          <span
-            v-if="hasFiltersCollision"
-            class="body-1">
-            / {{collisionSummaryUnfiltered.amount}}
-          </span>
-        </div>
+        <FcTextSummaryFraction
+          :a="collisionSummary.amount"
+          :b="collisionSummaryUnfiltered.amount"
+          class="mt-2"
+          :show-b="hasFiltersCollision" />
       </div>
       <div class="flex-grow-1 flex-shrink-1">
         <div class="body-1">
           KSI
         </div>
-        <div class="display-2 mt-2">
-          {{collisionSummary.ksi}}
-          <span
-            v-if="hasFiltersCollision"
-            class="body-1">
-            / {{collisionSummaryUnfiltered.ksi}}
-          </span>
-        </div>
+        <FcTextSummaryFraction
+          :a="collisionSummary.ksi"
+          :b="collisionSummaryUnfiltered.ksi"
+          class="mt-2"
+          :show-b="hasFiltersCollision" />
       </div>
       <div class="fc-collisions-validated flex-grow-0 flex-shrink-0 mr-8">
         <div class="body-1">
           Validated
         </div>
-        <div class="display-2 mt-2">
-          {{collisionSummary.validated}}
-          <span
-            v-if="hasFiltersCollision"
-            class="body-1">
-            / {{collisionSummaryUnfiltered.validated}}
-          </span>
-        </div>
+        <FcTextSummaryFraction
+          :a="collisionSummary.validated"
+          :b="collisionSummaryUnfiltered.validated"
+          class="mt-2"
+          :show-b="hasFiltersCollision" />
       </div>
       <FcButton
         class="flex-grow-0 flex-shrink-0"
@@ -57,12 +48,14 @@
 <script>
 import { mapGetters } from 'vuex';
 
+import FcTextSummaryFraction from '@/web/components/data/FcTextSummaryFraction.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 
 export default {
   name: 'FcDetailCollisions',
   components: {
     FcButton,
+    FcTextSummaryFraction,
   },
   props: {
     collisionSummary: Object,

--- a/web/components/data/FcDetailStudies.vue
+++ b/web/components/data/FcDetailStudies.vue
@@ -9,12 +9,6 @@
       There are no studies for this location,<br>
       please request a study if necessary
     </div>
-    <div
-      v-else-if="studySummary.length === 0"
-      class="my-8 py-12 secondary--text text-center">
-      No studies match the active filters,<br>
-      clear one or more filters to see studies
-    </div>
     <template v-else>
       <div
         v-for="item in items"
@@ -29,10 +23,7 @@
               {{item.category.studyType.label}}
             </div>
             <div class="mt-2 secondary--text">
-              <span v-if="item.mostRecent === null">
-                No studies
-              </span>
-              <span v-else>
+              <span v-if="item.mostRecent !== null">
                 Most Recent
                 {{item.mostRecent.startDate | date}} ({{item.mostRecent.startDate | dayOfWeek}})
                 &#x2022;
@@ -59,7 +50,7 @@
           </div>
           <FcButton
             class="flex-grow-0 flex-shrink-0"
-            v-if="item.category.studyType !== null"
+            :disabled="item.category.studyType === null || item.n === 0"
             type="tertiary"
             @click="$emit('show-reports', item)">
             <span>View Reports</span>
@@ -111,7 +102,7 @@ export default {
 
 <style lang="scss">
 .fc-detail-studies {
-  .fc-studies-n {
+  & .fc-studies-n {
     width: 120px;
   }
 }

--- a/web/components/data/FcDetailStudies.vue
+++ b/web/components/data/FcDetailStudies.vue
@@ -21,7 +21,7 @@
         :key="item.category.id"
         class="ml-5">
         <div class="align-center d-flex mb-4 pr-5">
-          <div class="flex-grow-1 flex-shrink-1 font-weight-regular title">
+          <div class="body-1 flex-grow-1 flex-shrink-1">
             <div v-if="item.category.studyType === null">
               Unknown
             </div>
@@ -52,7 +52,7 @@
               {{item.n}}
               <span
                 v-if="hasFiltersStudy"
-                class="font-weight-regular title">
+                class="body-1">
                 / {{item.nUnfiltered}}
               </span>
             </div>

--- a/web/components/data/FcDetailStudies.vue
+++ b/web/components/data/FcDetailStudies.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fc-data-table-studies">
+  <div class="fc-detail-studies">
     <v-progress-linear
       v-if="loading"
       indeterminate />
@@ -77,7 +77,7 @@ import { mapGetters } from 'vuex';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 
 export default {
-  name: 'FcDataTableStudies',
+  name: 'FcDetailStudies',
   components: {
     FcButton,
   },
@@ -110,7 +110,7 @@ export default {
 </script>
 
 <style lang="scss">
-.fc-data-table-studies {
+.fc-detail-studies {
   .fc-studies-n {
     width: 120px;
   }

--- a/web/components/data/FcDetailStudies.vue
+++ b/web/components/data/FcDetailStudies.vue
@@ -22,31 +22,16 @@
             <div v-else>
               {{item.category.studyType.label}}
             </div>
-            <div class="mt-2 secondary--text">
-              <span v-if="item.mostRecent !== null">
-                Most Recent
-                {{item.mostRecent.startDate | date}} ({{item.mostRecent.startDate | dayOfWeek}})
-                &#x2022;
-                <span v-if="item.mostRecent.duration !== null">
-                  {{item.mostRecent.duration | durationHuman}} ({{item.mostRecent.duration}} hrs)
-                </span>
-                <span
-                  v-else-if="item.mostRecent.hours !== null"
-                  :title="item.mostRecent.hours.hint">
-                  {{item.mostRecent.hours.description}}
-                </span>
-              </span>
-            </div>
+            <FcTextMostRecent
+              v-if="item.mostRecent !== null"
+              class="mt-2"
+              :study="item.mostRecent" />
           </div>
           <div class="fc-studies-n flex-grow-0 flex-shrink-0 mr-8">
-            <div class="display-2">
-              {{item.n}}
-              <span
-                v-if="hasFiltersStudy"
-                class="body-1">
-                / {{item.nUnfiltered}}
-              </span>
-            </div>
+            <FcTextSummaryFraction
+              :a="item.n"
+              :b="item.nUnfiltered"
+              :show-b="hasFiltersStudy" />
           </div>
           <FcButton
             class="flex-grow-0 flex-shrink-0"
@@ -65,12 +50,16 @@
 <script>
 import { mapGetters } from 'vuex';
 
+import FcTextMostRecent from '@/web/components/data/FcTextMostRecent.vue';
+import FcTextSummaryFraction from '@/web/components/data/FcTextSummaryFraction.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 
 export default {
   name: 'FcDetailStudies',
   components: {
     FcButton,
+    FcTextMostRecent,
+    FcTextSummaryFraction,
   },
   props: {
     loading: {

--- a/web/components/data/FcHeaderCollisions.vue
+++ b/web/components/data/FcHeaderCollisions.vue
@@ -1,0 +1,77 @@
+<template>
+  <header class="pa-5">
+    <div class="align-center d-flex">
+      <h2 class="headline">Collisions</h2>
+      <div class="pl-3 subtitle-1">{{collisionTotal}} total</div>
+      <v-spacer></v-spacer>
+      <FcDialogCollisionFilters
+        v-if="showFiltersCollision"
+        v-model="showFiltersCollision"
+        v-bind="filtersCollision"
+        @set-filters="setFiltersCollision">
+      </FcDialogCollisionFilters>
+      <FcButton
+        v-if="collisionTotal > 0"
+        type="secondary"
+        @click.stop="showFiltersCollision = true">
+        <v-icon
+          :color="colorIconFilterCollision"
+          left>mdi-filter-variant</v-icon>
+        Filter
+      </FcButton>
+    </div>
+
+    <div
+      v-if="filterChipsCollision.length > 0"
+      class="mt-5">
+      <v-chip
+        v-for="(filterChip, i) in filterChipsCollision"
+        :key="i"
+        class="mb-2 mr-2 primary--text"
+        color="light-blue lighten-5"
+        @click="removeFilterCollision(filterChip)">
+        {{filterChip.label}}
+        <v-icon right>mdi-close-circle</v-icon>
+      </v-chip>
+    </div>
+  </header>
+</template>
+
+<script>
+import { mapGetters, mapMutations, mapState } from 'vuex';
+
+import FcDialogCollisionFilters from '@/web/components/dialogs/FcDialogCollisionFilters.vue';
+import FcButton from '@/web/components/inputs/FcButton.vue';
+
+export default {
+  name: 'FcHeaderCollisions',
+  components: {
+    FcButton,
+    FcDialogCollisionFilters,
+  },
+  props: {
+    collisionTotal: Number,
+  },
+  data() {
+    return {
+      showFiltersCollision: false,
+    };
+  },
+  computed: {
+    colorIconFilterCollision() {
+      if (this.filterChipsCollision.length === 0) {
+        return 'unselected';
+      }
+      return 'primary';
+    },
+    ...mapState('viewData', ['filtersCollision']),
+    ...mapGetters('viewData', ['filterChipsCollision']),
+  },
+  methods: {
+    ...mapMutations('viewData', [
+      'removeFilterCollision',
+      'setFiltersCollision',
+    ]),
+  },
+};
+</script>

--- a/web/components/data/FcHeaderStudies.vue
+++ b/web/components/data/FcHeaderStudies.vue
@@ -19,13 +19,7 @@
           left>mdi-filter-variant</v-icon>
         Filter
       </FcButton>
-      <FcButton
-        class="ml-3"
-        type="primary"
-        @click="actionRequestStudy">
-        <v-icon left>mdi-plus-box</v-icon>
-        Request Study
-      </FcButton>
+      <slot name="action" />
     </div>
 
     <div
@@ -75,9 +69,6 @@ export default {
     ...mapGetters('viewData', ['filterChipsStudy']),
   },
   methods: {
-    actionRequestStudy() {
-      this.$router.push({ name: 'requestStudyNew' });
-    },
     ...mapMutations('viewData', [
       'removeFilterStudy',
       'setFiltersStudy',

--- a/web/components/data/FcHeaderStudies.vue
+++ b/web/components/data/FcHeaderStudies.vue
@@ -1,0 +1,87 @@
+<template>
+  <header class="pa-5">
+    <div class="align-center d-flex">
+      <h2 class="headline">Studies</h2>
+      <div class="pl-3 subtitle-1">{{studyTotal}} total</div>
+      <v-spacer></v-spacer>
+      <FcDialogStudyFilters
+        v-if="showFiltersStudy"
+        v-model="showFiltersStudy"
+        v-bind="filtersStudy"
+        @set-filters="setFiltersStudy">
+      </FcDialogStudyFilters>
+      <FcButton
+        v-if="studyTotal > 0"
+        type="secondary"
+        @click.stop="showFiltersStudy = true">
+        <v-icon
+          :color="colorIconFilterStudy"
+          left>mdi-filter-variant</v-icon>
+        Filter
+      </FcButton>
+      <FcButton
+        class="ml-3"
+        type="primary"
+        @click="actionRequestStudy">
+        <v-icon left>mdi-plus-box</v-icon>
+        Request Study
+      </FcButton>
+    </div>
+
+    <div
+      v-if="filterChipsStudy.length > 0"
+      class="mt-5">
+      <v-chip
+        v-for="(filterChip, i) in filterChipsStudy"
+        :key="i"
+        class="mb-2 mr-2 primary--text"
+        color="light-blue lighten-5"
+        @click="removeFilterStudy(filterChip)">
+        {{filterChip.label}}
+        <v-icon right>mdi-close-circle</v-icon>
+      </v-chip>
+    </div>
+  </header>
+</template>
+
+<script>
+import { mapGetters, mapMutations, mapState } from 'vuex';
+
+import FcDialogStudyFilters from '@/web/components/dialogs/FcDialogStudyFilters.vue';
+import FcButton from '@/web/components/inputs/FcButton.vue';
+
+export default {
+  name: 'FcHeaderStudies',
+  components: {
+    FcButton,
+    FcDialogStudyFilters,
+  },
+  props: {
+    studyTotal: Number,
+  },
+  data() {
+    return {
+      showFiltersStudy: false,
+    };
+  },
+  computed: {
+    colorIconFilterStudy() {
+      if (this.filterChipsStudy.length === 0) {
+        return 'unselected';
+      }
+      return 'primary';
+    },
+    ...mapState('viewData', ['filtersStudy']),
+    ...mapGetters('viewData', ['filterChipsStudy']),
+  },
+  methods: {
+    actionRequestStudy() {
+      this.$router.push({ name: 'requestStudyNew' });
+    },
+    ...mapMutations('viewData', [
+      'removeFilterStudy',
+      'setFiltersStudy',
+    ]),
+  },
+};
+</script>

--- a/web/components/data/FcSectionStudyRequestsPending.vue
+++ b/web/components/data/FcSectionStudyRequestsPending.vue
@@ -1,0 +1,29 @@
+<template>
+  <section class="pa-5">
+    <div
+      v-for="studyRequest in studyRequestsPending"
+      :key="studyRequest.id"
+      class="align-center d-flex">
+      <v-icon
+        color="warning"
+        left>mdi-information</v-icon>
+      <div>
+        {{studyRequest.studyType.label}}
+        has been requested on {{studyRequest.createdAt | date}}.
+        <router-link :to="{
+          name: 'requestStudyView',
+          params: { id: studyRequest.id },
+        }">View details.</router-link>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script>
+export default {
+  name: 'FcSectionStudyRequestsPending',
+  props: {
+    studyRequestsPending: Array,
+  },
+};
+</script>

--- a/web/components/data/FcTextMostRecent.vue
+++ b/web/components/data/FcTextMostRecent.vue
@@ -1,0 +1,24 @@
+<template>
+  <div class="secondary--text">
+    Most Recent
+    {{study.startDate | date}} ({{study.startDate | dayOfWeek}})
+    &#x2022;
+    <span v-if="study.duration !== null">
+      {{study.duration | durationHuman}} ({{study.duration}} hrs)
+    </span>
+    <span
+      v-else-if="study.hours !== null"
+      :title="study.hours.hint">
+      {{study.hours.description}}
+    </span>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'FcTextMostRecent',
+  props: {
+    study: Object,
+  },
+};
+</script>

--- a/web/components/data/FcTextSummaryFraction.vue
+++ b/web/components/data/FcTextSummaryFraction.vue
@@ -1,0 +1,25 @@
+<template>
+  <div :class="small ? 'display-1' : 'display-2'">
+    {{a}}
+    <span
+      v-if="showB"
+      class="body-1 secondary--text">
+      / {{b}}
+    </span>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'FcTextSummaryFraction',
+  props: {
+    a: Number,
+    b: Number,
+    showB: Boolean,
+    small: {
+      type: Boolean,
+      default: false,
+    },
+  },
+};
+</script>

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -1,21 +1,74 @@
 <template>
   <div class="fc-view-data-aggregate">
-    <h1 class="display-4 pa-5">TODO: implement aggregate view</h1>
+    <v-progress-linear
+      v-if="loading || locations.length === 0"
+      indeterminate />
+    <template v-else>
+      <section>
+        <FcHeaderCollisions :collision-total="collisionTotal" />
+        <div><h3>TODO: collision data</h3></div>
+      </section>
+
+      <section>
+        <FcHeaderStudies :study-total="studyTotal" />
+        <div><h3>TODO: study data</h3></div>
+      </section>
+    </template>
   </div>
 </template>
 
 <script>
+import { mapGetters } from 'vuex';
+
+import {
+  getCollisionsByCentrelineTotal,
+  getStudiesByCentrelineTotal,
+} from '@/lib/api/WebApi';
+import FcHeaderCollisions from '@/web/components/data/FcHeaderCollisions.vue';
+import FcHeaderStudies from '@/web/components/data/FcHeaderStudies.vue';
+
 export default {
   name: 'FcViewDataAggregate',
+  components: {
+    FcHeaderCollisions,
+    FcHeaderStudies,
+  },
   props: {
     locations: Array,
   },
   data() {
     return {
+      collisionTotal: 0,
       loading: false,
+      loadingCollisions: false,
+      loadingStudies: false,
+      studyTotal: 0,
     };
   },
+  computed: {
+    ...mapGetters('viewData', [
+      'filterChipsCollision',
+      'filterChipsStudy',
+      'filterParamsCollision',
+      'filterParamsStudy',
+    ]),
+  },
   watch: {
+    async filterParamsCollision() {
+      this.loadingCollisions = true;
+
+      // TODO: implement this
+      await new Promise(resolve => setTimeout(resolve, 400));
+
+      this.loadingCollisions = false;
+    },
+    async filterParamsStudy() {
+      this.loadingStudies = true;
+      // TODO: implement this
+      await new Promise(resolve => setTimeout(resolve, 400));
+
+      this.loadingStudies = false;
+    },
     locations() {
       this.syncLocations();
     },
@@ -25,12 +78,22 @@ export default {
   },
   methods: {
     async syncLocations() {
+      if (this.locations.length === 0) {
+        return;
+      }
+
       this.loading = true;
 
-      // TODO: actually implement this
-      await new Promise((resolve) => {
-        setTimeout(resolve, 400);
-      });
+      const tasks = [
+        getCollisionsByCentrelineTotal(this.locations),
+        getStudiesByCentrelineTotal(this.locations),
+      ];
+      const [
+        collisionTotal,
+        studyTotal,
+      ] = await Promise.all(tasks);
+      this.collisionTotal = collisionTotal;
+      this.studyTotal = studyTotal;
 
       this.loading = false;
     },

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -29,6 +29,8 @@
           :study-summary-per-location="studySummaryPerLocation"
           :study-summary-per-location-unfiltered="studySummaryPerLocationUnfiltered"
           :loading="loadingStudies"
+          :locations="locations"
+          :locations-selection="locationsSelection"
           @show-reports="actionShowReportsStudy" />
       </section>
     </template>
@@ -130,10 +132,15 @@ export default {
       }
 
       this.loadingStudies = true;
-      const studySummaryPerLocation = await getStudiesByCentrelineSummaryPerLocation(
-        this.locations,
-        this.filterParamsStudy,
-      );
+      const tasks = [
+        getStudiesByCentrelineSummary(this.locations, this.filterParamsStudy),
+        getStudiesByCentrelineSummaryPerLocation(this.locations, this.filterParamsStudy),
+      ];
+      const [
+        studySummary,
+        studySummaryPerLocation,
+      ] = await Promise.all(tasks);
+      this.studySummary = studySummary;
       this.studySummaryPerLocation = studySummaryPerLocation;
       this.loadingStudies = false;
     },

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -6,12 +6,24 @@
     <template v-else>
       <section>
         <FcHeaderCollisions :collision-total="collisionTotal" />
-        <div><h3>TODO: collision data</h3></div>
+
+        <FcAggregateCollisions
+          :collision-summary-per-location="collisionSummaryPerLocation"
+          :collision-summary-per-location-unfiltered="collisionSummaryPerLocationUnfiltered"
+          :loading="loadingCollisions"
+          @show-reports="actionShowReportsCollision" />
       </section>
+
+      <v-divider></v-divider>
 
       <section>
         <FcHeaderStudies :study-total="studyTotal" />
-        <div><h3>TODO: study data</h3></div>
+
+        <FcAggregateStudies
+          :collision-summary-per-location="collisionSummaryPerLocation"
+          :collision-summary-per-location-unfiltered="collisionSummaryPerLocationUnfiltered"
+          :loading="loadingCollisions"
+          @show-reports="actionShowReportsCollision" />
       </section>
     </template>
   </div>
@@ -26,12 +38,16 @@ import {
   getStudiesByCentrelineSummaryPerLocation,
   getStudiesByCentrelineTotal,
 } from '@/lib/api/WebApi';
+import FcAggregateCollisions from '@/web/components/data/FcAggregateCollisions.vue';
+import FcAggregateStudies from '@/web/components/data/FcAggregateStudies.vue';
 import FcHeaderCollisions from '@/web/components/data/FcHeaderCollisions.vue';
 import FcHeaderStudies from '@/web/components/data/FcHeaderStudies.vue';
 
 export default {
   name: 'FcViewDataAggregate',
   components: {
+    FcAggregateCollisions,
+    FcAggregateStudies,
     FcHeaderCollisions,
     FcHeaderStudies,
   },
@@ -63,8 +79,6 @@ export default {
   },
   computed: {
     ...mapGetters('viewData', [
-      'filterChipsCollision',
-      'filterChipsStudy',
       'filterParamsCollision',
       'filterParamsStudy',
     ]),

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -14,6 +14,7 @@
           :collision-summary-per-location-unfiltered="collisionSummaryPerLocationUnfiltered"
           :loading="loadingCollisions"
           :locations="locations"
+          :locations-selection="locationsSelection"
           @show-reports="actionShowReportsCollision" />
       </section>
 
@@ -60,6 +61,7 @@ export default {
   },
   props: {
     locations: Array,
+    locationsSelection: Object,
   },
   data() {
     const collisionSummaryPerLocationUnfiltered = this.locations.map(() => ({

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -21,7 +21,17 @@
       <v-divider></v-divider>
 
       <section>
-        <FcHeaderStudies :study-total="studyTotal" />
+        <FcHeaderStudies :study-total="studyTotal">
+          <template v-slot:action>
+            <FcButton
+              class="ml-3"
+              type="secondary"
+              @click="actionRequestStudy">
+              <v-icon color="primary" left>mdi-plus-box</v-icon>
+              Batch Request Study
+            </FcButton>
+          </template>
+        </FcHeaderStudies>
 
         <FcAggregateStudies
           :study-summary="studySummary"
@@ -52,12 +62,14 @@ import FcAggregateCollisions from '@/web/components/data/FcAggregateCollisions.v
 import FcAggregateStudies from '@/web/components/data/FcAggregateStudies.vue';
 import FcHeaderCollisions from '@/web/components/data/FcHeaderCollisions.vue';
 import FcHeaderStudies from '@/web/components/data/FcHeaderStudies.vue';
+import FcButton from '@/web/components/inputs/FcButton.vue';
 
 export default {
   name: 'FcViewDataAggregate',
   components: {
     FcAggregateCollisions,
     FcAggregateStudies,
+    FcButton,
     FcHeaderCollisions,
     FcHeaderStudies,
   },
@@ -152,6 +164,10 @@ export default {
     this.syncLocations();
   },
   methods: {
+    actionRequestStudy() {
+      /* eslint-disable-next-line no-alert */
+      window.alert('Coming Soon!');
+    },
     actionShowReportsCollision() {
       const params = this.locationsRouteParams;
       this.$router.push({

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -160,7 +160,8 @@ export default {
       });
     },
     actionShowReportsStudy() {
-      // TODO: implement this
+      /* eslint-disable-next-line no-alert */
+      window.alert('Coming Soon!');
     },
     async syncLocations() {
       if (this.locations.length === 0) {

--- a/web/components/data/FcViewDataDetail.vue
+++ b/web/components/data/FcViewDataDetail.vue
@@ -7,7 +7,7 @@
       <section>
         <FcHeaderCollisions :collision-total="collisionTotal" />
 
-        <FcDataTableCollisions
+        <FcDetailCollisions
           :collision-summary="collisionSummary"
           :collision-summary-unfiltered="collisionSummaryUnfiltered"
           :loading="loadingCollisions"
@@ -19,7 +19,7 @@
       <section>
         <FcHeaderStudies :study-total="studyTotal" />
 
-        <FcDataTableStudies
+        <FcDetailStudies
           :loading="loadingStudies"
           :study-summary="studySummary"
           :study-summary-unfiltered="studySummaryUnfiltered"
@@ -43,8 +43,8 @@ import {
   getStudiesByCentrelineTotal,
   getStudyRequestsByCentrelinePending,
 } from '@/lib/api/WebApi';
-import FcDataTableCollisions from '@/web/components/FcDataTableCollisions.vue';
-import FcDataTableStudies from '@/web/components/FcDataTableStudies.vue';
+import FcDetailCollisions from '@/web/components/data/FcDetailCollisions.vue';
+import FcDetailStudies from '@/web/components/data/FcDetailStudies.vue';
 import FcHeaderCollisions from '@/web/components/data/FcHeaderCollisions.vue';
 import FcHeaderStudies from '@/web/components/data/FcHeaderStudies.vue';
 import FcSectionStudyRequestsPending
@@ -57,8 +57,8 @@ export default {
     FcMixinAuthScope,
   ],
   components: {
-    FcDataTableCollisions,
-    FcDataTableStudies,
+    FcDetailCollisions,
+    FcDetailStudies,
     FcHeaderCollisions,
     FcHeaderStudies,
     FcSectionStudyRequestsPending,

--- a/web/components/data/FcViewDataDetail.vue
+++ b/web/components/data/FcViewDataDetail.vue
@@ -9,6 +9,7 @@
 
         <FcDataTableCollisions
           :collision-summary="collisionSummary"
+          :collision-summary-unfiltered="collisionSummaryUnfiltered"
           :loading="loadingCollisions"
           @show-reports="actionShowReportsCollision" />
       </section>
@@ -97,6 +98,11 @@ export default {
         ksi: 0,
         validated: 0,
       },
+      collisionSummaryUnfiltered: {
+        amount: 0,
+        ksi: 0,
+        validated: 0,
+      },
       collisionTotal: 0,
       loading: false,
       loadingCollisions: false,
@@ -104,6 +110,7 @@ export default {
       showFiltersStudy: false,
       studyRequestsPending: [],
       studySummary: [],
+      studySummaryUnfiltered: [],
       studyTotal: 0,
     };
   },
@@ -175,8 +182,10 @@ export default {
       this.loading = true;
       const locations = [this.location];
       const tasks = [
+        getCollisionsByCentrelineSummary(locations, {}),
         getCollisionsByCentrelineSummary(locations, this.filterParamsCollision),
         getCollisionsByCentrelineTotal(locations),
+        getStudiesByCentrelineSummary(locations, {}),
         getStudiesByCentrelineSummary(locations, this.filterParamsStudy),
         getStudiesByCentrelineTotal(locations),
       ];
@@ -184,15 +193,19 @@ export default {
         tasks.push(getStudyRequestsByCentrelinePending(locations));
       }
       const [
+        collisionSummaryUnfiltered,
         collisionSummary,
         collisionTotal,
+        studySummaryUnfiltered,
         studySummary,
         studyTotal,
         studyRequestsPending = [],
       ] = await Promise.all(tasks);
+      this.collisionSummaryUnfiltered = collisionSummaryUnfiltered;
       this.collisionSummary = collisionSummary;
       this.collisionTotal = collisionTotal;
       this.studyRequestsPending = studyRequestsPending;
+      this.studySummaryUnfiltered = studySummaryUnfiltered;
       this.studySummary = studySummary;
       this.studyTotal = studyTotal;
       this.loading = false;

--- a/web/components/data/FcViewDataDetail.vue
+++ b/web/components/data/FcViewDataDetail.vue
@@ -5,42 +5,7 @@
       indeterminate />
     <template v-else>
       <section>
-        <header class="pa-5">
-          <div class="align-center d-flex">
-            <h2 class="headline">Collisions</h2>
-            <div class="pl-3 subtitle-1">{{collisionTotal}} total</div>
-            <v-spacer></v-spacer>
-            <FcDialogCollisionFilters
-              v-if="showFiltersCollision"
-              v-model="showFiltersCollision"
-              v-bind="filtersCollision"
-              @set-filters="setFiltersCollision">
-            </FcDialogCollisionFilters>
-            <FcButton
-              v-if="collisionTotal > 0"
-              type="secondary"
-              @click.stop="showFiltersCollision = true">
-              <v-icon
-                :color="colorIconFilterCollision"
-                left>mdi-filter-variant</v-icon>
-              Filter
-            </FcButton>
-          </div>
-
-          <div
-            v-if="filterChipsCollision.length > 0"
-            class="mt-5">
-            <v-chip
-              v-for="(filterChip, i) in filterChipsCollision"
-              :key="i"
-              class="mb-2 mr-2 primary--text"
-              color="light-blue lighten-5"
-              @click="removeFilterCollision(filterChip)">
-              <v-icon left>mdi-check</v-icon>
-              {{filterChip.label}}
-            </v-chip>
-          </div>
-        </header>
+        <FcHeaderCollisions :collision-total="collisionTotal" />
 
         <FcDataTableCollisions
           :collision-summary="collisionSummary"
@@ -51,49 +16,8 @@
       <v-divider></v-divider>
 
       <section>
-        <header class="pa-5">
-          <div class="align-center d-flex">
-            <h2 class="headline">Studies</h2>
-            <div class="pl-3 subtitle-1">{{studyTotal}} total</div>
-            <v-spacer></v-spacer>
-            <FcDialogStudyFilters
-              v-if="showFiltersStudy"
-              v-model="showFiltersStudy"
-              v-bind="filtersStudy"
-              @set-filters="setFiltersStudy">
-            </FcDialogStudyFilters>
-            <FcButton
-              v-if="studyTotal > 0"
-              type="secondary"
-              @click.stop="showFiltersStudy = true">
-              <v-icon
-                :color="colorIconFilterStudy"
-                left>mdi-filter-variant</v-icon>
-              Filter
-            </FcButton>
-            <FcButton
-              class="ml-3"
-              type="primary"
-              @click="actionRequestStudy">
-              <v-icon left>mdi-plus-box</v-icon>
-              Request Study
-            </FcButton>
-          </div>
+        <FcHeaderStudies :study-total="studyTotal" />
 
-          <div
-            v-if="filterChipsStudy.length > 0"
-            class="mt-5">
-            <v-chip
-              v-for="(filterChip, i) in filterChipsStudy"
-              :key="i"
-              class="mb-2 mr-2 primary--text"
-              color="light-blue lighten-5"
-              @click="removeFilterStudy(filterChip)">
-              <v-icon left>mdi-check</v-icon>
-              {{filterChip.label}}
-            </v-chip>
-          </div>
-        </header>
         <div
           v-if="studyTotal === 0"
           class="my-8 py-12 secondary--text text-center">
@@ -111,6 +35,7 @@
           :loading="loadingStudies"
           :study-summary="studySummary"
           @show-reports="actionShowReportsStudy" />
+
         <div class="pa-5">
           <div
             v-for="studyRequest in studyRequestsPending"
@@ -147,9 +72,8 @@ import {
 } from '@/lib/api/WebApi';
 import FcDataTableCollisions from '@/web/components/FcDataTableCollisions.vue';
 import FcDataTableStudies from '@/web/components/FcDataTableStudies.vue';
-import FcDialogCollisionFilters from '@/web/components/dialogs/FcDialogCollisionFilters.vue';
-import FcDialogStudyFilters from '@/web/components/dialogs/FcDialogStudyFilters.vue';
-import FcButton from '@/web/components/inputs/FcButton.vue';
+import FcHeaderCollisions from '@/web/components/data/FcHeaderCollisions.vue';
+import FcHeaderStudies from '@/web/components/data/FcHeaderStudies.vue';
 import FcMixinAuthScope from '@/web/mixins/FcMixinAuthScope';
 
 export default {
@@ -158,11 +82,10 @@ export default {
     FcMixinAuthScope,
   ],
   components: {
-    FcButton,
     FcDataTableCollisions,
     FcDataTableStudies,
-    FcDialogCollisionFilters,
-    FcDialogStudyFilters,
+    FcHeaderCollisions,
+    FcHeaderStudies,
   },
   props: {
     location: Object,
@@ -178,7 +101,6 @@ export default {
       loading: false,
       loadingCollisions: false,
       loadingStudies: false,
-      showFiltersCollision: false,
       showFiltersStudy: false,
       studyRequestsPending: [],
       studySummary: [],
@@ -186,39 +108,35 @@ export default {
     };
   },
   computed: {
-    colorIconFilterCollision() {
-      if (this.filterChipsCollision.length === 0) {
-        return 'unselected';
-      }
-      return 'primary';
-    },
-    colorIconFilterStudy() {
-      if (this.filterChipsStudy.length === 0) {
-        return 'unselected';
-      }
-      return 'primary';
-    },
     ...mapGetters('viewData', [
-      'filterChipsCollision',
-      'filterChipsStudy',
       'filterParamsCollision',
       'filterParamsStudy',
     ]),
   },
   watch: {
     async filterParamsCollision() {
+      if (this.location === null) {
+        return;
+      }
+
       this.loadingCollisions = true;
+      const locations = [this.location];
       const collisionSummary = await getCollisionsByCentrelineSummary(
-        this.locations,
+        locations,
         this.filterParamsCollision,
       );
       this.collisionSummary = collisionSummary;
       this.loadingCollisions = false;
     },
     async filterParamsStudy() {
+      if (this.location === null) {
+        return;
+      }
+
       this.loadingStudies = true;
+      const locations = [this.location];
       const studySummary = await getStudiesByCentrelineSummary(
-        this.locations,
+        locations,
         this.filterParamsStudy,
       );
       this.studySummary = studySummary;
@@ -232,9 +150,6 @@ export default {
     this.syncLocation();
   },
   methods: {
-    actionRequestStudy() {
-      this.$router.push({ name: 'requestStudyNew' });
-    },
     actionShowReportsCollision() {
       const params = this.locationsRouteParams;
       this.$router.push({

--- a/web/components/data/FcViewDataDetail.vue
+++ b/web/components/data/FcViewDataDetail.vue
@@ -19,43 +19,15 @@
       <section>
         <FcHeaderStudies :study-total="studyTotal" />
 
-        <div
-          v-if="studyTotal === 0"
-          class="my-8 py-12 secondary--text text-center">
-          There are no studies for this location,<br>
-          please request a study if necessary
-        </div>
-        <div
-          v-else-if="studySummary.length === 0"
-          class="my-8 py-12 secondary--text text-center">
-          No studies match the active filters,<br>
-          clear one or more filters to see studies
-        </div>
         <FcDataTableStudies
-          v-else
           :loading="loadingStudies"
           :study-summary="studySummary"
+          :study-summary-unfiltered="studySummaryUnfiltered"
           @show-reports="actionShowReportsStudy" />
-
-        <div class="pa-5">
-          <div
-            v-for="studyRequest in studyRequestsPending"
-            :key="studyRequest.id"
-            class="align-center d-flex">
-            <v-icon
-              color="warning"
-              left>mdi-information</v-icon>
-            <div>
-              {{studyRequest.studyType.label}}
-              has been requested on {{studyRequest.createdAt | date}}.
-              <router-link :to="{
-                name: 'requestStudyView',
-                params: { id: studyRequest.id },
-              }">View details.</router-link>
-            </div>
-          </div>
-        </div>
       </section>
+
+      <FcSectionStudyRequestsPending
+        :study-requests-pending="studyRequestsPending" />
     </template>
   </div>
 </template>
@@ -75,6 +47,8 @@ import FcDataTableCollisions from '@/web/components/FcDataTableCollisions.vue';
 import FcDataTableStudies from '@/web/components/FcDataTableStudies.vue';
 import FcHeaderCollisions from '@/web/components/data/FcHeaderCollisions.vue';
 import FcHeaderStudies from '@/web/components/data/FcHeaderStudies.vue';
+import FcSectionStudyRequestsPending
+  from '@/web/components/data/FcSectionStudyRequestsPending.vue';
 import FcMixinAuthScope from '@/web/mixins/FcMixinAuthScope';
 
 export default {
@@ -87,6 +61,7 @@ export default {
     FcDataTableStudies,
     FcHeaderCollisions,
     FcHeaderStudies,
+    FcSectionStudyRequestsPending,
   },
   props: {
     location: Object,

--- a/web/components/data/FcViewDataDetail.vue
+++ b/web/components/data/FcViewDataDetail.vue
@@ -17,7 +17,17 @@
       <v-divider></v-divider>
 
       <section>
-        <FcHeaderStudies :study-total="studyTotal" />
+        <FcHeaderStudies :study-total="studyTotal">
+          <template v-slot:action>
+            <FcButton
+              class="ml-3"
+              type="secondary"
+              @click="actionRequestStudy">
+              <v-icon color="primary" left>mdi-plus-box</v-icon>
+              Request Study
+            </FcButton>
+          </template>
+        </FcHeaderStudies>
 
         <FcDetailStudies
           :loading="loadingStudies"
@@ -49,6 +59,7 @@ import FcHeaderCollisions from '@/web/components/data/FcHeaderCollisions.vue';
 import FcHeaderStudies from '@/web/components/data/FcHeaderStudies.vue';
 import FcSectionStudyRequestsPending
   from '@/web/components/data/FcSectionStudyRequestsPending.vue';
+import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcMixinAuthScope from '@/web/mixins/FcMixinAuthScope';
 
 export default {
@@ -57,6 +68,7 @@ export default {
     FcMixinAuthScope,
   ],
   components: {
+    FcButton,
     FcDetailCollisions,
     FcDetailStudies,
     FcHeaderCollisions,
@@ -133,6 +145,9 @@ export default {
     this.syncLocation();
   },
   methods: {
+    actionRequestStudy() {
+      this.$router.push({ name: 'requestStudyNew' });
+    },
     actionShowReportsCollision() {
       // TODO: go to reports for specific location!
       const params = this.locationsRouteParams;

--- a/web/components/data/FcViewDataDetail.vue
+++ b/web/components/data/FcViewDataDetail.vue
@@ -146,26 +146,16 @@ export default {
   },
   methods: {
     actionRequestStudy() {
-      this.$router.push({ name: 'requestStudyNew' });
+      /* eslint-disable-next-line no-alert */
+      window.alert('Coming Soon!');
     },
     actionShowReportsCollision() {
-      // TODO: go to reports for specific location!
-      const params = this.locationsRouteParams;
-      this.$router.push({
-        name: 'viewCollisionReportsAtLocation',
-        params,
-      });
+      /* eslint-disable-next-line no-alert */
+      window.alert('Coming Soon!');
     },
-    actionShowReportsStudy({ category: { studyType } }) {
-      // TODO: go to reports for specific location!
-      const params = this.locationsRouteParams;
-      this.$router.push({
-        name: 'viewStudyReportsAtLocation',
-        params: {
-          ...params,
-          studyTypeName: studyType.name,
-        },
-      });
+    actionShowReportsStudy(/* { category: { studyType } } */) {
+      /* eslint-disable-next-line no-alert */
+      window.alert('Coming Soon!');
     },
     async syncLocation() {
       if (this.location === null) {

--- a/web/components/data/FcViewDataDetail.vue
+++ b/web/components/data/FcViewDataDetail.vue
@@ -93,6 +93,7 @@ export default {
     ...mapGetters('viewData', [
       'filterParamsCollision',
       'filterParamsStudy',
+      'locationsRouteParams',
     ]),
   },
   watch: {
@@ -133,6 +134,7 @@ export default {
   },
   methods: {
     actionShowReportsCollision() {
+      // TODO: go to reports for specific location!
       const params = this.locationsRouteParams;
       this.$router.push({
         name: 'viewCollisionReportsAtLocation',
@@ -140,6 +142,7 @@ export default {
       });
     },
     actionShowReportsStudy({ category: { studyType } }) {
+      // TODO: go to reports for specific location!
       const params = this.locationsRouteParams;
       this.$router.push({
         name: 'viewStudyReportsAtLocation',

--- a/web/components/data/FcViewDataMultiEdit.vue
+++ b/web/components/data/FcViewDataMultiEdit.vue
@@ -9,7 +9,7 @@
           class="my-6"
           no-gutters>
           <v-col cols="4">
-            <div class="font-weight-regular title">
+            <div class="body-1">
               Total Collisions
             </div>
             <div class="display-2 mt-2">
@@ -17,7 +17,7 @@
             </div>
           </v-col>
           <v-col cols="4">
-            <div class="font-weight-regular title">
+            <div class="body-1">
               Total Studies
             </div>
             <div class="display-2 mt-2">
@@ -55,13 +55,12 @@
 </template>
 
 <script>
-import { CentrelineType } from '@/lib/Constants';
 import {
   getCollisionsByCentrelineTotal,
   getStudiesByCentrelineSummary,
   getStudiesByCentrelineTotal,
 } from '@/lib/api/WebApi';
-import { getLocationsWaypointIndices } from '@/lib/geo/CentrelineUtils';
+import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
 import DateTime from '@/lib/time/DateTime';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 import FcIconLocationMulti from '@/web/components/location/FcIconLocationMulti.vue';
@@ -85,20 +84,7 @@ export default {
   },
   computed: {
     locationsIconProps() {
-      const locationsWaypointIndices = getLocationsWaypointIndices(
-        this.locations,
-        this.locationsSelection.locations,
-      );
-      return this.locations.map(({ centrelineType }, i) => {
-        const midblock = centrelineType === CentrelineType.SEGMENT;
-        const waypointIndices = locationsWaypointIndices[i];
-        const n = waypointIndices.length;
-        if (n === 0) {
-          return { locationIndex: -1, midblock };
-        }
-        const locationIndex = waypointIndices[n - 1];
-        return { locationIndex, midblock };
-      });
+      return getLocationsIconProps(this.locations, this.locationsSelection.locations);
     },
     textMostRecentStudy() {
       const n = this.studySummary.length;

--- a/web/components/data/FcViewDataMultiEdit.vue
+++ b/web/components/data/FcViewDataMultiEdit.vue
@@ -122,6 +122,10 @@ export default {
   },
   methods: {
     async syncLocations() {
+      if (this.locations.length === 0) {
+        return;
+      }
+
       this.loading = true;
 
       const tasks = [

--- a/web/store/modules/viewData.js
+++ b/web/store/modules/viewData.js
@@ -144,6 +144,12 @@ export default {
       }
       return params;
     },
+    hasFiltersCollision(state, getters) {
+      return getters.filterChipsCollision.length > 0;
+    },
+    hasFiltersStudy(state, getters) {
+      return getters.filterChipsStudy.length > 0;
+    },
   },
   mutations: {
     removeFilterCollision(state, { filter, value }) {


### PR DESCRIPTION
# Issue Addressed
This PR closes #514 , and addresses one of the tasks identified in #535 .

# Description
We implement `FcViewDataAggregate`, breaking out several pieces of the View Data interface into reusable components in the process.  We also add AADT estimates to centreline segments as returned by `CentrelineDAO`, so that we can then use those estimates to render selected midblocks with the correct volume-based line width.

The bulk of this work is in creating new REST API endpoints that provide per-location summaries of collision and study data, and in using those endpoints from within an accordion-based interface.

# Tests
Tested quickly in frontend; `npm run test:test-db` for AADT changes.