### PR TITLE
FcListLocationMulti: reusable multi-location list component

### DIFF
--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -47,20 +47,12 @@
                   <v-icon right>mdi-menu-down</v-icon>
                 </FcButton>
               </template>
-              <v-list>
-                <v-list-item
-                  v-for="(location, i) in locations"
-                  :key="i"
-                  :disabled="collisionSummaryPerLocation[i].amount === 0"
-                  @click="setLocationsIndex(i)">
-                  <v-list-item-title>
-                    <div class="d-flex">
-                      <FcIconLocationMulti v-bind="locationsIconProps[i]" />
-                      <span class="pl-2">{{location.description}}</span>
-                    </div>
-                  </v-list-item-title>
-                </v-list-item>
-              </v-list>
+              <FcListLocationMulti
+                :disabled="disabledPerLocation"
+                icon-classes="mr-2"
+                :locations="locations"
+                :locations-selection="locationsSelection"
+                @click-location="setLocationsIndex" />
             </v-menu>
             <span v-if="filterChipsCollision.length > 0"> &#x2022;</span>
           </div>
@@ -142,6 +134,7 @@ import FcDialogConfirm from '@/web/components/dialogs/FcDialogConfirm.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcMenuDownloadReportFormat from '@/web/components/inputs/FcMenuDownloadReportFormat.vue';
 import FcIconLocationMulti from '@/web/components/location/FcIconLocationMulti.vue';
+import FcListLocationMulti from '@/web/components/location/FcListLocationMulti.vue';
 import FcReport from '@/web/components/reports/FcReport.vue';
 import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
 
@@ -157,6 +150,7 @@ export default {
     FcButton,
     FcDialogConfirm,
     FcIconLocationMulti,
+    FcListLocationMulti,
     FcMenuDownloadReportFormat,
     FcReport,
   },
