### PR TITLE
Deprecate location getter in favour of locationActive

### DIFF
--- a/web/App.vue
+++ b/web/App.vue
@@ -93,7 +93,6 @@ export default {
       'auth',
       'dialog',
       'dialogData',
-      'location',
       'toast',
       'toastData',
       'toastKey',

--- a/web/components/FcDrawerRequestStudy.vue
+++ b/web/components/FcDrawerRequestStudy.vue
@@ -182,7 +182,7 @@ export default {
       return this.$route.name === 'requestStudyNew';
     },
     labelNavigateBack() {
-      if (this.isCreate && this.location === null) {
+      if (this.isCreate && this.locationActive === null) {
         return 'View Map';
       }
       return 'View Data';
@@ -205,10 +205,10 @@ export default {
       };
     },
     subtitle() {
-      if (this.location === null) {
+      if (this.locationActive === null) {
         return 'needs location';
       }
-      return this.location.description;
+      return this.locationActive.description;
     },
     title() {
       if (this.isCreate) {
@@ -218,13 +218,13 @@ export default {
       return `Edit Request #${id}`;
     },
     ...mapState(['locations', 'now']),
-    ...mapGetters(['location', 'locationsEmpty', 'locationsRouteParams']),
+    ...mapGetters(['locationActive', 'locationsEmpty', 'locationsRouteParams']),
   },
   watch: {
     estimatedDeliveryDate() {
       this.studyRequest.estimatedDeliveryDate = this.estimatedDeliveryDate;
     },
-    location() {
+    locationActive() {
       this.updateStudyRequestLocation();
     },
   },
@@ -270,9 +270,9 @@ export default {
       let studyRequest;
       let studyRequestLocation;
       if (this.isCreate) {
-        const { location, now } = this;
+        const { locationActive, now } = this;
         studyRequest = makeStudyRequest(now);
-        studyRequestLocation = location;
+        studyRequestLocation = locationActive;
       } else {
         const { id } = to.params;
         const result = await getStudyRequest(id);
@@ -284,8 +284,8 @@ export default {
       this.updateStudyRequestLocation();
     },
     updateStudyRequestLocation() {
-      const { location } = this;
-      if (location === null) {
+      const { locationActive } = this;
+      if (locationActive === null) {
         this.studyRequest.centrelineId = null;
         this.studyRequest.centrelineType = null;
         this.studyRequest.geom = null;
@@ -295,7 +295,7 @@ export default {
           centrelineType,
           lng,
           lat,
-        } = location;
+        } = locationActive;
         const geom = {
           type: 'Point',
           coordinates: [lng, lat],

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -17,9 +17,9 @@
         <FcSelectorSingleLocation />
         <FcHeaderSingleLocation
           class="mt-6"
-          :location="location" />
+          :location="locationActive" />
         <div class="d-flex mt-4">
-          <FcSummaryPoi :location="location" />
+          <FcSummaryPoi :location="locationActive" />
           <v-spacer></v-spacer>
           <FcButton
             type="secondary"
@@ -41,10 +41,7 @@
           :locations="locationsEdit"
           :locations-selection="locationsEditSelection" />
         <FcViewDataDetail
-          v-else-if="locationMode === LocationMode.SINGLE"
-          :location="location" />
-        <FcViewDataDetail
-          v-else-if="detailView"
+          v-else-if="locationMode === LocationMode.SINGLE || detailView"
           :location="locationActive" />
         <FcViewDataAggregate
           v-else
@@ -108,7 +105,6 @@ export default {
     ]),
     ...mapState('viewData', ['detailView']),
     ...mapGetters([
-      'location',
       'locationActive',
       'locationsEmpty',
       'locationsRouteParams',

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -325,7 +325,6 @@ export default {
       'locationsSelection',
     ]),
     ...mapGetters([
-      'location',
       'locationActive',
       'locationsRouteParams',
     ]),

--- a/web/components/inputs/FcSelectorSingleLocation.vue
+++ b/web/components/inputs/FcSelectorSingleLocation.vue
@@ -20,7 +20,7 @@ export default {
   computed: {
     internalLocation: {
       get() {
-        return this.location;
+        return this.locationActive;
       },
       set(internalLocation) {
         const locations = [];
@@ -34,7 +34,7 @@ export default {
         });
       },
     },
-    ...mapGetters(['location']),
+    ...mapGetters(['locationActive']),
   },
   methods: {
     ...mapMutations(['setLocations', 'setLocationsSelection']),

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -90,16 +90,13 @@ export default new Vuex.Store({
       return scope;
     },
     // LOCATION
-    location(state, getters) {
-      if (getters.locationsEmpty) {
-        return null;
-      }
-      const { locations } = state.locationsSelection;
-      return locations[0];
-    },
     locationActive(state, getters) {
       if (state.locationMode === LocationMode.SINGLE) {
-        return getters.location;
+        if (getters.locationsEmpty) {
+          return null;
+        }
+        const { locations } = state.locationsSelection;
+        return locations[0];
       }
       const n = state.locations.length;
       if (state.locationsIndex < 0 || state.locationsIndex >= n) {


### PR DESCRIPTION
# Issue Addressed
This PR closes #590 .

# Description
Move `location` logic into the `LocationMode.SINGLE` branch of `locationActive`, and replace the use of the `location` getter with `locationActive`.

# Tests
Tested all the pages that were changed, except for Request Study (which isn't reachable right now by normal interaction).