### PR TITLE
Edit actions for bulk and non-bulk study requests

### DIFF
--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -530,25 +530,20 @@ async function putStudyRequest(csrf, studyRequest) {
     csrf,
     data: studyRequest,
   };
-  const response = await apiClient.fetch(url, options);
-  const responseSchema = Joi.object().keys({
-    studyRequest: StudyRequest.read,
-    studyRequestChange: StudyRequestChange.read.allow(null),
-  });
-  return responseSchema.validateAsync(response);
+  const studyRequestUpdated = await apiClient.fetch(url, options);
+  return StudyRequest.read.validateAsync(studyRequestUpdated);
 }
 
 async function putStudyRequestBulk(csrf, studyRequestBulk) {
   const { id: studyRequestBulkId } = studyRequestBulk;
-  // TODO: this endpoint doesn't exist yet!
   const url = `/requests/study/bulk/${studyRequestBulkId}`;
   const options = {
     method: 'PUT',
     csrf,
     data: studyRequestBulk,
   };
-  const response = await apiClient.fetch(url, options);
-  return StudyRequestBulk.read.validateAsync(response);
+  const studyRequestBulkUpdated = await apiClient.fetch(url, options);
+  return StudyRequestBulk.read.validateAsync(studyRequestBulkUpdated);
 }
 
 async function putStudyRequestComment(csrf, studyRequest, comment) {

--- a/lib/auth/StudyRequestPermissions.js
+++ b/lib/auth/StudyRequestPermissions.js
@@ -3,6 +3,16 @@ import Boom from '@hapi/boom';
 import { AuthScope, StudyRequestStatus } from '@/lib/Constants';
 import { hasAuthScope } from '@/lib/auth/ScopeMatcher';
 
+/**
+ * Checks the details of a study request to ensure that we're not trying to update
+ * non-updatable columns.  Works for both bulk and non-bulk requests.
+ *
+ * @param {Object} studyRequestNew - new study request object, usually as passed in the payload
+ * of a `PUT` request
+ * @param {Object} studyRequestOld - old study request object, usually as fetched using
+ * {@link StudyRequestDAO.byId}
+ * @returns {hapi.Boom?} `Boom` error if the update cannot proceed, or `null` if it can
+ */
 function canUpdateStudyRequestDetails(studyRequestNew, studyRequestOld) {
   if (studyRequestNew.id !== studyRequestOld.id) {
     return Boom.badRequest('cannot change ID for study request');
@@ -26,12 +36,24 @@ function canUpdateStudyRequestDetails(studyRequestNew, studyRequestOld) {
   return null;
 }
 
+/**
+ *
+ * @param {Object} studyRequestNew - new study request object, usually as passed in the payload
+ * of a `PUT` request
+ * @param {Object} studyRequestOld - old study request object, usually as fetched using
+ * {@link StudyRequestDAO.byId}
+ * @param {Object} user - user making the update
+ * @returns {hapi.Boom?} `Boom` error if the update cannot proceed, or `null` if it can
+ */
 function canUpdateStudyRequest(studyRequestNew, studyRequestOld, user) {
   const err = canUpdateStudyRequestDetails(studyRequestNew, studyRequestOld);
   if (err !== null) {
     return err;
   }
 
+  if (studyRequestNew.studyBulkRequestId !== studyRequestOld.studyBulkRequestId) {
+    return Boom.badRequest('cannot change bulk request ID for study request');
+  }
   if (studyRequestNew.status !== studyRequestOld.status
     && !studyRequestOld.status.canTransitionTo(studyRequestNew.status)) {
     return Boom.badRequest(
@@ -60,6 +82,15 @@ function canUpdateStudyRequest(studyRequestNew, studyRequestOld, user) {
   return null;
 }
 
+/**
+ *
+ * @param {Object} studyRequestBulkNew - new bulk study request object, usually as passed in
+ * the payload of a `PUT` request
+ * @param {Object} studyRequestBulkOld - old bulk study request object, usually as fetched using
+ * {@link StudyRequestBulkDAO.byId}
+ * @param {Object} user - user making the update
+ * @returns {hapi.Boom?} `Boom` error if the update cannot proceed, or `null` if it can
+ */
 function canUpdateStudyRequestBulk(studyRequestBulkNew, studyRequestBulkOld, user) {
   let err = canUpdateStudyRequestDetails(studyRequestBulkNew, studyRequestBulkOld);
   if (err !== null) {
@@ -89,6 +120,9 @@ function canUpdateStudyRequestBulk(studyRequestBulkNew, studyRequestBulkOld, use
   return null;
 }
 
+/**
+ * @namespace
+ */
 const StudyRequestPermissions = {
   canUpdateStudyRequest,
   canUpdateStudyRequestBulk,

--- a/lib/auth/StudyRequestPermissions.js
+++ b/lib/auth/StudyRequestPermissions.js
@@ -1,0 +1,101 @@
+import Boom from '@hapi/boom';
+
+import { AuthScope, StudyRequestStatus } from '@/lib/Constants';
+import { hasAuthScope } from '@/lib/auth/ScopeMatcher';
+
+function canUpdateStudyRequestDetails(studyRequestNew, studyRequestOld) {
+  if (studyRequestNew.id !== studyRequestOld.id) {
+    return Boom.badRequest('cannot change ID for study request');
+  }
+  if (!studyRequestNew.createdAt.equals(studyRequestOld.createdAt)) {
+    return Boom.badRequest('cannot change creation timestamp for study request');
+  }
+  if (studyRequestNew.userId !== studyRequestOld.userId) {
+    return Boom.badRequest('cannot change owner for study request');
+  }
+  if (studyRequestNew.lastEditorId !== studyRequestOld.lastEditorId) {
+    return Boom.badRequest('cannot change last editor for study request');
+  }
+  if (studyRequestNew.lastEditedAt === null) {
+    if (studyRequestOld.lastEditedAt !== null) {
+      return Boom.badRequest('cannot change last edit timestamp for study request');
+    }
+  } else if (!studyRequestNew.lastEditedAt.equals(studyRequestOld.lastEditedAt)) {
+    return Boom.badRequest('cannot change last edit timestamp for study request');
+  }
+  return null;
+}
+
+function canUpdateStudyRequest(studyRequestNew, studyRequestOld, user) {
+  const err = canUpdateStudyRequestDetails(studyRequestNew, studyRequestOld);
+  if (err !== null) {
+    return err;
+  }
+
+  if (studyRequestNew.status !== studyRequestOld.status
+    && !studyRequestOld.status.canTransitionTo(studyRequestNew.status)) {
+    return Boom.badRequest(
+      `invalid state transition: ${studyRequestOld.status} -> ${studyRequestNew.status}`,
+    );
+  }
+
+  if (!hasAuthScope(user, AuthScope.STUDY_REQUESTS_ADMIN)) {
+    if (studyRequestOld.userId !== user.id) {
+      return Boom.forbidden('not authorized to change study request owned by another user');
+    }
+    if (studyRequestNew.assignedTo !== studyRequestOld.assignedTo) {
+      return Boom.forbidden('not authorized to change assignment for study request');
+    }
+    if (studyRequestNew.status !== studyRequestOld.status
+      && studyRequestNew.status !== StudyRequestStatus.CANCELLED
+      && studyRequestOld.status !== StudyRequestStatus.CANCELLED) {
+      /*
+       * Non-admin requesters can only change the status to cancel requests, or to
+       * reopen previously cancelled requests.
+       */
+      return Boom.forbidden('not authorized to change status for study request');
+    }
+  }
+
+  return null;
+}
+
+function canUpdateStudyRequestBulk(studyRequestBulkNew, studyRequestBulkOld, user) {
+  let err = canUpdateStudyRequestDetails(studyRequestBulkNew, studyRequestBulkOld);
+  if (err !== null) {
+    return err;
+  }
+
+  const n = studyRequestBulkNew.studyRequests.length;
+  if (n !== studyRequestBulkOld.studyRequests.length) {
+    return Boom.badRequest('cannot add / remove requests for bulk study request');
+  }
+
+  for (let i = 0; i < n; i++) {
+    const studyRequestNew = studyRequestBulkNew.studyRequests[i];
+    const studyRequestOld = studyRequestBulkOld.studyRequests[i];
+    err = canUpdateStudyRequest(studyRequestNew, studyRequestOld, user);
+    if (err !== null) {
+      return err;
+    }
+  }
+
+  if (!hasAuthScope(user, AuthScope.STUDY_REQUESTS_ADMIN)) {
+    if (studyRequestBulkOld.userId !== user.id) {
+      return Boom.forbidden('not authorized to change study request owned by another user');
+    }
+  }
+
+  return null;
+}
+
+const StudyRequestPermissions = {
+  canUpdateStudyRequest,
+  canUpdateStudyRequestBulk,
+};
+
+export {
+  StudyRequestPermissions as default,
+  canUpdateStudyRequest,
+  canUpdateStudyRequestBulk,
+};

--- a/lib/controller/StudyRequestBulkController.js
+++ b/lib/controller/StudyRequestBulkController.js
@@ -1,5 +1,6 @@
 import Boom from '@hapi/boom';
 
+import { canUpdateStudyRequestBulk } from '@/lib/auth/StudyRequestPermissions';
 import { AuthScope, LocationSelectionType } from '@/lib/Constants';
 import StudyRequestBulkDAO from '@/lib/db/StudyRequestBulkDAO';
 import StudyRequestChangeDAO from '@/lib/db/StudyRequestChangeDAO';
@@ -160,7 +161,63 @@ StudyRequestBulkController.push({
   },
 });
 
-// TODO: add PUT endpoint here
+/**
+ * Update the given bulk study request.
+ *
+ * The request body should contain the bulk request to be updated; the ID of that bulk request
+ * should match the request URL.
+ *
+ * Note that you cannot use this endpoint to remove requests from, or add requests to, a bulk
+ * request.  You can, however, use it to update existing requests.
+ *
+ * @memberof StudyRequestBulkController
+ * @name putStudyRequestBulk
+ * @type {Hapi.ServerRoute}
+ */
+StudyRequestBulkController.push({
+  method: 'PUT',
+  path: '/requests/study/bulk/{id}',
+  options: {
+    auth: {
+      scope: [AuthScope.STUDY_REQUESTS_EDIT.name],
+    },
+    response: {
+      schema: StudyRequestBulk.read,
+    },
+    validate: {
+      params: {
+        id: Joi.number().integer().positive().required(),
+      },
+      payload: StudyRequestBulk.update,
+    },
+  },
+  handler: async (request) => {
+    const user = request.auth.credentials;
+    const { id } = request.params;
+    const studyRequestBulkNew = request.payload;
+
+    const studyRequestBulkOld = await StudyRequestBulkDAO.byId(id);
+    if (studyRequestBulkOld === null) {
+      return Boom.notFound(`no bulk study request found with ID ${id}`);
+    }
+    const err = canUpdateStudyRequestBulk(studyRequestBulkNew, studyRequestBulkOld, user);
+    if (err !== null) {
+      return err;
+    }
+
+    const tasks = [StudyRequestBulkDAO.update(studyRequestBulkNew, user)];
+    const n = studyRequestBulkNew.studyRequests.length;
+    for (let i = 0; i < n; i++) {
+      const studyRequestNew = studyRequestBulkNew.studyRequests[i];
+      const studyRequestOld = studyRequestBulkOld.studyRequests[i];
+      if (studyRequestNew.status !== studyRequestOld.status) {
+        tasks.push(StudyRequestChangeDAO.create(studyRequestNew, user));
+      }
+    }
+    const [studyRequestBulk] = await Promise.all(tasks);
+    return studyRequestBulk;
+  },
+});
 
 // STUDY REQUEST CHANGES
 

--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -1,7 +1,7 @@
 import Boom from '@hapi/boom';
 
-import { AuthScope, StudyRequestStatus } from '@/lib/Constants';
-import { hasAuthScope } from '@/lib/auth/ScopeMatcher';
+import { AuthScope } from '@/lib/Constants';
+import { canUpdateStudyRequest } from '@/lib/auth/StudyRequestPermissions';
 import StudyRequestDAO from '@/lib/db/StudyRequestDAO';
 import StudyRequestBulkDAO from '@/lib/db/StudyRequestBulkDAO';
 import StudyRequestChangeDAO from '@/lib/db/StudyRequestChangeDAO';
@@ -166,11 +166,8 @@ StudyRequestController.push({
 /**
  * Update the given study request.
  *
- * The request body should contain the request, including any studies requested
- * therein, in JSON format.  The list of studies for the current request will be
- * updated to match the request body.
- *
- * The ID of the request URI should match the ID of the request in the body.
+ * The request body should contain the request to be updated; the ID of that request should
+ * match the request URL.
  *
  * @memberof StudyRequestController
  * @name putStudyRequest
@@ -184,10 +181,7 @@ StudyRequestController.push({
       scope: [AuthScope.STUDY_REQUESTS_EDIT.name],
     },
     response: {
-      schema: {
-        studyRequest: StudyRequest.read,
-        studyRequestChange: StudyRequestChange.read.allow(null),
-      },
+      schema: StudyRequest.read,
     },
     validate: {
       params: {
@@ -205,55 +199,13 @@ StudyRequestController.push({
     if (studyRequestOld === null) {
       return Boom.notFound(`no study request found with ID ${id}`);
     }
-
-    if (studyRequestNew.id !== studyRequestOld.id) {
-      return Boom.badRequest('cannot change ID for study request');
-    }
-    if (!studyRequestNew.createdAt.equals(studyRequestOld.createdAt)) {
-      return Boom.badRequest('cannot change creation timestamp for study request');
-    }
-    if (studyRequestNew.userId !== studyRequestOld.userId) {
-      return Boom.badRequest('cannot change owner for study request');
-    }
-    if (studyRequestNew.lastEditorId !== studyRequestOld.lastEditorId) {
-      return Boom.badRequest('cannot change last editor for study request');
-    }
-    if (studyRequestNew.lastEditedAt === null) {
-      if (studyRequestOld.lastEditedAt !== null) {
-        return Boom.badRequest('cannot change last edit timestamp for study request');
-      }
-    } else if (!studyRequestNew.lastEditedAt.equals(studyRequestOld.lastEditedAt)) {
-      return Boom.badRequest('cannot change last edit timestamp for study request');
-    }
-
-    if (studyRequestNew.status !== studyRequestOld.status
-      && !studyRequestOld.status.canTransitionTo(studyRequestNew.status)) {
-      return Boom.badRequest(
-        `invalid state transition: ${studyRequestOld.status} -> ${studyRequestNew.status}`,
-      );
-    }
-
-    if (!hasAuthScope(user, AuthScope.STUDY_REQUESTS_ADMIN)) {
-      if (studyRequestOld.userId !== user.id) {
-        return Boom.forbidden('not authorized to change study request owned by another user');
-      }
-      if (studyRequestNew.assignedTo !== studyRequestOld.assignedTo) {
-        return Boom.forbidden('not authorized to change assignment for study request');
-      }
-      if (studyRequestNew.status !== studyRequestOld.status
-        && studyRequestNew.status !== StudyRequestStatus.CANCELLED
-        && studyRequestOld.status !== StudyRequestStatus.CANCELLED) {
-        /*
-         * Non-admin requesters can only change the status to cancel requests, or to
-         * reopen previously cancelled requests.
-         */
-        return Boom.forbidden('not authorized to change status for study request');
-      }
+    const err = canUpdateStudyRequest(studyRequestNew, studyRequestOld, user);
+    if (err !== null) {
+      return err;
     }
 
     const tasks = [StudyRequestDAO.update(studyRequestNew, user)];
     if (studyRequestNew.status !== studyRequestOld.status) {
-      // TODO: move `StudyRequestChangeDAO.create` calls right into `StudyRequestDAO.update`
       /*
        * At one point, we had planned to log all changes in `study_request_changes`.
        * This was abandoned in favour of the current "status changes only" approach,
@@ -262,8 +214,8 @@ StudyRequestController.push({
        */
       tasks.push(StudyRequestChangeDAO.create(studyRequestNew, user));
     }
-    const [studyRequest, studyRequestChange = null] = await Promise.all(tasks);
-    return { studyRequest, studyRequestChange };
+    const [studyRequest] = await Promise.all(tasks);
+    return studyRequest;
   },
 });
 

--- a/lib/db/StudyRequestBulkDAO.js
+++ b/lib/db/StudyRequestBulkDAO.js
@@ -116,6 +116,12 @@ INSERT INTO "study_requests_bulk" (
     return StudyRequestBulk.read.validateAsync(persistedStudyRequestBulk);
   }
 
+  /**
+   * Fetch the bulk study request with the given ID.
+   *
+   * @param {number} id - ID to fetch bulk study request for
+   * @returns {Object} bulk study request object, or null if no such bulk study request exists
+   */
   static async byId(id) {
     const sql = `SELECT ${STUDY_REQUESTS_BULK_FIELDS} WHERE "id" = $(id)`;
     const studyRequestBulk = await db.oneOrNone(sql, { id });

--- a/tests/jest/api/RestApi.spec.js
+++ b/tests/jest/api/RestApi.spec.js
@@ -611,9 +611,8 @@ test('StudyRequestController', async () => {
     data: persistedStudyRequest,
   });
   expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
-  expect(response.result.studyRequest.id).toEqual(persistedStudyRequest.id);
-  expect(response.result.studyRequestChange).toBeNull();
-  persistedStudyRequest = response.result.studyRequest;
+  expect(response.result.id).toEqual(persistedStudyRequest.id);
+  persistedStudyRequest = response.result;
 
   response = await client.fetch(`/requests/study/${persistedStudyRequest.id}`);
   expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
@@ -636,8 +635,7 @@ test('StudyRequestController', async () => {
     data: persistedStudyRequest,
   });
   expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
-  expect(response.result.studyRequestChange).toBeNull();
-  persistedStudyRequest = response.result.studyRequest;
+  persistedStudyRequest = response.result;
 
   response = await client.fetch(`/requests/study/${persistedStudyRequest.id}`);
   fetchedStudyRequest = response.result;

--- a/web/components/FcDataTableRequests.vue
+++ b/web/components/FcDataTableRequests.vue
@@ -100,7 +100,6 @@
           )">
         <template v-slot:activator="{ on }">
           <FcButton
-            :loading="loadingItems.has(item.id)"
             class="body-1 text-none"
             small
             type="secondary"
@@ -173,7 +172,6 @@
             :is-expanded-child="true"
             :items="item.studyRequestBulk.studyRequests"
             :loading="loading"
-            :loading-items="loadingItems"
             :sort-by="internalSortBy"
             @assign-to="actionAssignTo"
             @show-item="actionShowItem" />
@@ -217,7 +215,6 @@ export default {
       type: Boolean,
       default: false,
     },
-    loadingItems: Set,
     sortBy: String,
   },
   data() {

--- a/web/components/FcDrawerRequestStudyEdit.vue
+++ b/web/components/FcDrawerRequestStudyEdit.vue
@@ -35,7 +35,10 @@ import { mapActions, mapGetters } from 'vuex';
 
 import { LocationSelectionType } from '@/lib/Constants';
 import { getStudyRequest } from '@/lib/api/WebApi';
+import FcDialogConfirmRequestStudyLeave
+  from '@/web/components/dialogs/FcDialogConfirmRequestStudyLeave.vue';
 import FcDetailsStudyRequest from '@/web/components/requests/FcDetailsStudyRequest.vue';
+import FcHeaderRequestStudy from '@/web/components/requests/FcHeaderRequestStudy.vue';
 import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
 
 export default {
@@ -43,6 +46,8 @@ export default {
   mixins: [FcMixinRouteAsync],
   components: {
     FcDetailsStudyRequest,
+    FcDialogConfirmRequestStudyLeave,
+    FcHeaderRequestStudy,
   },
   data() {
     return {

--- a/web/components/requests/FcHeaderRequestStudy.vue
+++ b/web/components/requests/FcHeaderRequestStudy.vue
@@ -4,7 +4,6 @@
     no-gutters>
     <v-col cols="2">
       <FcButton
-        v-if="isCreate"
         type="secondary"
         @click="$emit('action-navigate-back')">
         <v-icon left>mdi-chevron-left</v-icon>

--- a/web/components/requests/status/FcMenuStudyRequestsStatus.vue
+++ b/web/components/requests/status/FcMenuStudyRequestsStatus.vue
@@ -1,10 +1,11 @@
 <template>
   <v-menu
-    v-model="internalValue"
+    v-model="showMenu"
     :close-on-content-click="false"
     min-width="200">
     <template v-slot:activator="{ on, attrs }">
       <FcButton
+        :class="buttonClass"
         :disabled="disabled"
         type="secondary"
         v-bind="attrs"
@@ -19,7 +20,9 @@
         <v-list-item
           v-if="item.items === undefined || item.items.length === 0"
           :key="i"
-          @click="actionMenu(item)">
+          class="fc-item-study-requests-status"
+          :disabled="item.disabled"
+          @click="actionMenu(item, null)">
           <v-list-item-title>
             <v-icon :color="item.value.color" left>mdi-circle-medium</v-icon>
             <span>{{item.text}}</span>
@@ -27,7 +30,9 @@
         </v-list-item>
         <v-list-group
           v-else
-          :key="i">
+          :key="i"
+          class="fc-submenu-study-requests-status"
+          :disabled="item.disabled">
           <template v-slot:activator>
             <v-list-item-title>
               <v-icon :color="item.value.color" left>mdi-circle-medium</v-icon>
@@ -38,7 +43,7 @@
             v-for="(subitem, j) in item.items"
             :key="i + '_' + j"
             link
-            @click="actionSubmenu(item, subitem)">
+            @click="actionMenu(item, subitem)">
             <v-list-item-title>{{subitem.text}}</v-list-item-title>
           </v-list-item>
         </v-list-group>
@@ -48,15 +53,21 @@
 </template>
 
 <script>
-import { StudyRequestAssignee, StudyRequestStatus } from '@/lib/Constants';
+import { AuthScope, StudyRequestAssignee, StudyRequestStatus } from '@/lib/Constants';
 import FcButton from '@/web/components/inputs/FcButton.vue';
+import FcMixinAuthScope from '@/web/mixins/FcMixinAuthScope';
 
 export default {
   name: 'FcMenuStudyRequestsStatus',
+  mixins: [FcMixinAuthScope],
   components: {
     FcButton,
   },
   props: {
+    buttonClass: {
+      type: String,
+      default: null,
+    },
     disabled: {
       type: Boolean,
       default: false,
@@ -66,14 +77,55 @@ export default {
   },
   data() {
     return {
-      internalValue: false,
+      showMenu: false,
     };
   },
   computed: {
+    canAssignTo() {
+      if (!this.hasAuthScope(AuthScope.STUDY_REQUESTS_ADMIN)) {
+        return false;
+      }
+      return this.studyRequests.every(
+        ({ status }) => status.canTransitionTo(StudyRequestStatus.ASSIGNED),
+      );
+    },
+    canCancel() {
+      return this.studyRequests.every(
+        ({ status }) => status.canTransitionTo(StudyRequestStatus.CANCELLED),
+      );
+    },
+    canMarkCompleted() {
+      return this.studyRequests.every(
+        ({ status }) => status.canTransitionTo(StudyRequestStatus.COMPLETED),
+      );
+    },
+    canRejectData() {
+      return this.studyRequests.every(
+        ({ status }) => status.canTransitionTo(StudyRequestStatus.REJECTED),
+      );
+    },
+    canReopen() {
+      return this.studyRequests.every(
+        ({ closed, status }) => closed && status.canTransitionTo(StudyRequestStatus.REQUESTED),
+      );
+    },
+    canRequestChanges() {
+      if (!this.hasAuthScope(AuthScope.STUDY_REQUESTS_ADMIN)) {
+        return false;
+      }
+      return this.studyRequests.every(
+        ({ status }) => status.canTransitionTo(StudyRequestStatus.CHANGES_NEEDED),
+      );
+    },
     items() {
       return [
-        { text: 'Needs Changes', value: StudyRequestStatus.CHANGES_NEEDED },
         {
+          disabled: !this.canRequestChanges,
+          text: 'Request Changes',
+          value: StudyRequestStatus.CHANGES_NEEDED,
+        },
+        {
+          disabled: !this.canAssignTo,
           items: [
             { text: 'None', value: null },
             ...StudyRequestAssignee.enumValues.map(
@@ -83,21 +135,102 @@ export default {
           text: 'Assign To',
           value: StudyRequestStatus.ASSIGNED,
         },
-        { text: 'Mark Completed', value: StudyRequestStatus.COMPLETED },
-        { text: 'Reject Data', value: StudyRequestStatus.REJECTED },
-        { text: 'Cancel Request', value: StudyRequestStatus.CANCELLED },
+        {
+          disabled: !this.canMarkCompleted,
+          text: 'Mark Completed',
+          value: StudyRequestStatus.COMPLETED,
+        },
+        {
+          disabled: !this.canRejectData,
+          text: 'Reject Data',
+          value: StudyRequestStatus.REJECTED,
+        },
+        {
+          disabled: !this.canCancel,
+          text: 'Cancel',
+          value: StudyRequestStatus.CANCELLED,
+        },
+        {
+          disabled: !this.canReopen,
+          text: 'Reopen',
+          value: StudyRequestStatus.REQUESTED,
+        },
       ];
     },
   },
   methods: {
-    actionMenu(item) {
-      this.internalValue = false;
-      this.$emit('action-menu', { item, subitem: null });
+    /* eslint-disable no-param-reassign */
+    actionAssignTo(subitem) {
+      const assignedTo = subitem.value;
+
+      this.studyRequests.forEach((studyRequest) => {
+        studyRequest.assignedTo = assignedTo;
+        if (assignedTo === null) {
+          studyRequest.status = StudyRequestStatus.REQUESTED;
+        } else {
+          studyRequest.status = StudyRequestStatus.ASSIGNED;
+        }
+      });
     },
-    actionSubmenu(item, subitem) {
-      this.internalValue = false;
-      this.$emit('action-menu', { item, subitem });
+    actionCancel() {
+      this.studyRequests.forEach((studyRequest) => {
+        studyRequest.status = StudyRequestStatus.CANCELLED;
+        studyRequest.closed = true;
+      });
     },
+    actionMarkCompleted() {
+      this.studyRequests.forEach((studyRequest) => {
+        studyRequest.status = StudyRequestStatus.COMPLETED;
+        studyRequest.closed = true;
+      });
+    },
+    actionMenu(item, subitem) {
+      this.showMenu = false;
+
+      if (item.value === StudyRequestStatus.CHANGES_NEEDED) {
+        this.actionRequestChanges();
+      } else if (item.value === StudyRequestStatus.ASSIGNED) {
+        this.actionAssignTo(subitem);
+      } else if (item.value === StudyRequestStatus.COMPLETED) {
+        this.actionMarkCompleted();
+      } else if (item.value === StudyRequestStatus.REJECTED) {
+        this.actionRejectData();
+      } else if (item.value === StudyRequestStatus.CANCELLED) {
+        this.actionCancel();
+      } else if (item.value === StudyRequestStatus.REQUESTED) {
+        this.actionReopen();
+      }
+
+      this.$emit('update');
+    },
+    actionRejectData() {
+      this.studyRequests.forEach((studyRequest) => {
+        studyRequest.status = StudyRequestStatus.REJECTED;
+        studyRequest.closed = true;
+      });
+    },
+    actionReopen() {
+      this.studyRequests.forEach((studyRequest) => {
+        studyRequest.status = StudyRequestStatus.REQUESTED;
+        studyRequest.closed = false;
+      });
+    },
+    actionRequestChanges() {
+      this.studyRequests.forEach((studyRequest) => {
+        studyRequest.status = StudyRequestStatus.CHANGES_NEEDED;
+      });
+    },
+    /* eslint-enable no-param-reassign */
   },
 };
 </script>
+
+<style lang="scss">
+.fc-submenu-study-requests-status.v-list-group--disabled {
+  opacity: 0.38;
+}
+
+.fc-item-study-requests-status.v-list-item--disabled .v-icon {
+  opacity: 0.38;
+}
+</style>

--- a/web/components/requests/status/FcMenuStudyRequestsStatus.vue
+++ b/web/components/requests/status/FcMenuStudyRequestsStatus.vue
@@ -1,0 +1,103 @@
+<template>
+  <v-menu
+    v-model="internalValue"
+    :close-on-content-click="false"
+    min-width="200">
+    <template v-slot:activator="{ on, attrs }">
+      <FcButton
+        :disabled="disabled"
+        type="secondary"
+        v-bind="attrs"
+        v-on="on">
+        <v-icon :color="status.color" left>mdi-circle-medium</v-icon>
+        <span>Status</span>
+        <v-icon right>mdi-menu-down</v-icon>
+      </FcButton>
+    </template>
+    <v-list>
+      <template v-for="(item, i) in items">
+        <v-list-item
+          v-if="item.items === undefined || item.items.length === 0"
+          :key="i"
+          @click="actionMenu(item)">
+          <v-list-item-title>
+            <v-icon :color="item.value.color" left>mdi-circle-medium</v-icon>
+            <span>{{item.text}}</span>
+          </v-list-item-title>
+        </v-list-item>
+        <v-list-group
+          v-else
+          :key="i">
+          <template v-slot:activator>
+            <v-list-item-title>
+              <v-icon :color="item.value.color" left>mdi-circle-medium</v-icon>
+              <span>{{item.text}}</span>
+            </v-list-item-title>
+          </template>
+          <v-list-item
+            v-for="(subitem, j) in item.items"
+            :key="i + '_' + j"
+            link
+            @click="actionSubmenu(item, subitem)">
+            <v-list-item-title>{{subitem.text}}</v-list-item-title>
+          </v-list-item>
+        </v-list-group>
+      </template>
+    </v-list>
+  </v-menu>
+</template>
+
+<script>
+import { StudyRequestAssignee, StudyRequestStatus } from '@/lib/Constants';
+import FcButton from '@/web/components/inputs/FcButton.vue';
+
+export default {
+  name: 'FcMenuStudyRequestsStatus',
+  components: {
+    FcButton,
+  },
+  props: {
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    status: StudyRequestStatus,
+    studyRequests: Array,
+  },
+  data() {
+    return {
+      internalValue: false,
+    };
+  },
+  computed: {
+    items() {
+      return [
+        { text: 'Needs Changes', value: StudyRequestStatus.CHANGES_NEEDED },
+        {
+          items: [
+            { text: 'None', value: null },
+            ...StudyRequestAssignee.enumValues.map(
+              enumValue => ({ text: enumValue.text, value: enumValue }),
+            ),
+          ],
+          text: 'Assign To',
+          value: StudyRequestStatus.ASSIGNED,
+        },
+        { text: 'Mark Completed', value: StudyRequestStatus.COMPLETED },
+        { text: 'Reject Data', value: StudyRequestStatus.REJECTED },
+        { text: 'Cancel Request', value: StudyRequestStatus.CANCELLED },
+      ];
+    },
+  },
+  methods: {
+    actionMenu(item) {
+      this.internalValue = false;
+      this.$emit('action-menu', { item, subitem: null });
+    },
+    actionSubmenu(item, subitem) {
+      this.internalValue = false;
+      this.$emit('action-menu', { item, subitem });
+    },
+  },
+};
+</script>

--- a/web/components/requests/status/FcMenuStudyRequestsStatus.vue
+++ b/web/components/requests/status/FcMenuStudyRequestsStatus.vue
@@ -2,7 +2,8 @@
   <v-menu
     v-model="showMenu"
     :close-on-content-click="false"
-    min-width="200">
+    min-width="200"
+    z-index="100">
     <template v-slot:activator="{ on, attrs }">
       <FcButton
         :class="buttonClass"
@@ -31,6 +32,7 @@
         <v-list-group
           v-else
           :key="i"
+          v-model="showSubmenu"
           class="fc-submenu-study-requests-status"
           :disabled="item.disabled">
           <template v-slot:activator>
@@ -78,6 +80,7 @@ export default {
   data() {
     return {
       showMenu: false,
+      showSubmenu: false,
     };
   },
   computed: {
@@ -156,6 +159,13 @@ export default {
           value: StudyRequestStatus.REQUESTED,
         },
       ];
+    },
+  },
+  watch: {
+    showMenu() {
+      if (!this.showMenu) {
+        this.showSubmenu = false;
+      }
     },
   },
   methods: {

--- a/web/components/requests/summary/FcSummaryStudy.vue
+++ b/web/components/requests/summary/FcSummaryStudy.vue
@@ -52,7 +52,7 @@ export default {
   },
   computed: {
     messagesDaysOfWeek() {
-      const { daysOfWeek, duration, studyType } = this.studyRequest;
+      const { daysOfWeek, duration, studyType } = this.study;
       if (studyType.automatic) {
         const k = numConsecutiveDaysOfWeek(daysOfWeek);
         const n = duration / 24;

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -290,7 +290,7 @@ export default new Vuex.Store({
         });
       } else {
         const toast = update ? REQUEST_STUDY_UPDATED : REQUEST_STUDY_SUBMITTED;
-        commit('setToast', toast);
+        commit('setToastInfo', toast.text);
       }
 
       const { csrf } = state.auth;
@@ -309,7 +309,7 @@ export default new Vuex.Store({
         });
       } else {
         const toast = update ? REQUEST_STUDY_UPDATED : REQUEST_STUDY_SUBMITTED;
-        commit('setToast', toast);
+        commit('setToastInfo', toast.text);
       }
 
       const { csrf } = state.auth;

--- a/web/views/FcRequestStudyBulkView.vue
+++ b/web/views/FcRequestStudyBulkView.vue
@@ -83,16 +83,10 @@
               class="mr-6"
               :indeterminate="selectAll === null"></v-simple-checkbox>
 
-            <FcMenu
-              button-class="mr-2"
-              :items="itemsStatus">
-              <span>Mark all as</span>
-            </FcMenu>
-            <FcMenu
-              button-class="mr-2"
-              :items="itemsAssignedTo">
-              <span>Assign all to</span>
-            </FcMenu>
+            <FcMenuStudyRequestsStatus
+              :disabled="selectAll === false"
+              :status="bulkStatus"
+              :study-requests="selectedStudyRequests" />
           </div>
 
           <v-divider></v-divider>
@@ -114,6 +108,7 @@
 </template>
 
 <script>
+import { Ripple } from 'vuetify/lib/directives';
 import { mapActions } from 'vuex';
 
 import { AuthScope, StudyRequestAssignee } from '@/lib/Constants';
@@ -123,11 +118,12 @@ import { getStudyRequestItem } from '@/lib/requests/RequestItems';
 import RequestDataTableColumns from '@/lib/requests/RequestDataTableColumns';
 import { bulkStatus } from '@/lib/requests/RequestStudyBulkUtils';
 import FcDataTableRequests from '@/web/components/FcDataTableRequests.vue';
+import FcMenuStudyRequestsStatus
+  from '@/web/components/requests/status/FcMenuStudyRequestsStatus.vue';
 import FcStatusStudyRequests from '@/web/components/requests/status/FcStatusStudyRequests.vue';
 import FcSummaryStudyRequest from '@/web/components/requests/summary/FcSummaryStudyRequest.vue';
 import FcPaneMap from '@/web/components/FcPaneMap.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
-import FcMenu from '@/web/components/inputs/FcMenu.vue';
 import FcMixinAuthScope from '@/web/mixins/FcMixinAuthScope';
 import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
 
@@ -137,10 +133,13 @@ export default {
     FcMixinAuthScope,
     FcMixinRouteAsync,
   ],
+  directives: {
+    Ripple,
+  },
   components: {
     FcButton,
     FcDataTableRequests,
-    FcMenu,
+    FcMenuStudyRequestsStatus,
     FcPaneMap,
     FcStatusStudyRequests,
     FcSummaryStudyRequest,
@@ -222,6 +221,9 @@ export default {
           this.selectedItems = [];
         }
       },
+    },
+    selectedStudyRequests() {
+      return this.selectedItems.map(({ studyRequest }) => studyRequest);
     },
   },
   methods: {

--- a/web/views/FcRequestsTrack.vue
+++ b/web/views/FcRequestsTrack.vue
@@ -60,7 +60,6 @@
             :has-filters="hasFilters"
             :items="items"
             :loading="loading"
-            :loading-items="loadingSaveStudyRequest"
             :sort-by.sync="sortBy"
             @assign-to="actionAssignTo"
             @show-item="actionShowItem" />
@@ -191,7 +190,6 @@ export default {
         studyTypes: [],
         userOnly: false,
       },
-      loadingSaveStudyRequest: new Set(),
       search: {
         column: null,
         query: null,
@@ -269,13 +267,10 @@ export default {
         studyRequest.status = StudyRequestStatus.ASSIGNED;
       }
 
-      this.loadingSaveStudyRequest.add(item.id);
-      const {
-        studyRequest: studyRequestUpdated,
-      } = await this.saveStudyRequest(studyRequest);
-      /* eslint-disable-next-line no-param-reassign */
-      item.studyRequest = studyRequestUpdated;
-      this.loadingSaveStudyRequest.delete(item.id);
+      this.loading = false;
+      await this.saveStudyRequest(studyRequest);
+      await this.loadAsyncForRoute(this.$route);
+      this.loading = false;
     },
     actionDownload(items) {
       const rows = items.map(getItemRow);


### PR DESCRIPTION
# Issue Addressed
This PR closes #607 and makes further progress on #608 .

# Description
We introduce `FcMenuStudyRequestStatus`, a component for managing status change actions in both bulk and non-bulk study requests.  We then use that component from within the bulk and non-bulk View Request flows.

For bulk requests, this is powered by the new `PUT /request/study/bulk/{id}` endpoint.

To simplify the frontend and reduce the number of interface states, we also change both bulk and non-bulk `PUT` endpoints to _not_ return `StudyRequestChange` objects as well.  As part of this, status change actions now result in a full data reload via `loadAsyncForRoute` - this does result in more data fetching, but is significantly simpler.

# Tests
Tested in frontend.  Updated `test:test-db` and `test:test-api` test suites as needed and ran these successfully.