### PR TITLE
Stub modes for multi-location Request Study

### DIFF
--- a/web/components/FcDetailsStudyRequest.vue
+++ b/web/components/FcDetailsStudyRequest.vue
@@ -1,5 +1,8 @@
 <template>
   <section>
+    <v-messages
+      v-bind="attrsMessagesTop"></v-messages>
+
     <div class="mt-4">
       <FcRadioGroup
         v-model="v.studyType.$model"
@@ -173,8 +176,10 @@ import {
   REQUEST_STUDY_PROVIDE_URGENT_DUE_DATE,
   REQUEST_STUDY_PROVIDE_URGENT_REASON,
   REQUEST_STUDY_REQUIRES_DAYS_OF_WEEK,
+  REQUEST_STUDY_REQUIRES_LOCATION,
   REQUEST_STUDY_REQUIRES_REASONS,
   REQUEST_STUDY_REQUIRES_STUDY_TYPE,
+  REQUEST_STUDY_TIME_TO_FULFILL,
 } from '@/lib/i18n/Strings';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 import FcCheckboxGroupChips from '@/web/components/inputs/FcCheckboxGroupChips.vue';
@@ -194,6 +199,7 @@ export default {
   },
   props: {
     isCreate: Boolean,
+    location: Object,
     v: Object,
   },
   data() {
@@ -208,6 +214,19 @@ export default {
     };
   },
   computed: {
+    attrsMessagesTop() {
+      if (!this.v.centrelineId.required
+        || !this.v.centrelineType.required
+        || !this.v.geom.required) {
+        return {
+          color: 'error',
+          value: [REQUEST_STUDY_REQUIRES_LOCATION.text],
+        };
+      }
+      return {
+        value: [REQUEST_STUDY_TIME_TO_FULFILL.text],
+      };
+    },
     errorMessagesCcEmails() {
       const errors = [];
       if (!this.v.ccEmails.requiredIfUrgent) {
@@ -407,6 +426,38 @@ export default {
       } else {
         this.internalValue.dueDate = this.dueDate;
       }
+    },
+    location() {
+      this.updateStudyRequestLocation();
+    },
+  },
+  created() {
+
+  },
+  methods: {
+    updateStudyRequestLocation() {
+      if (this.location === null) {
+        this.studyRequest.centrelineId = null;
+        this.studyRequest.centrelineType = null;
+        this.studyRequest.geom = null;
+      } else {
+        const {
+          centrelineId,
+          centrelineType,
+          lng,
+          lat,
+        } = this.location;
+        const geom = {
+          type: 'Point',
+          coordinates: [lng, lat],
+        };
+        this.studyRequest.centrelineId = centrelineId;
+        this.studyRequest.centrelineType = centrelineType;
+        this.studyRequest.geom = geom;
+      }
+      this.v.centrelineId.$touch();
+      this.v.centrelineType.$touch();
+      this.v.geom.$touch();
     },
   },
 };

--- a/web/components/FcDetailsStudyRequest.vue
+++ b/web/components/FcDetailsStudyRequest.vue
@@ -181,6 +181,7 @@ import {
   REQUEST_STUDY_REQUIRES_STUDY_TYPE,
   REQUEST_STUDY_TIME_TO_FULFILL,
 } from '@/lib/i18n/Strings';
+import DateTime from '@/lib/time/DateTime';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 import FcCheckboxGroupChips from '@/web/components/inputs/FcCheckboxGroupChips.vue';
 import FcDatePicker from '@/web/components/inputs/FcDatePicker.vue';
@@ -302,6 +303,23 @@ export default {
       }
       return errors;
     },
+    estimatedDeliveryDate() {
+      const { now, studyRequest } = this;
+      if (studyRequest === null) {
+        return null;
+      }
+      const { dueDate, urgent } = studyRequest;
+      if (dueDate === null) {
+        return null;
+      }
+      if (urgent) {
+        return dueDate;
+      }
+      return DateTime.max(
+        dueDate.minus({ weeks: 1 }),
+        now.plus({ months: 2 }),
+      );
+    },
     itemsDaysOfWeek() {
       return TimeFormatters.DAYS_OF_WEEK.map((text, value) => ({ text, value }));
     },
