### PR TITLE
Multi-location: integration with View Reports

### DIFF
--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -178,7 +178,7 @@ export default {
     };
   },
   computed: {
-    activeLocations() {
+    locationsActive() {
       if (this.locationMode === LocationMode.SINGLE || this.detailView) {
         return [this.locationActive];
       }
@@ -207,10 +207,6 @@ export default {
       locationsIconProps[this.locationsIndex].selected = true;
       return locationsIconProps;
     },
-    reportParameters() {
-      // TODO: we'll probably have to figure this one out...
-      return {};
-    },
     ...mapState([
       'locationMode',
       'locations',
@@ -226,7 +222,7 @@ export default {
     ...mapGetters('viewData', ['filterChipsCollision', 'filterParamsCollision']),
   },
   watch: {
-    activeLocations() {
+    locationsActive() {
       this.updateReportLayout();
     },
     activeReportType() {
@@ -307,7 +303,7 @@ export default {
       }
       this.loadingReportLayout = true;
 
-      const id = CompositeId.encode(this.activeLocations);
+      const id = CompositeId.encode(this.locationsActive);
       const reportLayout = await getReportWeb(
         this.activeReportType,
         id,

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -325,7 +325,7 @@ export default {
 
 <style lang="scss">
 .fc-drawer-view-collision-reports {
-  max-height: 50vh;
+  max-height: calc(50vh - 26px);
 
   .fc-report-wrapper {
     position: relative;
@@ -338,6 +338,6 @@ export default {
 }
 
 .drawer-open .fc-drawer-view-collision-reports {
-  max-height: calc(100vh - 60px);
+  max-height: calc(100vh - 116px);
 }
 </style>

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -95,7 +95,6 @@ export default {
   },
   data() {
     return {
-      detailView: false,
       LocationMode,
     };
   },
@@ -107,6 +106,7 @@ export default {
       'locationsEditSelection',
       'locationsSelection',
     ]),
+    ...mapState('viewData', ['detailView']),
     ...mapGetters([
       'location',
       'locationActive',
@@ -116,7 +116,7 @@ export default {
   },
   watch: {
     locationMode() {
-      this.detailView = false;
+      this.setDetailView(false);
     },
     locationsSelection: {
       deep: true,
@@ -160,10 +160,10 @@ export default {
     actionToggleDetailView() {
       if (this.detailView) {
         this.setLocationsIndex(-1);
-        this.detailView = false;
+        this.setDetailView(false);
       } else {
         this.setLocationsIndex(0);
-        this.detailView = true;
+        this.setDetailView(true);
       }
     },
     async loadAsyncForRoute(to) {
@@ -176,6 +176,7 @@ export default {
       'setLocationMode',
       'setLocationsIndex',
     ]),
+    ...mapMutations('viewData', ['setDetailView']),
     ...mapActions(['initLocations']),
   },
 };

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -48,6 +48,7 @@
                 <v-list-item
                   v-for="(location, i) in locations"
                   :key="i"
+                  :disabled="studySummaryPerLocation[0].perLocation[i].n === 0"
                   @click="setLocationsIndex(i)">
                   <v-list-item-title>
                     <div class="d-flex">
@@ -178,6 +179,7 @@ import {
   getReport,
   getReportWeb,
   getStudiesByCentreline,
+  getStudiesByCentrelineSummaryPerLocation,
 } from '@/lib/api/WebApi';
 import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
 import CompositeId from '@/lib/io/CompositeId';
@@ -229,6 +231,7 @@ export default {
       showConfirmLeave: false,
       showReportParameters: false,
       studies: [],
+      studySummaryPerLocation: [],
     };
   },
   computed: {
@@ -405,13 +408,25 @@ export default {
         this.setLocationsIndex(0);
       }
       const studyType = StudyType.enumValueOf(studyTypeName);
-      const studies = await getStudiesByCentreline(
-        [this.locationActive],
-        studyType,
-        this.filterParamsStudyReports,
-        { limit: 10, offset: 0 },
-      );
+
+      const tasks = [
+        getStudiesByCentreline(
+          [this.locationActive],
+          studyType,
+          this.filterParamsStudyReports,
+          { limit: 10, offset: 0 },
+        ),
+        getStudiesByCentrelineSummaryPerLocation(
+          this.locations,
+          this.filterParamsStudyReports,
+        ),
+      ];
+      const [
+        studies,
+        studySummaryPerLocation,
+      ] = await Promise.all(tasks);
       this.studies = studies;
+      this.studySummaryPerLocation = studySummaryPerLocation;
     },
     setReportParameters(reportParameters) {
       this.reportParameters = reportParameters;

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -26,7 +26,7 @@
           <h1 class="headline ml-4">{{studyType.label}}</h1>
           <div
             class="ml-1 font-weight-regular headline secondary--text">
-            <span>&#x2022; {{locationsDescription}}</span>
+            <span>&#x2022; {{locationActive.description}}</span>
             <span v-if="filterChipsStudyNoStudyTypes.length > 0"> &#x2022;</span>
           </div>
           <div
@@ -264,7 +264,10 @@ export default {
       return StudyType.enumValueOf(studyTypeName);
     },
     ...mapState(['locations']),
-    ...mapGetters(['locationsDescription', 'locationsRouteParams']),
+    ...mapGetters([
+      'locationActive',
+      'locationsRouteParams',
+    ]),
     ...mapGetters('viewData', ['filterChipsStudy', 'filterParamsStudy']),
   },
   watch: {
@@ -273,6 +276,18 @@ export default {
     },
     activeStudy() {
       this.updateReportLayout();
+    },
+    async locationActive() {
+      const studies = await getStudiesByCentreline(
+        [this.locationActive],
+        this.studyType,
+        this.filterParamsStudyReports,
+        { limit: 10, offset: 0 },
+      );
+
+      this.indexActiveReportType = 0;
+      this.indexActiveStudy = 0;
+      this.studies = studies;
     },
   },
   beforeRouteLeave(to, from, next) {
@@ -330,7 +345,7 @@ export default {
 
       const studyType = StudyType.enumValueOf(studyTypeName);
       const studies = await getStudiesByCentreline(
-        this.locations,
+        [this.locationActive],
         studyType,
         this.filterParamsStudyReports,
         { limit: 10, offset: 0 },
@@ -355,7 +370,7 @@ export default {
 
       this.loadingReportLayout = false;
     },
-    ...mapMutations(['setLocations']),
+    ...mapMutations(['setLocationsIndex']),
     ...mapActions(['initLocations']),
   },
 };

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -41,7 +41,7 @@
             </v-chip>
           </div>
           <v-spacer></v-spacer>
-          <v-menu>
+          <v-menu v-if="studies.length > 0">
             <template v-slot:activator="{ on, attrs }">
               <FcButton
                 v-bind="attrs"
@@ -69,7 +69,8 @@
         <v-tabs v-model="indexActiveReportType">
           <v-tab
             v-for="reportType in reportTypes"
-            :key="reportType.name">
+            :key="reportType.name"
+            :disabled="studies.length === 0">
             {{reportType.label}}
           </v-tab>
         </v-tabs>
@@ -88,6 +89,13 @@
             size="80" />
           <div class="font-weight-regular headline secondary--text">
             This page is loading, please wait.
+          </div>
+        </div>
+        <div
+          v-else-if="studies.length === 0"
+          class="ma-3 text-center">
+          <div class="font-weight-regular headline secondary--text">
+            Report not available, try a different location.
           </div>
         </div>
         <div
@@ -343,6 +351,9 @@ export default {
       const selectionType = LocationSelectionType.enumValueOf(selectionTypeName);
       await this.initLocations({ features, selectionType });
 
+      if (this.locationActive === null) {
+        this.setLocationsIndex(0);
+      }
       const studyType = StudyType.enumValueOf(studyTypeName);
       const studies = await getStudiesByCentreline(
         [this.locationActive],
@@ -359,6 +370,7 @@ export default {
     async updateReportLayout() {
       const { activeReportType, activeStudy, reportParameters } = this;
       if (activeReportType === null || activeStudy === null) {
+        this.reportLayout = null;
         return;
       }
       this.loadingReportLayout = true;

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -28,7 +28,7 @@
             class="ml-1 font-weight-regular headline secondary--text">
             <span>&#x2022;</span>
             <span v-if="locationMode === LocationMode.SINGLE">
-              {{location.description}}
+              {{locationActive.description}}
             </span>
             <v-menu
               v-else

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -455,7 +455,7 @@ export default {
 
 <style lang="scss">
 .fc-drawer-view-study-reports {
-  max-height: 50vh;
+  max-height: calc(50vh - 26px);
 
   .fc-report-wrapper {
     position: relative;
@@ -468,6 +468,6 @@ export default {
 }
 
 .drawer-open .fc-drawer-view-study-reports {
-  max-height: calc(100vh - 60px);
+  max-height: calc(100vh - 116px);
 }
 </style>

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -11,8 +11,11 @@
       <div
         class="pane-map-location-search"
         v-if="!drawerOpen">
+        <FcSelectorCollapsedLocation
+          v-if="collapseLocationSearch"
+          class="mt-5 ml-5" />
         <FcSelectorMultiLocation
-          v-if="locationMode.multi"
+          v-else-if="locationMode.multi"
           class="elevation-2">
           <template v-slot:action>
             <FcButton
@@ -107,6 +110,7 @@ import GeoStyle from '@/lib/geo/GeoStyle';
 import FcPaneMapPopup from '@/web/components/FcPaneMapPopup.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcPaneMapLegend from '@/web/components/inputs/FcPaneMapLegend.vue';
+import FcSelectorCollapsedLocation from '@/web/components/inputs/FcSelectorCollapsedLocation.vue';
 import FcSelectorMultiLocation from '@/web/components/inputs/FcSelectorMultiLocation.vue';
 import FcSelectorSingleLocation from '@/web/components/inputs/FcSelectorSingleLocation.vue';
 
@@ -146,6 +150,7 @@ export default {
     FcButton,
     FcPaneMapLegend,
     FcPaneMapPopup,
+    FcSelectorCollapsedLocation,
     FcSelectorMultiLocation,
     FcSelectorSingleLocation,
   },
@@ -212,6 +217,11 @@ export default {
       }
       const { layer: { id: layerId } } = this.selectedFeature;
       return layerId === 'intersections' || layerId === 'midblocks';
+    },
+    collapseLocationSearch() {
+      const { name } = this.$route;
+      return name === 'viewCollisionReportsAtLocation'
+        || name === 'viewStudyReportsAtLocation';
     },
     featureKeyHovered() {
       return getFeatureKey(this.hoveredFeature);

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -76,7 +76,7 @@
                   <FcButton
                     class="mr-n4 mt-2"
                     type="tertiary"
-                    @click="$emit('show-reports', j)">
+                    @click="$emit('show-reports', { item, locationsIndex: j })">
                     <span>View Reports</span>
                   </FcButton>
                 </div>

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -353,7 +353,6 @@ export default {
       'setToast',
       'setToastInfo',
     ]),
-    ...mapMutations('viewData', ['setDetailView']),
   },
 };
 </script>

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -188,10 +188,10 @@ export default {
   },
   computed: {
     ...mapState(['auth']),
+    ...mapGetters(['locationsRouteParams']),
     ...mapGetters('viewData', [
       'filterParamsCollision',
       'filterParamsStudy',
-      'locationsRouteParams',
     ]),
   },
   watch: {
@@ -280,9 +280,20 @@ export default {
         params,
       });
     },
-    actionShowReportsStudy() {
-      /* eslint-disable-next-line no-alert */
-      window.alert('Coming Soon!');
+    actionShowReportsStudy({
+      item: { category: { studyType } },
+      locationsIndex,
+    }) {
+      this.setLocationsIndex(locationsIndex);
+
+      const params = {
+        ...this.locationsRouteParams,
+        studyTypeName: studyType.name,
+      };
+      this.$router.push({
+        name: 'viewStudyReportsAtLocation',
+        params,
+      });
     },
     async syncLocations() {
       if (this.locations.length === 0) {
@@ -337,7 +348,12 @@ export default {
         this.setToastInfo('You\'re currently in Export Report Mode.');
       }
     },
-    ...mapMutations(['setToast', 'setToastInfo']),
+    ...mapMutations([
+      'setLocationsIndex',
+      'setToast',
+      'setToastInfo',
+    ]),
+    ...mapMutations('viewData', ['setDetailView']),
   },
 };
 </script>

--- a/web/components/data/FcViewDataDetail.vue
+++ b/web/components/data/FcViewDataDetail.vue
@@ -150,12 +150,21 @@ export default {
       window.alert('Coming Soon!');
     },
     actionShowReportsCollision() {
-      /* eslint-disable-next-line no-alert */
-      window.alert('Coming Soon!');
+      const params = this.locationsRouteParams;
+      this.$router.push({
+        name: 'viewCollisionReportsAtLocation',
+        params,
+      });
     },
-    actionShowReportsStudy(/* { category: { studyType } } */) {
-      /* eslint-disable-next-line no-alert */
-      window.alert('Coming Soon!');
+    actionShowReportsStudy({ category: { studyType } }) {
+      const params = {
+        ...this.locationsRouteParams,
+        studyTypeName: studyType.name,
+      };
+      this.$router.push({
+        name: 'viewStudyReportsAtLocation',
+        params,
+      });
     },
     async syncLocation() {
       if (this.location === null) {

--- a/web/components/data/FcViewDataDetail.vue
+++ b/web/components/data/FcViewDataDetail.vue
@@ -102,10 +102,10 @@ export default {
     };
   },
   computed: {
+    ...mapGetters(['locationsRouteParams']),
     ...mapGetters('viewData', [
       'filterParamsCollision',
       'filterParamsStudy',
-      'locationsRouteParams',
     ]),
   },
   watch: {

--- a/web/components/inputs/FcMenuDownloadReportFormat.vue
+++ b/web/components/inputs/FcMenuDownloadReportFormat.vue
@@ -12,7 +12,8 @@
           :color="type === 'secondary' ? 'primary' : 'white'">
           mdi-cloud-download
         </v-icon>
-        Download
+        <span>Download</span>
+        <v-icon right>mdi-menu-down</v-icon>
       </FcButton>
     </template>
     <v-list>

--- a/web/components/inputs/FcSelectorCollapsedLocation.vue
+++ b/web/components/inputs/FcSelectorCollapsedLocation.vue
@@ -1,0 +1,39 @@
+<template>
+  <div class="fc-selector-collapsed-location">
+    <v-tooltip
+      right
+      :z-index="100">
+      <template v-slot:activator="{ on }">
+        <FcButton
+          aria-label="Search for new location"
+          class="fc-search-bar-open"
+          type="fab-text"
+          @click="$router.push({ name: 'viewData' })"
+          v-on="on">
+          <v-icon class="unselected--text">mdi-magnify</v-icon>
+        </FcButton>
+      </template>
+      <span>Search for new location</span>
+    </v-tooltip>
+  </div>
+</template>
+
+<script>
+import FcButton from '@/web/components/inputs/FcButton.vue';
+
+export default {
+  name: 'FcSelectorCollapsedLocation',
+  components: {
+    FcButton,
+  },
+};
+</script>
+
+<style lang="scss">
+.fc-selector-collapsed-location {
+  & > button.fc-button.v-btn.fc-search-bar-open {
+    min-width: 36px;
+    width: 36px;
+  }
+}
+</style>

--- a/web/components/inputs/FcSelectorSingleLocation.vue
+++ b/web/components/inputs/FcSelectorSingleLocation.vue
@@ -1,23 +1,6 @@
 <template>
   <div class="fc-selector-single-location">
-    <v-tooltip
-      v-if="collapseSearchBar"
-      right
-      :z-index="100">
-      <template v-slot:activator="{ on }">
-        <FcButton
-          aria-label="Search for new location"
-          class="fc-search-bar-open"
-          type="fab-text"
-          @click="$router.push({ name: 'viewData' })"
-          v-on="on">
-          <v-icon class="unselected--text">mdi-magnify</v-icon>
-        </FcButton>
-      </template>
-      <span>Search for new location</span>
-    </v-tooltip>
     <FcInputLocationSearch
-      v-else
       v-model="internalLocation"
       class="elevation-2" />
   </div>
@@ -27,21 +10,14 @@
 import { mapGetters, mapMutations } from 'vuex';
 
 import { LocationSelectionType } from '@/lib/Constants';
-import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcInputLocationSearch from '@/web/components/inputs/FcInputLocationSearch.vue';
 
 export default {
   name: 'FcSelectorSingleLocation',
   components: {
-    FcButton,
     FcInputLocationSearch,
   },
   computed: {
-    collapseSearchBar() {
-      const { name } = this.$route;
-      return name === 'viewCollisionReportsAtLocation'
-        || name === 'viewStudyReportsAtLocation';
-    },
     internalLocation: {
       get() {
         return this.location;
@@ -70,11 +46,6 @@ export default {
 .fc-selector-single-location {
   & > .fc-input-location-search {
     width: 392px;
-  }
-
-  & > button.fc-button.v-btn.fc-search-bar-open {
-    min-width: 36px;
-    width: 36px;
   }
 }
 </style>

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -97,7 +97,10 @@ export default new Vuex.Store({
       const { locations } = state.locationsSelection;
       return locations[0];
     },
-    locationActive(state) {
+    locationActive(state, getters) {
+      if (state.locationMode === LocationMode.SINGLE) {
+        return getters.location;
+      }
       const n = state.locations.length;
       if (state.locationsIndex < 0 || state.locationsIndex >= n) {
         return null;

--- a/web/store/modules/viewData.js
+++ b/web/store/modules/viewData.js
@@ -4,6 +4,7 @@ import TimeFormatters from '@/lib/time/TimeFormatters';
 export default {
   namespaced: true,
   state: {
+    detailView: false,
     filtersCollision: {
       datesFrom: -1,
       daysOfWeek: [],
@@ -175,6 +176,9 @@ export default {
           values.splice(i, 1);
         }
       }
+    },
+    setDetailView(state, detailView) {
+      state.detailView = detailView;
     },
     setFiltersCollision(state, filtersCollision) {
       state.filtersCollision = filtersCollision;

--- a/web/views/FcDownloadsManage.vue
+++ b/web/views/FcDownloadsManage.vue
@@ -54,24 +54,24 @@
         </v-card-title>
       </v-card>
       <template v-else>
-        <section v-if="jobsInProgress.length > 0">
+        <section v-if="jobsSections.inProgress.length > 0">
           <h2 class="my-6">In Progress</h2>
           <FcCardJob
-            v-for="job in jobsInProgress"
+            v-for="job in jobsSections.inProgress"
             :key="job.jobId"
             :job="job" />
         </section>
-        <section v-if="jobsNewlyCompleted.length > 0">
+        <section v-if="jobsSections.newlyCompleted.length > 0">
           <h2 class="my-6">Completed</h2>
           <FcCardJob
-            v-for="job in jobsNewlyCompleted"
+            v-for="job in jobsSections.newlyCompleted"
             :key="job.jobId"
             :job="job" />
         </section>
-        <section v-if="jobsOld.length > 0">
+        <section v-if="jobsSections.old.length > 0">
           <h2 class="my-6">History</h2>
           <FcCardJob
-            v-for="job in jobsOld"
+            v-for="job in jobsSections.old"
             :key="job.jobId"
             :job="job" />
         </section>
@@ -103,14 +103,23 @@ export default {
     };
   },
   computed: {
-    jobsInProgress() {
-      return this.jobs.filter(job => job.state === 'created' || job.state === 'active');
-    },
-    jobsNewlyCompleted() {
-      return this.jobs.filter(job => job.state === 'completed' && !job.dismissed);
-    },
-    jobsOld() {
-      return this.jobs.filter(job => job.dismissed);
+    jobsSections() {
+      const jobsSections = {
+        inProgress: [],
+        newlyCompleted: [],
+        old: [],
+      };
+      this.jobs.forEach((job) => {
+        const { dismissed, state } = job;
+        if (state === 'created' || state === 'active') {
+          jobsSections.inProgress.push(job);
+        } else if (state === 'completed' && !dismissed) {
+          jobsSections.newlyCompleted.push(job);
+        } else {
+          jobsSections.old.push(job);
+        }
+      });
+      return jobsSections;
     },
     labelViewData() {
       if (this.locationsEmpty) {


### PR DESCRIPTION
# Issue Addressed
This PR closes #564 .

# Description
We integrate multi-location `locationMode`, `detailView`, and other relevant pieces of state with View Collision Reports and View Study Reports.  In detail view View Reports, the user can also change which location they're viewing reports for using the location dropdown.

# Tests
Tested quickly in frontend.
