### PR TITLE
Dual-push configuration and GitLab CI setup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,12 +4,12 @@ stages:
 
 cache:
   paths:
-    - .npm/
+    - node_modules/
 
 before_script:
   - nvm install
   - nvm use
-  - npm ci --cache .npm --prefer-offline
+  - npm install
 
 test-coverage:
   stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,8 @@ cache:
 before_script:
   - nvm install
   - nvm use
-  - npm install
+  - npm install -g pnpm
+  - pnpm install
 
 test-coverage:
   stage: test
@@ -26,7 +27,7 @@ test-coverage:
 
 test-build:
   stage: test
-    script:
+  script:
     - npm run docs:build
     - npm run frontend:build
   only:
@@ -45,4 +46,4 @@ deploy:
   script:
     - echo deploy
   only:
-    - master
+   - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,25 +1,36 @@
 stages:
-  - install-system
   - install-app
   - test
   - deploy
 
-install-system:
-  stage: install-system
-  script:
-  - echo install-system
-
 install-app:
   stage: install-app
   script:
-  - echo install-app
+  - nvm install
+  - nvm use
+  - npm install
 
-test:
+test-build:
   stage: test
   script:
-  - echo test
+  - npm run docs:build
+  - npm run frontend:build
+
+# test-coverage:
+#   stage: test
+#   script:
+#   - npm run test:db-startup
+#   - npm run ci:jest-coverage
+#   - npm run test:db-shutdown
+
+test-compliance:
+  stage: test
+  script:
+  - npm run ci:npm-audit
+  - npm run ci:npm-outdated
 
 deploy:
   stage: deploy
   script:
   - echo deploy
+  only: master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,10 +9,14 @@ cache:
 before_script:
   - nvm install
   - nvm use
-  - npm install
+  - npm install -g pnpm
+  - pnpm install
 
 test-coverage:
   stage: test
+  before_script:
+  - cp ~/private.js lib/config/private.js
+  - cp ~/extra-ca-certs.cer ssl/extra-ca-certs.cer
   script:
   - npm run test:db-startup
   - npm run ci:jest-coverage

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,25 @@
+stages:
+  - install-system
+  - install-app
+  - test
+  - deploy
+
+install-system:
+  stage: install-system
+  script:
+  - echo install-system
+
+install-app:
+  stage: install-app
+  script:
+  - echo install-app
+
+test:
+  stage: test
+  script:
+  - echo test
+
+deploy:
+  stage: deploy
+  script:
+  - echo deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,44 +3,46 @@ stages:
   - deploy
 
 cache:
+  key:
+    files:
+      - package.json
   paths:
     - node_modules/
 
 before_script:
   - nvm install
   - nvm use
-  - npm install -g pnpm
-  - pnpm install
+  - npm install
 
 test-coverage:
   stage: test
   before_script:
-  - cp ~/private.js lib/config/private.js
-  - cp ~/extra-ca-certs.cer ssl/extra-ca-certs.cer
+    - cp ~/private.js lib/config/private.js
+    - cp ~/extra-ca-certs.cer ssl/extra-ca-certs.cer
   script:
-  - npm run test:db-startup
-  - npm run ci:jest-coverage
-  - npm run test:db-shutdown
+    - npm run test:db-startup
+    - npm run ci:jest-coverage
+    - npm run test:db-shutdown
 
 test-build:
   stage: test
-  script:
-  - npm run docs:build
-  - npm run frontend:build
+    script:
+    - npm run docs:build
+    - npm run frontend:build
   only:
-  - /^.*-version-.*$/
+    - /^.*-version-.*$/
 
 test-compliance:
   stage: test
   script:
-  - npm run ci:npm-audit
-  - npm run ci:npm-outdated
+    - npm run ci:npm-audit
+    - npm run ci:npm-outdated
   only:
-  - /^.*-version-.*$/
+    - /^.*-version-.*$/
 
 deploy:
   stage: deploy
   script:
-  - echo deploy
+    - echo deploy
   only:
-  - master
+    - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,32 +17,56 @@ before_script:
   - cp ~/private.js lib/config/private.js
   - cp ~/extra-ca-certs.cer ssl/extra-ca-certs.cer
 
+# run coverage tests on every feature branch
 test-coverage:
   stage: test
   script:
     - npm run test:db-startup
     - npm run ci:jest-coverage
     - npm run test:db-shutdown
-
-test-build:
-  stage: test
-  script:
-    - npm run docs:build
-    - npm run frontend:build
   only:
-    - /^.*-version-.*$/
+    - /^gh.*-.*$/
 
-test-compliance:
+# run rest of CI tests on every release branch
+test-ci-rest:
   stage: test
   script:
     - npm run ci:npm-audit
     - npm run ci:npm-outdated
+    - npm run docs:build
+    - npm run frontend:build
   only:
-    - /^.*-version-.*$/
+    - /^gh.*-version-.*$/
 
-deploy:
+# deploy master to dev automatically
+deploy-dev:
   stage: deploy
   script:
-    - echo deploy
+    - echo deploy-dev
   only:
-   - master
+    - master
+
+# deploy QA branch automatically
+deploy-qa:
+  stage: deploy
+  script:
+    - echo deploy-qa
+  only:
+    - deploy-qa
+
+# deploy staging automatically
+deploy-staging:
+  stage: deploy
+  script:
+    - echo deploy-staging
+  only:
+    - deploy-staging
+
+# deploy prod manually after approval
+deploy-prod:
+  stage: deploy
+  script:
+    - echo deploy-prod
+  only:
+    - deploy-prod
+  when: manual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,8 +14,7 @@ before_script:
   - nvm use
   - npm install -g pnpm
   - pnpm install
-  - cp ~/private.js lib/config/private.js
-  - cp ~/extra-ca-certs.cer ssl/extra-ca-certs.cer
+  - cp -r /data/config-private/* .
 
 # run coverage tests on every feature branch
 test-coverage:
@@ -42,8 +41,9 @@ test-ci-rest:
 deploy-dev:
   stage: deploy
   script:
-    - echo deploy-dev
+    - git push https://git-codecommit.ca-central-1.amazonaws.com/v1/repos/bdit_flashcrow HEAD:master
   only:
+    - gh577-dual-push-config
     - master
 
 # deploy QA branch automatically

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,17 +1,19 @@
 stages:
-  - install-app
+  - build
   - test
   - deploy
 
-install-app:
-  stage: install-app
-  script:
+cache:
+  paths:
+    - node_modules/
+
+before_script:
   - nvm install
   - nvm use
   - npm install
 
-test-build:
-  stage: test
+build:
+  stage: build
   script:
   - npm run docs:build
   - npm run frontend:build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,4 +33,5 @@ deploy:
   stage: deploy
   script:
   - echo deploy
-  only: master
+  only:
+  - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,35 +1,38 @@
 stages:
-  - build
   - test
   - deploy
 
 cache:
   paths:
-    - node_modules/
+    - .npm/
 
 before_script:
   - nvm install
   - nvm use
-  - npm install
+  - npm ci --cache .npm --prefer-offline
 
-build:
-  stage: build
+test-coverage:
+  stage: test
+  script:
+  - npm run test:db-startup
+  - npm run ci:jest-coverage
+  - npm run test:db-shutdown
+
+test-build:
+  stage: test
   script:
   - npm run docs:build
   - npm run frontend:build
-
-# test-coverage:
-#   stage: test
-#   script:
-#   - npm run test:db-startup
-#   - npm run ci:jest-coverage
-#   - npm run test:db-shutdown
+  only:
+  - /^.*-version-.*$/
 
 test-compliance:
   stage: test
   script:
   - npm run ci:npm-audit
   - npm run ci:npm-outdated
+  only:
+  - /^.*-version-.*$/
 
 deploy:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,16 +9,15 @@ cache:
   paths:
     - node_modules/
 
-before_script:
-  - nvm install
-  - nvm use
-  - npm install -g pnpm
-  - pnpm install
-  - cp -r /data/config-private/* .
-
 # run coverage tests on every feature branch
 test-coverage:
   stage: test
+  before_script:
+    - nvm install
+    - nvm use
+    - npm install -g pnpm
+    - pnpm install
+    - cp -r /data/config-private/* .
   script:
     - npm run test:db-startup
     - npm run ci:jest-coverage
@@ -29,6 +28,12 @@ test-coverage:
 # run rest of CI tests on every release branch
 test-ci-rest:
   stage: test
+  before_script:
+    - nvm install
+    - nvm use
+    - npm install -g pnpm
+    - pnpm install
+    - cp -r /data/config-private/* .
   script:
     - npm run ci:npm-audit
     - npm run ci:npm-outdated
@@ -41,9 +46,8 @@ test-ci-rest:
 deploy-dev:
   stage: deploy
   script:
-    - git push https://git-codecommit.ca-central-1.amazonaws.com/v1/repos/bdit_flashcrow HEAD:master
+    - echo deploy-dev
   only:
-    - gh577-dual-push-config
     - master
 
 # deploy QA branch automatically

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,12 +14,11 @@ before_script:
   - nvm use
   - npm install -g pnpm
   - pnpm install
+  - cp ~/private.js lib/config/private.js
+  - cp ~/extra-ca-certs.cer ssl/extra-ca-certs.cer
 
 test-coverage:
   stage: test
-  before_script:
-    - cp ~/private.js lib/config/private.js
-    - cp ~/extra-ca-certs.cer ssl/extra-ca-certs.cer
   script:
     - npm run test:db-startup
     - npm run ci:jest-coverage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bdit_flashcrow
 
-Flashcrow is a data platform for viewing, requesting, and analyzing data related to City of Toronto rights-of-way.  This includes:
+MOVE is a data platform for viewing, requesting, and analyzing data related to City of Toronto rights-of-way.  This includes:
 
 - CRASH collision data;
 - FLOW counts;
@@ -9,13 +9,13 @@ Flashcrow is a data platform for viewing, requesting, and analyzing data related
 
 ## Points of Contact
 
-To contact the Flashcrow team:
+To contact the MOVE team:
 
 | If... | Contact: | Who? |
 | --- | --- | --- |
-| You have a question related to Flashcrow development, deployment, security, or of an otherwise technical nature | Tech Lead | [Evan Savage](mailto:Evan.Savage@toronto.ca) |
-| You have a question related to Flashcrow design practices, usability, or accessibility | Design Lead | [Shine Chaudhuri](Shine.Chaudhuri@toronto.ca) |
-| You have a question related to Flashcrow user testing, upcoming launches, or roadmaps | Product Manager | [Ruth Birman](Ruth.Birman@toronto.ca) |
+| You have a question related to MOVE development, deployment, security, or of an otherwise technical nature | Tech Lead | [Evan Savage](mailto:Evan.Savage@toronto.ca) |
+| You have a question related to MOVE design practices, usability, or accessibility | Design Lead | [Shine Chaudhuri](Shine.Chaudhuri@toronto.ca) |
+| You have a question related to MOVE user testing, upcoming launches, or roadmaps | Product Manager | [Maddy Ewins](Maddy.Ewins@toronto.ca) |
 | Your question isn't captured above, or you're not sure who to contact | Service Owner | [Aakash Harpalani](mailto:Aakash.Harpalani@toronto.ca) |
 
 We will try to respond to any questions within 48 hours.  However, given the small size of our team, please understand if it takes us a bit longer to respond sometimes.
@@ -25,27 +25,13 @@ We will try to respond to any questions within 48 hours.  However, given the sma
 See the [MOVE Developer Handbook](https://www.notion.so/bditto/MOVE-Developer-Handbook-182de05ad8a94888b52ccc68093a497a).  This guide will help you:
 
 - request the necessary permissions from City of Toronto IT and the Big Data Innovation Team;
-- install Flashcrow prerequisites on your City of Toronto computer;
-- configure and run Flashcrow inside a virtual machine using [Vagrant](https://www.vagrantup.com/);
+- install MOVE prerequisites on your City of Toronto computer;
+- configure and run MOVE inside a virtual machine using [Vagrant](https://www.vagrantup.com/);
 - understand team practices around communication, source control, code editing, and code style.
-
-## Deployment
-
-To deploy the Flashcrow web application, you will need access to the AWS CodeCommit repository.  Once you have that:
-
-```
-git remote add code-commit https://git-codecommit.us-east-1.amazonaws.com/v1/repos/bdit_flashcrow
-
-env $(xargs < ~/move-env.config) ./scripts/deployment/code-commit/deploy_code_commit.sh
-```
-
-For now, please use the `deploy_code_commit.sh` script for all deployments to AWS CodeCommit!  We're working with Cloud Services on a deployment process that includes continuous integration (CI) testing; in the meantime, that script runs our CI tests before pushing to AWS CodeCommit.
-
-Any versions pushed to AWS CodeCommit are automatically deployed to [`web-dev`](https://move.intra.dev-toronto.ca).
 
 ## Code Documentation
 
-Working on Flashcrow development?  Help improve our documentation!  If you come across something you'd like to see documented, first [submit a bug report](https://github.com/CityofToronto/bdit_flashcrow/issues/new/choose) with the [documentation label](https://github.com/CityofToronto/bdit_flashcrow/labels/documentation).
+Working on MOVE development?  Help improve our documentation!  If you come across something you'd like to see documented, first [submit a bug report](https://github.com/CityofToronto/bdit_flashcrow/issues/new/choose) with the [documentation label](https://github.com/CityofToronto/bdit_flashcrow/labels/documentation).
 
 Once the bug report has been submitted, you can either [submit a pull request](https://github.com/CityofToronto/bdit_flashcrow/pulls), or assign it to whoever's best suited to follow up.
 

--- a/buildspecs/build-with-cache.yml
+++ b/buildspecs/build-with-cache.yml
@@ -2,25 +2,9 @@ version: 0.2
 runas: ec2-user
 
 phases:
-  install:
-    commands:
-      - echo Installing package.json..
-      - npm install
-  pre_build:
-    commands:
-      - echo Installing source NPM placeholder dependencies...
   build:
     commands:
-      - echo Build started on `date`
-      - echo Compiling the Node.js code
-      # commenting out temporarily
-      #- npm run ci:test-unit
-  post_build:
-    commands:
-      - echo Build completed on `date`
-cache:
-  paths:
-    - 'node_modules/**/*'
+      - echo "build-with-cache"
 artifacts:
   files:
     - '**/*'

