### PR TITLE
Report generation: frontend stub

### DIFF
--- a/web/App.vue
+++ b/web/App.vue
@@ -5,16 +5,9 @@
       v-model="hasDialog"
       :is="'FcDialog' + dialog"
       v-bind="dialogData" />
-    <v-snackbar
-      v-if="hasToast"
-      v-model="hasToast"
-      bottom
-      class="fc-toast"
-      :color="toast.variant"
-      left
-      :timeout="10000">
-      <span class="body-1">{{toast.text}}</span>
-    </v-snackbar>
+    <FcToast
+      v-if="toast !== null"
+      v-bind="toast" />
     <v-navigation-drawer
       app
       mini-variant
@@ -52,6 +45,7 @@ import FcDialogAlertStudyRequestUrgent from
   '@/web/components/dialogs/FcDialogAlertStudyRequestUrgent.vue';
 import FcDialogConfirmUnauthorized from
   '@/web/components/dialogs/FcDialogConfirmUnauthorized.vue';
+import FcToast from '@/web/components/dialogs/FcToast.vue';
 import FcDashboardNav from '@/web/components/nav/FcDashboardNav.vue';
 import FcDashboardNavBrand from '@/web/components/nav/FcDashboardNavBrand.vue';
 import FcDashboardNavInDevelopment from '@/web/components/nav/FcDashboardNavInDevelopment.vue';
