### PR TITLE
Interim CD to dev via CodeCommit

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,8 +46,9 @@ test-ci-rest:
 deploy-dev:
   stage: deploy
   script:
-    - echo deploy-dev
+    - ./scripts/deployment/code-commit/deploy_code_commit.sh
   only:
+    - gh579-cd-interim-codecommit
     - master
 
 # deploy QA branch automatically

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,7 +48,6 @@ deploy-dev:
   script:
     - ./scripts/deployment/code-commit/deploy_code_commit.sh
   only:
-    - gh579-cd-interim-codecommit
     - master
 
 # deploy QA branch automatically

--- a/scripts/deployment/code-commit/deploy_code_commit.sh
+++ b/scripts/deployment/code-commit/deploy_code_commit.sh
@@ -2,18 +2,7 @@
 
 set -euo pipefail
 
-# make sure code is up to date
-if ! git ls-remote --exit-code code-commit; then
-  echo "ERROR: code-commit remote is missing."
-  echo "Ping MOVE developers on #prj_move in Slack to configure this git remote."
-  exit 1
-fi
-git checkout master
-git fetch
-git pull
-
 # notify prj_move on Slack
-CURRENT_REVISION=$(git rev-parse HEAD)
-curl -H "Content-Type: application/json; charset=utf-8" -d "{\"text\": \"<!here> MOVE down for deployment: ${CURRENT_REVISION} -> flashcrow-dev0\"}" "$SLACK_WEBHOOK_URL"
+curl -H "Content-Type: application/json; charset=utf-8" -d "{\"text\": \"<!here> MOVE down for deployment: ${CI_COMMIT_REF_NAME} @ ${CI_COMMIT_SHORT_SHA} -> flashcrow-dev0\"}" "$SLACK_WEBHOOK_URL"
 
-git push code-commit master
+git push https://git-codecommit.ca-central-1.amazonaws.com/v1/repos/bdit_flashcrow HEAD:master


### PR DESCRIPTION
# Issue Addressed
This PR makes progress on #579 .

# Description
We simplify and slightly rework `deploy_code_commit.sh`, then use it from `.gitlab-ci.yml` to trigger deployment to dev via CodeCommit when `master` is updated.

# Tests
Added the feature branch to `only` temporarily, then pushed: this resulted in a successful push to CodeCommit, and the ensuing deployment was also successful.
