### PR TITLE
Nightly autovacuum to prevent dead tuple buildup

### DIFF
--- a/scripts/airflow/dags/autovacuum_cleanup.py
+++ b/scripts/airflow/dags/autovacuum_cleanup.py
@@ -1,0 +1,16 @@
+"""
+autovacuum_cleanup
+
+A maintenance workflow that runs `VACUUM ANALYZE` nightly on all materialized views in
+the MOVE database, to mitigate service degradation and/or downtime due to autovacuum
+operations.
+"""
+from datetime import datetime
+
+from airflow_utils import create_dag, create_bash_task_nested
+
+START_DATE = datetime(2020, 8, 19)
+SCHEDULE_INTERVAL = '0 23 * * *'
+DAG = create_dag(__file__, __doc__, START_DATE, SCHEDULE_INTERVAL)
+
+AUTOVACUUM_CLEANUP = create_bash_task_nested(DAG, 'autovacuum_cleanup')

--- a/scripts/airflow/tasks/autovacuum_cleanup/autovacuum_cleanup.sh
+++ b/scripts/airflow/tasks/autovacuum_cleanup/autovacuum_cleanup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+GIT_ROOT=/home/ec2-user/flashcrow
+TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
+AUTOVACUUM_SQL=/data/autovacuum_cleanup/autovacuum_cleanup.sql
+
+mkdir -p /data/autovacuum_cleanup
+{
+  # shellcheck disable=SC2046
+  env $(xargs < /home/ec2-user/cot-env.config) psql -v ON_ERROR_STOP=1 -tAc "SELECT format('\"%s\".\"%s\"', schemaname, matviewname) FROM pg_matviews WHERE matviewowner = 'flashcrow'" | while read line; do
+    echo "VACUUM ANALYZE ${line};"
+  done
+} > "${AUTOVACUUM_SQL}"
+
+# shellcheck disable=SC2046
+env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 < "${AUTOVACUUM_SQL}"


### PR DESCRIPTION
# Issue Addressed
This PR closes #482 .

# Description
We use `pg_matviews` to fetch the list of all materialized views in the `flashcrow` database, then run `VACUUM ANALYZE` on each.

As noted in the issue, failing to `VACUUM` regularly has resulted previously in service degradation on MOVE.

# Tests
Ran DAG manually at ~5pm and automatically at ~7pm - both ran successfully.