### PR TITLE
Update CI configuration to use current branch for deployment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,7 +54,7 @@ deploy-dev:
 deploy-qa:
   stage: deploy
   script:
-    - echo deploy-qa
+    - ./scripts/deployment/code-commit/deploy_code_commit.sh
   only:
     - deploy-qa
 

--- a/scripts/deployment/code-commit/deploy_code_commit.sh
+++ b/scripts/deployment/code-commit/deploy_code_commit.sh
@@ -2,7 +2,17 @@
 
 set -euo pipefail
 
-# notify prj_move on Slack
-curl -H "Content-Type: application/json; charset=utf-8" -d "{\"text\": \"<!here> MOVE down for deployment: ${CI_COMMIT_REF_NAME} @ ${CI_COMMIT_SHORT_SHA} -> flashcrow-dev0\"}" "$SLACK_WEBHOOK_URL"
+TARGET_ENV=
+if [ "${CI_COMMIT_REF_NAME}" = "master" ]; then
+  TARGET_ENV="flashcrow-dev0"
+elif [ "${CI_COMMIT_REF_NAME}" = "deploy-qa" ]; then
+  TARGET_ENV="flashcrow-qa0"
+else
+  echo "Invalid branch for deployment: ${CI_COMMIT_REF_NAME}"
+  exit 1
+fi
 
-git push https://git-codecommit.ca-central-1.amazonaws.com/v1/repos/bdit_flashcrow HEAD:master
+# notify prj_move on Slack
+curl -H "Content-Type: application/json; charset=utf-8" -d "{\"text\": \"<!here> MOVE down for deployment: ${CI_COMMIT_REF_NAME} @ ${CI_COMMIT_SHORT_SHA} -> ${TARGET_ENV}\"}" "$SLACK_WEBHOOK_URL"
+
+git push https://git-codecommit.ca-central-1.amazonaws.com/v1/repos/bdit_flashcrow "HEAD:${CI_COMMIT_REF_NAME}"


### PR DESCRIPTION
# Issue Addressed
This PR comes _very, very close_ to #292 .

# Description
We update `deploy_code_commit.sh` to allow for deployment from either `master` or `deploy-qa`, and update `.gitlab-ci.yml` to call this script on the `deploy-qa` branch.  (Even though this makes the CI / CD configurations for `master` and `deploy-qa` essentially identical, we don't merge those blocks, as we might eventually add additional verification steps in here somewhere.)

# Tests
Test to make sure we're on a deployable branch in `deploy_code_commit.sh` - ran this with manually-set environment variables locally.  Will merge into `master` and observe CI / CD logs to ensure that `flashcrow-dev0` deployments work, then (if working) merge into `deploy-qa` and observe those logs as well.