@@ -178,6 +172,9 @@ export default {
     };
   },
   computed: {
+    disabledPerLocation() {
+      return this.collisionSummaryPerLocation.map(({ amount }) => amount === 0);
+    },
     locationsActive() {
       if (this.locationMode === LocationMode.SINGLE || this.detailView) {
         return [this.locationActive];

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -44,20 +44,12 @@
                   <v-icon right>mdi-menu-down</v-icon>
                 </FcButton>
               </template>
-              <v-list>
-                <v-list-item
-                  v-for="(location, i) in locations"
-                  :key="i"
-                  :disabled="studySummaryPerLocation[0].perLocation[i].n === 0"
-                  @click="setLocationsIndex(i)">
-                  <v-list-item-title>
-                    <div class="d-flex">
-                      <FcIconLocationMulti v-bind="locationsIconProps[i]" />
-                      <span class="pl-2">{{location.description}}</span>
-                    </div>
-                  </v-list-item-title>
-                </v-list-item>
-              </v-list>
+              <FcListLocationMulti
+                :disabled="disabledPerLocation"
+                icon-classes="mr-2"
+                :locations="locations"
+                :locations-selection="locationsSelection"
+                @click-location="setLocationsIndex" />
             </v-menu>
             <span v-if="filterChipsStudyNoStudyTypes.length > 0"> &#x2022;</span>
           </div>
@@ -189,6 +181,7 @@ import FcDialogReportParameters from '@/web/components/dialogs/FcDialogReportPar
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcMenuDownloadReportFormat from '@/web/components/inputs/FcMenuDownloadReportFormat.vue';
 import FcIconLocationMulti from '@/web/components/location/FcIconLocationMulti.vue';
+import FcListLocationMulti from '@/web/components/location/FcListLocationMulti.vue';
 import FcReport from '@/web/components/reports/FcReport.vue';
 import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
 
@@ -205,6 +198,7 @@ export default {
     FcDialogConfirm,
     FcDialogReportParameters,
     FcIconLocationMulti,
+    FcListLocationMulti,
     FcMenuDownloadReportFormat,
     FcReport,
   },
@@ -248,6 +242,11 @@ export default {
         return null;
       }
       return reportTypes[indexActiveReportType];
+    },
+    disabledPerLocation() {
+      return this.studySummaryPerLocation[0].perLocation.map(
+        ({ n }) => n === 0,
+      );
     },
     filterChipsStudyNoStudyTypes() {
       return this.filterChipsStudy

--- a/web/components/data/FcAggregateCollisions.vue
+++ b/web/components/data/FcAggregateCollisions.vue
@@ -35,7 +35,7 @@
                 <FcTextSummaryFraction
                   :a="collisionSummaryPerLocation[i][field.name]"
                   :b="collisionSummaryPerLocationUnfiltered[i][field.name]"
-                  class="flex-grow-0 flex-shrink-0 mr-5"
+                  class="mr-9"
                   :show-b="hasFiltersCollision"
                   small />
               </template>

--- a/web/components/data/FcAggregateCollisions.vue
+++ b/web/components/data/FcAggregateCollisions.vue
@@ -25,31 +25,21 @@
               small />
           </v-expansion-panel-header>
           <v-expansion-panel-content class="shading pt-1">
-            <div
-              v-for="(location, i) in locations"
-              :key="i"
-              class="d-flex pa-3 pr-8"
-              :class="{
-                'data-empty': collisionSummaryPerLocation[i][field.name] === 0,
-              }">
-              <FcIconLocationMulti v-bind="locationsIconProps[i]" />
-              <span
-                class="title"
-                :class="{
-                  'pl-4': locationsIconProps[i].midblock,
-                  'pl-5': !locationsIconProps[i].midblock,
-                  'font-weight-regular': locationsIconProps[i].locationIndex === -1,
-                }">
-                {{location.description}}
-              </span>
-              <v-spacer></v-spacer>
-              <FcTextSummaryFraction
-                :a="collisionSummaryPerLocation[i][field.name]"
-                :b="collisionSummaryPerLocationUnfiltered[i][field.name]"
-                class="flex-grow-0 flex-shrink-0 mr-5"
-                :show-b="hasFiltersCollision"
-                small />
-            </div>
+            <FcListLocationMulti
+              class="shading"
+              :disabled="disabledPerLocationByField[field.name]"
+              icon-classes="mr-4"
+              :locations="locations"
+              :locations-selection="locationsSelection">
+              <template v-slot:action="{ i }">
+                <FcTextSummaryFraction
+                  :a="collisionSummaryPerLocation[i][field.name]"
+                  :b="collisionSummaryPerLocationUnfiltered[i][field.name]"
+                  class="flex-grow-0 flex-shrink-0 mr-5"
+                  :show-b="hasFiltersCollision"
+                  small />
+              </template>
+            </FcListLocationMulti>
           </v-expansion-panel-content>
         </v-expansion-panel>
       </v-expansion-panels>
@@ -62,12 +52,12 @@ import { mapGetters } from 'vuex';
 
 import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
 import FcTextSummaryFraction from '@/web/components/data/FcTextSummaryFraction.vue';
-import FcIconLocationMulti from '@/web/components/location/FcIconLocationMulti.vue';
+import FcListLocationMulti from '@/web/components/location/FcListLocationMulti.vue';
 
 export default {
   name: 'FcAggregateCollisions',
   components: {
-    FcIconLocationMulti,
+    FcListLocationMulti,
     FcTextSummaryFraction,
   },
   props: {
@@ -92,6 +82,15 @@ export default {
     };
   },
   computed: {
+    disabledPerLocationByField() {
+      const disabledPerLocationByField = {};
+      this.fields.forEach((field) => {
+        disabledPerLocationByField[field.name] = this.collisionSummaryPerLocation.map(
+          value => value[field.name] === 0,
+        );
+      });
+      return disabledPerLocationByField;
+    },
     locationsIconProps() {
       return getLocationsIconProps(this.locations, this.locationsSelection.locations);
     },

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -38,50 +38,37 @@
               small />
           </v-expansion-panel-header>
           <v-expansion-panel-content class="shading pt-1">
-            <div
-              v-for="(location, j) in locations"
-              :key="i + '_' + j"
-              class="d-flex pa-3 pr-8"
-              :class="{
-                'data-empty': itemsPerLocation[i][j].mostRecent === null,
-              }">
-              <FcIconLocationMulti v-bind="locationsIconProps[j]" />
-              <div
-                class="body-1 flex-grow-1 flex-shrink-1"
-                :class="{
-                  'pl-4': locationsIconProps[j].midblock,
-                  'pl-5': !locationsIconProps[j].midblock,
-                }">
-                <div
-                  :class="{
-                    'body-1': locationsIconProps[j].locationIndex === -1,
-                    title: locationsIconProps[j].locationIndex !== -1,
-                  }">
-                  {{location.description}}
-                </div>
+            <FcListLocationMulti
+              class="shading"
+              :disabled="disabledPerLocationByItem[i]"
+              icon-classes="mr-4"
+              :locations="locations"
+              :locations-selection="locationsSelection">
+              <template v-slot:subtitle="{ i: j }">
                 <FcTextMostRecent
                   v-if="itemsPerLocation[i][j].mostRecent !== null"
                   class="mt-2"
                   :study="itemsPerLocation[i][j].mostRecent" />
