### PR TITLE
Integrate background report generation with frontend

### DIFF
--- a/lib/FunctionUtils.js
+++ b/lib/FunctionUtils.js
@@ -1,4 +1,15 @@
 /**
+ *
+ * @param {number} wait - time, in milliseconds, to delay for
+ * @returns {Promise<void>} a promise that resolves after given delay
+ */
+function asyncDelay(wait) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, wait);
+  });
+}
+
+/**
  * "Debounces" `func` by wrapping it in a function that, when called,
  * resets an internal timeout.  `func` is only called once it's been
  * `wait` milliseconds since the last call to the function returned by
@@ -51,6 +62,7 @@ function noop() {}
  * @namespace
  */
 const FunctionUtils = {
+  asyncDelay,
   debounce,
   identity,
   noop,
@@ -58,6 +70,7 @@ const FunctionUtils = {
 
 export {
   FunctionUtils as default,
+  asyncDelay,
   debounce,
   identity,
   noop,

--- a/lib/api/QueryString.js
+++ b/lib/api/QueryString.js
@@ -33,7 +33,7 @@ class QueryString {
           const qsPart = QueryString.keyValuePart(key, subValue);
           qsParts.push(qsPart);
         });
-      } else {
+      } else if (value !== null) {
         const qsPart = QueryString.keyValuePart(key, value);
         qsParts.push(qsPart);
       }

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -194,6 +194,14 @@ async function getReportWeb(type, id, reportParameters) {
   };
 }
 
