### PR TITLE
Change .compositeId() validator to return string

### DIFF
--- a/lib/controller/CollisionController.js
+++ b/lib/controller/CollisionController.js
@@ -1,6 +1,7 @@
 import Boom from '@hapi/boom';
 
 import CollisionDAO from '@/lib/db/CollisionDAO';
+import CompositeId from '@/lib/io/CompositeId';
 import CollisionEvent from '@/lib/model/CollisionEvent';
 import CollisionFilters from '@/lib/model/CollisionFilters';
 import Joi from '@/lib/model/Joi';
@@ -65,7 +66,8 @@ CollisionController.push({
     },
   },
   handler: async (request) => {
-    const { s1: features, ...collisionQuery } = request.query;
+    const { s1, ...collisionQuery } = request.query;
+    const features = CompositeId.decode(s1);
     return CollisionDAO.byCentreline(features, collisionQuery);
   },
 });
@@ -96,7 +98,8 @@ CollisionController.push({
     },
   },
   handler: async (request) => {
-    const { s1: features, ...collisionQuery } = request.query;
+    const { s1, ...collisionQuery } = request.query;
+    const features = CompositeId.decode(s1);
     return CollisionDAO.byCentrelineSummary(features, collisionQuery);
   },
 });
@@ -138,7 +141,8 @@ CollisionController.push({
     },
   },
   handler: async (request) => {
-    const { s1: features, ...collisionQuery } = request.query;
+    const { s1, ...collisionQuery } = request.query;
+    const features = CompositeId.decode(s1);
     return CollisionDAO.byCentrelineSummaryPerLocation(features, collisionQuery);
   },
 });
@@ -165,7 +169,8 @@ CollisionController.push({
     },
   },
   handler: async (request) => {
-    const { s1: features } = request.query;
+    const { s1 } = request.query;
+    const features = CompositeId.decode(s1);
     const total = await CollisionDAO.byCentrelineTotal(features);
     return { total };
   },