@@ -374,6 +392,9 @@ export default {
     ...mapState(['now']),
   },
   watch: {
+    estimatedDeliveryDate() {
+      this.studyRequest.estimatedDeliveryDate = this.estimatedDeliveryDate;
+    },
     'internalValue.studyType.automatic': function watchStudyTypeAutomatic() {
       if (this.internalValue.studyType.automatic) {
         this.internalValue.duration = 24;

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -270,8 +270,11 @@ export default {
       this.reportExportMode = null;
     },
     actionRequestStudy() {
-      /* eslint-disable-next-line no-alert */
-      window.alert('Coming Soon!');
+      const params = this.locationsRouteParams;
+      this.$router.push({
+        name: 'requestStudyNew',
+        params,
+      });
     },
     actionShowReportsCollision() {
       const params = this.locationsRouteParams;

--- a/web/components/dialogs/FcDialogConfirmRequestStudyLeave.vue
+++ b/web/components/dialogs/FcDialogConfirmRequestStudyLeave.vue
@@ -1,0 +1,36 @@
+<template>
+  <FcDialogConfirm
+      v-model="internalValue"
+      :textCancel="isCreate ? 'Stay on this page' : 'Keep editing'"
+      :textOk="isCreate ? 'Quit' : 'Discard'"
+      :title="isCreate ? 'Quit study request?' : 'Discard changes?'"
+      @action-ok="$emit('action-ok')">
+      <span class="body-1">
+        <span v-if="isCreate">
+          Leaving this page will cause a loss of all entered data.
+          Are you sure you want to quit?
+        </span>
+        <span v-else>
+          You have made changes to the study request that have not been saved.
+          Do you wish to discard these changes?
+        </span>
+      </span>
+    </FcDialogConfirm>
+</template>
+
+<script>
+
+import FcDialogConfirm from '@/web/components/dialogs/FcDialogConfirm.vue';
+import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+
+export default {
+  name: 'FcDialogConfirmRequestStudyLeave',
+  mixins: [FcMixinVModelProxy(Boolean)],
+  components: {
+    FcDialogConfirm,
+  },
+  props: {
+    isCreate: Boolean,
+  },
+};
+</script>

--- a/web/components/requests/FcDetailsStudyRequest.vue
+++ b/web/components/requests/FcDetailsStudyRequest.vue
@@ -445,38 +445,6 @@ export default {
         this.internalValue.dueDate = this.dueDate;
       }
     },
-    location() {
-      this.updateStudyRequestLocation();
-    },
-  },
-  created() {
-    this.updateStudyRequestLocation();
-  },
-  methods: {
-    updateStudyRequestLocation() {
-      if (this.location === null) {
-        this.studyRequest.centrelineId = null;
-        this.studyRequest.centrelineType = null;
-        this.studyRequest.geom = null;
-      } else {
-        const {
-          centrelineId,
-          centrelineType,
-          lng,
-          lat,
-        } = this.location;
-        const geom = {
-          type: 'Point',
-          coordinates: [lng, lat],
-        };
-        this.studyRequest.centrelineId = centrelineId;
-        this.studyRequest.centrelineType = centrelineType;
-        this.studyRequest.geom = geom;
-      }
-      this.v.centrelineId.$touch();
-      this.v.centrelineType.$touch();
-      this.v.geom.$touch();
-    },
   },
 };
 </script>

--- a/web/components/requests/FcDetailsStudyRequest.vue
+++ b/web/components/requests/FcDetailsStudyRequest.vue
@@ -13,7 +13,7 @@
         </template>
       </FcRadioGroup>
       <v-messages
-        class="mt-1"
+        class="mt-2"
         color="error"
         :value="errorMessagesStudyType"></v-messages>
     </div>
@@ -281,9 +281,6 @@ export default {
     },
     errorMessagesReasons() {
       const errors = [];
-      if (!this.v.reasons.$dirty) {
-        return errors;
-      }
       if (!this.v.reasons.required) {
         errors.push(REQUEST_STUDY_REQUIRES_REASONS.text);
       }
@@ -453,7 +450,7 @@ export default {
     },
   },
   created() {
-
+    this.updateStudyRequestLocation();
   },
   methods: {
     updateStudyRequestLocation() {

--- a/web/components/requests/FcDetailsStudyRequestBulk.vue
+++ b/web/components/requests/FcDetailsStudyRequestBulk.vue
@@ -1,0 +1,14 @@
+<template>
+  <section>
+    <h2>TODO: bulk study request editor</h2>
+  </section>
+</template>
+
+<script>
+export default {
+  name: 'FcDetailsStudyRequestBulk',
+  props: {
+    isCreate: Boolean,
+  },
+};
+</script>

--- a/web/components/requests/FcFooterRequestStudy.vue
+++ b/web/components/requests/FcFooterRequestStudy.vue
@@ -1,0 +1,32 @@
+<template>
+  <div class="align-center d-flex px-3 py-2">
+    <v-spacer></v-spacer>
+    <FcButton
+      class="mr-2"
+      type="tertiary"
+      @click="$emit('action-navigate-back')">
+      Cancel
+    </FcButton>
+    <FcButton
+      :disabled="v.$invalid"
+      type="primary"
+      @click="$emit('action-submit')">
+      Submit
+    </FcButton>
+  </div>
+</template>
+
+<script>
+import FcButton from '@/web/components/inputs/FcButton.vue';
+
+export default {
+  name: 'FcFooterRequestStudy',
+  components: {
+    FcButton,
+  },
+  props: {
+    studyRequest: Object,
+    v: Object,
+  },
+};
+</script>

--- a/web/components/requests/FcHeaderRequestStudy.vue
+++ b/web/components/requests/FcHeaderRequestStudy.vue
@@ -36,41 +36,46 @@ export default {
     FcButton,
   },
   props: {
+    isBulk: Boolean,
     isCreate: Boolean,
-    isSingleLocation: Boolean,
   },
   computed: {
     labelNavigateBack() {
-      if (this.isCreate && this.locationActive === null) {
-        return 'View Map';
+      if (this.isCreate) {
+        if (this.locationsEmpty) {
+          return 'View Map';
+        }
+        return 'View Data';
       }
-      return 'View Data';
+      // TODO: handle bulk requests
+      const { id } = this.$route.params;
+      return `View Request #${id}`;
     },
     subtitle() {
-      if (this.isSingleLocation) {
-        if (this.locationActive === null) {
-          return 'needs location';
-        }
-        return this.locationActive.description;
+      if (this.isBulk) {
+        return getLocationsDescription(this.locations);
       }
-      return getLocationsDescription(this.locations);
+      if (this.locationActive === null) {
+        return 'needs location';
+      }
+      return this.locationActive.description;
     },
     title() {
       if (this.isCreate) {
-        if (this.isSingleLocation) {
-          return 'Request Study';
+        if (this.isBulk) {
+          return 'Bulk Request Study';
         }
-        return 'Bulk Request Study';
+        return 'Request Study';
       }
       const { id } = this.$route.params;
-      if (this.isSingleLocation) {
-        return `Edit Request #${id}`;
+      if (this.isBulk) {
+        return `Edit Bulk Request #${id}`;
       }
-      return `Edit Bulk Request #${id}`;
+      return `Edit Request #${id}`;
     },
     ...mapState(['locationMode', 'locations']),
     ...mapState('viewData', ['detailView']),
-    ...mapGetters(['locationActive']),
+    ...mapGetters(['locationActive', 'locationsEmpty']),
   },
 };
 </script>

--- a/web/components/requests/FcHeaderRequestStudy.vue
+++ b/web/components/requests/FcHeaderRequestStudy.vue
@@ -1,0 +1,63 @@
+<template>
+  <v-row
+    class="align-center px-3 py-2"
+    no-gutters>
+    <v-col cols="2">
+      <FcButton
+        v-if="isCreate"
+        type="secondary"
+        @click="$emit('action-navigate-back')">
+        <v-icon left>mdi-chevron-left</v-icon>
+        {{labelNavigateBack}}
+      </FcButton>
+    </v-col>
+    <v-col class="text-center" cols="8">
+      <h1 class="headline">
+        <span>
+          {{title}}:
+        </span>
+        <span class="font-weight-regular">
+          {{subtitle}}
+        </span>
+      </h1>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+import { mapGetters } from 'vuex';
+
+import FcButton from '@/web/components/inputs/FcButton.vue';
+
+export default {
+  name: 'FcHeaderRequestStudy',
+  components: {
+    FcButton,
+  },
+  props: {
+    isCreate: Boolean,
+  },
+  computed: {
+    labelNavigateBack() {
+      if (this.isCreate && this.locationActive === null) {
+        return 'View Map';
+      }
+      return 'View Data';
+    },
+    subtitle() {
+      if (this.locationActive === null) {
+        return 'needs location';
+      }
+      return this.locationActive.description;
+    },
+    title() {
+      if (this.isCreate) {
+        return 'Request Study';
+      }
+      const { id } = this.$route.params;
+      return `Edit Request #${id}`;
+    },
+    ...mapGetters(['locationActive']),
+  },
+};
+</script>

--- a/web/components/requests/FcHeaderRequestStudy.vue
+++ b/web/components/requests/FcHeaderRequestStudy.vue
@@ -25,8 +25,9 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex';
+import { mapGetters, mapState } from 'vuex';
 
+import { getLocationsDescription } from '@/lib/geo/CentrelineUtils';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 
 export default {
@@ -36,6 +37,7 @@ export default {
   },
   props: {
     isCreate: Boolean,
+    isSingleLocation: Boolean,
   },
   computed: {
     labelNavigateBack() {
@@ -45,18 +47,29 @@ export default {
       return 'View Data';
     },
     subtitle() {
-      if (this.locationActive === null) {
-        return 'needs location';
+      if (this.isSingleLocation) {
+        if (this.locationActive === null) {
+          return 'needs location';
+        }
+        return this.locationActive.description;
       }
-      return this.locationActive.description;
+      return getLocationsDescription(this.locations);
     },
     title() {
       if (this.isCreate) {
-        return 'Request Study';
+        if (this.isSingleLocation) {
+          return 'Request Study';
+        }
+        return 'Bulk Request Study';
       }
       const { id } = this.$route.params;
-      return `Edit Request #${id}`;
+      if (this.isSingleLocation) {
+        return `Edit Request #${id}`;
+      }
+      return `Edit Bulk Request #${id}`;
     },
+    ...mapState(['locationMode', 'locations']),
+    ...mapState('viewData', ['detailView']),
     ...mapGetters(['locationActive']),
   },
 };

--- a/web/router.js
+++ b/web/router.js
@@ -112,7 +112,7 @@ const router = new Router({
         },
         component: () => import(/* webpackChunkName: "home" */ '@/web/components/FcDrawerViewCollisionReports.vue'),
         beforeEnter(to, from, next) {
-          store.commit('setDrawerOpen', false);
+          store.commit('setDrawerOpen', true);
           next();
         },
       }, {
@@ -125,11 +125,11 @@ const router = new Router({
         },
         component: () => import(/* webpackChunkName: "home" */ '@/web/components/FcDrawerViewStudyReports.vue'),
         beforeEnter(to, from, next) {
-          store.commit('setDrawerOpen', false);
+          store.commit('setDrawerOpen', true);
           next();
         },
       }, {
-        path: '/requests/study/new',
+        path: '/requests/study/new/:s1/:selectionTypeName',
         name: 'requestStudyNew',
         meta: {
           auth: {


### PR DESCRIPTION
# Issue Addressed
This PR closes #598 .

# Description
We refactor `FcDrawerRequestStudy` to handle two sets of modes: create vs. edit, and bulk vs. non-bulk.  To facilitate this, we add location selection parameters to the route for Request Study, and use those with `initLocations()` to determine whether to load the bulk or non-bulk interface.

For now, the bulk interface is just a `<h2>` with a TODO message - we'll be filling that out as we work on #599 and beyond.

# Tests
Tested quickly in frontend - testing will get more stringent as we proceed through these tasks.