-              </div>
-              <v-spacer></v-spacer>
-              <div class="display-1 flex-grow-0 flex-shrink-0 mr-5">
-                <FcTextSummaryFraction
-                  :a="itemsPerLocation[i][j].n"
-                  :b="itemsPerLocation[i][j].nUnfiltered"
-                  class="text-right"
-                  :show-b="hasFiltersStudy"
-                  small />
-                <div v-if="itemsPerLocation[i][j].n > 0">
-                  <FcButton
-                    class="mr-n4 mt-2"
-                    type="tertiary"
-                    @click="$emit('show-reports', { item, locationsIndex: j })">
-                    <span>View Reports</span>
-                  </FcButton>
+              </template>
+              <template v-slot:action="{ i: j }">
+                <div class="mr-9">
+                  <FcTextSummaryFraction
+                    :a="itemsPerLocation[i][j].n"
+                    :b="itemsPerLocation[i][j].nUnfiltered"
+                    class="text-right"
+                    :show-b="hasFiltersStudy"
+                    small />
+                  <div v-if="itemsPerLocation[i][j].n > 0">
+                    <FcButton
+                      class="mr-n4 mt-1"
+                      type="tertiary"
+                      @click="$emit('show-reports', { item, locationsIndex: j })">
+                      <span>View Reports</span>
+                    </FcButton>
+                  </div>
                 </div>
-              </div>
-            </div>
+              </template>
+            </FcListLocationMulti>
           </v-expansion-panel-content>
         </v-expansion-panel>
       </v-expansion-panels>
@@ -96,13 +83,13 @@ import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
 import FcTextMostRecent from '@/web/components/data/FcTextMostRecent.vue';
 import FcTextSummaryFraction from '@/web/components/data/FcTextSummaryFraction.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
