### PR TITLE
Fetch available reports from study query

### DIFF
--- a/lib/controller/JobController.js
+++ b/lib/controller/JobController.js
@@ -1,11 +1,14 @@
 import Boom from '@hapi/boom';
 
-import { HttpStatus } from '@/lib/Constants';
+import { HttpStatus, ReportFormat } from '@/lib/Constants';
 import JobMetadataDAO from '@/lib/db/JobMetadataDAO';
+import ReportDAO from '@/lib/db/ReportDAO';
 import JobManager from '@/lib/jobs/JobManager';
 import JobType from '@/lib/jobs/JobType';
 import JobMetadata from '@/lib/model/JobMetadata';
 import Joi from '@/lib/model/Joi';
+import StudyFilters from '@/lib/model/StudyFilters';
+import CentrelineSelection from '@/lib/model/helpers/CentrelineSelection';
 
 /**
  * Background job-related routes.
@@ -16,28 +19,39 @@ const JobController = [];
 
 /**
  * @memberof JobController
- * @name postJob
+ * @name postJobGenerateReports
  * @type {Hapi.ServerRoute}
  */
 JobController.push({
   method: 'POST',
-  path: '/jobs',
+  path: '/jobs/GENERATE_REPORTS',
   options: {
     response: {
       schema: JobMetadata.read,
     },
     validate: {
       payload: {
-        type: Joi.enum().ofType(JobType).required(),
-        data: Joi.object().unknown(),
+        ...CentrelineSelection,
+        ...StudyFilters,
+        mostRecent: Joi.number().integer().min(1).default(null),
+        reportFormat: Joi.enum().ofType(ReportFormat).required(),
       },
     },
   },
   handler: async (request) => {
     const user = request.auth.credentials;
-    const { type: jobType, data } = request.payload;
+    const {
+      s1: features,
+      reportFormat,
+      ...studyQuery
+    } = request.payload;
     try {
-      const jobMetadata = await JobManager.publish(jobType, data, user);
+      const reports = await ReportDAO.byCentreline(features, studyQuery, reportFormat);
+      if (reports.length === 0) {
+        return Boom.notFound('no reports for given filters');
+      }
+      const data = { reports };
+      const jobMetadata = await JobManager.publish(JobType.GENERATE_REPORTS, data, user);
       return jobMetadata;
     } catch (err) {
       const { statusCode } = HttpStatus.BAD_REQUEST;

--- a/lib/controller/StudyController.js
+++ b/lib/controller/StudyController.js
@@ -50,7 +50,8 @@ StudyController.push({
       ...studyQuery
     } = request.query;
     try {
-      const studies = await StudyDAO.byCentreline(features, studyQuery, { limit, offset });
+      const pagination = { limit, offset };
+      const studies = await StudyDAO.byCentreline(features, studyQuery, pagination);
       return studies;
     } catch (err) {
       return Boom.badRequest(err.message);

--- a/lib/db/ReportDAO.js
+++ b/lib/db/ReportDAO.js
@@ -1,0 +1,48 @@
+import StudyDAO from '@/lib/db/StudyDAO';
+import ArrayStats from '@/lib/math/ArrayStats';
+
+const LIMIT = 100;
+
+class ReportDAO {
+  static getReportsForStudy(study, reportFormat) {
+    const { countGroupId, type } = study;
+    const { id: categoryId, studyType } = type;
+    const id = `${categoryId}/${countGroupId}`;
+    /*
+     * To simplify bulk report generation, we only generate reports of types that do not
+     * have user-supplied parameters.
+     */
+    return studyType.reportTypes
+      .filter(reportType => !Object.prototype.hasOwnProperty.call(reportType, 'options'))
+      .map(reportType => ({ type: reportType, id, format: reportFormat }));
+  }
+
+  static async byCentreline(features, studyQuery, reportFormat) {
+    const reports = [];
+
+    const studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);
+    const studyTotal = ArrayStats.sum(
+      studySummary.map(({ n }) => n),
+    );
+    if (studyTotal === 0) {
+      return reports;
+    }
+
+    for (let offset = 0; offset < studyTotal; offset += LIMIT) {
+      const pagination = { limit: LIMIT, offset };
+      /* eslint-disable-next-line no-await-in-loop */
+      const studies = await StudyDAO.byCentreline(features, studyQuery, pagination);
+
+      studies.forEach((study) => {
+        const reportsForStudy = ReportDAO.getReportsForStudy(study, reportFormat);
+        reportsForStudy.forEach((report) => {
+          reports.push(report);
+        });
+      });
+    }
+
+    return reports;
+  }
+}
+
+export default ReportDAO;


### PR DESCRIPTION
# Issue Addressed
This PR closes #557 .

# Description
For now, this excludes the "most recent" controls - still need to clarify if those are per study type or across all study types.

# Tests
Tested quickly by launching `npm run frontend`, `npm run backend` and searching for a location with studies, then using the `s1` location ID from that to craft a request to `scheduler`, then actually starting `npm run scheduler` and making the request using `curl`.
