### PR TITLE
Remove scope requirement from non-export-mode buttons

### DIFF
--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -32,7 +32,6 @@
               :disabled="
                 collisionSummary.amount === 0
                 || reportExportMode === ReportExportMode.STUDIES"
-              :scope="[]"
               type="secondary"
               @click="actionShowReportsCollision">
               <v-icon color="primary" left>mdi-file-eye</v-icon>
@@ -40,6 +39,7 @@
             </FcButton>
             <FcMenuDownloadReportFormat
               v-else
+              :require-auth="true"
               @download-report-format="actionDownloadReportFormatCollisions" />
           </template>
         </FcHeaderCollisions>
@@ -84,7 +84,6 @@
               :disabled="
                 studySummary.length === 0
                 || reportExportMode === ReportExportMode.COLLISIONS"
-              :scope="[]"
               type="secondary"
               @click="actionRequestStudy">
               <v-icon color="primary" left>mdi-plus-box</v-icon>
@@ -92,6 +91,7 @@
             </FcButton>
             <FcMenuDownloadReportFormat
               v-else
+              :require-auth="true"
               @download-report-format="actionDownloadReportFormatStudies" />
           </template>
         </FcHeaderStudies>

--- a/web/components/inputs/FcMenuDownloadReportFormat.vue
+++ b/web/components/inputs/FcMenuDownloadReportFormat.vue
@@ -6,6 +6,7 @@
         v-on="on"
         class="ml-2"
         :loading="loading"
+        :scope="requireAuth ? [] : null"
         :type="type">
         <v-icon
           left
@@ -51,6 +52,10 @@ export default {
     reportType: {
       type: ReportType,
       default: null,
+    },
+    requireAuth: {
+      type: Boolean,
+      default: false,
     },
     type: {
       type: String,


### PR DESCRIPTION
# Issue Addressed
This PR closes #592 .

# Description
Removed scope requirement from buttons that are not related to export mode - this should only be on buttons that enter export mode, as well as on those that appear while in it.

# Tests
Tested that both authenticated and unauthenticated users can access the non-export-mode buttons, that unauthenticated users are still prompted to log in on export-mode buttons, and that authenticated users can still successfully click export-mode buttons without a login prompt.
