### PR TITLE
Show deselected states on locations that aren't part of bulk request

### DIFF
--- a/lib/requests/RequestStudyBulkUtils.js
+++ b/lib/requests/RequestStudyBulkUtils.js
@@ -1,5 +1,5 @@
 import { Enum } from '@/lib/ClassUtils';
-import { StudyRequestStatus } from '@/lib/Constants';
+import { centrelineKey, StudyRequestStatus } from '@/lib/Constants';
 
 function bulkAssignedToStr(studyRequests) {
   const assignedTos = new Set(
@@ -8,6 +8,18 @@ function bulkAssignedToStr(studyRequests) {
   return Array.from(assignedTos)
     .map(assignedTo => (assignedTo === null ? 'Unassigned' : assignedTo.text))
     .join(', ');
+}
+
+function bulkIndicesDeselected(locations, studyRequests) {
+  const keys = new Set(studyRequests.map(centrelineKey));
+  const indicesDeselected = [];
+  locations.forEach((location, i) => {
+    const key = centrelineKey(location);
+    if (!keys.has(key)) {
+      indicesDeselected.push(i);
+    }
+  });
+  return indicesDeselected;
 }
 
 function bulkStatus(studyRequests) {
@@ -38,6 +50,7 @@ ItemType.init(['STUDY_REQUEST', 'STUDY_REQUEST_BULK']);
 
 const RequestStudyBulkUtils = {
   bulkAssignedToStr,
+  bulkIndicesDeselected,
   bulkStatus,
   ItemType,
 };
@@ -45,6 +58,7 @@ const RequestStudyBulkUtils = {
 export {
   RequestStudyBulkUtils as default,
   bulkAssignedToStr,
+  bulkIndicesDeselected,
   bulkStatus,
   ItemType,
 };

--- a/web/components/FcDrawerRequestStudyBulkEdit.vue
+++ b/web/components/FcDrawerRequestStudyBulkEdit.vue
@@ -21,10 +21,11 @@
 </template>
 
 <script>
-import { mapActions } from 'vuex';
+import { mapActions, mapMutations, mapState } from 'vuex';
 
 import { getStudyRequestBulk } from '@/lib/api/WebApi';
 import CompositeId from '@/lib/io/CompositeId';
+import { bulkIndicesDeselected } from '@/lib/requests/RequestStudyBulkUtils';
 import FcEditStudyRequestBulk from '@/web/components/requests/FcEditStudyRequestBulk.vue';
 import FcNavStudyRequest from '@/web/components/requests/nav/FcNavStudyRequest.vue';
 import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
@@ -40,6 +41,15 @@ export default {
     return {
       studyRequestBulk: null,
     };
+  },
+  computed: {
+    ...mapState(['locations']),
+  },
+  created() {
+    this.setLocationsIndicesDeselected([]);
+  },
+  beforeDestroy() {
+    this.setLocationsIndicesDeselected([]);
   },
   methods: {
     actionCancel() {
@@ -57,7 +67,14 @@ export default {
       await this.initLocations({ features, selectionType });
 
       this.studyRequestBulk = studyRequestBulk;
+
+      const indicesDeselected = bulkIndicesDeselected(
+        this.locations,
+        this.studyRequestBulk.studyRequests,
+      );
+      this.setLocationsIndicesDeselected(indicesDeselected);
     },
+    ...mapMutations(['setLocationsIndicesDeselected']),
     ...mapActions(['initLocations', 'saveStudyRequestBulk']),
   },
 };

--- a/web/views/FcRequestStudyBulkView.vue
+++ b/web/views/FcRequestStudyBulkView.vue
@@ -83,14 +83,14 @@
 
 <script>
 import { Ripple } from 'vuetify/lib/directives';
-import { mapActions } from 'vuex';
+import { mapActions, mapMutations, mapState } from 'vuex';
 
 import { AuthScope } from '@/lib/Constants';
 import { getStudyRequestBulk } from '@/lib/api/WebApi';
 import CompositeId from '@/lib/io/CompositeId';
 import { getStudyRequestItem } from '@/lib/requests/RequestItems';
 import RequestDataTableColumns from '@/lib/requests/RequestDataTableColumns';
-import { bulkStatus } from '@/lib/requests/RequestStudyBulkUtils';
+import { bulkIndicesDeselected, bulkStatus } from '@/lib/requests/RequestStudyBulkUtils';
 import FcDataTableRequests from '@/web/components/FcDataTableRequests.vue';
 import FcBreadcrumbsStudyRequest
   from '@/web/components/requests/nav/FcBreadcrumbsStudyRequest.vue';
@@ -184,6 +184,13 @@ export default {
     selectedStudyRequests() {
       return this.selectedItems.map(({ studyRequest }) => studyRequest);
     },
+    ...mapState(['locations']),
+  },
+  created() {
+    this.setLocationsIndicesDeselected([]);
+  },
+  beforeDestroy() {
+    this.setLocationsIndicesDeselected([]);
   },
   methods: {
     actionEdit() {
@@ -217,6 +224,12 @@ export default {
       this.studyRequestChanges = studyRequestChanges;
       this.studyRequestLocations = studyRequestLocations;
 
+      const indicesDeselected = bulkIndicesDeselected(
+        this.locations,
+        this.studyRequestBulk.studyRequests,
+      );
+      this.setLocationsIndicesDeselected(indicesDeselected);
+
       const { user } = this.auth;
       this.studyRequestUsers.set(user.id, user);
       this.studyRequestUsers = studyRequestUsers;
@@ -228,6 +241,7 @@ export default {
       await this.loadAsyncForRoute(this.$route);
       this.loadingItems = false;
     },
+    ...mapMutations(['setLocationsIndicesDeselected']),
     ...mapActions(['initLocations', 'saveStudyRequest', 'saveStudyRequestBulk']),
   },
 };


### PR DESCRIPTION
Issue Addressed
This PR closes #644 .

# Description
We add `bulkIndicesDeselected` in `RequestStudyBulkUtils` - this utility function takes a list of locations and a list of study requests, and it returns the list of indices of locations that are not covered by some request in the list of study requests.  (This could generalize to other feature-like lists, but we don't have a compelling reason to do that right now.)

This function is then used in the bulk study request view and edit flows to show deselected states on the map.

# Tests
Tested as per issue acceptance checklist.