### PR TITLE
Bulk Request Study: bulk actions for setting study request parameters

### DIFF
--- a/tests/jest/api/RestApi.spec.js
+++ b/tests/jest/api/RestApi.spec.js
@@ -458,13 +458,12 @@ test('StudyRequestController', async () => {
 
   const now = DateTime.local();
   const transientStudyRequest = {
-    serviceRequestId: null,
     urgent: false,
     urgentReason: null,
-    assignedTo: null,
     dueDate: now.plus({ months: 3 }),
     estimatedDeliveryDate: now.plus({ months: 2, weeks: 3 }),
-    reasons: [StudyRequestReason.TSC, StudyRequestReason.PED_SAFETY],
+    reason: StudyRequestReason.PED_SAFETY,
+    reasonOther: null,
     ccEmails: [],
     studyType: StudyType.TMC,
     daysOfWeek: [2, 3, 4],
@@ -579,8 +578,8 @@ test('StudyRequestController', async () => {
   expect(fetchedStudyRequests).toContainEqual(persistedStudyRequest);
 
   // update study request fields
-  persistedStudyRequest.reasons = [StudyRequestReason.TSC];
-  persistedStudyRequest.serviceRequestId = '12345';
+  persistedStudyRequest.reason = StudyRequestReason.OTHER;
+  persistedStudyRequest.reasonOther = 'not really sure, but it seemed good at the time';
 
   // cannot update non-existent study request
   client.setUser(requester);
@@ -623,6 +622,7 @@ test('StudyRequestController', async () => {
   expect(fetchedStudyRequest.lastEditorId).toEqual(requester.id);
 
   // update more study request fields and set urgent
+  persistedStudyRequest.ccEmails = ['Evan.Savage@toronto.ca'];
   persistedStudyRequest.daysOfWeek = [3, 4];
   persistedStudyRequest.hours = StudyHours.SCHOOL;
   persistedStudyRequest.notes = 'oops, this is actually a school count';

--- a/tests/jest/db/StudyRequestChangeDAO.spec.js
+++ b/tests/jest/db/StudyRequestChangeDAO.spec.js
@@ -25,13 +25,13 @@ test('StudyRequestChangeDAO', async () => {
   const persistedUser1 = await UserDAO.create(transientUser1);
   const now = DateTime.local();
   const transientStudyRequest = {
-    serviceRequestId: '12345',
     urgent: false,
     urgentReason: null,
     assignedTo: StudyRequestAssignee.FIELD_STAFF,
     dueDate: now.plus({ months: 4 }),
     estimatedDeliveryDate: now.plus({ months: 3, weeks: 3 }),
-    reasons: [StudyRequestReason.TSC, StudyRequestReason.PED_SAFETY],
+    reason: StudyRequestReason.PED_SAFETY,
+    reasonOther: null,
     ccEmails: [],
     studyType: StudyType.TMC,
     daysOfWeek: [2, 3, 4],

--- a/tests/jest/db/StudyRequestCommentDAO.spec.js
+++ b/tests/jest/db/StudyRequestCommentDAO.spec.js
@@ -1,7 +1,6 @@
 import {
   CentrelineType,
   StudyHours,
-  StudyRequestAssignee,
   StudyRequestReason,
   StudyType,
 } from '@/lib/Constants';
@@ -24,13 +23,12 @@ test('StudyRequestCommentDAO', async () => {
   const userCreated1 = await UserDAO.create(user1);
   const now = DateTime.local();
   const transientStudyRequest = {
-    serviceRequestId: '12345',
     urgent: false,
     urgentReason: null,
-    assignedTo: StudyRequestAssignee.FIELD_STAFF,
     dueDate: now.plus({ months: 4 }),
     estimatedDeliveryDate: now.plus({ months: 3, weeks: 3 }),
-    reasons: [StudyRequestReason.TSC, StudyRequestReason.PED_SAFETY],
+    reason: StudyRequestReason.PED_SAFETY,
+    reasonOther: null,
     ccEmails: [],
     studyType: StudyType.TMC,
     daysOfWeek: [2, 3, 4],

--- a/web/components/requests/FcHeaderStudyRequestBulkLocations.vue
+++ b/web/components/requests/FcHeaderStudyRequestBulkLocations.vue
@@ -31,13 +31,63 @@
         </v-list>
       </v-menu>
 
-      <v-menu>
+      <v-menu min-width="120">
         <template v-slot:activator="{ on, attrs }">
           <FcButton
             v-bind="attrs"
             v-on="on"
             class="ml-2"
             :disabled="selectAll === false"
+            type="secondary">
+            <span>Days</span>
+            <v-icon right>mdi-menu-down</v-icon>
+          </FcButton>
+        </template>
+        <v-list>
+          <v-list-item
+            v-for="({ selected, text, value }, i) in itemsDaysOfWeek"
+            :key="i"
+            @click="actionSetDaysOfWeek(value, selected)">
+            <v-list-item-title class="align-center d-flex">
+              <v-simple-checkbox
+                class="mx-2"
+                dense
+                :indeterminate="selected === null"
+                :value="selected"
+                @click="actionSetDaysOfWeek(value, selected)" />
+              <span>{{text}}</span>
+            </v-list-item-title>
+          </v-list-item>
+        </v-list>
+      </v-menu>
+
+      <v-menu v-if="showDuration">
+        <template v-slot:activator="{ on, attrs }">
+          <FcButton
+            v-bind="attrs"
+            v-on="on"
+            class="ml-2"
+            type="secondary">
+            <span>Duration</span>
+            <v-icon right>mdi-menu-down</v-icon>
+          </FcButton>
+        </template>
+        <v-list>
+          <v-list-item
+            v-for="({ text, value }, i) in itemsDuration"
+            :key="i"
+            @click="actionSetDuration(value)">
+            <v-list-item-title>{{text}}</v-list-item-title>
+          </v-list-item>
+        </v-list>
+      </v-menu>
+
+      <v-menu v-if="showHours">
+        <template v-slot:activator="{ on, attrs }">
+          <FcButton
+            v-bind="attrs"
+            v-on="on"
+            class="ml-2"
             type="secondary">
             <span>Hours</span>
             <v-icon right>mdi-menu-down</v-icon>
@@ -59,6 +109,7 @@
 <script>
 import ArrayUtils from '@/lib/ArrayUtils';
 import { StudyHours, StudyType } from '@/lib/Constants';
+import TimeFormatters from '@/lib/time/TimeFormatters';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
@@ -74,6 +125,31 @@ export default {
     title: String,
   },
   computed: {
+    itemsDuration() {
+      return [
+        { text: '1 day', value: 24 },
+        { text: '2 days', value: 48 },
+        { text: '3 days', value: 72 },
+        { text: '4 days', value: 96 },
+        { text: '5 days', value: 120 },
+        { text: '1 week', value: 168 },
+      ];
+    },
+    itemsDaysOfWeek() {
+      return TimeFormatters.DAYS_OF_WEEK.map((text, value) => {
+        const k = this.internalValue.length;
+        const s = this.internalValue
+          .filter(i => this.studyRequests[i].daysOfWeek.includes(value))
+          .length;
+        let selected = null;
+        if (s === 0) {
+          selected = false;
+        } else if (s === k) {
+          selected = true;
+        }
+        return { selected, text, value };
+      });
+    },
     itemsHours() {
       return StudyHours.enumValues.map((value) => {
         const { description } = value;
@@ -106,6 +182,24 @@ export default {
         }
       },
     },
+    showDuration() {
+      if (this.selectAll === false) {
+        return false;
+      }
+      return this.internalValue.every((i) => {
+        const { studyType } = this.studyRequests[i];
+        return studyType !== null && studyType.automatic;
+      });
+    },
+    showHours() {
+      if (this.selectAll === false) {
+        return false;
+      }
+      return this.internalValue.every((i) => {
+        const { studyType } = this.studyRequests[i];
+        return studyType !== null && !studyType.automatic;
+      });
+    },
     subtitle() {
       const k = this.internalValue.length;
       const n = this.indices.length;
@@ -113,6 +207,33 @@ export default {
     },
   },
   methods: {
+    actionSetDaysOfWeek(dayOfWeek, selectedPrev) {
+      console.log(dayOfWeek, selectedPrev);
+      const selected = selectedPrev !== true;
+      if (selected) {
+        this.internalValue.forEach((i) => {
+          const { daysOfWeek } = this.studyRequests[i];
+          const j = daysOfWeek.indexOf(dayOfWeek);
+          if (j === -1) {
+            daysOfWeek.push(dayOfWeek);
+            this.studyRequests[i].daysOfWeek = ArrayUtils.sortBy(daysOfWeek, d => d);
+          }
+        });
+      } else {
+        this.internalValue.forEach((i) => {
+          const { daysOfWeek } = this.studyRequests[i];
+          const j = daysOfWeek.indexOf(dayOfWeek);
+          if (j !== -1) {
+            daysOfWeek.splice(j, 1);
+          }
+        });
+      }
+    },
+    actionSetDuration(duration) {
+      this.internalValue.forEach((i) => {
+        this.studyRequests[i].duration = duration;
+      });
+    },
     actionSetHours(hours) {
       this.internalValue.forEach((i) => {
         this.studyRequests[i].hours = hours;


### PR DESCRIPTION
# Issue Addressed
This PR makes further progress on #600 .

# Description
We add bulk actions for days of week and duration, and also show / hide hours and duration as appropriate for study types at selected locations.  Also updated several DAO and REST API tests to account for recent changes in study request schema.

# Tests
`npm run test:test-db`, `npm run test:test-api`, test frontend changes quickly.