-import FcIconLocationMulti from '@/web/components/location/FcIconLocationMulti.vue';
+import FcListLocationMulti from '@/web/components/location/FcListLocationMulti.vue';
 
 export default {
   name: 'FcAggregateStudies',
   components: {
     FcButton,
-    FcIconLocationMulti,
+    FcListLocationMulti,
     FcTextMostRecent,
     FcTextSummaryFraction,
   },
@@ -121,6 +108,11 @@ export default {
     };
   },
   computed: {
+    disabledPerLocationByItem() {
+      return this.itemsPerLocation.map(
+        itemsPerLocation => itemsPerLocation.map(({ n }) => n === 0),
+      );
+    },
     items() {
       return this.studySummaryUnfiltered.map(({ category, n }) => {
         let item = this.studySummary.find(

--- a/web/components/data/FcViewDataMultiEdit.vue
+++ b/web/components/data/FcViewDataMultiEdit.vue
@@ -32,23 +32,11 @@
       </div>
       <div class="mt-5">
         <h2 class="fc-multi-edit-inset headline pb-1">Selected Locations</h2>
-        <div class="ml-6">
-          <div
-            v-for="(location, i) in locations"
-            :key="i"
-            class="d-flex mt-8">
-            <FcIconLocationMulti v-bind="locationsIconProps[i]" />
-            <span
-              class="title"
-              :class="{
-                'pl-8': locationsIconProps[i].midblock,
-                'pl-9': !locationsIconProps[i].midblock,
-                'font-weight-regular': locationsIconProps[i].locationIndex === -1,
-              }">
-              {{location.description}}
-            </span>
-          </div>
-        </div>
+        <FcListLocationMulti
+          class="ml-6"
+          icon-classes="mr-5"
+          :locations="locations"
+          :locations-selection="locationsSelection" />
       </div>
     </template>
   </div>
@@ -63,12 +51,12 @@ import {
 import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
 import DateTime from '@/lib/time/DateTime';
 import TimeFormatters from '@/lib/time/TimeFormatters';
-import FcIconLocationMulti from '@/web/components/location/FcIconLocationMulti.vue';
+import FcListLocationMulti from '@/web/components/location/FcListLocationMulti.vue';
 
 export default {
   name: 'FcViewDataMultiEdit',
   components: {
-    FcIconLocationMulti,
+    FcListLocationMulti,
   },
   props: {
     locations: Array,

--- a/web/components/location/FcIconLocationMulti.vue
+++ b/web/components/location/FcIconLocationMulti.vue
@@ -5,7 +5,7 @@
       :alt="alt"
       height="20"
       :src="src"
-      :width="width" />
+      :width="16" />
     <div
       v-if="locationIndex !== -1"
       class="subtitle-2"
@@ -51,9 +51,6 @@ export default {
         return `/icons/map/location-multi-corridor${suffixMidblock}${suffixSelected}.svg`;
       }
       return `/icons/map/location-multi-small${suffixSelected}.svg`;
-    },
-    width() {
-      return this.midblock ? 20 : 16;
     },
   },
 };

--- a/web/components/location/FcListLocationMulti.vue
+++ b/web/components/location/FcListLocationMulti.vue
@@ -3,7 +3,8 @@
     <v-list-item
       v-for="(location, i) in locations"
       :key="i"
-      :disabled="disabledNormalized[i]">
+      :disabled="disabledNormalized[i]"
+      @click="$emit('click-location', i)">
       <v-list-item-title>
         <div class="d-flex">
           <FcIconLocationMulti

--- a/web/components/location/FcListLocationMulti.vue
+++ b/web/components/location/FcListLocationMulti.vue
@@ -1,0 +1,65 @@
+<template>
+  <v-list class="fc-list-location-multi">
+    <v-list-item
+      v-for="(location, i) in locations"
+      :key="i"
+      :disabled="disabledNormalized[i]">
+      <v-list-item-title>
+        <div class="d-flex">
+          <FcIconLocationMulti
+            v-bind="locationsIconProps[i]"
+            :class="iconClasses" />
+          <div class="body-1 flex-grow-1 flex-shrink-1">
+            <div
+              :class="{
+                'body-1': locationsIconProps[i].locationIndex === -1,
+                title: locationsIconProps[i].locationIndex !== -1,
+              }">
+              {{location.description}}
+            </div>
+            <slot name="subtitle" v-bind="{ location, i }" />
+          </div>
+          <v-spacer></v-spacer>
+          <div class="flex-grow-0 flex-shrink-0">
+            <slot name="action" v-bind="{ location, i }" />
+          </div>
+        </div>
+      </v-list-item-title>
+    </v-list-item>
+  </v-list>
+</template>
+
+<script>
+import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
+import FcIconLocationMulti from '@/web/components/location/FcIconLocationMulti.vue';
+
+export default {
+  name: 'FcListLocationMulti',
+  components: {
+    FcIconLocationMulti,
+  },
+  props: {
+    disabled: {
+      type: Array,
+      default: null,
+    },
+    iconClasses: {
+      type: String,
+      default: null,
+    },
+    locations: Array,
+    locationsSelection: Object,
+  },
+  computed: {
+    disabledNormalized() {
+      if (this.disabled === null) {
+        return this.locations.map(() => false);
+      }
+      return this.disabled;
+    },
+    locationsIconProps() {
+      return getLocationsIconProps(this.locations, this.locationsSelection.locations);
+    },
+  },
+};
+</script>


### PR DESCRIPTION
# Issue Addressed
This PR closes #589 .

# Description
We introduce `FcListLocationMulti`, a new multi-location list component designed primarily for lists, menus, and other places where a list or summary data view over a multi-location selection is needed.  This is then used in View Data aggregate view and View Reports (both studies and collisions) - the idea is that this will make it easier to change look-and-feel here in the future.

# Tests
Quickly tested in frontend.
