### PR TITLE
Add AADT estimates to dev dataset

### DIFF
--- a/scripts/airflow/tasks/dev_data/create_schemas.sql
+++ b/scripts/airflow/tasks/dev_data/create_schemas.sql
@@ -4,6 +4,7 @@ drop schema if exists gis cascade;
 drop schema if exists location_search cascade;
 drop schema if exists routing cascade;
 drop schema if exists "TRAFFIC" cascade;
+drop schema if exists volume cascade;
 
 create schema collisions;
 create schema counts;
@@ -11,3 +12,4 @@ create schema gis;
 create schema location_search;
 create schema routing;
 create schema "TRAFFIC";
+create schema volume;

--- a/scripts/airflow/tasks/dev_data/dump_dev_data.sh
+++ b/scripts/airflow/tasks/dev_data/dump_dev_data.sh
@@ -35,6 +35,9 @@ mkdir -p /data/dev_data
   # shellcheck disable=SC2046
   env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t flashcrow_dev_data.traffic_arterydata -x --no-owner --clean --if-exists --schema-only | sed 's/flashcrow_dev_data.traffic_arterydata/"TRAFFIC"."ARTERYDATA"/g'
 
+  # shellcheck disable=SC2046
+  env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t flashcrow_dev_data.volume_aadt -x --no-owner --clean --if-exists --schema-only | sed 's/flashcrow_dev_data.volume_aadt/volume.aadt/g'
+
   #
   # copy data for unsampled views
   #
@@ -72,6 +75,11 @@ mkdir -p /data/dev_data
   echo 'COPY "TRAFFIC"."ARTERYDATA" FROM stdin;'
   # shellcheck disable=SC2046
   env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -c "COPY (SELECT * FROM \"TRAFFIC\".\"ARTERYDATA\") TO stdout (FORMAT text, ENCODING 'UTF-8')"
+  echo '\.'
+
+  echo 'COPY volume.aadt FROM stdin;'
+  # shellcheck disable=SC2046
+  env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -c "COPY (SELECT * FROM volume.aadt) TO stdout (FORMAT text, ENCODING 'UTF-8')"
   echo '\.'
 
   #

--- a/scripts/airflow/tasks/dev_data/sample_dev_data.sql
+++ b/scripts/airflow/tasks/dev_data/sample_dev_data.sql
@@ -13,6 +13,8 @@ drop table if exists flashcrow_dev_data.gis_traffic_signal;
 drop table if exists flashcrow_dev_data.traffic_arterydata;
 drop table if exists flashcrow_dev_data.traffic_category;
 
+drop table if exists flashcrow_dev_data.volume_aadt;
+
 create table flashcrow_dev_data.counts_arteries_centreline (like counts.arteries_centreline including indexes);
 
 create table flashcrow_dev_data.gis_centreline (like gis.centreline including indexes);
@@ -23,6 +25,8 @@ create table flashcrow_dev_data.gis_traffic_signal (like gis.traffic_signal incl
 
 create table flashcrow_dev_data.traffic_arterydata (like "TRAFFIC"."ARTERYDATA" including indexes);
 create table flashcrow_dev_data.traffic_category (like "TRAFFIC"."CATEGORY" including indexes);
+
+create table flashcrow_dev_data.volume_aadt (like volume.aadt including indexes);
 
 -- SAMPLED DATA
 
@@ -41,8 +45,12 @@ drop table if exists flashcrow_dev_data.traffic_cnt_det;
 
 create table flashcrow_dev_data.collisions_events (like collisions.events including indexes);
 insert into flashcrow_dev_data.collisions_events
+  select * from collisions.events
+  where ksi;
+insert into flashcrow_dev_data.collisions_events
   select * from collisions.events tablesample bernoulli (10)
-  where accdate >= '2009-01-01';
+  where accdate >= '2005-01-01'
+on conflict do nothing;
 insert into flashcrow_dev_data.collisions_events
   select t.* from collisions.events as t
   join collisions.events_centreline as u USING (collision_id)
@@ -66,16 +74,16 @@ insert into flashcrow_dev_data.collisions_involved
 
 create table flashcrow_dev_data.counts_studies (like counts.studies including indexes);
 insert into flashcrow_dev_data.counts_studies
-  select * from counts.studies tablesample bernoulli (0.25)
-  where start_date >= '2009-01-01'
+  select * from counts.studies tablesample bernoulli (0.1)
+  where start_date >= '2005-01-01'
   and "CATEGORY_ID" = 2;
 insert into flashcrow_dev_data.counts_studies
-  select * from counts.studies tablesample bernoulli (0.5)
-  where start_date >= '2009-01-01'
+  select * from counts.studies tablesample bernoulli (1)
+  where start_date >= '2005-01-01'
   and "CATEGORY_ID" = 6;
 insert into flashcrow_dev_data.counts_studies
-  select * from counts.studies tablesample bernoulli (2)
-  where start_date >= '2009-01-01'
+  select * from counts.studies tablesample bernoulli (5)
+  where start_date >= '2005-01-01'
   and "CATEGORY_ID" not in (2, 6);
 insert into flashcrow_dev_data.counts_studies
   select * from counts.studies


### PR DESCRIPTION
# Issue Addressed
This PR makes progress on #535 .

# Description
(This was from a while ago, and just never got merged.)

Add AADT estimates to the dev dataset, so that we can return them from `CentrelineDAO` and other DAOs when fetching centreline features - this allows us to use those estimates to match selected midblock line widths to the widths in our centreline vector tiles.

# Tests
Ran it a while back.  Have been using these estimates in local development for a while now.