### PR TITLE
Bulk downloads: notification dot, authentication, prioritization

### DIFF
--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -95,6 +95,11 @@ async function getJobs() {
   return normalizeJobMetadatas(jobMetadatas);
 }
 
+async function getJobsExistsNew() {
+  const response = await schedulerClient.fetch('/jobs/existsNew');
+  return response.existsNew;
+}
+
 async function getLocationsByCentreline(features) {
   if (features.length === 0) {
     return [];
@@ -513,6 +518,7 @@ const WebApi = {
   getCollisionsByCentrelineTotal,
   getJob,
   getJobs,
+  getJobsExistsNew,
   getLocationByCentreline,
   getLocationsByCentreline,
   getLocationsByCorridor,
@@ -552,6 +558,7 @@ export {
   getCollisionsByCentrelineTotal,
   getJob,
   getJobs,
+  getJobsExistsNew,
   getLocationByCentreline,
   getLocationsByCentreline,
   getLocationsByCorridor,

--- a/lib/controller/JobController.js
+++ b/lib/controller/JobController.js
@@ -180,6 +180,29 @@ JobController.push({
 
 /**
  * @memberof JobController
+ * @name getJobsExistsNew
+ * @type {Hapi.ServerRoute}
+ */
+JobController.push({
+  method: 'GET',
+  path: '/jobs/existsNew',
+  options: {
+    auth: {},
+    response: {
+      schema: {
+        existsNew: Joi.boolean().required(),
+      },
+    },
+  },
+  handler: async (request) => {
+    const user = request.auth.credentials;
+    const existsNew = await JobMetadataDAO.byUserExistsNew(user);
+    return { existsNew };
+  },
+});
+
+/**
+ * @memberof JobController
  * @name putJobCancel
  * @type {Hapi.ServerRoute}
  */

--- a/lib/db/JobMetadataDAO.js
+++ b/lib/db/JobMetadataDAO.js
@@ -101,6 +101,18 @@ ORDER BY "createdAt" DESC`;
     return normalizeJobMetadatas(persistedJobMetadatas);
   }
 
+  static async byUserExistsNew(user) {
+    const sql = `
+SELECT EXISTS (
+  SELECT 1 FROM job_metadata
+  WHERE "userId" = $(userId)
+  AND NOT "dismissed"
+) AS "existsNew"`;
+    const { id: userId } = user;
+    const result = await db.one(sql, { userId });
+    return result.existsNew;
+  }
+
   static async update(jobMetadata) {
     const sql = `
 UPDATE "job_metadata" SET

--- a/lib/jobs/JobPoller.js
+++ b/lib/jobs/JobPoller.js
@@ -63,10 +63,7 @@ class JobPoller extends EventTarget {
     if (state === 'completed') {
       return `Reports ready (${progressTotal} reports)`;
     }
-    if (state === 'failed') {
-      return 'Reports failed';
-    }
-    return null;
+    return `Reports ${state}`;
   }
 
   get textTimeRemaining() {

--- a/scripts/db/schema-14.up.sql
+++ b/scripts/db/schema-14.up.sql
@@ -1,5 +1,6 @@
 BEGIN;
 
+TRUNCATE TABLE "job_metadata";
 ALTER TABLE "job_metadata" ADD COLUMN "description" VARCHAR NOT NULL;
 ALTER TABLE "job_metadata" ADD COLUMN "metadata" JSONB NOT NULL;
 

--- a/tests/jest/db/JobMetadataDAO.spec.js
+++ b/tests/jest/db/JobMetadataDAO.spec.js
@@ -66,6 +66,15 @@ test('JobMetadataDAO', async () => {
   let fetchedJobMetadatas = await JobMetadataDAO.byUser(persistedUser);
   expect(fetchedJobMetadatas).toContainEqual(persistedJobMetadata1);
 
+  let existsNew = await JobMetadataDAO.byUserExistsNew(persistedUser);
+  expect(existsNew).toBe(true);
+
+  persistedJobMetadata1.dismissed = true;
+  fetchedJobMetadata = await JobMetadataDAO.update(persistedJobMetadata1);
+  expect(fetchedJobMetadata).toEqual(persistedJobMetadata1);
+  existsNew = await JobMetadataDAO.byUserExistsNew(persistedUser);
+  expect(existsNew).toBe(false);
+
   const jobId2 = uuidv4();
   const transientJob2 = {
     id: jobId2,
@@ -93,4 +102,7 @@ test('JobMetadataDAO', async () => {
   persistedJobMetadata2.result = { namespace: 'reports', key: '1f2e3d4c.zip' };
   fetchedJobMetadata = await JobMetadataDAO.update(persistedJobMetadata2);
   expect(fetchedJobMetadata).toEqual(persistedJobMetadata2);
+
+  existsNew = await JobMetadataDAO.byUserExistsNew(persistedUser);
+  expect(existsNew).toBe(true);
 });

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -14,6 +14,7 @@
               :disabled="
                 collisionSummary.amount === 0
                 || reportExportMode === ReportExportMode.STUDIES"
+              :scope="[]"
               type="secondary"
               @click="actionToggleReportExportMode(ReportExportMode.COLLISIONS)">
               <template v-if="reportExportMode === ReportExportMode.COLLISIONS">
@@ -31,6 +32,7 @@
               :disabled="
                 collisionSummary.amount === 0
                 || reportExportMode === ReportExportMode.STUDIES"
+              :scope="[]"
               type="secondary"
               @click="actionShowReportsCollision">
               <v-icon color="primary" left>mdi-file-eye</v-icon>
@@ -64,6 +66,7 @@
               :disabled="
                 studySummary.length === 0
                 || reportExportMode === ReportExportMode.COLLISIONS"
+              :scope="[]"
               type="secondary"
               @click="actionToggleReportExportMode(ReportExportMode.STUDIES)">
               <template v-if="reportExportMode === ReportExportMode.STUDIES">
@@ -81,6 +84,7 @@
               :disabled="
                 studySummary.length === 0
                 || reportExportMode === ReportExportMode.COLLISIONS"
+              :scope="[]"
               type="secondary"
               @click="actionRequestStudy">
               <v-icon color="primary" left>mdi-plus-box</v-icon>
@@ -126,9 +130,13 @@ import FcHeaderCollisions from '@/web/components/data/FcHeaderCollisions.vue';
 import FcHeaderStudies from '@/web/components/data/FcHeaderStudies.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcMenuDownloadReportFormat from '@/web/components/inputs/FcMenuDownloadReportFormat.vue';
+import FcMixinAuthScope from '@/web/mixins/FcMixinAuthScope';
 
 export default {
   name: 'FcViewDataAggregate',
+  mixins: [
+    FcMixinAuthScope,
+  ],
   components: {
     FcAggregateCollisions,
     FcAggregateStudies,

--- a/web/components/jobs/FcCardJob.vue
+++ b/web/components/jobs/FcCardJob.vue
@@ -1,12 +1,15 @@
 <template>
   <v-card
-    class="fc-card-job mb-4"
+    class="fc-card-job mb-4 ml-4"
     :class="{
+      'fc-card-job-cancelled': internalJob.state === 'cancelled',
       'fc-card-job-dismissed': internalJob.dismissed,
-    }">
+      'fc-card-job-failed': internalJob.state === 'failed',
+    }"
+    :outlined="internalJob.state === 'cancelled' || internalJob.state === 'failed'">
     <v-card-title>
       <div>
-        <h2>{{job.description}}</h2>
+        <h3>{{job.description}}</h3>
         <div class="body-1 mt-1">
           {{text}} &#x2022; {{textUpdatedAt}}
         </div>
@@ -18,9 +21,7 @@
         v-if="action !== null"
         :type="internalJob.dismissed ? 'secondary' : 'primary'"
         @click="actionCard">
-        <v-icon
-          :color="internalJob.dismissed ? 'primary' : 'white'"
-          left>
+        <v-icon left>
           {{iconAction}}
         </v-icon>
         {{action}}
@@ -146,6 +147,10 @@ export default {
 <style lang="scss">
 .v-sheet.v-card.fc-card-job {
   border-left: 4px solid var(--v-primary-base);
+  &.fc-card-job-cancelled,
+  &.fc-card-job-failed {
+    opacity: 0.5;
+  }
   &.fc-card-job-dismissed {
     border-left: 0;
   }

--- a/web/components/nav/FcDashboardNav.vue
+++ b/web/components/nav/FcDashboardNav.vue
@@ -20,6 +20,7 @@
       label="Track Requests"
       :to="{ name: 'requestsTrack' }" />
     <FcDashboardNavItem
+      :badge="jobsExistsNew"
       icon="download"
       label="Manage Downloads"
       :to="{ name: 'downloadsManage' }" />
@@ -27,14 +28,21 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex';
+import { mapGetters, mapState } from 'vuex';
 
+import { getJobsExistsNew } from '@/lib/api/WebApi';
 import FcDashboardNavItem from '@/web/components/nav/FcDashboardNavItem.vue';
 
 export default {
   name: 'FcDashboardNav',
   components: {
     FcDashboardNavItem,
+  },
+  data() {
+    return {
+      jobsExistsNew: false,
+      loading: true,
+    };
   },
   computed: {
     toViewMap() {
@@ -47,7 +55,29 @@ export default {
         params,
       };
     },
+    ...mapState(['auth']),
     ...mapGetters(['locationsEmpty', 'locationsRouteParams']),
+  },
+  watch: {
+    'auth.loggedIn': function watchAuthLoggedIn() {
+      this.loadAsync();
+    },
+  },
+  created() {
+    this.loadAsync();
+  },
+  methods: {
+    async loadAsync() {
+      if (!this.auth.loggedIn) {
+        this.jobsExistsNew = false;
+        return;
+      }
+
+      this.loading = true;
+      const jobsExistsNew = await getJobsExistsNew();
+      this.jobsExistsNew = jobsExistsNew;
+      this.loading = false;
+    },
   },
 };
 </script>

--- a/web/components/nav/FcDashboardNavItem.vue
+++ b/web/components/nav/FcDashboardNavItem.vue
@@ -13,7 +13,13 @@
         :to="to"
         @click="actionClick">
         <v-list-item-icon>
-          <v-icon>mdi-{{icon}}</v-icon>
+          <div class="fc-badge-wrapper">
+            <v-icon>mdi-{{icon}}</v-icon>
+            <div
+              v-if="badge"
+              class="fc-badge primary">
+            </div>
+          </div>
         </v-list-item-icon>
         <v-list-item-content>
           <v-list-item-title>{{label}}</v-list-item-title>
@@ -33,6 +39,10 @@ export default {
     activeRouteNames: {
       type: Array,
       default() { return []; },
+    },
+    badge: {
+      type: Boolean,
+      default: false,
     },
     disabled: {
       type: Boolean,
@@ -77,6 +87,18 @@ export default {
     }
     & .v-icon.v-icon {
       color: var(--v-primary-base);
+    }
+  }
+
+  & .fc-badge-wrapper {
+    position: relative;
+    & > .fc-badge {
+      border-radius: 2.5px;
+      height: 5px;
+      position: absolute;
+      right: 0;
+      top: 0;
+      width: 5px;
     }
   }
 }

--- a/web/views/FcDownloadsManage.vue
+++ b/web/views/FcDownloadsManage.vue
@@ -54,10 +54,27 @@
         </v-card-title>
       </v-card>
       <template v-else>
-        <FcCardJob
-          v-for="job in jobs"
-          :key="job.jobId"
-          :job="job" />
+        <section v-if="jobsInProgress.length > 0">
+          <h2 class="my-6">In Progress</h2>
+          <FcCardJob
+            v-for="job in jobsInProgress"
+            :key="job.jobId"
+            :job="job" />
+        </section>
+        <section v-if="jobsNewlyCompleted.length > 0">
+          <h2 class="my-6">Completed</h2>
+          <FcCardJob
+            v-for="job in jobsNewlyCompleted"
+            :key="job.jobId"
+            :job="job" />
+        </section>
+        <section v-if="jobsOld.length > 0">
+          <h2 class="my-6">History</h2>
+          <FcCardJob
+            v-for="job in jobsOld"
+            :key="job.jobId"
+            :job="job" />
+        </section>
       </template>
     </section>
   </section>
@@ -86,6 +103,15 @@ export default {
     };
   },
   computed: {
+    jobsInProgress() {
+      return this.jobs.filter(job => job.state === 'created' || job.state === 'active');
+    },
+    jobsNewlyCompleted() {
+      return this.jobs.filter(job => job.state === 'completed' && !job.dismissed);
+    },
+    jobsOld() {
+      return this.jobs.filter(job => job.dismissed);
+    },
     labelViewData() {
       if (this.locationsEmpty) {
         return 'View Map';


### PR DESCRIPTION
# Issue Addressed
This PR closes #563 .

# Description
We add a new `GET /jobs/existsNew` endpoint to `scheduler`, and call this endpoint on page load to determine whether to show a "new downloads" notification dot in the left navbar.

We also add auth / scope check functionality to `FcButton`, then use this functionality to force login when an unauthenticated user attempts to enter bulk report mode.  (Even if they could enter bulk report mode, the relevant backend endpoints would return HTTP 403, but it's still good practice.)

Finally, download jobs in the download manager are prioritized to bring in-progress and newly completed jobs to the top.  This helps the user quickly find the most salient details.  (For now, we don't do any pagination on the list of download jobs - we can always add that later!)

# Tests
Added tests for DAO method that powers `GET /jobs/existsNew` in `JobMetadataDAO.spec.js`.  Tested flows manually in frontend.
