### PR TITLE
formatCombinedStreet: properly handle single space fields

### DIFF
--- a/lib/StringFormatters.js
+++ b/lib/StringFormatters.js
@@ -36,7 +36,13 @@ function formatCombinedStreet(name, type, dir) {
       parts.push(dir);
     }
   }
-  return parts.map(part => part.trim()).join(' ');
+  const combinedStreet = parts.map(part => part.trim())
+    .join(' ')
+    .trim();
+  if (combinedStreet === '') {
+    return null;
+  }
+  return combinedStreet;
 }
 
 /**

--- a/tests/jest/unit/StringFormatters.spec.js
+++ b/tests/jest/unit/StringFormatters.spec.js
@@ -7,6 +7,9 @@ import {
 
 test('StringFormatters.formatCombinedStreet', async () => {
   expect(formatCombinedStreet(null, null, null)).toBe(null);
+  expect(formatCombinedStreet(' ', null, null)).toBe(null);
+  expect(formatCombinedStreet(' ', ' ', null)).toBe(null);
+  expect(formatCombinedStreet(' ', ' ', ' ')).toBe(null);
   expect(formatCombinedStreet(null, 'Ave', 'W')).toBe(null);
 
   expect(formatCombinedStreet(


### PR DESCRIPTION
# Issue Addressed
This PR closes #591 .

# Description
These were resulting in empty strings for `street2` in some cases, which `Joi.string().allow(null)` does not like: it'll allow `null`, but by default the empty string does not validate.

# Tests
Updated `StringFormatters.spec.js` to handle this case, and made it pass.  Found an example in the dev dataset; verified that a) it failed before the fix, b) logs show the same kind of failure as we observed on AWS, and c) it succeeded after the fix.