+async function getStorage(namespace, key) {
+  const options = {
+    method: 'GET',
+    responseType: 'blob',
+  };
+  return apiClient.fetch(`/storage/${namespace}/${key}`, options);
+}
+
 async function getStudiesByCentreline(features, studyType, filters, pagination) {
   const s1 = CompositeId.encode(features);
   const data = { s1, ...filters, ...pagination };
@@ -408,6 +416,17 @@ async function postStudyRequestComment(csrf, studyRequest, comment) {
   return responseSchema.validateAsync(response);
 }
 
+async function putJobCancel(csrf, jobMetadata) {
+  const { jobId } = jobMetadata;
+  const url = `/jobs/${jobId}/cancel`;
+  const options = {
+    method: 'PUT',
+    csrf,
+  };
+  const persistedJobMetadata = await schedulerClient.fetch(url, options);
+  return JobMetadata.read.validateAsync(persistedJobMetadata);
+}
+
 async function putStudyRequest(csrf, studyRequest) {
   const { id: studyRequestId } = studyRequest;
   const url = `/requests/study/${studyRequestId}`;
@@ -472,6 +491,7 @@ const WebApi = {
   getPoiByCentrelineSummary,
   getReport,
   getReportWeb,
+  getStorage,
   getStudiesByCentreline,
   getStudiesByCentrelineSummary,
   getStudiesByCentrelineSummaryPerLocation,
@@ -484,6 +504,7 @@ const WebApi = {
   postJobGenerateReports,
   postStudyRequest,
   postStudyRequestComment,
+  putJobCancel,
   putStudyRequest,
   putStudyRequestComment,
   putUser,
@@ -507,6 +528,7 @@ export {
   getPoiByCentrelineSummary,
   getReport,
   getReportWeb,
+  getStorage,
   getStudiesByCentreline,
   getStudiesByCentrelineSummary,
   getStudiesByCentrelineSummaryPerLocation,
@@ -519,6 +541,7 @@ export {
   postJobGenerateReports,
   postStudyRequest,
   postStudyRequestComment,
+  putJobCancel,
   putStudyRequest,
   putStudyRequestComment,
   putUser,

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -10,6 +10,7 @@ import CompositeId from '@/lib/io/CompositeId';
 import AuthState from '@/lib/model/AuthState';
 import Category from '@/lib/model/Category';
 import CollisionEvent from '@/lib/model/CollisionEvent';
+import JobMetadata from '@/lib/model/JobMetadata';
 import Joi from '@/lib/model/Joi';
 import Study from '@/lib/model/Study';
 import StudyRequest from '@/lib/model/StudyRequest';
@@ -22,6 +23,7 @@ import DateTime from '@/lib/time/DateTime';
 
 const apiClient = new AxiosBackendClient('/api');
 const reporterClient = new AxiosBackendClient('/reporter');
+const schedulerClient = new AxiosBackendClient('/scheduler');
 
 async function deleteStudyRequestComment(csrf, studyRequest, comment) {
   const { id: commentId } = comment;
@@ -78,6 +80,17 @@ async function getCollisionsByCentrelineTotal(features) {
   const options = { data };
   const { total } = await apiClient.fetch('/collisions/byCentreline/total', options);
   return total;
+}
+
+async function getJob(jobId) {
+  const jobMetadata = await schedulerClient.fetch(`/jobs/${jobId}`);
+  return JobMetadata.read.validateAsync(jobMetadata);
+}
+
+async function getJobs() {
+  const jobMetadatas = await schedulerClient.fetch('/jobs');
+  const jobMetadatasSchema = Joi.array().items(JobMetadata.read);
+  return jobMetadatasSchema.validateAsync(jobMetadatas);
 }
 
 async function getLocationsByCentreline(features) {
@@ -353,6 +366,22 @@ async function getUsers() {
   return usersSchema.validateAsync(users);
 }
 
+async function postJobGenerateReports(csrf, features, filters, reportFormat) {
+  const s1 = CompositeId.encode(features);
+  const data = {
+    s1,
+    ...filters,
+    reportFormat,
+  };
+  const options = {
+    method: 'POST',
+    csrf,
+    data,
+  };
+  const jobMetadata = await schedulerClient.fetch('/jobs/GENERATE_REPORTS', options);
+  return JobMetadata.read.validateAsync(jobMetadata);
+}
+
 async function postStudyRequest(csrf, studyRequest) {
   const options = {
     method: 'POST',
@@ -434,6 +463,8 @@ const WebApi = {
   getCollisionsByCentrelineSummary,
   getCollisionsByCentrelineSummaryPerLocation,
   getCollisionsByCentrelineTotal,
+  getJob,
+  getJobs,
   getLocationByCentreline,
   getLocationsByCentreline,
   getLocationsByCorridor,
@@ -450,6 +481,7 @@ const WebApi = {
   getStudyRequestsByCentrelinePending,
   getUsers,
   getUsersByIds,
+  postJobGenerateReports,
   postStudyRequest,
   postStudyRequestComment,
   putStudyRequest,
@@ -466,6 +498,8 @@ export {
   getCollisionsByCentrelineSummary,
   getCollisionsByCentrelineSummaryPerLocation,
   getCollisionsByCentrelineTotal,
+  getJob,
+  getJobs,
   getLocationByCentreline,
   getLocationsByCentreline,
   getLocationsByCorridor,
@@ -482,6 +516,7 @@ export {
   getStudyRequestsByCentrelinePending,
   getUsers,
   getUsersByIds,
+  postJobGenerateReports,
   postStudyRequest,
   postStudyRequestComment,
   putStudyRequest,

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -374,7 +374,7 @@ async function getUsers() {
   return usersSchema.validateAsync(users);
 }
 
-async function postJobGenerateReports(csrf, features, filters, reportFormat) {
+async function postJobGenerateCollisionReports(csrf, features, filters, reportFormat) {
   const s1 = CompositeId.encode(features);
   const data = {
     s1,
@@ -386,7 +386,23 @@ async function postJobGenerateReports(csrf, features, filters, reportFormat) {
     csrf,
     data,
   };
-  const jobMetadata = await schedulerClient.fetch('/jobs/GENERATE_REPORTS', options);
+  const jobMetadata = await schedulerClient.fetch('/jobs/generateCollisionReports', options);
+  return JobMetadata.read.validateAsync(jobMetadata);
+}
+
+async function postJobGenerateStudyReports(csrf, features, filters, reportFormat) {
+  const s1 = CompositeId.encode(features);
+  const data = {
+    s1,
+    ...filters,
+    reportFormat,
+  };
+  const options = {
+    method: 'POST',
+    csrf,
+    data,
+  };
+  const jobMetadata = await schedulerClient.fetch('/jobs/generateStudyReports', options);
   return JobMetadata.read.validateAsync(jobMetadata);
 }
 
@@ -501,7 +517,8 @@ const WebApi = {
   getStudyRequestsByCentrelinePending,
   getUsers,
   getUsersByIds,
-  postJobGenerateReports,
+  postJobGenerateCollisionReports,
+  postJobGenerateStudyReports,
   postStudyRequest,
   postStudyRequestComment,
   putJobCancel,
@@ -538,7 +555,8 @@ export {
   getStudyRequestsByCentrelinePending,
   getUsers,
   getUsersByIds,
-  postJobGenerateReports,
+  postJobGenerateCollisionReports,
+  postJobGenerateStudyReports,
   postStudyRequest,
   postStudyRequestComment,
   putJobCancel,

--- a/lib/controller/JobController.js
+++ b/lib/controller/JobController.js
@@ -111,4 +111,39 @@ JobController.push({
   },
 });
 
+/**
+ * @memberof JobController
+ * @name putJobCancel
+ * @type {Hapi.ServerRoute}
+ */
+JobController.push({
+  method: 'PUT',
+  path: '/jobs/{id}/cancel',
+  options: {
+    auth: {},
+    response: {
+      schema: JobMetadata.read,
+    },
+    validate: {
+      params: {
+        id: Joi.string().uuid().required(),
+      },
+    },
+  },
+  handler: async (request) => {
+    const { id } = request.params;
+
+    const jobMetadata = await JobMetadataDAO.byJobId(id);
+    if (jobMetadata === null) {
+      return Boom.notFound(`no job found with ID ${id}`);
+    }
+    const { state } = jobMetadata;
+    if (state !== 'created' && state !== 'active') {
+      return Boom.badRequest(`cannot cancel job ${id}: state is ${state}`);
+    }
+
+    return JobManager.cancel(jobMetadata);
+  },
+});
+
 export default JobController;

--- a/lib/controller/JobController.js
+++ b/lib/controller/JobController.js
@@ -5,6 +5,7 @@ import JobMetadataDAO from '@/lib/db/JobMetadataDAO';
 import ReportDAO from '@/lib/db/ReportDAO';
 import JobManager from '@/lib/jobs/JobManager';
 import JobType from '@/lib/jobs/JobType';
+import CollisionFilters from '@/lib/model/CollisionFilters';
 import JobMetadata from '@/lib/model/JobMetadata';
 import Joi from '@/lib/model/Joi';
 import StudyFilters from '@/lib/model/StudyFilters';
@@ -19,12 +20,59 @@ const JobController = [];
 
 /**
  * @memberof JobController
- * @name postJobGenerateReports
+ * @name postJobGenerateCollisionReports
  * @type {Hapi.ServerRoute}
  */
 JobController.push({
   method: 'POST',
-  path: '/jobs/GENERATE_REPORTS',
+  path: '/jobs/generateCollisionReports',
+  options: {
+    auth: {},
+    response: {
+      schema: JobMetadata.read,
+    },
+    validate: {
+      payload: {
+        ...CentrelineSelection,
+        ...CollisionFilters,
+        reportFormat: Joi.enum().ofType(ReportFormat).required(),
+      },
+    },
+  },
+  handler: async (request) => {
+    const user = request.auth.credentials;
+    const {
+      s1: features,
+      reportFormat,
+      ...collisionQuery
+    } = request.payload;
+    try {
+      const reports = await ReportDAO.byCentrelineAndCollisionQuery(
+        features,
+        collisionQuery,
+        reportFormat,
+      );
+      if (reports.length === 0) {
+        return Boom.notFound('no reports for given filters');
+      }
+      const data = { reports };
+      const jobMetadata = await JobManager.publish(JobType.GENERATE_REPORTS, data, user);
+      return jobMetadata;
+    } catch (err) {
+      const { statusCode } = HttpStatus.BAD_REQUEST;
+      return Boom.boomify(err, { statusCode, override: false });
+    }
+  },
+});
+
+/**
+ * @memberof JobController
+ * @name postJobGenerateStudyReports
+ * @type {Hapi.ServerRoute}
+ */
+JobController.push({
+  method: 'POST',
+  path: '/jobs/generateStudyReports',
   options: {
     auth: {},
     response: {
@@ -47,7 +95,11 @@ JobController.push({
       ...studyQuery
     } = request.payload;
     try {
-      const reports = await ReportDAO.byCentreline(features, studyQuery, reportFormat);
+      const reports = await ReportDAO.byCentrelineAndStudyQuery(
+        features,
+        studyQuery,
+        reportFormat,
+      );
       if (reports.length === 0) {
         return Boom.notFound('no reports for given filters');
       }

--- a/lib/controller/StorageController.js
+++ b/lib/controller/StorageController.js
@@ -1,6 +1,7 @@
 import Boom from '@hapi/boom';
 import MimeTypes from 'mime-types';
 
+import { HttpStatus } from '@/lib/Constants';
 import storageStrategy from '@/lib/io/storage/StorageStrategy';
 import Joi from '@/lib/model/Joi';
 
@@ -31,7 +32,13 @@ StorageController.push({
   },
   handler: async (request, h) => {
     const { namespace, key } = request.params;
-    const fileExists = await storageStrategy.has(namespace, key);
+    let fileExists;
+    try {
+      fileExists = await storageStrategy.has(namespace, key);
+    } catch (err) {
+      const { statusCode } = HttpStatus.BAD_REQUEST;
+      return Boom.boomify(err, { statusCode, override: false });
+    }
     if (!fileExists) {
       return Boom.notFound(`file not found in storage: ${namespace}/${key}`);
     }

--- a/lib/controller/StorageController.js
+++ b/lib/controller/StorageController.js
@@ -1,0 +1,50 @@
+import Boom from '@hapi/boom';
+import MimeTypes from 'mime-types';
+
+import storageStrategy from '@/lib/io/storage/StorageStrategy';
+import Joi from '@/lib/model/Joi';
+
+/**
+ * Reporting-related routes.
+ *
+ * @type {Array<Hapi.ServerRoute>}
+ */
+const StorageController = [];
+
+/**
+ * Fetch the given report in the given format.
+ *
+ * @memberof StorageController
+ * @name getStorage
+ * @type {Hapi.ServerRoute}
+ */
+StorageController.push({
+  method: 'GET',
+  path: '/storage/{namespace}/{key}',
+  options: {
+    validate: {
+      params: {
+        namespace: Joi.string().required(),
+        key: Joi.string().required(),
+      },
+    },
+  },
+  handler: async (request, h) => {
+    const { namespace, key } = request.params;
+    const fileExists = await storageStrategy.has(namespace, key);
+    if (!fileExists) {
+      return Boom.notFound(`file not found in storage: ${namespace}/${key}`);
+    }
+
+    let mimeType = MimeTypes.lookup(key);
+    if (mimeType === false) {
+      mimeType = 'application/octet-stream';
+    }
+
+    const fileStream = storageStrategy.getStream(namespace, key);
+    return h.response(fileStream)
+      .type(mimeType);
+  },
+});
+
+export default StorageController;

--- a/lib/db/ReportDAO.js
+++ b/lib/db/ReportDAO.js
@@ -1,6 +1,12 @@
+import { ReportType } from '@/lib/Constants';
 import StudyDAO from '@/lib/db/StudyDAO';
+import CompositeId from '@/lib/io/CompositeId';
 import ArrayStats from '@/lib/math/ArrayStats';
 
+const REPORT_TYPES_COLLISION = [
+  ReportType.COLLISION_DIRECTORY,
+  ReportType.COLLISION_TABULATION,
+];
 const LIMIT = 100;
 
 class ReportDAO {
@@ -13,11 +19,28 @@ class ReportDAO {
      * have user-supplied parameters.
      */
     return studyType.reportTypes
+      .filter(reportType => reportType.formats.includes(reportFormat))
       .filter(reportType => !Object.prototype.hasOwnProperty.call(reportType, 'options'))
-      .map(reportType => ({ type: reportType, id, format: reportFormat }));
+      .map(reportType => ({
+        type: reportType,
+        id,
+        format: reportFormat,
+      }));
   }
 
-  static async byCentreline(features, studyQuery, reportFormat) {
+  static async byCentrelineAndCollisionQuery(features, collisionQuery, reportFormat) {
+    const id = CompositeId.encode(features);
+    return REPORT_TYPES_COLLISION
+      .filter(reportType => reportType.formats.includes(reportFormat))
+      .map(reportType => ({
+        type: reportType,
+        id,
+        format: reportFormat,
+        ...collisionQuery,
+      }));
+  }
+
+  static async byCentrelineAndStudyQuery(features, studyQuery, reportFormat) {
     const reports = [];
 
     const studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);

--- a/lib/io/storage/StorageStrategyFilesystem.js
+++ b/lib/io/storage/StorageStrategyFilesystem.js
@@ -20,6 +20,14 @@ class StorageStrategyFilesystem extends StorageStrategyBase {
   }
 
   /**
+   * Get the full on-disk path to the given `namespace` and `key`.  We use `path` / `indexOf`
+   * checks to guard against directory traversal attempts - since `namespace` and `key` can
+   * both be used in this way, we must check after each one is added to the path.
+   *
+   * This is important, as {@link StorageController.getStorage} accepts `namespace` and `key`
+   * parameters from the user.  Every method in {@link StorageStrategyFilesystem} MUST call
+   * this.
+   *
    * @param {string} namespace
    * @param {string} key
    * @returns {string} full path to file at given `namespace` and `key`, including the `root`
@@ -27,10 +35,21 @@ class StorageStrategyFilesystem extends StorageStrategyBase {
    */
   getFullPath(namespace, key) {
     const { root } = this;
+    const namespaceDir = path.join(root, namespace);
+    if (namespaceDir.indexOf(root) !== 0) {
+      throw new Error('directory traversal not allowed');
+    }
+
     const hash = StorageHash.get(key);
     const a = hash.slice(0, 2);
     const b = hash.slice(2, 4);
-    return path.join(root, namespace, a, b, `${hash}_${key}`);
+    const fullDir = path.join(namespaceDir, a, b);
+
+    const fullPath = path.join(fullDir, `${hash}_${key}`);
+    if (path.dirname(fullPath) !== fullDir) {
+      throw new Error('directory traversal not allowed');
+    }
+    return fullPath;
   }
 
   async has(namespace, key) {

--- a/lib/jobs/JobManager.js
+++ b/lib/jobs/JobManager.js
@@ -121,6 +121,18 @@ class JobManager {
     jobMetadata.state = stateCompleted;
     await JobMetadataDAO.update(jobMetadata);
   }
+
+  static async cancel(jobMetadata) {
+    const { jobId } = jobMetadata;
+    await PG_BOSS.cancel(jobId);
+
+    const jobCancelled = await JobDAO.byId(jobId);
+    const persistedJobMetadata = {
+      ...jobMetadata,
+      state: jobCancelled.state,
+    };
+    return JobMetadataDAO.update(persistedJobMetadata);
+  }
 }
 
 PG_BOSS.on('error', JobManager.onError);

--- a/lib/jobs/JobRunnerGenerateReports.js
+++ b/lib/jobs/JobRunnerGenerateReports.js
@@ -2,6 +2,8 @@
 import archiver from 'archiver';
 import stream from 'stream';
 
+import { asyncDelay } from '@/lib/FunctionUtils';
+import Random from '@/lib/Random';
 import AxiosBackendClient from '@/lib/api/AxiosBackendClient';
 import httpsAgentLocal from '@/lib/api/httpsAgentLocal';
 import config from '@/lib/config/MoveConfig';
@@ -14,7 +16,21 @@ const reporterClientOptions = {};
 if (config.https !== null) {
   reporterClientOptions.httpsAgent = httpsAgentLocal;
 }
-const reporterClient = new AxiosBackendClient('https://localhost:8200', reporterClientOptions);
+const reporterClient = new AxiosBackendClient(config.reporter, reporterClientOptions);
+
+/*
+ * To prevent any one bulk report generation job from overwhelming `reporter`, we force all
+ * such jobs to wait between report requests.
+ *
+ * Furthermore, since regularly spaced delays can lead to load spikes, we impose a random
+ * delay each time.  Under heavier load, this should result in more uniform request rates.
+ *
+ * Finally: if we're ever in a situation where `reporter` cannot handle load, but we also
+ * cannot quickly add more `reporter` instances, we can tweak these values and restart
+ * `scheduler`.
+ */
+const DELAY_MIN = 2000;
+const DELAY_MAX = 4000;
 
 class JobRunnerGenerateReports extends JobRunnerBase {
   static async fetchReportStream(report) {
@@ -30,11 +46,12 @@ class JobRunnerGenerateReports extends JobRunnerBase {
     const { namespace, key } = StoragePath.forReport(report);
     const reportExists = await storageStrategy.has(namespace, key);
     if (reportExists) {
-      return;
+      return false;
     }
     const valueStream = await JobRunnerGenerateReports.fetchReportStream(report);
     const writableStream = await storageStrategy.putStream(namespace, key, valueStream);
     await writableStreamFinish(writableStream);
+    return true;
   }
 
   async zipReports(reports) {
@@ -70,9 +87,16 @@ class JobRunnerGenerateReports extends JobRunnerBase {
     for (let i = 0; i < n; i++) {
       const report = reports[i];
       /* eslint-disable-next-line no-await-in-loop */
-      await this.saveReport(report);
+      const savedNew = await this.saveReport(report);
       /* eslint-disable-next-line no-await-in-loop */
       await this.incrProgressCurrent();
+
+      if (savedNew) {
+        // Random delay strategy; see `DELAY_MIN` / `DELAY_MAX` above.
+        const wait = Random.range(DELAY_MIN, DELAY_MAX);
+        /* eslint-disable-next-line no-await-in-loop */
+        await asyncDelay(wait);
+      }
     }
     return this.zipReports(reports);
   }

--- a/lib/jobs/JobType.js
+++ b/lib/jobs/JobType.js
@@ -19,7 +19,7 @@ JobType.init({
           type: Joi.enum().ofType(ReportType).required(),
           id: Joi.string().required(),
           format: Joi.enum().ofType(ReportFormat).required(),
-        }),
+        }).unknown(),
       ),
     }),
     getProgressTotal({ reports }) {

--- a/lib/time/DateTimeZone.js
+++ b/lib/time/DateTimeZone.js
@@ -28,6 +28,10 @@ class DateTimeZone {
     return this.toSQL();
   }
 
+  valueOf() {
+    return this.dt.valueOf();
+  }
+
   static fromJSON(value) {
     return DateTimeZone.fromSQL(value);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20606,11 +20606,18 @@
       "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
     },
     "mime-types": {
-      "version": "2.1.24",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
       "requires": {
-        "mime-db": "1.40.0"
+        "mime-db": "1.44.0"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.44.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+          "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+        }
       }
     },
     "mimic-fn": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "jsdom": "^16.4.0",
     "luxon": "^1.24.1",
     "mapbox-gl": "^1.12.0",
+    "mime-types": "^2.1.27",
     "module-alias": "^2.2.2",
     "mustache": "^4.0.1",
     "openid-client": "^3.11.0",

--- a/scripts/db/schema-13.down.sql
+++ b/scripts/db/schema-13.down.sql
@@ -3,5 +3,7 @@ BEGIN;
 DROP TABLE "job_metadata" CASCADE;
 DROP TABLE "sessions" CASCADE;
 
+DROP SCHEMA IF EXISTS pgboss CASCADE;
+
 UPDATE "APP_META"."DB_UPDATE" SET "currentVersion" = 12;
 COMMIT;

--- a/scripts/db/schema-13.up.sql
+++ b/scripts/db/schema-13.up.sql
@@ -1,5 +1,8 @@
 BEGIN;
 
+-- The `pgboss` schema is created by `scheduler` via `PG_BOSS.start()`, and does
+-- not need to be created here.
+
 CREATE TABLE "sessions" (
   "id" UUID PRIMARY KEY NOT NULL DEFAULT gen_random_uuid(),
   "createdAt" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/tests/jest/unit/FunctionUtils.spec.js
+++ b/tests/jest/unit/FunctionUtils.spec.js
@@ -1,17 +1,40 @@
-import FunctionUtils from '@/lib/FunctionUtils';
+import { asyncDelay, debounce } from '@/lib/FunctionUtils';
 
 jest.useFakeTimers();
 
-test('FunctionUtils.debounce()', () => {
+test('FunctionUtils.asyncDelay', async () => {
+  let resolved = false;
+  async function asyncDelayHelper(wait) {
+    await asyncDelay(wait);
+    resolved = true;
+  }
+
+  const WAIT_MS = 10;
+  asyncDelayHelper(WAIT_MS);
+  expect(resolved).toBe(false);
+
+  jest.advanceTimersByTime(WAIT_MS - 1);
+  /*
+   * Allow event loop to fire so that our `asyncDelayHelper` promise can be
+   * resolved if it's ready.  (It's not ready yet, but we use the same trick
+   * below once it is.)
+   */
+  await Promise.resolve();
+  expect(resolved).toBe(false);
+
+  jest.advanceTimersByTime(1);
+  await Promise.resolve();
+  expect(resolved).toBe(true);
+});
+
+test('FunctionUtils.debounce', () => {
   const WAIT_MS = 10;
   let x = 0;
-  const foo = FunctionUtils.debounce(() => {
+  const foo = debounce(() => {
     x += 1;
   }, WAIT_MS);
 
   foo();
-  expect(setTimeout).toHaveBeenCalledTimes(1);
-  expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), WAIT_MS);
   expect(x).toEqual(0);
 
   foo();

--- a/tests/jest/unit/api/QueryString.spec.js
+++ b/tests/jest/unit/api/QueryString.spec.js
@@ -16,3 +16,13 @@ test('QueryString.get', () => {
     a: ['1', '2'],
   })).toEqual('a=1&a=2');
 });
+
+test('QueryString.get [null values]', () => {
+  expect(QueryString.get({
+    a: null,
+  })).toEqual('');
+  expect(QueryString.get({
+    a: '1',
+    b: null,
+  })).toEqual('a=1');
+});

--- a/tests/jest/unit/io/storage/StorageStrategyFilesystem.spec.js
+++ b/tests/jest/unit/io/storage/StorageStrategyFilesystem.spec.js
@@ -61,6 +61,23 @@ test('StorageStrategyFilesystem [buffer API, fuzz test]', async () => {
   }
 });
 
+test('StorageStrategyFilesystem [buffer API, directory traversal]', async () => {
+  const storage = new StorageStrategyFilesystem('/data/move-storage/buffer');
+
+  let namespace = '../..';
+  let key = 'bar';
+  const value = Buffer.from('baz');
+  await expect(storage.put(namespace, key, value)).rejects.toBeInstanceOf(Error);
+  await expect(storage.has(namespace, key)).rejects.toBeInstanceOf(Error);
+  await expect(storage.get(namespace, key)).rejects.toBeInstanceOf(Error);
+
+  namespace = 'bar';
+  key = '../..';
+  await expect(storage.put(namespace, key, value)).rejects.toBeInstanceOf(Error);
+  await expect(storage.has(namespace, key)).rejects.toBeInstanceOf(Error);
+  await expect(storage.get(namespace, key)).rejects.toBeInstanceOf(Error);
+});
+
 test('StorageStrategyFilesystem [stream API]', async () => {
   const storage = new StorageStrategyFilesystem('/data/move-storage/stream');
   const namespace = 'foo';
@@ -113,4 +130,26 @@ test('StorageStrategyFilesystem [stream API, fuzz test]', async () => {
     valueStream = storage.getStream(namespace, key);
     await expect(readableStreamToBuffer(valueStream)).resolves.toEqual(value);
   }
+});
+
+test('StorageStrategyFilesystem [stream API, directory traversal]', async () => {
+  const storage = new StorageStrategyFilesystem('/data/move-storage/stream');
+
+  let namespace = '../..';
+  let key = 'bar';
+  const value = Buffer.from('baz');
+  const valueStream = bufferToDuplexStream(value);
+  await expect(storage.putStream(namespace, key, valueStream)).rejects.toBeInstanceOf(Error);
+  await expect(storage.has(namespace, key)).rejects.toBeInstanceOf(Error);
+  expect(() => {
+    storage.getStream(namespace, key);
+  }).toThrow(Error);
+
+  namespace = 'bar';
+  key = '../..';
+  await expect(storage.putStream(namespace, key, valueStream)).rejects.toBeInstanceOf(Error);
+  await expect(storage.has(namespace, key)).rejects.toBeInstanceOf(Error);
+  expect(() => {
+    storage.getStream(namespace, key);
+  }).toThrow(Error);
 });

--- a/web/App.vue
+++ b/web/App.vue
@@ -5,9 +5,11 @@
       v-model="hasDialog"
       :is="'FcDialog' + dialog"
       v-bind="dialogData" />
-    <FcToast
-      v-if="toast !== null"
-      v-bind="toast" />
+    <component
+      v-if="hasToast"
+      v-model="hasToast"
+      :is="'FcToast' + toast"
+      v-bind="toastData" />
     <v-navigation-drawer
       app
       mini-variant
@@ -45,7 +47,8 @@ import FcDialogAlertStudyRequestUrgent from
   '@/web/components/dialogs/FcDialogAlertStudyRequestUrgent.vue';
 import FcDialogConfirmUnauthorized from
   '@/web/components/dialogs/FcDialogConfirmUnauthorized.vue';
-import FcToast from '@/web/components/dialogs/FcToast.vue';
+import FcToastInfo from '@/web/components/dialogs/FcToastInfo.vue';
+import FcToastJob from '@/web/components/dialogs/FcToastJob.vue';
 import FcDashboardNav from '@/web/components/nav/FcDashboardNav.vue';
 import FcDashboardNavBrand from '@/web/components/nav/FcDashboardNavBrand.vue';
 import FcDashboardNavInDevelopment from '@/web/components/nav/FcDashboardNavInDevelopment.vue';
@@ -61,7 +64,8 @@ export default {
     FcDialogAlertInDevelopment,
     FcDialogAlertStudyRequestUrgent,
     FcDialogConfirmUnauthorized,
-    FcToast,
+    FcToastInfo,
+    FcToastJob,
   },
   computed: {
     hasDialog: {
@@ -74,12 +78,23 @@ export default {
         }
       },
     },
+    hasToast: {
+      get() {
+        return this.toast !== null;
+      },
+      set(hasToast) {
+        if (!hasToast) {
+          this.clearDialog();
+        }
+      },
+    },
     ...mapState([
       'auth',
       'dialog',
       'dialogData',
       'location',
       'toast',
+      'toastData',
     ]),
   },
   methods: {

--- a/web/WebServer.js
+++ b/web/WebServer.js
@@ -3,6 +3,7 @@ import CollisionController from '@/lib/controller/CollisionController';
 import DynamicTileController from '@/lib/controller/DynamicTileController';
 import LocationController from '@/lib/controller/LocationController';
 import PoiController from '@/lib/controller/PoiController';
+import StorageController from '@/lib/controller/StorageController';
 import StudyController from '@/lib/controller/StudyController';
 import StudyRequestController from '@/lib/controller/StudyRequestController';
 import UserController from '@/lib/controller/UserController';
@@ -18,6 +19,7 @@ class WebServer extends MoveServer {
       .addController(DynamicTileController)
       .addController(LocationController)
       .addController(PoiController)
+      .addController(StorageController)
       .addController(StudyController)
       .addController(StudyRequestController)
       .addController(UserController)

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -99,7 +99,7 @@
 </template>
 
 <script>
-import { mapGetters, mapMutations } from 'vuex';
+import { mapGetters, mapMutations, mapState } from 'vuex';
 
 import { Enum } from '@/lib/ClassUtils';
 import {
@@ -109,6 +109,7 @@ import {
   getStudiesByCentrelineSummary,
   getStudiesByCentrelineSummaryPerLocation,
   getStudiesByCentrelineTotal,
+  postJobGenerateReports,
 } from '@/lib/api/WebApi';
 import FcAggregateCollisions from '@/web/components/data/FcAggregateCollisions.vue';
 import FcAggregateStudies from '@/web/components/data/FcAggregateStudies.vue';
@@ -175,6 +176,7 @@ export default {
     };
   },
   computed: {
+    ...mapState(['auth']),
     ...mapGetters('viewData', [
       'filterParamsCollision',
       'filterParamsStudy',
@@ -226,16 +228,17 @@ export default {
     this.syncLocations();
   },
   methods: {
-    actionDownloadReportFormat() {
+    async actionDownloadReportFormat(reportFormat) {
+      const job = await postJobGenerateReports(
+        this.auth.csrf,
+        this.locations,
+        this.filterParamsStudy,
+        reportFormat,
+      );
+
       this.setToast({
-        action: {
-          callback: () => {
-            /* eslint-disable-next-line no-alert */
-            window.alert('Coming Soon!');
-          },
-          text: 'Undo',
-        },
-        text: 'Generating reports (10 of 23, 2 minutes)',
+        toast: 'Job',
+        toastData: { job },
       });
     },
     actionRequestStudy() {
@@ -302,12 +305,10 @@ export default {
         this.exportMode = null;
       } else {
         this.exportMode = exportMode;
-        this.setToast({
-          text: 'You\'re currently in Export Report Mode.',
-        });
+        this.setToastInfo('You\'re currently in Export Report Mode.');
       }
     },
-    ...mapMutations(['setToast']),
+    ...mapMutations(['setToast', 'setToastInfo']),
   },
 };
 </script>

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -34,7 +34,7 @@
             </FcButton>
             <FcMenuDownloadReportFormat
               v-else
-              @download-report-format="actionDownloadReportFormat" />
+              @download-report-format="actionDownloadReportFormatCollisions" />
           </template>
         </FcHeaderCollisions>
 
@@ -80,7 +80,7 @@
             </FcButton>
             <FcMenuDownloadReportFormat
               v-else
-              @download-report-format="actionDownloadReportFormat" />
+              @download-report-format="actionDownloadReportFormatStudies" />
           </template>
         </FcHeaderStudies>
 
@@ -109,7 +109,8 @@ import {
   getStudiesByCentrelineSummary,
   getStudiesByCentrelineSummaryPerLocation,
   getStudiesByCentrelineTotal,
-  postJobGenerateReports,
+  postJobGenerateCollisionReports,
+  postJobGenerateStudyReports,
 } from '@/lib/api/WebApi';
 import FcAggregateCollisions from '@/web/components/data/FcAggregateCollisions.vue';
 import FcAggregateStudies from '@/web/components/data/FcAggregateStudies.vue';
@@ -228,19 +229,23 @@ export default {
     this.syncLocations();
   },
   methods: {
-    async actionDownloadReportFormat(reportFormat) {
-      if (this.exportMode === ExportMode.COLLISIONS) {
-        this.actionDownloadReportFormatCollisions(reportFormat);
-      } else if (this.exportMode === ExportMode.STUDIES) {
-        this.actionDownloadReportFormatStudies(reportFormat);
-      }
-    },
-    async actionDownloadReportFormatCollisions(/* reportFormat */) {
-      /* eslint-disable-next-line no-alert */
-      window.alert('Coming Soon!');
+    async actionDownloadReportFormatCollisions(reportFormat) {
+      const job = await postJobGenerateCollisionReports(
+        this.auth.csrf,
+        this.locations,
+        this.filterParamsCollision,
+        reportFormat,
+      );
+
+      this.setToast({
+        toast: 'Job',
+        toastData: { job },
+      });
+
+      this.exportMode = null;
     },
     async actionDownloadReportFormatStudies(reportFormat) {
-      const job = await postJobGenerateReports(
+      const job = await postJobGenerateStudyReports(
         this.auth.csrf,
         this.locations,
         this.filterParamsStudy,
@@ -251,6 +256,8 @@ export default {
         toast: 'Job',
         toastData: { job },
       });
+
+      this.exportMode = null;
     },
     actionRequestStudy() {
       /* eslint-disable-next-line no-alert */

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -229,6 +229,17 @@ export default {
   },
   methods: {
     async actionDownloadReportFormat(reportFormat) {
+      if (this.exportMode === ExportMode.COLLISIONS) {
+        this.actionDownloadReportFormatCollisions(reportFormat);
+      } else if (this.exportMode === ExportMode.STUDIES) {
+        this.actionDownloadReportFormatStudies(reportFormat);
+      }
+    },
+    async actionDownloadReportFormatCollisions(/* reportFormat */) {
+      /* eslint-disable-next-line no-alert */
+      window.alert('Coming Soon!');
+    },
+    async actionDownloadReportFormatStudies(reportFormat) {
       const job = await postJobGenerateReports(
         this.auth.csrf,
         this.locations,

--- a/web/components/dialogs/FcToast.vue
+++ b/web/components/dialogs/FcToast.vue
@@ -10,6 +10,7 @@
       <FcButton
         v-if="action !== null"
         color="white"
+        :disabled="loading"
         :loading="loading"
         type="tertiary"
         v-bind="attrs"

--- a/web/components/dialogs/FcToast.vue
+++ b/web/components/dialogs/FcToast.vue
@@ -1,19 +1,20 @@
 <template>
   <v-snackbar
-    v-model="hasToast"
+    v-model="internalValue"
     bottom
     class="fc-toast pb-5 pl-7"
-    :color="color + ' darken-2'"
+    :color="color + ' darker-1'"
     :timeout="timeout">
     <span class="body-1">{{text}}</span>
     <template v-slot:action="{ attrs }">
       <FcButton
         v-if="action !== null"
         color="white"
+        :loading="loading"
         type="tertiary"
         v-bind="attrs"
         @click="actionCallback">
-        {{action.text}}
+        {{action}}
       </FcButton>
     </template>
   </v-snackbar>
@@ -23,44 +24,40 @@
 import { mapMutations } from 'vuex';
 
 import FcButton from '@/web/components/inputs/FcButton.vue';
+import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
 const TIMEOUT_NEVER = -1;
-const TIMEOUT_NON_CLOSEABLE = 10000;
+const TIMEOUT_AUTO_CLOSE = 10000;
 
 export default {
   name: 'FcToast',
+  mixins: [FcMixinVModelProxy(Boolean)],
   components: {
     FcButton,
   },
   props: {
     action: {
-      type: Object,
+      type: String,
       default: null,
     },
     color: {
       type: String,
       default: 'black',
     },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
     text: String,
   },
   computed: {
-    hasToast: {
-      get() {
-        return this.toast !== null;
-      },
-      set(hasToast) {
-        if (!hasToast) {
-          this.clearToast();
-        }
-      },
-    },
     timeout() {
-      return this.action === null ? TIMEOUT_NON_CLOSEABLE : TIMEOUT_NEVER;
+      return this.action === null ? TIMEOUT_AUTO_CLOSE : TIMEOUT_NEVER;
     },
   },
   methods: {
     actionCallback() {
-      this.action.callback();
+      this.$emit('toast-action');
       this.clearToast();
     },
     ...mapMutations(['clearToast']),

--- a/web/components/dialogs/FcToastInfo.vue
+++ b/web/components/dialogs/FcToastInfo.vue
@@ -1,0 +1,21 @@
+<template>
+  <FcToast
+    v-model="internalValue"
+    :text="text" />
+</template>
+
+<script>
+import FcToast from '@/web/components/dialogs/FcToast.vue';
+import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+
+export default {
+  name: 'FcToastInfo',
+  mixins: [FcMixinVModelProxy(Boolean)],
+  components: {
+    FcToast,
+  },
+  props: {
+    text: String,
+  },
+};
+</script>

--- a/web/components/dialogs/FcToastJob.vue
+++ b/web/components/dialogs/FcToastJob.vue
@@ -190,7 +190,10 @@ export default {
       }
 
       const now = DateTimeZone.utc();
-      const elapsed = now.valueOf() - startedAt.valueOf();
+      let elapsed = now.valueOf() - startedAt.valueOf();
+      if (elapsed < INTERVAL_GET_JOB) {
+        elapsed = INTERVAL_GET_JOB;
+      }
       const f = progressCurrent / progressTotal;
       const timeRemaining = Math.round(elapsed * (1 - f) / f);
 

--- a/web/components/dialogs/FcToastJob.vue
+++ b/web/components/dialogs/FcToastJob.vue
@@ -1,0 +1,180 @@
+<template>
+  <FcToast
+    v-model="internalValue"
+    :action="action"
+    :color="color"
+    :loading="loading"
+    :text="text"
+    @toast-action="actionToast" />
+</template>
+
+<script>
+import { mapMutations } from 'vuex';
+
+import { getJob } from '@/lib/api/WebApi';
+import DateTime from '@/lib/time/DateTime';
+import FcToast from '@/web/components/dialogs/FcToast.vue';
+import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+
+const INTERVAL_TICK = 1000;
+const INTERVAL_GET_JOB = 5000;
+
+export default {
+  name: 'FcToastJob',
+  mixins: [FcMixinVModelProxy(Boolean)],
+  components: {
+    FcToast,
+  },
+  props: {
+    job: Object,
+  },
+  data() {
+    return {
+      internalJob: this.job,
+      loading: false,
+      progressCurrentPrev: 0,
+      timeRemaining: null,
+    };
+  },
+  created() {
+    this.setIntervals();
+  },
+  beforeDestroy() {
+    this.clearIntervals();
+  },
+  computed: {
+    action() {
+      const { state } = this.job;
+      if (state === 'created' || state === 'active') {
+        return 'Undo';
+      }
+      if (state === 'completed') {
+        return 'Download';
+      }
+      return null;
+    },
+    color() {
+      const { state } = this.job;
+      if (state === 'failed') {
+        return 'error';
+      }
+      return 'black';
+    },
+    text() {
+      const { progressCurrent, progressTotal, state } = this.job;
+      if (state === 'created') {
+        return 'Generating reports (waiting to start)';
+      }
+      if (progressCurrent === progressTotal) {
+        return 'Archiving reports';
+      }
+      if (progressCurrent === 0 || this.timeRemaining === null) {
+        return 'Generating reports (estimating time)';
+      }
+      return `Generating reports (${progressCurrent} of ${progressTotal}, ${this.textTimeRemaining})`;
+    },
+    textTimeRemaining() {
+      if (this.timeRemaining === null) {
+        return null;
+      }
+
+      let s = Math.floor(this.timeRemaining / 1000);
+      let m = Math.floor(s / 60);
+      const h = Math.floor(m / 60);
+      m %= 60;
+      s %= 60;
+
+      if (h > 1) {
+        return 'a while';
+      }
+      if (h === 1) {
+        return `1 hour ${m} minutes`;
+      }
+      if (m > 1) {
+        return `${m} minutes`;
+      }
+      if (m === 1) {
+        return `1 minute ${s} seconds`;
+      }
+      if (s > 1) {
+        return `${s} seconds`;
+      }
+      if (s === 1) {
+        return '1 second';
+      }
+      return 'now';
+    },
+  },
+  methods: {
+    actionDownload() {
+      /* eslint-disable-next-line no-alert */
+      window.alert('Coming Soon!');
+    },
+    actionToast() {
+      const { state } = this.job;
+      if (state === 'created' || state === 'active') {
+        this.actionUndo();
+      } else if (state === 'completed') {
+        this.actionDownload();
+      }
+    },
+    actionUndo() {
+      /* eslint-disable-next-line no-alert */
+      window.alert('Coming Soon!');
+    },
+    clearIntervals() {
+      if (this.intervalGetJob !== null) {
+        window.clearInterval(this.intervalGetJob);
+        this.intervalGetJob = null;
+      }
+      if (this.intervalTick !== null) {
+        window.clearInterval(this.intervalTick);
+        this.intervalTick = null;
+      }
+    },
+    setIntervals() {
+      this.intervalGetJob = window.setInterval(
+        this.updateGetJob.bind(this),
+        INTERVAL_GET_JOB,
+      );
+      this.intervalTick = window.setInterval(
+        this.updateTick.bind(this),
+        INTERVAL_TICK,
+      );
+    },
+    async updateGetJob() {
+      const job = await getJob(this.job.jobId);
+      this.internalJob = job;
+
+      const {
+        progressCurrent,
+        progressTotal,
+        startedAt,
+        state,
+      } = this.internalJob;
+      if (state !== 'created' || state !== 'active') {
+        this.clearIntervals();
+        this.timeRemaining = null;
+      }
+      if (progressCurrent === this.progressCurrentPrev) {
+        return;
+      }
+
+      const now = DateTime.local();
+      const elapsed = now.valueOf() - startedAt.valueOf();
+      const f = progressCurrent / progressTotal;
+      const timeRemaining = Math.round(elapsed * (1 - f) / f);
+
+      this.timeRemaining = timeRemaining;
+      this.progressCurrentPrev = progressCurrent;
+    },
+    updateTick() {
+      if (this.timeRemaining === null) {
+        return;
+      }
+      this.timeRemaining -= INTERVAL_TICK;
+    },
+    ...mapMutations(['clearToast']),
+  },
+};
+</script>

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -42,6 +42,7 @@ export default new Vuex.Store({
     dialogData: {},
     drawerOpen: false,
     toast: null,
+    toastData: {},
     // NAVIGATION
     backViewRequest: { name: 'requestsTrack' },
     // LOCATION
@@ -152,6 +153,7 @@ export default new Vuex.Store({
     },
     clearToast(state) {
       Vue.set(state, 'toast', null);
+      Vue.set(state, 'toastData', {});
     },
     setDialog(state, { dialog, dialogData = {} }) {
       Vue.set(state, 'dialog', dialog);
@@ -160,8 +162,13 @@ export default new Vuex.Store({
     setDrawerOpen(state, drawerOpen) {
       Vue.set(state, 'drawerOpen', drawerOpen);
     },
-    setToast(state, toast) {
+    setToast(state, { toast, toastData = {} }) {
       Vue.set(state, 'toast', toast);
+      Vue.set(state, 'toastData', toastData);
+    },
+    setToastInfo(state, text) {
+      Vue.set(state, 'toast', 'Info');
+      Vue.set(state, 'toastData', { text });
     },
     // NAVIGATION
     setBackViewRequest(state, backViewRequest) {


### PR DESCRIPTION
# Issue Addressed
This PR closes #560 .

# Description
We integrate backgroudn report generation via `scheduler` / `reporter` in the aggregate view within View Data, adding new buttons / modes to match designs and connecting those to new methods in `WebApi` that call relevant API endpoints.

We also add `FcToastJob`, which polls `GET /job/{id}` in the `scheduler` service to check on the status of the given job.  This toast offers job state-dependent actions: undo (i.e. cancel) when the job is in progress, download once it has completed.  Downloads are powered by the new `StorageController`, which returns the result of `storageStrategy.getStream()` in the response and uses `mime-types` to infer MIME type from the storage `key`.

Note that this does _not_ yet include any of the selection / filter modal parts of this feature from the designs; those are coming soon!

# Tests
Tested bulk reporting modes in the frontend for both collision and study reports.  Added unit tests for directory traversal mitigation in `StorageStrategyFilesystem`, as well as for `null` parameters in `QueryString`.