### PR TITLE
Integrate analytics using the Oracle Infinity Data Collection API

### DIFF
--- a/web/analytics/AnalyticsTypes.js
+++ b/web/analytics/AnalyticsTypes.js
@@ -8,6 +8,15 @@ AnalyticsEventType.init({
   BUTTON_CLICK: {
     code: '29',
   },
+  LOCATION_SEARCH: {
+    code: '26',
+  },
+  SIGN_IN: {
+    code: '27',
+  },
+  SIGN_OUT: {
+    code: '27',
+  },
 });
 
 const AnalyticsTypes = {

--- a/web/analytics/AnalyticsTypes.js
+++ b/web/analytics/AnalyticsTypes.js
@@ -1,0 +1,20 @@
+import { Enum } from '@/lib/ClassUtils';
+
+class AnalyticsEventType extends Enum {}
+AnalyticsEventType.init({
+  APP_ROUTE: {
+    code: '0',
+  },
+  BUTTON_CLICK: {
+    code: '29',
+  },
+});
+
+const AnalyticsTypes = {
+  AnalyticsEventType,
+};
+
+export {
+  AnalyticsTypes as default,
+  AnalyticsEventType,
+};

--- a/web/analytics/AnalyticsTypes.js
+++ b/web/analytics/AnalyticsTypes.js
@@ -1,5 +1,12 @@
 import { Enum } from '@/lib/ClassUtils';
 
+/**
+ * Maps MOVE event types (e.g. application route, location search) to values for the `wt.dl`
+ * parameter in Oracle Infinity's Data Collection API.
+ *
+ * @param {string} code - value of `wt.dl` for this event type
+ * @see https://docs.oracle.com/en/cloud/saas/marketing/infinity-user/Help/parameters/event_tracking.htm
+ */
 class AnalyticsEventType extends Enum {}
 AnalyticsEventType.init({
   APP_ROUTE: {

--- a/web/analytics/analyticsClient.js
+++ b/web/analytics/analyticsClient.js
@@ -4,23 +4,26 @@ import { AnalyticsEventType } from '@/web/analytics/AnalyticsTypes';
 
 const STORAGE_KEY_VISITOR_ID = 'ca.toronto.move.visitorId';
 
-class VisitorId {
-  static get() {
-    let visitorId = window.localStorage.getItem(STORAGE_KEY_VISITOR_ID);
-    if (visitorId === null) {
-      visitorId = uuidv4();
-      window.localStorage.setItem(STORAGE_KEY_VISITOR_ID, visitorId);
-    }
-    return visitorId;
-  }
-}
-
 /**
  * Client for Oracle Infinity.  Wraps the Data Collection API in an interface that makes
  * it easier to log important interaction events throughout MOVE.
  *
+ * Note that event sending is asynchronous.  It is recommended that you avoid blocking user
+ * interaction wherever possible.  This usually means calling `send(events)` *without* `await`,
+ * or at least waiting until the user-facing changes resulting from that interaction have
+ * taken place to send the events.
+ *
+ * One exception is in actions that load a different page, such as the sign in / sign out
+ * actions.  In those cases, it is acceptable to `await send(events)` to prevent a race
+ * between the page load and the analytics API request.  Note, however, that this cannot
+ * be reliably done from within native event handlers (e.g. `onsubmit`).
+ *
  * @param {string} accountId - Oracle Infinity account ID
- * @param {string} dcsId - additional Oracle Infinity identifier
+ * @param {string} dcsId - Oracle Infinity tag ID
+ * @example
+ * const event = analyticsClient.buttonEvent();
+ * // within a component: this.$analytics.buttonEvent()
+ * await analyticsClient.send([event]);
  */
 class AnalyticsClient {
   constructor(accountId, dcsId) {
@@ -29,6 +32,7 @@ class AnalyticsClient {
     this.analyticsDomain = AnalyticsClient.getAnalyticsDomain();
     this.dcsId = dcsId;
     this.userLanguage = AnalyticsClient.getUserLanguage();
+    this.visitorId = AnalyticsClient.getVisitorId();
   }
 
   /**
@@ -68,6 +72,7 @@ class AnalyticsClient {
    * @param {Element} $el
    * @returns {string?} identifier as described above, or `null` if either no such container
    * element exists or that container element lacks both `id` and `class` attributes
+   * @see https://docs.oracle.com/en/cloud/saas/marketing/infinity-user/Help/parameters/div_table.htm
    */
   static getContainerIdentifier($el) {
     const $container = $el.closest('div, table');
@@ -79,6 +84,19 @@ class AnalyticsClient {
       || null;
   }
 
+  /**
+   * Given route parameters, extracts a series of content subgroups.  This is used alongside
+   * `wt.cg_n` - we're using the content group / subgroup feature to store information about
+   * which application route is active.
+   *
+   * One issue here is that content subgroups are treated as a sequential list in the Oracle
+   * Infinity dashboard, but for analytics purposes these would best be considered independent
+   * dimensions.  To correct that, we will likely need to define custom parameters.
+   *
+   * @param {Object} params - route params to extract content subgroups from
+   * @returns {Array<string>} list of content subgroups
+   * @see https://docs.oracle.com/en/cloud/saas/marketing/infinity-user/Help/parameters/content_group.htm#wt.cg_s
+   */
   static getContentSubgroups(params) {
     const contentSubgroups = [];
     if (Object.prototype.hasOwnProperty.call(params, 'selectionTypeName')) {
@@ -92,6 +110,7 @@ class AnalyticsClient {
 
   /**
    * @returns {string} screen resolution, in `${width}x${height}` format
+   * @see https://docs.oracle.com/en/cloud/saas/marketing/infinity-user/Help/parameters/web-client.htm#wt.sr
    */
   static getScreenResolution() {
     const { height, width } = window.screen;
@@ -100,6 +119,7 @@ class AnalyticsClient {
 
   /**
    * @returns {string} current page title
+   * @see https://docs.oracle.com/en/cloud/saas/marketing/infinity-user/Help/parameters/title.htm
    */
   static getTitle() {
     const { title } = window.document;
@@ -108,14 +128,53 @@ class AnalyticsClient {
 
   /**
    * @returns {string} current user language
+   * @see https://docs.oracle.com/en/cloud/saas/marketing/infinity-user/Help/parameters/web-client.htm#wt.ul
    */
   static getUserLanguage() {
     const { language } = window.navigator;
     return language;
   }
 
+  /**
+   * Returns a unique anonymous visitor ID.  This ID is not related in any way to user
+   * credentials, and does not need to be kept secret.
+   *
+   * If possible, uses `window.localStorage` to persist this visitor ID across separate sessions
+   * in the same browser.  (This is not quite the same as sessions for the same user, but is
+   * probably the best we can do without compromising the "anonymous" part.)
+   *
+   * @returns {string} visitor ID
+   */
+  static getVisitorId() {
+    try {
+      let visitorId = window.localStorage.getItem(STORAGE_KEY_VISITOR_ID);
+      if (visitorId === null) {
+        visitorId = uuidv4();
+        window.localStorage.setItem(STORAGE_KEY_VISITOR_ID, visitorId);
+      }
+      return visitorId;
+    } catch (err) {
+      /*
+       * In this case, `window.localStorage` is likely missing or unavailable.  Since the result
+       * is stored in `this.visitorId` once during construction, and since we keep the same
+       * `AnalyticsClient` while the page is open, we can generate a new UUID here and at least
+       * group all user actions in the same page load under the same visitor.
+       */
+      return uuidv4();
+    }
+  }
+
   // EVENTS
 
+  /**
+   * Handles event parameters common to all event types, and combines them with
+   * type-specific parameters to form ready-to-send analytics events.
+   *
+   * @param {AnalyticsEventType} eventType - determines value of `wt.dl` event-tracking
+   * parameter
+   * @param {Object<string, string>} eventOptions - additional options to include in the
+   * event; can use this to override common parameters as well
+   */
   event(eventType, eventOptions) {
     if (this.appContext === null) {
       throw new Error('must call setAppContext() before event()');
@@ -124,26 +183,68 @@ class AnalyticsClient {
     const { name, params, path } = this.appContext.$route;
     const now = new Date();
 
+    /*
+     * Note that all values here are strings - numeric values (e.g. time-related details)
+     * must be converted using `.toString()`.
+     */
     const event = {
       dcsuri: path,
+      /*
+       * Hour of day in browser-local time.  Used to see daily usage patterns.
+       */
       'wt.bh': now.getHours().toString(),
+      /*
+       * As noted elsewhere, we use content groups and subgroups to store information about the
+       * active route.
+       */
       'wt.cg_n': name,
       'wt.cg_s': AnalyticsClient.getContentSubgroups(params),
       'wt.dl': eventType.code,
+      /*
+       * From testing via `curl` and the Oracle Infinity dashboard, `wt.es` must be present, and
+       * should be set to `{domain}{path}` as here.  (No idea what happens, or what might break,
+       * if this invariant is not kept.)
+       */
       'wt.es': `${this.analyticsDomain}${path}`,
+      /*
+       * Timestamp in UNIX epoch seconds (not milliseconds, as the docs claim!)
+       */
       'wt.ets': Math.floor(now.valueOf() / 1000).toString(),
+      /*
+       * We fetch screen resolution on each event, as it is possible for users with multi-screen
+       * setups to move the browser window to a different screen between analytics events.
+       */
       'wt.sr': AnalyticsClient.getScreenResolution(),
       'wt.ti': AnalyticsClient.getTitle(),
+      /*
+       * Timezone offset, in hours.  A negative value indicates that local time is earlier than UTC,
+       * hence the negation of `now.getTimezoneOffset()`.
+       */
       'wt.tz': Math.floor(-now.getTimezoneOffset() / 60).toString(),
       ...eventOptions,
     };
     return event;
   }
 
+  /**
+   * Oracle Infinity's conceptual model is rooted in page loads ("views").  As an SPA, MOVE's
+   * equivalent is `vue-router` transitions, so we log these in the `router.afterEach()` hook.
+   *
+   * @returns {Object<string, string>} event representing a page load or route transition
+   */
   appRouteEvent() {
     return this.event(AnalyticsEventType.APP_ROUTE, {});
   }
 
+  /**
+   * Used to capture button clicks.  Here we use the "form button click" event type - even
+   * though most button interactions in MOVE don't involve `<form>` elements, this allows those
+   * interactions to show up in the dashboard as clicks.
+   *
+   * @param {string} ihtml - textual representation of button
+   * @param {Element} $el - root element of button component
+   * @returns {Object<string, string>} event representing a button click
+   */
   buttonEvent(ihtml, $el) {
     const nv = AnalyticsClient.getContainerIdentifier($el) || 'app';
 
@@ -155,6 +256,16 @@ class AnalyticsClient {
     return this.event(AnalyticsEventType.BUTTON_CLICK, eventOptions);
   }
 
+  /**
+   * Used to capture location search interactions.  Here we use the "form GET action" event
+   * type - again, this isn't in a `<form>`, and as an SPA MOVE relies more on AJAX-y API
+   * calls, but this allows us to record these in a way visible to Oracle Infinity.
+   *
+   * @param {string} query - query sent to the backend
+   * @param {number} numResults - number of results returned from the search backend, or 0
+   * if the search was unsuccessful
+   * @returns {Object<string, string>} event representing a location search
+   */
   locationSearchEvent(query, numResults) {
     const eventOptions = {
       dcsuri: '/api/locations/suggest',
@@ -170,6 +281,16 @@ class AnalyticsClient {
     return this.event(AnalyticsEventType.LOCATION_SEARCH, eventOptions);
   }
 
+  /**
+   * Sign in event - either from an explicit click on the user "Sign In" button at bottom
+   * left, or via auto-redirect when the user navigates to a part of MOVE that requires
+   * authentication (e.g. Track Requests).
+   *
+   * In the explicit click case, we'll also see a button click event from that button; this
+   * helps us understand how many sign in events are explicit vs. automatic.
+   *
+   * @returns {Object<string, string>} event representing a user sign-in
+   */
   signInEvent() {
     const eventOptions = {
       dcsuri: '/api/auth/adfs-init',
@@ -181,6 +302,11 @@ class AnalyticsClient {
     return this.event(AnalyticsEventType.SIGN_IN, eventOptions);
   }
 
+  /**
+   * Sign out event from the bottom left user dropdown.
+   *
+   * @returns {Object<string, string>} event representing a user sign-out
+   */
   signOutEvent() {
     const eventOptions = {
       dcsuri: '/api/auth/logout',
@@ -192,18 +318,30 @@ class AnalyticsClient {
     return this.event(AnalyticsEventType.SIGN_OUT, eventOptions);
   }
 
+  /**
+   * Sends one or more events to Oracle Infinity.
+   *
+   * This method should *never* throw an error; if events are malformed, or the Oracle Infinity
+   * service is unreachable, the rest of MOVE should continue to function.  We currently wrap
+   * the `window.fetch` call in a try-catch block, and might eventually wrap other parts in
+   * that same block.
+   *
+   * @param {Array<Object<string, string>>} events - events to send
+   */
   async send(events) {
-    const url = `https://dc.oracleinfinity.io/v3/${this.accountId}`;
+    if (events.length === 0) {
+      return;
+    }
 
-    const visitorId = VisitorId.get();
+    const url = `https://dc.oracleinfinity.io/v3/${this.accountId}`;
     const data = {
       events,
       static: {
         dcssip: this.analyticsDomain,
-        'wt.co_f': visitorId,
+        'wt.co_f': this.visitorId,
         'wt.dcsid': this.dcsId,
         'wt.ul': this.userLanguage,
-        'wt.vtid': visitorId,
+        'wt.vtid': this.visitorId,
       },
     };
     const body = JSON.stringify(data);
@@ -220,6 +358,16 @@ class AnalyticsClient {
   }
 }
 
+/**
+ * Singleton analytics client instance, for use across the application.
+ *
+ * We include the account and tag IDs here, as these are not intended to be secret; indeed,
+ * when loading the Oracle Infinity `<script>` tag, both values are easily accessible in
+ * plaintext from the browser.  This is deliberate, as it means we can send analytics
+ * events directly to Oracle Infinity without needing to store them ourselves.
+ *
+ * @type {AnalyticsClient}
+ */
 const analyticsClient = new AnalyticsClient(
   '97j62divdr',
   'dcs222ldvxk938tpne9uk1e3u_1c4g',

--- a/web/analytics/analyticsClient.js
+++ b/web/analytics/analyticsClient.js
@@ -79,6 +79,17 @@ class AnalyticsClient {
       || null;
   }
 
+  static getContentSubgroups(params) {
+    const contentSubgroups = [];
+    if (Object.prototype.hasOwnProperty.call(params, 'selectionTypeName')) {
+      contentSubgroups.push(params.selectionTypeName);
+    }
+    if (Object.prototype.hasOwnProperty.call(params, 'studyTypeName')) {
+      contentSubgroups.push(params.studyTypeName);
+    }
+    return contentSubgroups;
+  }
+
   /**
    * @returns {string} screen resolution, in `${width}x${height}` format
    */
@@ -110,13 +121,14 @@ class AnalyticsClient {
       throw new Error('must call setAppContext() before event()');
     }
 
-    const { name, path } = this.appContext.$route;
+    const { name, params, path } = this.appContext.$route;
     const now = new Date();
 
     const event = {
       dcsuri: path,
       'wt.bh': now.getHours().toString(),
       'wt.cg_n': name,
+      'wt.cg_s': AnalyticsClient.getContentSubgroups(params),
       'wt.dl': eventType.code,
       'wt.es': `${this.analyticsDomain}${path}`,
       'wt.ets': Math.floor(now.valueOf() / 1000).toString(),
@@ -141,6 +153,43 @@ class AnalyticsClient {
       'wt.z_url': 'NaN',
     };
     return this.event(AnalyticsEventType.BUTTON_CLICK, eventOptions);
+  }
+
+  locationSearchEvent(query, numResults) {
+    const eventOptions = {
+      dcsuri: '/api/locations/suggest',
+      query,
+      'wt.es': `${this.analyticsDomain}/api/locations/suggest`,
+      'wt.ihtml': 'Search',
+      'wt.nv': 'fc-input-location-search',
+      'wt.oss': query,
+      'wt.oss_r': numResults,
+      'wt.search-term': query,
+      'wt.z_url': 'NaN',
+    };
+    return this.event(AnalyticsEventType.LOCATION_SEARCH, eventOptions);
+  }
+
+  signInEvent() {
+    const eventOptions = {
+      dcsuri: '/api/auth/adfs-init',
+      'wt.es': `${this.analyticsDomain}/api/auth/adfs-init`,
+      'wt.ihtml': 'Sign In',
+      'wt.nv': 'auth',
+      'wt.z_url': 'NaN',
+    };
+    return this.event(AnalyticsEventType.SIGN_IN, eventOptions);
+  }
+
+  signOutEvent() {
+    const eventOptions = {
+      dcsuri: '/api/auth/logout',
+      'wt.es': `${this.analyticsDomain}/api/auth/logout`,
+      'wt.ihtml': 'Sign Out',
+      'wt.nv': 'auth',
+      'wt.z_url': 'NaN',
+    };
+    return this.event(AnalyticsEventType.SIGN_OUT, eventOptions);
   }
 
   async send(events) {

--- a/web/analytics/analyticsClient.js
+++ b/web/analytics/analyticsClient.js
@@ -59,22 +59,6 @@ class AnalyticsClient {
   }
 
   /**
-   * Returns a textual representation of the given button.  Note that this would *not* be a
-   * good candidate for Vue computed properties, as the component root element reference
-   * `this.$el` is not reactive.
-   *
-   * @param {Vue} $vm - `<FcButton>` instance
-   * @returns {string} text of the button, either `aria-label` for icon buttons or
-   * `innerText` for buttons with text
-   */
-  static getButtonText($vm) {
-    if (Object.prototype.hasOwnProperty.call($vm.$attrs, 'aria-label')) {
-      return $vm.$attrs['aria-label'];
-    }
-    return $vm.$el.innerText.trim();
-  }
-
-  /**
    * Finds the closest containing `<div>` or `<table>` to `$el`, then returns its ID or class
    * as an identifier for that container.
    *
@@ -148,9 +132,8 @@ class AnalyticsClient {
     return this.event(AnalyticsEventType.APP_ROUTE, {});
   }
 
-  buttonEvent($vm) {
-    const ihtml = AnalyticsClient.getButtonText($vm) || '';
-    const nv = AnalyticsClient.getContainerIdentifier($vm.$el) || 'app';
+  buttonEvent(ihtml, $el) {
+    const nv = AnalyticsClient.getContainerIdentifier($el) || 'app';
 
     const eventOptions = {
       'wt.ihtml': ihtml,

--- a/web/analyticsClient.js
+++ b/web/analyticsClient.js
@@ -1,0 +1,188 @@
+import { v4 as uuidv4 } from 'uuid';
+
+import { Enum } from '@/lib/ClassUtils';
+
+class AnalyticsEventType extends Enum {}
+AnalyticsEventType.init({
+  API_GET: {
+    code: '26',
+  },
+  CLICK: {
+    code: '1',
+  },
+  DOWNLOAD: {
+    code: '20',
+  },
+  PAGE_VIEW: {
+    code: '0',
+  },
+});
+
+const STORAGE_KEY_VISITOR_ID = 'ca.toronto.move.visitorId';
+
+class VisitorId {
+  static get() {
+    let visitorId = window.localStorage.getItem(STORAGE_KEY_VISITOR_ID);
+    if (visitorId === null) {
+      visitorId = uuidv4();
+      window.localStorage.setItem(STORAGE_KEY_VISITOR_ID, visitorId);
+    }
+    return visitorId;
+  }
+}
+
+/**
+ * Client for Oracle Infinity.  Wraps the Data Collection API in an interface that makes
+ * it easier to log important interaction events throughout MOVE.
+ *
+ * @param {string} accountId - Oracle Infinity account ID
+ * @param {string} dcsId - additional Oracle Infinity identifier
+ */
+class AnalyticsClient {
+  constructor(accountId, dcsId) {
+    this.accountId = accountId;
+    this.appContext = null;
+    this.analyticsDomain = AnalyticsClient.getAnalyticsDomain();
+    this.dcsId = dcsId;
+    this.userLanguage = AnalyticsClient.getUserLanguage();
+  }
+
+  /**
+   * @param {Vue} appContext - Vue application context, used to fetch application-wide
+   * information such as current route, whether the user is logged in, etc.
+   */
+  setAppContext(appContext) {
+    this.appContext = appContext;
+  }
+
+  // GLOBAL / BROWSER STATE HELPERS
+
+  /**
+   * Returns current page domain for analytics purposes.  In some cases (e.g. spinning up a new
+   * environment, testing in local development) this can be different from the *actual* page domain
+   * as returned by `window.document.domain`.
+   *
+   * @returns {string} domain (see above)
+   */
+  static getAnalyticsDomain() {
+    const { domain } = window.document;
+    if (domain === 'localhost') {
+      // TODO: remove this once we've tested everything, but keep the function so we have a
+      // layer of indirection in case we need to do something like this
+      return 'move.intra.dev-toronto.ca';
+    }
+    return domain;
+  }
+
+  /**
+   * @returns {string} screen resolution, in `${width}x${height}` format
+   */
+  static getScreenResolution() {
+    const { height, width } = window.screen;
+    return `${width}x${height}`;
+  }
+
+  /**
+   * @returns {string} current page title
+   */
+  static getTitle() {
+    const { title } = window.document;
+    return title;
+  }
+
+  /**
+   * @returns {string} current user language
+   */
+  static getUserLanguage() {
+    const { language } = window.navigator;
+    return language;
+  }
+
+  // ROUTER STATE HELPERS
+
+  static getContentSubgroups(params) {
+    const contentSubgroups = [];
+    if (Object.prototype.hasOwnProperty.call(params, 'selectionTypeName')) {
+      contentSubgroups.push(params.selectionTypeName);
+    }
+    if (Object.prototype.hasOwnProperty.call(params, 'studyTypeName')) {
+      contentSubgroups.push(params.studyTypeName);
+    }
+    return contentSubgroups;
+  }
+
+  // EVENTS
+
+  event(eventType, options) {
+    if (this.appContext === null) {
+      throw new Error('must call setAppContext() before event()');
+    }
+
+    const { name, params, path } = this.appContext.$route;
+    const now = new Date();
+
+    const event = {
+      dcsuri: path,
+      'wt.bh': now.getHours(),
+      'wt.cg_n': name,
+      'wt.dl': eventType.code,
+      'wt.es': `${this.analyticsDomain}${path}`,
+      'wt.ets': Math.floor(now.valueOf() / 1000),
+      'wt.sr': AnalyticsClient.getScreenResolution(),
+      'wt.ti': AnalyticsClient.getTitle(),
+      'wt.tz': Math.floor(-now.getTimezoneOffset() / 60),
+      ...options,
+    };
+
+    let contentSubgroups = AnalyticsClient.getContentSubgroups(params);
+    if (contentSubgroups.length > 0) {
+      if (Object.prototype.hasOwnProperty.call(event, 'wt.cg_s')) {
+        const parts = event['wt.cg_s'].split(';');
+        contentSubgroups = [...parts, ...contentSubgroups];
+      }
+      event['wt.cg_s'] = contentSubgroups.join(';');
+    }
+    return event;
+  }
+
+  locationSearchEvent(query, results) {
+    return this.event(AnalyticsEventType.API_GET, {
+      'wt.oss': query,
+      'wt.oss_r': results.length.toString(),
+    });
+  }
+
+  routeEvent() {
+    return this.event(AnalyticsEventType.PAGE_VIEW, {});
+  }
+
+  async send(events) {
+    const url = `https://dc.oracleinfinity.io/v3/${this.accountId}`;
+
+    const visitorId = VisitorId.get();
+    const data = {
+      events,
+      static: {
+        dcssip: this.analyticsDomain,
+        'wt.co_f': visitorId,
+        'wt.dcsid': this.dcsId,
+        'wt.ria_a': 'MOVE',
+        'wt.ul': this.userLanguage,
+        'wt.vtid': visitorId,
+      },
+    };
+    const body = JSON.stringify(data);
+    const options = {
+      body,
+      credentials: 'include',
+      method: 'POST',
+    };
+    await fetch(url, options);
+  }
+}
+
+const analyticsClient = new AnalyticsClient(
+  '97j62divdr',
+  'dcs222ldvxk938tpne9uk1e3u_1c4g',
+);
+export default analyticsClient;

--- a/web/components/inputs/FcButton.vue
+++ b/web/components/inputs/FcButton.vue
@@ -51,12 +51,15 @@ export default {
     },
   },
   methods: {
-    /*
-     * Note that this will be called *in addition to* any `@click` handlers declared from the
-     * parent component.
-     */
     actionClick() {
-      const event = analyticsClient.buttonEvent(this);
+      let ihtml = '';
+      if (Object.prototype.hasOwnProperty.call(this.$attrs, 'aria-label')) {
+        ihtml = this.$attrs['aria-label'];
+      } else {
+        ihtml = this.$el.innerText.trim();
+      }
+
+      const event = analyticsClient.buttonEvent(ihtml, this.$el);
       analyticsClient.send([event]);
     },
   },

--- a/web/components/inputs/FcButton.vue
+++ b/web/components/inputs/FcButton.vue
@@ -5,12 +5,15 @@
       ...typeAttrs,
       ...$attrs,
     }"
+    @click="actionClick"
     v-on="$listeners">
     <slot></slot>
   </v-btn>
 </template>
 
 <script>
+import analyticsClient from '@/web/analytics/analyticsClient';
+
 const BUTTON_ATTRS = {
   primary: {
     color: 'primary',
@@ -45,6 +48,16 @@ export default {
   computed: {
     typeAttrs() {
       return BUTTON_ATTRS[this.type];
+    },
+  },
+  methods: {
+    /*
+     * Note that this will be called *in addition to* any `@click` handlers declared from the
+     * parent component.
+     */
+    actionClick() {
+      const event = analyticsClient.buttonEvent(this);
+      analyticsClient.send([event]);
     },
   },
 };

--- a/web/components/inputs/FcButton.vue
+++ b/web/components/inputs/FcButton.vue
@@ -12,8 +12,6 @@
 </template>
 
 <script>
-import analyticsClient from '@/web/analytics/analyticsClient';
-
 const BUTTON_ATTRS = {
   primary: {
     color: 'primary',
@@ -59,8 +57,8 @@ export default {
         ihtml = this.$el.innerText.trim();
       }
 
-      const event = analyticsClient.buttonEvent(ihtml, this.$el);
-      analyticsClient.send([event]);
+      const event = this.$analytics.buttonEvent(ihtml, this.$el);
+      this.$analytics.send([event]);
     },
   },
 };

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -144,13 +144,17 @@ export default {
       }
       this.loading = true;
       this.state = LocationSearchState.QUERY_SENT;
-      const locationSuggestions = await getLocationSuggestions(this.query, {});
+      const { query } = this;
+      const locationSuggestions = await getLocationSuggestions(query, {});
       if (this.state !== LocationSearchState.QUERY_SENT) {
         return;
       }
       this.locationSuggestions = locationSuggestions;
       this.loading = false;
       this.state = LocationSearchState.SUGGESTIONS_RECEIVED;
+
+      const event = this.$analytics.locationSearchEvent(query, locationSuggestions.length);
+      await this.$analytics.send([event]);
     }, 200),
     showLocationSuggestions() {
       if (this.showLocationSuggestions) {

--- a/web/components/nav/FcDashboardNavBrand.vue
+++ b/web/components/nav/FcDashboardNavBrand.vue
@@ -24,14 +24,12 @@
 </template>
 
 <script>
-import analyticsClient from '@/web/analytics/analyticsClient';
-
 export default {
   name: 'FcDashboardNavBrand',
   methods: {
     actionClick() {
-      const event = analyticsClient.buttonEvent('MOVE', this.$el);
-      analyticsClient.send([event]);
+      const event = this.$analytics.buttonEvent('MOVE', this.$el);
+      this.$analytics.send([event]);
     },
   },
 };

--- a/web/components/nav/FcDashboardNavBrand.vue
+++ b/web/components/nav/FcDashboardNavBrand.vue
@@ -7,7 +7,8 @@
         v-on="on"
         class="fc-nav-brand"
         link
-        :to="{ name: 'viewData' }">
+        :to="{ name: 'viewData' }"
+        @click="actionClick">
         <v-list-item-icon>
           <v-img
             alt="MOVE Logo"
@@ -23,8 +24,16 @@
 </template>
 
 <script>
+import analyticsClient from '@/web/analytics/analyticsClient';
+
 export default {
   name: 'FcDashboardNavBrand',
+  methods: {
+    actionClick() {
+      const event = analyticsClient.buttonEvent('MOVE', this.$el);
+      analyticsClient.send([event]);
+    },
+  },
 };
 </script>
 

--- a/web/components/nav/FcDashboardNavItem.vue
+++ b/web/components/nav/FcDashboardNavItem.vue
@@ -25,8 +25,6 @@
 </template>
 
 <script>
-import analyticsClient from '@/web/analytics/analyticsClient';
-
 import { mapState } from 'vuex';
 
 export default {
@@ -62,8 +60,8 @@ export default {
   },
   methods: {
     actionClick() {
-      const event = analyticsClient.buttonEvent(this.label, this.$el);
-      analyticsClient.send([event]);
+      const event = this.$analytics.buttonEvent(this.label, this.$el);
+      this.$analytics.send([event]);
     },
   },
 };

--- a/web/components/nav/FcDashboardNavItem.vue
+++ b/web/components/nav/FcDashboardNavItem.vue
@@ -10,7 +10,8 @@
         color="primary"
         :disabled="disabled"
         link
-        :to="to">
+        :to="to"
+        @click="actionClick">
         <v-list-item-icon>
           <v-icon>mdi-{{icon}}</v-icon>
         </v-list-item-icon>
@@ -24,6 +25,8 @@
 </template>
 
 <script>
+import analyticsClient from '@/web/analytics/analyticsClient';
+
 import { mapState } from 'vuex';
 
 export default {
@@ -56,6 +59,12 @@ export default {
       return name === 'requestStudyView' && backViewRequestName === toName;
     },
     ...mapState(['backViewRequest']),
+  },
+  methods: {
+    actionClick() {
+      const event = analyticsClient.buttonEvent(this.label, this.$el);
+      analyticsClient.send([event]);
+    },
   },
 };
 </script>

--- a/web/components/nav/FcDashboardNavUser.vue
+++ b/web/components/nav/FcDashboardNavUser.vue
@@ -87,12 +87,18 @@ export default {
   },
   methods: {
     actionSignIn() {
-      Vue.nextTick(() => {
+      Vue.nextTick(async () => {
+        const event = this.$analytics.signInEvent();
+        await this.$analytics.send([event]);
+
         saveLoginState(this.$route);
         this.$refs.formSignIn.submit();
       });
     },
-    actionSignOut() {
+    async actionSignOut() {
+      const event = this.$analytics.signOutEvent();
+      await this.$analytics.send([event]);
+
       this.$refs.formSignOut.submit();
     },
   },

--- a/web/main.js
+++ b/web/main.js
@@ -69,6 +69,12 @@ const vuetify = new Vuetify({
   },
 });
 
+/*
+ * Inject the singleton analytics client into all Vue components as `this.$analytics`.
+ * See https://vuejs.org/v2/guide/plugins.html#Writing-a-Plugin for why this works.
+ *
+ * Note that, at this point, `analyticsClient.appContext === null`.
+ */
 Object.defineProperty(Vue.prototype, '$analytics', {
   get() { return analyticsClient; },
 });
@@ -79,4 +85,17 @@ const appContext = new Vue({
   store,
   vuetify,
 }).$mount('#app');
+
+/*
+ * Once the application context has been created above, set that context in our
+ * singleton analytics client.
+ *
+ * Note that, due to the tick-based nature of Vue rendering, this will be called
+ * before any components actually render, and definitely before `router.afterEach()`
+ * is reached.  This allows us to ensure that `analyticsClient.appContext !== null`
+ * before any analytics events are sent.
+ *
+ * This two-stage init / set approach is necessary to avoid a circular dependency
+ * between the application context and the analytics client.
+ */
 analyticsClient.setAppContext(appContext);

--- a/web/main.js
+++ b/web/main.js
@@ -4,11 +4,12 @@ import Vuelidate from 'vuelidate';
 import Vuetify from 'vuetify/lib/framework';
 import en from 'vuetify/es5/locale/en';
 
-import App from '@/web/App.vue';
-import router from '@/web/router';
-import store from '@/web/store';
 import { formatDuration } from '@/lib/StringFormatters';
 import TimeFormatters from '@/lib/time/TimeFormatters';
+import App from '@/web/App.vue';
+import analyticsClient from '@/web/analyticsClient';
+import router from '@/web/router';
+import store from '@/web/store';
 
 Vue.use(Vuelidate);
 Vue.use(Vuetify);
@@ -68,9 +69,14 @@ const vuetify = new Vuetify({
   },
 });
 
-new Vue({
+Object.defineProperty(Vue.prototype, '$analytics', {
+  get() { return analyticsClient; },
+});
+
+const appContext = new Vue({
   render: h => h(App),
   router,
   store,
   vuetify,
 }).$mount('#app');
+analyticsClient.setAppContext(appContext);

--- a/web/main.js
+++ b/web/main.js
@@ -7,7 +7,7 @@ import en from 'vuetify/es5/locale/en';
 import { formatDuration } from '@/lib/StringFormatters';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 import App from '@/web/App.vue';
-import analyticsClient from '@/web/analyticsClient';
+import analyticsClient from '@/web/analytics/analyticsClient';
 import router from '@/web/router';
 import store from '@/web/store';
 

--- a/web/router.js
+++ b/web/router.js
@@ -3,7 +3,7 @@ import Router from 'vue-router';
 
 import { AuthScope } from '@/lib/Constants';
 import { hasAuthScope } from '@/lib/auth/ScopeMatcher';
-import analyticsClient from '@/web/analyticsClient';
+import analyticsClient from '@/web/analytics/analyticsClient';
 import store from '@/web/store';
 import { restoreLoginState, saveLoginState } from '@/web/store/LoginState';
 
@@ -272,8 +272,8 @@ function afterEachSetTitle(to) {
   document.title = title;
 }
 
-function afterEachAnalyticsRouteEvent() {
-  const event = analyticsClient.routeEvent();
+function afterEachAppRouteEvent() {
+  const event = analyticsClient.appRouteEvent();
   analyticsClient.send([event]);
 }
 
@@ -284,8 +284,14 @@ router.afterEach((to) => {
    * To accurately log the page title, this must be called after `afterEachSetTitle()`.
    * Otherwise, the analytics event will contain the old page title from before the
    * `vue-router` transition.
+   *
+   * Since the event is recorded in `afterEach`, an error here (e.g. if the analytics
+   * service is unreachable) cannot abort the route transition.  That's a good thing!
+   * In the event of an analytics outage, or of a bug in `analyticsClient`, ideally
+   * only analytics tracking should be affected - the rest of MOVE should continue to
+   * function as normal.
    */
-  afterEachAnalyticsRouteEvent();
+  afterEachAppRouteEvent();
 });
 
 function onErrorShowToast(err) {

--- a/web/router.js
+++ b/web/router.js
@@ -243,6 +243,10 @@ router.beforeEach(async (to, from, next) => {
       }
     } else {
       next(false);
+
+      const event = analyticsClient.signInEvent();
+      await analyticsClient.send([event]);
+
       saveLoginState(to);
       document.forms.formSignIn.submit();
     }

--- a/web/router.js
+++ b/web/router.js
@@ -3,6 +3,7 @@ import Router from 'vue-router';
 
 import { AuthScope } from '@/lib/Constants';
 import { hasAuthScope } from '@/lib/auth/ScopeMatcher';
+import analyticsClient from '@/web/analyticsClient';
 import store from '@/web/store';
 import { restoreLoginState, saveLoginState } from '@/web/store/LoginState';
 
@@ -271,8 +272,20 @@ function afterEachSetTitle(to) {
   document.title = title;
 }
 
+function afterEachAnalyticsRouteEvent() {
+  const event = analyticsClient.routeEvent();
+  analyticsClient.send([event]);
+}
+
 router.afterEach((to) => {
   afterEachSetTitle(to);
+
+  /*
+   * To accurately log the page title, this must be called after `afterEachSetTitle()`.
+   * Otherwise, the analytics event will contain the old page title from before the
+   * `vue-router` transition.
+   */
+  afterEachAnalyticsRouteEvent();
 });
 
 function onErrorShowToast(err) {


### PR DESCRIPTION
# Issue Addressed
This PR closes #549 .

# Description
We investigate the use of the [Oracle Infinity Data Collection API](https://docs.oracle.com/en/cloud/saas/marketing/infinity-user/Help/data_collection/dcapi.htm) to dynamically log events from MOVE.  This PR logs several types of events:

- all route transitions, including the initial page load;
- all button clicks;
- all clicks on elements of the left navigation bar;
- all sign in / sign out events;
- all search queries sent to the location suggestion API.

This was more complicated than originally supposed - the main wrinkles here were the [number of possible parameters](https://docs.oracle.com/en/cloud/saas/marketing/infinity-user/Help/parameters/reference.htm) to this API, and the difficulty of finding sets of parameters that result in events actually showing up in the dashboard.  Getting to a working set of events required us to carefully read through this documentation to find relevant parameters, observe `dcs.gif` requests sent by other City properties that use the `<script>` tag (e.g. the main toronto.ca website), craft `curl` requests to generate analytics events, and finally verify whether those events showed up in the dashboard.

(It didn't help that some of the documentation is flat out wrong or outdated.  When does that ever happen?  😬 )

Once that was done, we took those working `curl` requests and packaged them up into their `window.fetch()` equivalents in a new module `AnalyticsClient`.  Here there was another challenge: this client needs to both be accessible to components in our Vue app, and to have a reference to that Vue app internally to extract application state for logging - a circular dependency!  The solution was to export a singleton instance of `AnalyticsClient` from `@/web/analytics/analyticsClient`, extend `Vue.prototype` _before_ instantiating the Vue app to inject this instance into all components, and then finally call a `setAppContext` method to provide the app context to this client.

All in all: more work than expected, and there may still be rough edges around logging analytics events, but the path to making further changes is much better understood now.

# Tests
Tested individual events via `curl` / checking the dashboard.  Tested `AnalyticsClient` integration by checking in devtools Network tab that analytics requests are sent, and checking in the Oracle Infinity dashboard that those events can be viewed there.