@@ -67,6 +61,7 @@ export default {
     FcDialogAlertInDevelopment,
     FcDialogAlertStudyRequestUrgent,
     FcDialogConfirmUnauthorized,
+    FcToast,
   },
   computed: {
     hasDialog: {
@@ -76,16 +71,6 @@ export default {
       set(hasDialog) {
         if (!hasDialog) {
           this.clearDialog();
-        }
-      },
-    },
-    hasToast: {
-      get() {
-        return this.toast !== null;
-      },
-      set(hasToast) {
-        if (!hasToast) {
-          this.clearToast();
         }
       },
     },
@@ -109,10 +94,6 @@ export default {
   font-size: 0.875rem;
   font-weight: normal;
   line-height: 1.25rem;
-
-  & .fc-toast {
-    left: 76px;
-  }
 
   & .v-input--selection-controls__input + .v-label {
     color: var(--v-default-base);

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -71,28 +71,9 @@
           class="fc-report-wrapper pa-3">
           <FcReport v-bind="reportLayout" />
           <div class="fc-report-actions pa-3">
-            <v-menu>
-              <template v-slot:activator="{ on, attrs }">
-                <FcButton
-                  v-bind="attrs"
-                  v-on="on"
-                  class="ml-2"
-                  type="secondary"
-                  :loading="loadingDownload">
-                  <v-icon color="primary" left>mdi-cloud-download</v-icon> Download
-                </FcButton>
-              </template>
-              <v-list>
-                <v-list-item
-                  v-for="{ label, value } in itemsDownloadFormats"
-                  :key="value"
-                  @click="actionDownload(value)">
-                  <v-list-item-title>
-                    {{label}}
-                  </v-list-item-title>
-                </v-list-item>
-              </v-list>
-            </v-menu>
+            <FcMenuDownloadReportFormat
+              type="secondary"
+              @download-report-format="actionDownload" />
           </div>
         </div>
       </section>
@@ -109,6 +90,7 @@ import { getReport, getReportWeb } from '@/lib/api/WebApi';
 import CompositeId from '@/lib/io/CompositeId';
 import FcDialogConfirm from '@/web/components/dialogs/FcDialogConfirm.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
+import FcMenuDownloadReportFormat from '@/web/components/inputs/FcMenuDownloadReportFormat.vue';
 import FcReport from '@/web/components/reports/FcReport.vue';
 import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
 
@@ -123,6 +105,7 @@ export default {
   components: {
     FcButton,
     FcDialogConfirm,
+    FcMenuDownloadReportFormat,
     FcReport,
   },
   data() {

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -109,28 +109,9 @@
               <v-icon color="primary" left>mdi-cog</v-icon>
               Set Parameters
             </FcButton>
-            <v-menu>
-              <template v-slot:activator="{ on, attrs }">
-                <FcButton
-                  v-bind="attrs"
-                  v-on="on"
-                  class="ml-2"
-                  type="secondary"
-                  :loading="loadingDownload">
-                  <v-icon color="primary" left>mdi-cloud-download</v-icon> Download
-                </FcButton>
-              </template>
-              <v-list>
-                <v-list-item
-                  v-for="{ label, value } in itemsDownloadFormats"
-                  :key="value"
-                  @click="actionDownload(value)">
-                  <v-list-item-title>
-                    {{label}}
-                  </v-list-item-title>
-                </v-list-item>
-              </v-list>
-            </v-menu>
+            <FcMenuDownloadReportFormat
+              type="secondary"
+              @download-report-format="actionDownload" />
           </div>
         </div>
       </section>
@@ -163,6 +144,7 @@ import TimeFormatters from '@/lib/time/TimeFormatters';
 import FcDialogConfirm from '@/web/components/dialogs/FcDialogConfirm.vue';
 import FcDialogReportParameters from '@/web/components/dialogs/FcDialogReportParameters.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
+import FcMenuDownloadReportFormat from '@/web/components/inputs/FcMenuDownloadReportFormat.vue';
 import FcReport from '@/web/components/reports/FcReport.vue';
 import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
 
@@ -178,6 +160,7 @@ export default {
     FcButton,
     FcDialogConfirm,
     FcDialogReportParameters,
+    FcMenuDownloadReportFormat,
     FcReport,
   },
   data() {

--- a/web/components/data/FcAggregateCollisions.vue
+++ b/web/components/data/FcAggregateCollisions.vue
@@ -53,16 +53,6 @@
           </v-expansion-panel-content>
         </v-expansion-panel>
       </v-expansion-panels>
-      <div class="d-flex mt-4 mr-5">
-        <v-spacer></v-spacer>
-        <FcButton
-          class="flex-grow-0 flex-shrink-0"
-          :disabled="collisionSummary.amount === 0"
-          type="tertiary"
-          @click="$emit('show-reports')">
-          <span>View Total Reports</span>
-        </FcButton>
-      </div>
     </template>
   </div>
 </template>
@@ -72,13 +62,11 @@ import { mapGetters } from 'vuex';
 
 import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
 import FcTextSummaryFraction from '@/web/components/data/FcTextSummaryFraction.vue';
-import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcIconLocationMulti from '@/web/components/location/FcIconLocationMulti.vue';
 
 export default {
   name: 'FcAggregateCollisions',
   components: {
-    FcButton,
     FcIconLocationMulti,
     FcTextSummaryFraction,
   },

--- a/web/components/data/FcHeaderCollisions.vue
+++ b/web/components/data/FcHeaderCollisions.vue
@@ -12,6 +12,7 @@
       </FcDialogCollisionFilters>
       <FcButton
         v-if="collisionTotal > 0"
+        :disabled="disabled"
         type="secondary"
         @click.stop="showFiltersCollision = true">
         <v-icon
@@ -19,6 +20,7 @@
           left>mdi-filter-variant</v-icon>
         Filter
       </FcButton>
+      <slot name="action" />
     </div>
 
     <div
@@ -51,6 +53,10 @@ export default {
   },
   props: {
     collisionTotal: Number,
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     return {

--- a/web/components/data/FcHeaderStudies.vue
+++ b/web/components/data/FcHeaderStudies.vue
@@ -12,6 +12,7 @@
       </FcDialogStudyFilters>
       <FcButton
         v-if="studyTotal > 0"
+        :disabled="disabled"
         type="secondary"
         @click.stop="showFiltersStudy = true">
         <v-icon
@@ -51,6 +52,10 @@ export default {
     FcDialogStudyFilters,
   },
   props: {
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
     studyTotal: Number,
   },
   data() {

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -99,7 +99,7 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex';
+import { mapGetters, mapMutations } from 'vuex';
 
 import { Enum } from '@/lib/ClassUtils';
 import {
@@ -227,8 +227,16 @@ export default {
   },
   methods: {
     actionDownloadReportFormat() {
-      /* eslint-disable-next-line no-alert */
-      window.alert('Coming Soon!');
+      this.setToast({
+        action: {
+          callback: () => {
+            /* eslint-disable-next-line no-alert */
+            window.alert('Coming Soon!');
+          },
+          text: 'Undo',
+        },
+        text: 'Generating reports (10 of 23, 2 minutes)',
+      });
     },
     actionRequestStudy() {
       /* eslint-disable-next-line no-alert */
@@ -294,8 +302,12 @@ export default {
         this.exportMode = null;
       } else {
         this.exportMode = exportMode;
+        this.setToast({
+          text: 'You\'re currently in Export Report Mode.',
+        });
       }
     },
+    ...mapMutations(['setToast']),
   },
 };
 </script>

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -32,13 +32,9 @@
               <v-icon color="primary" left>mdi-file-eye</v-icon>
               <span>View Report</span>
             </FcButton>
-            <FcButton
+            <FcMenuDownloadReportFormat
               v-else
-              class="ml-2"
-              type="primary">
-              <v-icon left>mdi-cloud-download</v-icon>
-              Download
-            </FcButton>
+              @download-report-format="actionDownloadReportFormat" />
           </template>
         </FcHeaderCollisions>
 
@@ -82,13 +78,9 @@
               <v-icon color="primary" left>mdi-plus-box</v-icon>
               Request New Counts
             </FcButton>
-            <FcButton
+            <FcMenuDownloadReportFormat
               v-else
-              class="ml-2"
-              type="primary">
-              <v-icon left>mdi-cloud-download</v-icon>
-              Download
-            </FcButton>
+              @download-report-format="actionDownloadReportFormat" />
           </template>
         </FcHeaderStudies>
 
@@ -123,6 +115,7 @@ import FcAggregateStudies from '@/web/components/data/FcAggregateStudies.vue';
 import FcHeaderCollisions from '@/web/components/data/FcHeaderCollisions.vue';
 import FcHeaderStudies from '@/web/components/data/FcHeaderStudies.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
+import FcMenuDownloadReportFormat from '@/web/components/inputs/FcMenuDownloadReportFormat.vue';
 
 class ExportMode extends Enum {}
 ExportMode.init([
@@ -138,6 +131,7 @@ export default {
     FcButton,
     FcHeaderCollisions,
     FcHeaderStudies,
+    FcMenuDownloadReportFormat,
   },
   props: {
     locations: Array,
@@ -232,6 +226,10 @@ export default {
     this.syncLocations();
   },
   methods: {
+    actionDownloadReportFormat() {
+      /* eslint-disable-next-line no-alert */
+      window.alert('Coming Soon!');
+    },
     actionRequestStudy() {
       /* eslint-disable-next-line no-alert */
       window.alert('Coming Soon!');

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -5,7 +5,34 @@
       indeterminate />
     <template v-else>
       <section>
-        <FcHeaderCollisions :collision-total="collisionTotal" />
+        <FcHeaderCollisions
+          :collision-total="collisionTotal"
+          :disabled="exportMode === ExportMode.STUDIES">
+          <template v-slot:action>
+            <FcButton
+              class="ml-2"
+              :disabled="exportMode === ExportMode.STUDIES"
+              type="secondary"
+              @click="actionToggleExportMode(ExportMode.COLLISIONS)">
+              <template v-if="exportMode === ExportMode.COLLISIONS">
+                <v-icon color="primary" left>mdi-file-cancel-outline</v-icon>
+                <span>Cancel Export</span>
+              </template>
+              <template v-else>
+                <v-icon color="primary" left>mdi-file-export</v-icon>
+                <span>Export Reports</span>
+              </template>
+            </FcButton>
+            <FcButton
+              class="ml-2"
+              :disabled="collisionSummary.amount === 0 || exportMode === ExportMode.STUDIES"
+              type="secondary"
+              @click="actionShowReportsCollision">
+              <v-icon color="primary" left>mdi-file-eye</v-icon>
+              <span>View Report</span>
+            </FcButton>
+          </template>
+        </FcHeaderCollisions>
 
         <FcAggregateCollisions
           :collision-summary="collisionSummary"
@@ -14,21 +41,37 @@
           :collision-summary-per-location-unfiltered="collisionSummaryPerLocationUnfiltered"
           :loading="loadingCollisions"
           :locations="locations"
-          :locations-selection="locationsSelection"
-          @show-reports="actionShowReportsCollision" />
+          :locations-selection="locationsSelection" />
       </section>
 
       <v-divider></v-divider>
 
       <section>
-        <FcHeaderStudies :study-total="studyTotal">
+        <FcHeaderStudies
+          :disabled="exportMode === ExportMode.COLLISIONS"
+          :study-total="studyTotal">
           <template v-slot:action>
             <FcButton
-              class="ml-3"
+              class="ml-2"
+              :disabled="exportMode === ExportMode.COLLISIONS"
+              type="secondary"
+              @click="actionToggleExportMode(ExportMode.STUDIES)">
+              <template v-if="exportMode === ExportMode.STUDIES">
+                <v-icon color="primary" left>mdi-file-cancel-outline</v-icon>
+                <span>Cancel Export</span>
+              </template>
+              <template v-else>
+                <v-icon color="primary" left>mdi-file-export</v-icon>
+                <span>Export Reports</span>
+              </template>
+            </FcButton>
+            <FcButton
+              class="ml-2"
+              :disabled="exportMode === ExportMode.COLLISIONS"
               type="secondary"
               @click="actionRequestStudy">
               <v-icon color="primary" left>mdi-plus-box</v-icon>
-              Batch Request Study
+              Request New Counts
             </FcButton>
           </template>
         </FcHeaderStudies>
@@ -50,6 +93,7 @@
 <script>
 import { mapGetters } from 'vuex';
 
+import { Enum } from '@/lib/ClassUtils';
 import {
   getCollisionsByCentrelineSummary,
   getCollisionsByCentrelineSummaryPerLocation,
@@ -63,6 +107,12 @@ import FcAggregateStudies from '@/web/components/data/FcAggregateStudies.vue';
 import FcHeaderCollisions from '@/web/components/data/FcHeaderCollisions.vue';
 import FcHeaderStudies from '@/web/components/data/FcHeaderStudies.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
+
+class ExportMode extends Enum {}
+ExportMode.init([
+  'COLLISIONS',
+  'STUDIES',
+]);
 
 export default {
   name: 'FcViewDataAggregate',
@@ -102,6 +152,8 @@ export default {
       collisionSummaryPerLocation,
       collisionSummaryPerLocationUnfiltered,
       collisionTotal: 0,
+      exportMode: null,
+      ExportMode,
       loading: false,
       loadingCollisions: false,
       loadingStudies: false,
@@ -222,6 +274,13 @@ export default {
       this.studyTotal = studyTotal;
 
       this.loading = false;
+    },
+    actionToggleExportMode(exportMode) {
+      if (this.exportMode === exportMode) {
+        this.exportMode = null;
+      } else {
+        this.exportMode = exportMode;
+      }
     },
   },
 };

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -11,7 +11,7 @@
           <template v-slot:action>
             <FcButton
               class="ml-2"
-              :disabled="exportMode === ExportMode.STUDIES"
+              :disabled="collisionSummary.amount === 0 || exportMode === ExportMode.STUDIES"
               type="secondary"
               @click="actionToggleExportMode(ExportMode.COLLISIONS)">
               <template v-if="exportMode === ExportMode.COLLISIONS">
@@ -24,12 +24,20 @@
               </template>
             </FcButton>
             <FcButton
+              v-if="exportMode !== ExportMode.COLLISIONS"
               class="ml-2"
               :disabled="collisionSummary.amount === 0 || exportMode === ExportMode.STUDIES"
               type="secondary"
               @click="actionShowReportsCollision">
               <v-icon color="primary" left>mdi-file-eye</v-icon>
               <span>View Report</span>
+            </FcButton>
+            <FcButton
+              v-else
+              class="ml-2"
+              type="primary">
+              <v-icon left>mdi-cloud-download</v-icon>
+              Download
             </FcButton>
           </template>
         </FcHeaderCollisions>
@@ -66,12 +74,20 @@
               </template>
             </FcButton>
             <FcButton
+              v-if="exportMode !== ExportMode.STUDIES"
               class="ml-2"
               :disabled="exportMode === ExportMode.COLLISIONS"
               type="secondary"
               @click="actionRequestStudy">
               <v-icon color="primary" left>mdi-plus-box</v-icon>
               Request New Counts
+            </FcButton>
+            <FcButton
+              v-else
+              class="ml-2"
+              type="primary">
+              <v-icon left>mdi-cloud-download</v-icon>
+              Download
             </FcButton>
           </template>
         </FcHeaderStudies>

--- a/web/components/dialogs/FcToast.vue
+++ b/web/components/dialogs/FcToast.vue
@@ -1,0 +1,69 @@
+<template>
+  <v-snackbar
+    v-model="hasToast"
+    bottom
+    class="fc-toast pb-5 pl-7"
+    :color="color + ' darken-2'"
+    :timeout="timeout">
+    <span class="body-1">{{text}}</span>
+    <template v-slot:action="{ attrs }">
+      <FcButton
+        v-if="action !== null"
+        color="white"
+        type="tertiary"
+        v-bind="attrs"
+        @click="actionCallback">
+        {{action.text}}
+      </FcButton>
+    </template>
+  </v-snackbar>
+</template>
+
+<script>
+import { mapMutations } from 'vuex';
+
+import FcButton from '@/web/components/inputs/FcButton.vue';
+
+const TIMEOUT_NEVER = -1;
+const TIMEOUT_NON_CLOSEABLE = 10000;
+
+export default {
+  name: 'FcToast',
+  components: {
+    FcButton,
+  },
+  props: {
+    action: {
+      type: Object,
+      default: null,
+    },
+    color: {
+      type: String,
+      default: 'black',
+    },
+    text: String,
+  },
+  computed: {
+    hasToast: {
+      get() {
+        return this.toast !== null;
+      },
+      set(hasToast) {
+        if (!hasToast) {
+          this.clearToast();
+        }
+      },
+    },
+    timeout() {
+      return this.action === null ? TIMEOUT_NON_CLOSEABLE : TIMEOUT_NEVER;
+    },
+  },
+  methods: {
+    actionCallback() {
+      this.action.callback();
+      this.clearToast();
+    },
+    ...mapMutations(['clearToast']),
+  },
+};
+</script>

--- a/web/components/inputs/FcMenuDownloadReportFormat.vue
+++ b/web/components/inputs/FcMenuDownloadReportFormat.vue
@@ -1,0 +1,72 @@
+<template>
+  <v-menu>
+    <template v-slot:activator="{ on, attrs }">
+      <FcButton
+        v-bind="attrs"
+        v-on="on"
+        class="ml-2"
+        :loading="loading"
+        :type="type">
+        <v-icon
+          left
+          :color="type === 'secondary' ? 'primary' : 'white'">
+          mdi-cloud-download
+        </v-icon>
+        Download
+      </FcButton>
+    </template>
+    <v-list>
+      <v-list-item
+        v-for="{ label, value } in items"
+        :key="value"
+        @click="$emit('download-report-format', value)">
+        <v-list-item-title>
+          {{label}}
+        </v-list-item-title>
+      </v-list-item>
+    </v-list>
+  </v-menu>
+</template>
+
+<script>
+import { ReportFormat, ReportType } from '@/lib/Constants';
+import FcButton from '@/web/components/inputs/FcButton.vue';
+
+const DOWNLOAD_REPORT_FORMATS_SUPPORTED = [
+  ReportFormat.CSV,
+  ReportFormat.PDF,
+];
+
+export default {
+  name: 'FcMenuDownloadReportFormat',
+  components: {
+    FcButton,
+  },
+  props: {
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+    reportType: {
+      type: ReportType,
+      default: null,
+    },
+    type: {
+      type: String,
+      default: 'primary',
+    },
+  },
+  computed: {
+    items() {
+      if (this.loading) {
+        return [];
+      }
+      let items = DOWNLOAD_REPORT_FORMATS_SUPPORTED;
+      if (this.reportType !== null) {
+        items = items.filter(reportFormat => this.reportType.formats.includes(reportFormat));
+      }
+      return items.map(({ name }) => ({ label: name, value: name }));
+    },
+  },
+};
+</script>

--- a/web/router.js
+++ b/web/router.js
@@ -300,7 +300,7 @@ router.afterEach((to) => {
 
 function onErrorShowToast(err) {
   return {
-    variant: 'error',
+    color: 'error',
     text: err.message,
   };
 }


### PR DESCRIPTION
# Issue Addressed
This PR closes #559 .

# Description
`FcViewDataAggregate` now shows "Export Reports" buttons in the collisions and studies headers.  These buttons set the `exportMode`, which refocuses the Aggregate View interface on selecting parameters for bulk report generation.

For now, none of this does _anything_ of use - the idea is more to get the general flow in place.

# Tests
Tested buttons in frontend.  (There's probably some styling issues still; we'll work those out gradually over the next few PRs.)