--- a/lib/controller/JobController.js
+++ b/lib/controller/JobController.js
@@ -47,10 +47,11 @@ JobController.push({
   handler: async (request) => {
     const user = request.auth.credentials;
     const {
-      s1: features,
+      s1,
       reportFormat,
       ...collisionQuery
     } = request.payload;
+    const features = CompositeId.decode(s1);
     try {
       const reports = await ReportDAO.byCentrelineAndCollisionQuery(
         features,
@@ -60,7 +61,6 @@ JobController.push({
       if (reports.length === 0) {
         return Boom.notFound('no reports for given filters');
       }
-      const s1 = CompositeId.encode(features);
       const data = {
         reportExportMode: ReportExportMode.COLLISIONS,
         reports,
@@ -100,10 +100,11 @@ JobController.push({
   handler: async (request) => {
     const user = request.auth.credentials;
     const {
-      s1: features,
+      s1,
       reportFormat,
       ...studyQuery
     } = request.payload;
+    const features = CompositeId.decode(s1);
     try {
       const reports = await ReportDAO.byCentrelineAndStudyQuery(
         features,
@@ -113,7 +114,6 @@ JobController.push({
       if (reports.length === 0) {
         return Boom.notFound('no reports for given filters');
       }
-      const s1 = CompositeId.encode(features);
       const data = {
         reportExportMode: ReportExportMode.STUDIES,
         reports,

--- a/lib/controller/LocationController.js
+++ b/lib/controller/LocationController.js
@@ -142,7 +142,8 @@ LocationController.push({
     },
   },
   handler: async (request) => {
-    const { s1: features } = request.query;
+    const { s1 } = request.query;
+    const features = CompositeId.decode(s1);
     const locations = await CentrelineDAO.byFeatures(features);
     return filterLocations(locations);
   },
@@ -169,7 +170,8 @@ LocationController.push({
     },
   },
   handler: async (request) => {
-    const { s1: features } = request.query;
+    const { s1 } = request.query;
+    const features = CompositeId.decode(s1);
     const corridor = await RoutingDAO.routeCorridor(features);
     if (corridor === null) {
       return Boom.notFound('no corridor found on the given location selection');

--- a/lib/controller/StudyController.js
+++ b/lib/controller/StudyController.js
@@ -1,6 +1,7 @@
 import Boom from '@hapi/boom';
 
 import StudyDAO from '@/lib/db/StudyDAO';
+import CompositeId from '@/lib/io/CompositeId';
 import Category from '@/lib/model/Category';
 import Joi from '@/lib/model/Joi';
 import Study from '@/lib/model/Study';
@@ -46,9 +47,10 @@ StudyController.push({
     const {
       limit,
       offset,
-      s1: features,
+      s1,
       ...studyQuery
     } = request.query;
+    const features = CompositeId.decode(s1);
     try {
       const pagination = { limit, offset };
       const studies = await StudyDAO.byCentreline(features, studyQuery, pagination);
@@ -91,7 +93,8 @@ StudyController.push({
   },
   handler: async (request) => {
     try {
-      const { s1: features, ...studyQuery } = request.query;
+      const { s1, ...studyQuery } = request.query;
+      const features = CompositeId.decode(s1);
       const studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);
       return studySummary;
     } catch (err) {
@@ -151,7 +154,8 @@ StudyController.push({
   },
   handler: async (request) => {
     try {
-      const { s1: features, ...studyQuery } = request.query;
+      const { s1, ...studyQuery } = request.query;
+      const features = CompositeId.decode(s1);
       const studySummaryPerLocation = await StudyDAO.byCentrelineSummaryPerLocation(
         features,
         studyQuery,
@@ -184,7 +188,8 @@ StudyController.push({
     },
   },
   handler: async (request) => {
-    const { s1: features } = request.query;
+    const { s1 } = request.query;
+    const features = CompositeId.decode(s1);
     const total = await StudyDAO.byCentrelineTotal(features);
     return { total };
   },

--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -7,6 +7,7 @@ import StudyRequestChangeDAO from '@/lib/db/StudyRequestChangeDAO';
 import StudyRequestCommentDAO from '@/lib/db/StudyRequestCommentDAO';
 import EmailStudyRequestConfirmation from '@/lib/email/EmailStudyRequestConfirmation';
 import Mailer from '@/lib/email/Mailer';
+import CompositeId from '@/lib/io/CompositeId';
 import LogTag from '@/lib/log/LogTag';
 import Joi from '@/lib/model/Joi';
 import StudyRequest from '@/lib/model/StudyRequest';
@@ -118,7 +119,8 @@ StudyRequestController.push({
     },
   },
   handler: async (request) => {
-    const { s1: features } = request.query;
+    const { s1 } = request.query;
+    const features = CompositeId.decode(s1);
     return StudyRequestDAO.byCentrelinePending(features);
   },
 });

--- a/lib/db/JobDAO.js
+++ b/lib/db/JobDAO.js
@@ -20,7 +20,7 @@ async function normalizeJob(job) {
   const jobNormalized = await Job.read.validateAsync(job);
   const { data, name } = jobNormalized;
   const jobType = JobType.enumValueOf(name, 'jobName');
-  const dataNormalized = await jobType.validateData(data);
+  const dataNormalized = await jobType.dataSchema.validateAsync(data);
   jobNormalized.data = dataNormalized;
   return jobNormalized;
 }

--- a/lib/db/JobMetadataDAO.js
+++ b/lib/db/JobMetadataDAO.js
@@ -32,7 +32,7 @@ class JobMetadataDAO {
     const jobType = JobType.enumValueOf(name, 'jobName');
     const jobDescription = await JobDescription.get(jobType, data);
     let metadata = jobType.getMetadata(data);
-    metadata = await jobType.validateMetadata(metadata);
+    metadata = await jobType.metadataSchema.validateAsync(metadata);
     const progressTotal = jobType.getProgressTotal(data);
 
     const sql = `

--- a/lib/jobs/JobManager.js
+++ b/lib/jobs/JobManager.js
@@ -84,7 +84,7 @@ class JobManager {
   }
 
   static async publish(jobType, data, user) {
-    const jobData = await jobType.validateData(data);
+    const jobData = await jobType.dataSchema.validateAsync(data);
     const id = uuidv4();
     const job = {
       id,

--- a/lib/jobs/JobRunnerBase.js
+++ b/lib/jobs/JobRunnerBase.js
@@ -11,7 +11,7 @@ class JobRunnerBase {
   async init() {
     const { data } = this.job;
     const { type } = this.jobMetadata;
-    this.data = await type.validateData(data);
+    this.data = await type.dataSchema.validateAsync(data);
   }
 
   async incrProgressCurrent(n = 1) {

--- a/lib/jobs/JobType.js
+++ b/lib/jobs/JobType.js
@@ -10,41 +10,27 @@ class JobType extends Enum {
 }
 JobType.init({
   GENERATE_REPORTS: {
+    dataSchema: Joi.object().keys({
+      ...CentrelineSelection,
+      reportExportMode: Joi.enum().ofType(ReportExportMode),
+      reports: Joi.array().items(
+        Joi.object({
+          type: Joi.enum().ofType(ReportType).required(),
+          id: Joi.string().required(),
+          format: Joi.enum().ofType(ReportFormat).required(),
+        }).unknown(),
+      ),
+    }),
     getMetadata({ reportExportMode, s1 }) {
       return { reportExportMode, s1 };
     },
     getProgressTotal({ reports }) {
       return reports.length;
     },
-    async validateData(data) {
-      const dataSchema = Joi.object().keys({
-        ...CentrelineSelection,
-        reportExportMode: Joi.enum().ofType(ReportExportMode),
-        reports: Joi.array().items(
-          Joi.object({
-            type: Joi.enum().ofType(ReportType).required(),
-            id: Joi.string().required(),
-            format: Joi.enum().ofType(ReportFormat).required(),
-          }).unknown(),
-        ),
-      });
-
-      const { s1 } = data;
-      const dataNormalized = await dataSchema.validateAsync(data);
-      dataNormalized.s1 = s1;
-      return dataNormalized;
-    },
-    async validateMetadata(metadata) {
-      const metadataSchema = Joi.object().keys({
-        ...CentrelineSelection,
-        reportExportMode: Joi.enum().ofType(ReportExportMode),
-      });
-
-      const { s1 } = metadata;
-      const metadataNormalized = await metadataSchema.validateAsync(metadata);
-      metadataNormalized.s1 = s1;
-      return metadataNormalized;
-    },
+    metadataSchema: Joi.object().keys({
+      ...CentrelineSelection,
+      reportExportMode: Joi.enum().ofType(ReportExportMode),
+    }),
   },
 });
 JobType.NAME_PREFIX = 'MOVE:';

--- a/lib/model/Joi.js
+++ b/lib/model/Joi.js
@@ -52,7 +52,8 @@ const EXTENDED_JOI = Joi.extend({
           return helpers.error('compositeId.invalidValue', { prefix, value });
         }
         try {
-          return CompositeId.decode(value);
+          CompositeId.decode(value);
+          return value;
         } catch (err) {
           if (err instanceof InvalidCompositeIdError) {
             return helpers.error('compositeId.invalidValue', { prefix, value });

--- a/lib/model/helpers/NormalizeUtils.js
+++ b/lib/model/helpers/NormalizeUtils.js
@@ -24,7 +24,7 @@ function intersectionToFeature({
 async function normalizeJobMetadata(jobMetadata) {
   const jobMetadataNormalized = await JobMetadata.read.validateAsync(jobMetadata);
   const { metadata, type } = jobMetadataNormalized;
-  const metadataNormalized = await type.validateMetadata(metadata);
+  const metadataNormalized = await type.metadataSchema.validateAsync(metadata);
   jobMetadataNormalized.metadata = metadataNormalized;
   return jobMetadataNormalized;
 }
@@ -33,7 +33,7 @@ async function normalizeJobMetadatas(jobMetadatas) {
   const jobMetadatasSchema = Joi.array().items(JobMetadata.read);
   const jobMetadatasNormalized = await jobMetadatasSchema.validateAsync(jobMetadatas);
   const tasks = jobMetadatasNormalized.map(
-    ({ metadata, type }) => type.validateMetadata(metadata),
+    ({ metadata, type }) => type.metadataSchema.validateAsync(metadata),
   );
   const metadatasNormalized = await Promise.all(tasks);
   const n = jobMetadatasNormalized.length;

--- a/tests/jest/unit/model/Joi.spec.js
+++ b/tests/jest/unit/model/Joi.spec.js
@@ -1,5 +1,4 @@
 import { Enum } from '@/lib/ClassUtils';
-import { CentrelineType } from '@/lib/Constants';
 import Joi from '@/lib/model/Joi';
 import DateTime from '@/lib/time/DateTime';
 import DateTimeZone from '@/lib/time/DateTimeZone';
@@ -28,7 +27,7 @@ test('Joi.compositeId', () => {
   let compositeId = 's1:A';
   let result = Joi.compositeId().ofType('s1').validate(compositeId);
   expect(result.error).toBeUndefined();
-  expect(result.value).toEqual([]);
+  expect(result.value).toEqual(compositeId);
 
   compositeId = 's1:AAAAAA';
   result = Joi.compositeId().ofType('s1').validate(compositeId);
@@ -37,9 +36,12 @@ test('Joi.compositeId', () => {
   compositeId = 's1:ACAAAA';
   result = Joi.compositeId().ofType('s1').validate(compositeId);
   expect(result.error).toBeUndefined();
-  expect(result.value).toEqual([
-    { centrelineId: 1, centrelineType: CentrelineType.INTERSECTION },
-  ]);
+  expect(result.value).toEqual(compositeId);
+
+  compositeId = 's1:AQhwmBUvwmB';
+  result = Joi.compositeId().ofType('s1').validate(compositeId);
+  expect(result.error).toBeUndefined();
+  expect(result.value).toEqual(compositeId);
 
   compositeId = 's2:A';
   result = Joi.compositeId().ofType('s1').validate(compositeId);


### PR DESCRIPTION
# Issue Addressed
This PR closes #586 .

# Description
This causes our `Joi.compositeId()` validator to return the original string, but still validate using `CompositeId.decode()`.  While this *does* mean effectively double-decoding these in many cases, decoding is quite efficient, and we can then use the feature set in endpoints without worrying about validity.

# Tests
Changed `Joi.spec.js` tests - these pass.  Tested a variety of frontend use cases, including View Data, View Reports, and bulk report generation - all work as before.  Searched codebase to ensure all callsites are dealt with.