--- a/buildspecs/build-with-image-cache.yml
+++ b/buildspecs/build-with-image-cache.yml
@@ -1,14 +1,10 @@
 version: 0.2
+runas: ec2-user
 
 phases:
-  install:
-    commands:
-      - mkdir node_modules
-      - cp -a ~/node_modules_cache/. node_modules
-      - npm install
   build:
     commands:
-      - npm test
+      - echo "build-with-image-cache"
 artifacts:
   files:
     - '**/*'

--- a/deploy_scripts/install.sh
+++ b/deploy_scripts/install.sh
@@ -12,7 +12,7 @@ sudo amazon-linux-extras enable nginx1.12
 
 # section: install_base
 sudo yum update -y
-sudo yum install -y nginx gcc gcc-c++ git patch openssl-devel zlib-devel readline-devel sqlite-devel bzip2-devel libffi-devel xz-devel jq mailx postgresql postgresql-devel postgresql-contrib
+sudo yum install -y nginx postgresql postgresql-contrib
 
 # section: pre_install_flashcrow
 ## /install_node.sh
@@ -35,31 +35,4 @@ echo "installing node@lts/*..."
 nvm install lts/*
 echo "lts/*" > /home/ec2-user/.nvmrc
 nvm use lts/*
-npm install -g forever npm@latest
-
-## /install_python.sh
-echo "installing pyenv..."
-if [ ! -d /home/ec2-user/.pyenv ]; then
-  git clone https://github.com/pyenv/pyenv.git /home/ec2-user/.pyenv
-  cat <<'EOF' >> /home/ec2-user/.bashrc
-  export PYENV_ROOT="$HOME/.pyenv"
-  export PATH="$PYENV_ROOT/bin:$PATH"
-  if command -v pyenv 1>/dev/null 2>&1; then
-    eval "$(pyenv init -)"
-  fi
-EOF
-fi
-
-# ensure that pyenv shims are available in current shell session
-export PYENV_ROOT="$HOME/.pyenv"
-export PATH="$PYENV_ROOT/bin:$PATH"
-if command -v pyenv 1>/dev/null 2>&1; then
-  eval "$(pyenv init -)"
-fi
-
-# install correct version of Python
-echo "installing Python 3.7.2..."
-pyenv install -s 3.7.2
-pyenv rehash
-pyenv global 3.7.2
-pip install --upgrade pip
+npm install -g forever pnpm

--- a/deploy_scripts/start.sh
+++ b/deploy_scripts/start.sh
@@ -8,7 +8,7 @@ source /home/ec2-user/.bash_profile
 set -u
 
 # copy private config to repo
-cp /home/ec2-user/flashcrow.config.js /home/ec2-user/flashcrow/lib/config/private.js
+cp -r /data/config-private/* /home/ec2-user/flashcrow
 
 # copy nginx / forever configs from repo
 sudo cp /home/ec2-user/flashcrow/scripts/deployment/web/nginx/nginx.conf /etc/nginx/
@@ -18,17 +18,15 @@ cp /home/ec2-user/flashcrow/scripts/deployment/web/forever.json /home/ec2-user/f
 # make log directory
 mkdir -p /home/ec2-user/log/flashcrow
 
-# install node and Python dependencies
+# install node dependencies
 cd /home/ec2-user/flashcrow
-#?? fix issues with running "npm run frontend:build" (using codebuild node_modules): Error: Cannot find module '../package.json'
-rm -rf node_modules
-nvm use lts/*
-npm install
+nvm use
+pnpm install
 pip install -r requirements.txt
 
 # build static files into dist
-npm run frontend:build
-npm run docs:build
+pnpm run frontend:build
+pnpm run docs:build
 
 # copy to web root
 sudo rm -rf /usr/share/nginx/html/flashcrow

--- a/jest.config.js
+++ b/jest.config.js
@@ -39,7 +39,7 @@ module.exports = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
   },
-  setupFiles: [
+  setupFilesAfterEnv: [
     '<rootDir>/tests/unitSetup.js',
   ],
   snapshotSerializers: [

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,13 +1,13 @@
-# Flashcrow Scripts
+# MOVE Scripts
 
-The `scripts` folder contains various scripts used for development, deployment, and automation in Flashcrow:
+The `scripts` folder contains various scripts used for development, deployment, and automation in MOVE:
 
-- `airflow`: [Airflow](https://airflow.apache.org/) jobs, mostly used to perform migration, cleaning, and normalization of datasets used in Flashcrow;
+- `airflow`: [Airflow](https://airflow.apache.org/) jobs, mostly used to perform migration, cleaning, and normalization of datasets used in MOVE;
   - `airflow/dags`: [DAGs](https://airflow.apache.org/concepts.html#dags) that define tasks in jobs and their dependencies;
   - `airflow/tasks`: scripts for [tasks](https://airflow.apache.org/concepts.html#tasks), mostly Bash / Python;
   - `airflow/systemd`: [`systemd`](https://en.wikipedia.org/wiki/Systemd) configuration to run Airflow as a service in our ETL stack;
-- `db`: database migrations that define subsequent versions of the Flashcrow PostgreSQL data model;
+- `db`: database migrations that define subsequent versions of the MOVE PostgreSQL data model;
 - `deployment`: provisioning and deployment scripts;
   - [`deployment/web`](deployment/web/README.md) for our web stack;
   - [`deployment/etl`](deployment/etl/README.md) for our ETL stack;
-- [`dev`](dev/README.md): provisioning scripts for the Flashcrow development environment.
+- [`dev`](dev/README.md): provisioning scripts for the MOVE development environment.

--- a/scripts/deployment/etl/provision-etl-ec2.sh
+++ b/scripts/deployment/etl/provision-etl-ec2.sh
@@ -2,7 +2,7 @@
 #
 # provision-web-ec2.sh
 #
-# Provision the current machine as part of the Flashcrow Web Stack.  This is
+# Provision the current machine as part of the MOVE Web Stack.  This is
 # intended to be run on EC2.
 
 set -e

--- a/scripts/deployment/provision-user.sh
+++ b/scripts/deployment/provision-user.sh
@@ -2,7 +2,7 @@
 #
 # provision-user.sh
 #
-# Installs Python, node, and the Flashcrow application itself during
+# Installs Python, node, and the MOVE application itself during
 # provisioning.  This script is intended to be run as a non-root user, and is run
 # and is run after provision-admin.sh.
 #

--- a/scripts/deployment/web/provision-web-ec2.sh
+++ b/scripts/deployment/web/provision-web-ec2.sh
@@ -2,7 +2,7 @@
 #
 # provision-web-ec2.sh
 #
-# Provision the current machine as part of the Flashcrow Web Stack.  This is
+# Provision the current machine as part of the MOVE Web Stack.  This is
 # intended to be run on EC2.
 
 set -e

--- a/scripts/dev/README.md
+++ b/scripts/dev/README.md
@@ -4,96 +4,54 @@ New to MOVE development?  You're in the right place!  This guide walks you throu
 
 In this guide, you will:
 
-- install system prerequisites;
+- set up system prerequisites;
 - clone the MOVE repository;
-- on your host machine, add config files;
-- start up the MOVE development VM;
-- copy config files from your host machine to the VM;
-- within the VM, run the application.
+- set up the MOVE development VM;
+- within the VM:
+  - clone the MOVE repository;
+  - install private config files;
+  - install application dependencies;
+  - run the application to verify installation.
 
 Most of MOVE development takes place in a Vagrant VM.  This helps ensure that all developers have the same environment, and that this environment is as similar as possible to those in staging and production.
 
-The remainder of this guide will assume you're developing on a Windows machine, which is the default OS installed for City of Toronto users.  That said, many of these steps are OS-agnostic.
+## City of Toronto Developers: Read This!
 
-## System Prerequisites
+Developers at the City of Toronto have a couple of additional steps.  See [City of Toronto Installation Specifics](https://www.notion.so/bditto/City-of-Toronto-Installation-Specifics-27f8e51998e64d4dabc47d8d74a8c4eb), and refer to that guide throughout this process for further details.
 
-### PowerShell 5+
+## Set up System Prerequisites
 
-You should have PowerShell 5 or later installed.  You can follow [Microsoft docs](https://docs.microsoft.com/en-us/skypeforbusiness/set-up-your-computer-for-windows-powershell/download-and-install-windows-powershell-5-1) for details on setting that up.
+### Command-Line Tools: `git` and `vagrant`
 
-### Scoop
+Install [`git`](https://git-scm.com/) and [`vagrant`](https://www.vagrantup.com/downloads) for use on the command line.
 
-We recommend installing packages through [Scoop](https://scoop.sh/).  Open a PowerShell window and:
+### VirtualBox
 
-```powershell
-Set-ExecutionPolicy RemoteSigned -scope CurrentUser
-iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
-scoop config proxy currentuser:proxy.toronto.ca:8080
-```
+Install [VirtualBox](https://www.virtualbox.org/) as described on the VirtualBox site.
 
-### Git
-
-Now we'll install Git using Scoop, and set up the proxy:
-```powershell
-scoop install git
-git config --global http.proxy http://proxy.toronto.ca:8080
-```
-
-### Clone the MOVE Repository
+## Clone the MOVE repository
 
 Although development takes place within a Vagrant VM, you'll still need the Vagrant configuration from our repository.  You can install that once you clone the repo:
 
 ```powershell
 git clone https://github.com/CityofToronto/bdit_flashcrow.git
 ```
-That's when a window will pop up and ask you what credential manager you want to use. Select `manager`, and tell it to remember that setting. Then enter your GitHub credentials.
 
-### Install the rest of the Scoop requirements
+## Set up the MOVE development VM
 
-Now that we've got Scoop installed, and we've got MOVE cloned, we can read the Scoop requirements and install them:
+### Private Configuration
 
-```powershell
-cd bdit_flashcrow
-.\scripts\dev\scoop-requirements.ps1
-```
-
-If you run into a `Out-File : Could not find a part of the path 'C:\Users\akonoff\AppData\Roaming\pip\pip.ini'` error, simply create the pip folder:
-```powershell
-New-Item -Path $env:APPDATA -Name "pip" -ItemType "directory"
-```
-Now you should be ready to rock!
-
-### VirtualBox and Vagrant
-
-Install [VirtualBox](https://www.virtualbox.org/) if your machine does not already have it - you'll need version 5.2 if yours is a 32-bit machine.
-
-We already installed Vagrant above using `scoop-dependencies.ps1`, but we'll need a plugin to allow us to use it with a proxy, and, hilariously, we'll first have to configure Vagrant to use our proxy to download the proxy plugin:
-
-```powershell
-cd scripts\dev
-$env:http_proxy="http://proxy.toronto.ca:8080"
-vagrant plugin install vagrant-proxyconf
-```
-
-## Set up MOVE config files on Host Machine
-
-Our application config files are left out of source control to avoid exposing secrets (e.g. session cookie keys, database credentials, etc.).
-
-Copy-paste `lib/config/private.js` from [Accounts](https://www.notion.so/bditto/Accounts-30b1efa06aef4baaa0468f10b60e69f3).
-
-Next, generate a random database password and create a file at `scripts\dev\provision.conf.yml` as follows:
+Generate a random database password and create a file at `scripts\dev\provision.conf.yml` as follows:
 
 ```yaml
 gh_user: "{your Github username}"
 gh_password: "{your Github password}"
 pg_password: "{database password}"
-proxy_user: "{your City of Toronto username}"
-proxy_pass: "{your City of Toronto password}"
 ```
 
-These files should be `.gitignore`'d.  Double-check that you've named them properly by verifying that they do not show up as untracked in `git status`, and *NEVER* commit these files into the repo!
+This file should be `.gitignore`'d.  Double-check that you've named them properly by verifying that they do not show up as untracked in `git status`, and *NEVER* commit this files into the repo!
 
-## Start up the VM
+### Vagrant Cloud
 
 MOVE provides a private base box image at `cot-move/cot-move-dev` on Vagrant Cloud, based off the [Amazon Linux 2 VirtualBox image](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/amazon-linux-2-virtual-machine.html#amazon-linux-2-virtual-machine-download).  This image will be downloaded by `vagrant`.
 
@@ -106,20 +64,43 @@ vagrant login
 
 See [Accounts](https://www.notion.so/bditto/Accounts-30b1efa06aef4baaa0468f10b60e69f3) for Vagrant Cloud credentials.
 
+### Start up the VM
+
 This will allow you to install the private base box image, which you can then start up using:
 
 ```powershell
+cd scripts\dev
 vagrant up
 ```
 
-That's it!  This should install and run a working development environment.  The first time you run this, it will take about 20-30 minutes.
+That's it!  This should install and run the development VM.  The first time you run this, it will take about 20-30 minutes.
 
-## Copy configs to VM
+## Within the VM...
 
-You will need to `scp` the private config file from your host machine to the VM:
+To access the VM, you can use `vagrant ssh`:
 
 ```powershell
-scp lib\config\private.js vagrant@127.0.0.1:git/bdit_flashcrow/lib/config/private.js
+cd scripts\dev
+vagrant ssh
+```
+
+### Clone the MOVE repository (again)
+
+From within the development VM:
+
+```bash
+cd git
+git clone https://github.com/CityofToronto/bdit_flashcrow.git
+```
+
+### Install private config files
+
+See [Accounts :: Web Application Credentials](https://www.notion.so/bditto/Accounts-30b1efa06aef4baaa0468f10b60e69f3#c8ce1f4bab564efb8b23b37c64e679a6) for private config files.  Install these files within the VM as directed there.
+
+If you download these files to your host development machine, you can `scp` them over to the VM, e.g.:
+
+```powershell
+scp private.js vagrant@127.0.0.1:git/bdit_flashcrow/lib/config/private.js
 ```
 
 Again: these files should be `.gitignore`'d.  Double-check that you've named them properly by verifying that they do not show up as untracked in `git status`, and *NEVER* commit these files into the repo!
@@ -128,19 +109,17 @@ Again: these files should be `.gitignore`'d.  Double-check that you've named the
 
 It is highly recommended that you use [Visual Studio Code](https://code.visualstudio.com/).  The MOVE repo comes with a Visual Studio Code workspace configuration; to work in other editors, you will have to roll your own configuration.
 
-In particular, make sure that you have Visual Studio Code version 1.35 or later, as that version introduced support for [remote development over SSH](https://code.visualstudio.com/docs/remote/ssh).
+If you already have Visual Studio Code installed, make sure that you have updated to version 1.35 or later, as that version introduced support for [remote development over SSH](https://code.visualstudio.com/docs/remote/ssh).
 
-The rest of this section will assume that you're installing Visual Studio Code.
+The rest of this guide will assume that you're using Visual Studio Code with remote development over SSH.
 
 ### Install Visual Studio Code
 
-If you already have Visual Studio Code, use your Elevated Access User to update to the latest version.
+If you already have Visual Studio Code, update it to the latest version.  Otherwise, you can download the installer from the [Visual Studio Code website](https://code.visualstudio.com/) and run it.
 
-Otherwise, you can download the installer from the [Visual Studio Code website](https://code.visualstudio.com/).  Download and install it as your Elevated Access User, and make sure you're installing it system-wide (for all users).
+Open Visual Studio Code and install the [Remote Development](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) extension pack using the [Extension Marketplace](https://code.visualstudio.com/docs/editor/extension-gallery).
 
-Once that's installed, log back in as your normal user.  Open Visual Studio Code and install the [Remote Development](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) extension pack using the [Extension Marketplace](https://code.visualstudio.com/docs/editor/extension-gallery).
-
-The list of extensions we use is documented in `bdit_flashcrow.code-workspace` - in the future, we'll figure out how to configure Visual Studio Code to automatically install and update those extensions.  For now, work with an existing developer to install these, or install them from the [Extension Marketplace](https://code.visualstudio.com/docs/editor/extension-gallery) if you're already familiar with that process.
+The list of extensions we use is documented in `bdit_flashcrow.code-workspace`; Visual Studio Code should automatically recommend these extensions and prompt you to install them.
 
 ### SSH Configuration
 
@@ -166,19 +145,37 @@ At this point, you'll be in a Visual Studio Code window with SSH access to the V
 
 Go to **File > Open Workspace...** and open `git/bdit_flashcrow/bdit_flashcrow.code-workspace`.  You should only have to do this the first time you open the MOVE workspace; by default, Visual Studio Code re-opens your most recently open workspace on startup.
 
-## Run!
+## Within the VM...
 
-To run Flashcrow, you need to start three services:
+To finish this off, we'll now install application dependencies and run MOVE from our Visual Studio Code workspace.
+
+### Install application dependencies
+
+To install application dependencies:
+
+```bash
+nvm install
+nvm use
+npm install
+```
+
+### Run!
+
+To run Flashcrow, at a minimum you must start the frontend and `web` backend:
 
 - `npm run frontend` to serve static files;
-- `npm run backend` for the web application REST API;
-- `npm run reporter` for MOVE Reporter.
+- `npm run backend` for the web application REST API.
 
-With the MOVE workspace open in Visual Studio Code, you can run each from a separate terminal.
+With the MOVE workspace open in Visual Studio Code, you can run each from a separate terminal.  Once both are running, open [https://localhost:8080](https://localhost:8080) in your browser.
 
-Once all three are running, open [https://localhost:8080](https://localhost:8080) in your browser.
+To access reporting features, you will also need to run `reporter` and `scheduler`:
 
-## Celebrate!
+- `npm run reporter` to serve reports within the web interface;
+- `npm run scheduler` to handle bulk report generation and other background tasks.
+
+These can be run in additional separate terminals.
+
+### Celebrate!
 
 Congratulations!  Head back to the [MOVE Developer Handbook](https://www.notion.so/bditto/MOVE-Developer-Handbook-182de05ad8a94888b52ccc68093a497a#8da00ef06ab744bbafa1ca2a5b29ff6f) to continue your onboarding.
 

--- a/scripts/dev/README.md
+++ b/scripts/dev/README.md
@@ -119,7 +119,7 @@ If you already have Visual Studio Code, update it to the latest version.  Otherw
 
 Open Visual Studio Code and install the [Remote Development](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) extension pack using the [Extension Marketplace](https://code.visualstudio.com/docs/editor/extension-gallery).
 
-The list of extensions we use is documented in `bdit_flashcrow.code-workspace`; Visual Studio Code should automatically recommend these extensions and prompt you to install them.
+The list of extensions we use is documented in `bdit-flashcrow.code-workspace`; Visual Studio Code should automatically recommend these extensions and prompt you to install them.
 
 ### SSH Configuration
 
@@ -143,7 +143,7 @@ You can now follow step 2 on the [Remote Development using SSH](https://code.vis
 
 At this point, you'll be in a Visual Studio Code window with SSH access to the Vagrant VM, but you won't actually be in the MOVE workspace.
 
-Go to **File > Open Workspace...** and open `git/bdit_flashcrow/bdit_flashcrow.code-workspace`.  You should only have to do this the first time you open the MOVE workspace; by default, Visual Studio Code re-opens your most recently open workspace on startup.
+Go to **File > Open Workspace...** and open `git/bdit_flashcrow/bdit-flashcrow.code-workspace`.  You should only have to do this the first time you open the MOVE workspace; by default, Visual Studio Code re-opens your most recently open workspace on startup.
 
 ## Within the VM...
 
@@ -161,7 +161,7 @@ npm install
 
 ### Run!
 
-To run Flashcrow, at a minimum you must start the frontend and `web` backend:
+To run MOVE, at a minimum you must start the frontend and `web` backend:
 
 - `npm run frontend` to serve static files;
 - `npm run backend` for the web application REST API.

--- a/scripts/dev/provision-db-vagrant.sql
+++ b/scripts/dev/provision-db-vagrant.sql
@@ -6,8 +6,6 @@ GRANT ALL PRIVILEGES ON DATABASE flashcrow TO flashcrow;
 create extension pgcrypto;
 create extension postgis;
 create extension fuzzystrmatch;
-create extension postgis_tiger_geocoder;
-create extension postgis_topology;
 create extension pg_trgm;
 create extension pgrouting;
 set search_path=public,tiger;

--- a/scripts/dev/provision-user.sh
+++ b/scripts/dev/provision-user.sh
@@ -2,7 +2,7 @@
 #
 # provision-user.sh
 #
-# Installs Python, node, and the Flashcrow application itself during
+# Installs Python, node, and the MOVE application itself during
 # provisioning.  This script is intended to be run as a non-root user
 # (e.g. vagrant in development, ec2-user in production), and is run
 # after provision-admin.sh.

--- a/scripts/test/db/startup.sh
+++ b/scripts/test/db/startup.sh
@@ -50,6 +50,7 @@ echo "$RAMDISK_DEVICE" | sudo tee ${RAMDISK_DEVICE_FILE}
 
 # give 'vagrant' user/group ownership of the RAM-disk folder.
 sudo chown -R "${USER}:${USER}" ${RAMDISK_MOUNT_POINT}
+sudo chown -R "${USER}:${USER}" /var/run/postgresql/
 mkdir ${RAMDISK_DATA_DIR}
 chmod -R g+rw ${RAMDISK_MOUNT_POINT}
 touch "${RAMDISK_PGPASS}"

--- a/scripts/test/db/startup.sh
+++ b/scripts/test/db/startup.sh
@@ -49,7 +49,7 @@ RAMDISK_DEVICE=$(sudo mount -t tmpfs -o size=2g tmpfs ${RAMDISK_MOUNT_POINT})
 echo "$RAMDISK_DEVICE" | sudo tee ${RAMDISK_DEVICE_FILE}
 
 # give 'vagrant' user/group ownership of the RAM-disk folder.
-sudo chown -R vagrant:vagrant ${RAMDISK_MOUNT_POINT}
+sudo chown -R "${USER}:${USER}" ${RAMDISK_MOUNT_POINT}
 mkdir ${RAMDISK_DATA_DIR}
 chmod -R g+rw ${RAMDISK_MOUNT_POINT}
 touch "${RAMDISK_PGPASS}"

--- a/web/README.md
+++ b/web/README.md
@@ -19,7 +19,7 @@ The `web` folder contains the MOVE Web Application Frontend, written as an SPA (
 
 As noted, `web/views` is exclusively for components that appear as the top-level component bound to a route in `router.js`.  All other components should be in the `web/components` hierarchy.
 
-Note that we currently have no formal process around promoting components into `web/components/tds`.  It is recommended that any new components you create go in `web/components` or other subfolders thereof, and that their names start with `Fc` (short for "Flashcrow").
+Note that we currently have no formal process around promoting components into `web/components/tds`.  It is recommended that any new components you create go in `web/components` or other subfolders thereof, and that their names start with `Fc` (short for "Flashcrow", an old working project title for MOVE).
 
 Components in TDS should:
 


### PR DESCRIPTION
# Issue Addressed
This PR makes significant progress on #577 .

# Description
We decide upon, document, and start implementing a `git` workflow that allows us to retain our open-source repo on GitHub as the primary development repo while also giving us access to GitLab CI functionality on an instance within City networks.

# Tests
Tested that changes are pushed to both GitHub and GitLab, that CI pipelines run in GitLab, and that we can get CI coverage tests from MOVE passing (including the setup of a test database).

Tried to also get CD working, but ran into issues accessing CodeCommit / CodeDeploy from `etl` (where we're running `gitlab-runner`).
