### PR TITLE
Collision layer usability: disable in certain modes / flows

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -1,4 +1,5 @@
 import { Enum } from '@/lib/ClassUtils';
+import { STUDY_HOURS_HINT_OTHER } from '@/lib/i18n/Strings';
 
 /**
  * Authentication scopes.  Used to restrict access to certain REST API endpoints,
@@ -691,7 +692,7 @@ const SPEED_CLASSES = [
 class StudyHours extends Enum {
   get hint() {
     if (this === StudyHours.OTHER) {
-      return 'Please specify your desired schedule below';
+      return STUDY_HOURS_HINT_OTHER;
     }
     const { times } = this;
     const timesParts = times.map(([start, end]) => `${start} -- ${end}`);

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -182,6 +182,9 @@ HttpStatus.init({
   },
 });
 
+class LegendMode extends Enum {}
+LegendMode.init(['FOCUS_LOCATIONS', 'NORMAL']);
+
 class LocationMode extends Enum {}
 LocationMode.init({
   SINGLE: {
@@ -967,6 +970,7 @@ const Constants = {
   FEATURE_CODES_INTERSECTION,
   FEATURE_CODES_SEGMENT,
   HttpStatus,
+  LegendMode,
   LocationMode,
   LocationSearchType,
   LocationSelectionType,
@@ -1008,6 +1012,7 @@ export {
   FEATURE_CODES_INTERSECTION,
   FEATURE_CODES_SEGMENT,
   HttpStatus,
+  LegendMode,
   LocationMode,
   LocationSearchType,
   LocationSelectionType,

--- a/lib/FunctionUtils.js
+++ b/lib/FunctionUtils.js
@@ -52,20 +52,12 @@ function identity(x) {
 }
 
 /**
- * "No operation", i.e. a function that does nothing.
- *
- * @memberof FunctionUtils
- */
-function noop() {}
-
-/**
  * @namespace
  */
 const FunctionUtils = {
   asyncDelay,
   debounce,
   identity,
-  noop,
 };
 
 export {
@@ -73,5 +65,4 @@ export {
   asyncDelay,
   debounce,
   identity,
-  noop,
 };

--- a/lib/geo/GeoStyle.js
+++ b/lib/geo/GeoStyle.js
@@ -1,8 +1,4 @@
-import {
-  CentrelineType,
-  MapZoom,
-  RoadSegmentType,
-} from '@/lib/Constants';
+import { CentrelineType, MapZoom } from '@/lib/Constants';
 import rootStyleDark from '@/lib/geo/theme/dark/root.json';
 import metadataDark from '@/lib/geo/theme/dark/metadata.json';
 import rootStyleLight from '@/lib/geo/theme/light/root.json';
@@ -304,10 +300,9 @@ const aadtScaleLineWidth = aadtScaleFactory(WIDTH_VOLUME_LOW, WIDTH_VOLUME_MED, 
  * class-dependent AADT thresholds.
  *
  * The specific thresholds used here are from the City of Toronto's Road Classification
- * System, which provides rough AADT benchmarks for different classes of road.  In particular:
- *
- * - for expressways and major arterials, these are 120% and 200% of the minimum expected AADT;
- * - for other roads, these are 60% and 100% of the maximum expected AADT.
+ * System, which provides rough AADT benchmarks for different classes of road.  In particular,
+ * we use the local road maximum (2500 vehicles per day) as the low volume threshold, and
+ * the major arterial road maximum (20000 vehicles per day) as the high volume threshold.
  *
  * @see https://www.toronto.ca/services-payments/streets-parking-transportation/traffic-management/road-classification-system/about-the-road-classification-system/
  * @param {boolean} volume - is the volume layer turned on?
@@ -324,33 +319,7 @@ function aadtScaledFeature(volume, defaultValue, aadtScale) {
   return [
     'case',
     ['==', ['get', 'aadt'], null], defaultValue,
-    [
-      'match',
-      ['get', 'featureCode'],
-      [
-        RoadSegmentType.LOCAL.featureCode,
-        RoadSegmentType.OTHER.featureCode,
-        RoadSegmentType.OTHER_RAMP.featureCode,
-        RoadSegmentType.LANEWAY.featureCode,
-      ], aadtScale(1500, 2500),
-      [
-        RoadSegmentType.COLLECTOR.featureCode,
-        RoadSegmentType.COLLECTOR_RAMP.featureCode,
-      ], aadtScale(6000, 10000),
-      [
-        RoadSegmentType.MINOR_ARTERIAL.featureCode,
-        RoadSegmentType.MINOR_ARTERIAL_RAMP.featureCode,
-      ], aadtScale(12000, 20000),
-      [
-        RoadSegmentType.MAJOR_ARTERIAL.featureCode,
-        RoadSegmentType.MAJOR_ARTERIAL_RAMP.featureCode,
-      ], aadtScale(24000, 40000),
-      [
-        RoadSegmentType.EXPRESSWAY.featureCode,
-        RoadSegmentType.EXPRESSWAY_RAMP.featureCode,
-      ], aadtScale(48000, 80000),
-      defaultValue,
-    ],
+    aadtScale(2500, 20000),
   ];
 }
 

--- a/lib/i18n/Strings.js
+++ b/lib/i18n/Strings.js
@@ -146,6 +146,15 @@ const REQUEST_STUDY_REQUIRES_DAYS_OF_WEEK = {
 };
 
 /**
+ * @memberof Strings
+ * @type {StringMessage}
+ */
+const STUDY_HOURS_HINT_OTHER = {
+  variant: 'info',
+  text: 'Please specify your desired schedule below.',
+};
+
+/**
  * `Strings` is effectively a manifest of strings (messages) used in MOVE.
  * @type {object<string, StringMessage>}
  */
@@ -164,6 +173,7 @@ const Strings = {
   REQUEST_STUDY_SUBMITTED,
   REQUEST_STUDY_TIME_TO_FULFILL,
   REQUEST_STUDY_UPDATED,
+  STUDY_HOURS_HINT_OTHER,
 };
 
 export {
@@ -182,4 +192,5 @@ export {
   REQUEST_STUDY_SUBMITTED,
   REQUEST_STUDY_TIME_TO_FULFILL,
   REQUEST_STUDY_UPDATED,
+  STUDY_HOURS_HINT_OTHER,
 };

--- a/tests/jest/unit/Constants.spec.js
+++ b/tests/jest/unit/Constants.spec.js
@@ -1,0 +1,60 @@
+import {
+  HttpStatus,
+  ReportParameter,
+  StudyHours,
+  StudyRequestStatus,
+} from '@/lib/Constants';
+import { STUDY_HOURS_HINT_OTHER } from '@/lib/i18n/Strings';
+
+test('HttpStatus#isOk', () => {
+  expect(HttpStatus.OK.isOk()).toBe(true);
+  expect(HttpStatus.BAD_REQUEST.isOk()).toBe(false);
+});
+
+test('ReportParameter#defaultValue', () => {
+  expect(ReportParameter.BOOLEAN.defaultValue()).toEqual(true);
+  expect(ReportParameter.DATE_YEAR.defaultValue({
+    state: { now: { year: 2020 } },
+  })).toEqual(2017);
+  expect(ReportParameter.PREVENTABLE_COLLISIONS.defaultValue()).toEqual([0, 0, 0]);
+  expect(ReportParameter.USERNAME.defaultValue({
+    getters: { username: 'foo' },
+  })).toEqual('foo');
+});
+
+test('StudyHours#hint', () => {
+  expect(StudyHours.OTHER.hint).toEqual(STUDY_HOURS_HINT_OTHER);
+  expect(StudyHours.ROUTINE.hint)
+    .toEqual('07:30 -- 09:30, 10:00 -- 12:00, 13:00 -- 15:00, 16:00 -- 18:00');
+});
+
+test('StudyRequestStatus#canTransitionTo', () => {
+  function expectCanTransitionTo(statusFrom, statusTo, expected = true) {
+    const actual = statusFrom.canTransitionTo(statusTo);
+    expect(actual).toBe(expected);
+  }
+
+  expectCanTransitionTo(StudyRequestStatus.REQUESTED, StudyRequestStatus.CHANGES_NEEDED);
+  expectCanTransitionTo(StudyRequestStatus.REQUESTED, StudyRequestStatus.CANCELLED);
+  expectCanTransitionTo(StudyRequestStatus.REQUESTED, StudyRequestStatus.ASSIGNED);
+  expectCanTransitionTo(StudyRequestStatus.REQUESTED, StudyRequestStatus.REJECTED, false);
+  expectCanTransitionTo(StudyRequestStatus.REQUESTED, StudyRequestStatus.COMPLETED, false);
+
+  expectCanTransitionTo(StudyRequestStatus.CHANGES_NEEDED, StudyRequestStatus.REQUESTED);
+  expectCanTransitionTo(StudyRequestStatus.CHANGES_NEEDED, StudyRequestStatus.CANCELLED);
+  expectCanTransitionTo(StudyRequestStatus.CHANGES_NEEDED, StudyRequestStatus.ASSIGNED);
+
+  expectCanTransitionTo(StudyRequestStatus.CANCELLED, StudyRequestStatus.REQUESTED);
+
+  expectCanTransitionTo(StudyRequestStatus.ASSIGNED, StudyRequestStatus.REQUESTED);
+  expectCanTransitionTo(StudyRequestStatus.ASSIGNED, StudyRequestStatus.REJECTED);
+  expectCanTransitionTo(StudyRequestStatus.ASSIGNED, StudyRequestStatus.COMPLETED);
+
+  expectCanTransitionTo(StudyRequestStatus.COMPLETED, StudyRequestStatus.ASSIGNED, false);
+});
+
+test('StudyRequestStatus#transitionsTo', () => {
+  StudyRequestStatus.enumValues.forEach((status) => {
+    expect(status.transitionsTo).toBeInstanceOf(Array);
+  });
+});

--- a/tests/jest/unit/FunctionUtils.spec.js
+++ b/tests/jest/unit/FunctionUtils.spec.js
@@ -1,4 +1,4 @@
-import { asyncDelay, debounce } from '@/lib/FunctionUtils';
+import { asyncDelay, debounce, identity } from '@/lib/FunctionUtils';
 
 jest.useFakeTimers();
 
@@ -49,4 +49,12 @@ test('FunctionUtils.debounce', () => {
 
   jest.advanceTimersByTime(WAIT_MS);
   expect(x).toEqual(1);
+});
+
+test('FunctionUtils.identity', () => {
+  let x = 42;
+  expect(identity(x)).toBe(x);
+
+  x = { a: 'foo', b: true };
+  expect(identity(x)).toBe(x);
 });

--- a/web/components/data/FcDetailStudies.vue
+++ b/web/components/data/FcDetailStudies.vue
@@ -15,7 +15,9 @@
         :key="item.category.id"
         class="ml-5">
         <v-divider v-if="i > 0"></v-divider>
-        <div class="align-center d-flex mb-4 pr-5">
+        <div
+          class="align-center d-flex pr-5"
+          :class="i === 0 ? 'mb-4' : 'my-4'">
           <div class="body-1 flex-grow-1 flex-shrink-1">
             <div v-if="item.category.studyType === null">
               Unknown

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import Vuex from 'vuex';
 
 import {
+  LegendMode,
   LocationMode,
   LocationSelectionType,
   MAX_LOCATIONS,
@@ -50,6 +51,23 @@ export default new Vuex.Store({
     // NAVIGATION
     backViewRequest: { name: 'requestsTrack' },
     // LOCATION
+    legendMode: LegendMode.NORMAL,
+    legendOptions: {
+      datesFrom: 3,
+      layers: {
+        collisions: true,
+        studies: true,
+        volume: true,
+      },
+    },
+    legendOptionsFocusLocations: {
+      datesFrom: 3,
+      layers: {
+        collisions: false,
+        studies: true,
+        volume: true,
+      },
+    },
     locations: [],
     locationsIndex: -1,
     locationsIndicesDeselected: [],
@@ -64,14 +82,6 @@ export default new Vuex.Store({
       selectionType: LocationSelectionType.POINTS,
     },
     locationMode: LocationMode.SINGLE,
-    legendOptions: {
-      datesFrom: 3,
-      layers: {
-        collisions: true,
-        studies: true,
-        volume: true,
-      },
-    },
   },
   getters: {
     // NAVIGATION
@@ -114,6 +124,12 @@ export default new Vuex.Store({
       return scope;
     },
     // LOCATION
+    legendOptionsForMode(state) {
+      if (state.legendMode === LegendMode.FOCUS_LOCATIONS) {
+        return state.legendOptionsFocusLocations;
+      }
+      return state.legendOptions;
+    },
     locationActive(state, getters) {
       if (state.locationMode === LocationMode.SINGLE) {
         if (getters.locationsEmpty) {
@@ -236,6 +252,27 @@ export default new Vuex.Store({
         Vue.set(state, 'locationMode', LocationMode.SINGLE);
       }
     },
+    setLegendMode(state, legendMode) {
+      Vue.set(state, 'legendMode', legendMode);
+      if (legendMode === LegendMode.FOCUS_LOCATIONS) {
+        const { datesFrom, layers } = state.legendOptions;
+        const legendOptionsFocusLocations = {
+          datesFrom,
+          layers: {
+            ...layers,
+            collisions: false,
+          },
+        };
+        Vue.set(state, 'legendOptionsFocusLocations', legendOptionsFocusLocations);
+      }
+    },
+    setLegendOptions(state, legendOptions) {
+      if (state.legendMode === LegendMode.FOCUS_LOCATIONS) {
+        Vue.set(state, 'legendOptionsFocusLocations', legendOptions);
+      } else {
+        Vue.set(state, 'legendOptions', legendOptions);
+      }
+    },
     setLocationEdit(state, location) {
       if (state.locationsEditIndex === -1) {
         state.locationsEditSelection.locations.push(location);
@@ -292,9 +329,6 @@ export default new Vuex.Store({
     },
     setLocationsEdit(state, locationsEdit) {
       Vue.set(state, 'locationsEdit', [...locationsEdit]);
-    },
-    setLegendOptions(state, legendOptions) {
-      Vue.set(state, 'legendOptions', legendOptions);
     },
   },
   actions: {


### PR DESCRIPTION
# Issue Addressed
This PR closes #645 .

# Description
We add `LegendMode`, which provides `NORMAL` and `FOCUS_LOCATIONS` modes for controlling `FcPaneMap` / `FcPaneMapLegend`.  We store the active legend mode in the `vuex` store as `legendMode`, then use this to switch between `legendOptions` and `legendOptionsFocusLocations` as needed.

We also cover a few more branches in our unit tests, to ensure that we continue to meet our coverage targets.

# Tests
Ran unit tests in pre-commit check.  Tested legend changes in frontend.
