### PR TITLE
a11y: due date field, bulk request study wizard

### DIFF
--- a/lib/i18n/Strings.js
+++ b/lib/i18n/Strings.js
@@ -49,7 +49,7 @@ const REQUEST_STUDY_NOT_FOUND = {
  */
 const REQUEST_STUDY_PROVIDE_URGENT_DUE_DATE = {
   variant: 'info',
-  text: 'Please provide a due date for this request.',
+  text: 'Please provide a due date in MM/DD/YYYY format for this request.',
 };
 
 /*

--- a/web/components/FcDrawerRequestStudyNew.vue
+++ b/web/components/FcDrawerRequestStudyNew.vue
@@ -158,6 +158,18 @@ export default {
       'routeBackViewRequest',
     ]),
   },
+  watch: {
+    studyRequestBulk() {
+      if (this.studyRequestBulk !== null && this.studyRequestBulk.id !== undefined) {
+        /*
+         * This allows the user to leave the final "step" of the bulk request wizard without
+         * being warned about losing data - which is untrue at that point, as the request has
+         * already been saved.
+         */
+        this.leaveConfirmed = true;
+      }
+    },
+  },
   methods: {
     actionViewDetails() {
       const { id } = this.studyRequestBulk;
@@ -165,7 +177,6 @@ export default {
         name: 'requestStudyBulkView',
         params: { id },
       };
-      this.leaveConfirmed = true;
       this.$router.push(route);
     },
     async loadAsyncForRoute(to) {

--- a/web/components/inputs/FcDatePicker.vue
+++ b/web/components/inputs/FcDatePicker.vue
@@ -7,7 +7,7 @@
       min-width="290px"
       offset-y
       transition="scale-transition">
-      <template v-slot:activator="{ on }">
+      <template v-slot:activator="{ on: onMenu }">
         <v-text-field
           v-model="valueFormatted"
           append-icon="mdi-calendar"
@@ -17,7 +17,25 @@
           @blur="resetValueFormatted"
           @input="updateValueFormatted"
           @click:append="showMenu = !showMenu"
-          v-on="on"></v-text-field>
+          v-on="onMenu">
+          <template v-slot:append>
+            <v-tooltip right>
+              <template v-slot:activator="{ on: onTooltip }">
+                <v-icon
+                  aria-label="Select date using calendar"
+                  :color="color"
+                  right
+                  v-on="{
+                    ...onMenu,
+                    ...onTooltip,
+                  }">
+                  mdi-calendar
+                </v-icon>
+              </template>
+              <span>Select date using calendar</span>
+            </v-tooltip>
+          </template>
+        </v-text-field>
       </template>
       <v-date-picker
         v-model="internalValue"
@@ -79,6 +97,15 @@ export default {
     };
   },
   computed: {
+    color() {
+      if (this.$attrs.success) {
+        return 'success';
+      }
+      if (this.$attrs['error-messages'].length > 0) {
+        return 'error';
+      }
+      return null;
+    },
     internalMax() {
       return toInternalValue(this.max);
     },

--- a/web/components/inputs/FcInputTextArray.vue
+++ b/web/components/inputs/FcInputTextArray.vue
@@ -2,11 +2,28 @@
   <v-combobox
     v-model="internalValue"
     append-icon="mdi-plus"
-    deletable-chips
+    hide-no-data
     multiple
     outlined
-    small-chips
-    v-bind="$attrs"></v-combobox>
+    v-bind="$attrs">
+    <template v-slot:selection="{ attrs, item, parent, selected }">
+      <v-chip
+        color="secondary"
+        :input-value="selected"
+        label
+        small
+        v-bind="attrs">
+        <span>{{item}}</span>
+        <v-icon
+          :aria-label="'Remove ' + item"
+          right
+          small
+          @click="parent.selectItem(item)">
+          mdi-close-circle
+        </v-icon>
+      </v-chip>
+    </template>
+  </v-combobox>
 </template>
 
 <script>

--- a/web/components/requests/FcCreateStudyRequestBulk.vue
+++ b/web/components/requests/FcCreateStudyRequestBulk.vue
@@ -17,12 +17,14 @@
 
       <FcHeaderStudyRequestBulkLocations
         v-if="step === 1"
+        key="header_1"
         v-model="indicesIntersectionsSelected"
         :indices="indicesIntersections"
         :locations="locations"
         :study-requests="studyRequests" />
       <FcHeaderStudyRequestBulkLocations
         v-else-if="step === 2"
+        key="header_2"
         v-model="indicesMidblocksSelected"
         :indices="indicesMidblocks"
         :locations="locations"

--- a/web/components/requests/FcHeaderStudyRequestBulkLocations.vue
+++ b/web/components/requests/FcHeaderStudyRequestBulkLocations.vue
@@ -2,6 +2,7 @@
   <div class="mx-5">
     <div class="align-center d-flex">
       <v-checkbox
+        ref="autofocus"
         v-model="selectAll"
         class="mr-6"
         label="Select all"
@@ -62,11 +63,15 @@ import { StudyHours, StudyType } from '@/lib/Constants';
 import { getLocationStudyTypes } from '@/lib/geo/CentrelineUtils';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 import FcMenu from '@/web/components/inputs/FcMenu.vue';
+import FcMixinInputAutofocus from '@/web/mixins/FcMixinInputAutofocus';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
 export default {
   name: 'FcHeaderStudyRequestBulkLocations',
-  mixins: [FcMixinVModelProxy(Array)],
+  mixins: [
+    FcMixinInputAutofocus,
+    FcMixinVModelProxy(Array),
+  ],
   directives: {
     Ripple,
   },

--- a/web/components/requests/FcStepperStudyRequestBulk.vue
+++ b/web/components/requests/FcStepperStudyRequestBulk.vue
@@ -56,6 +56,17 @@ export default {
 .fc-stepper-study-request-bulk {
   &.v-stepper--alt-labels .v-stepper__step {
     flex-basis: auto;
+    & > .v-stepper__label {
+      color: var(--v-default-base);
+    }
+    &.v-stepper__step--inactive {
+      & > .v-stepper__step__step {
+        background: var(--v-secondary-base) !important;
+      }
+      & > .v-stepper__label {
+        color: var(--v-secondary-base);
+      }
+    }
   }
 }
 </style>

--- a/web/components/requests/FcStudyRequestBulkConfirm.vue
+++ b/web/components/requests/FcStudyRequestBulkConfirm.vue
@@ -4,7 +4,9 @@
       accordion
       flat
       focusable>
-      <v-expansion-panel class="fc-study-request-bulk-confirm-locations">
+      <v-expansion-panel
+        ref="autofocus"
+        class="fc-study-request-bulk-confirm-locations">
         <v-expansion-panel-header>
           <span class="body-1">Intersections</span>
           <v-spacer></v-spacer>
@@ -29,7 +31,7 @@
               <v-tooltip right>
                 <template v-slot:activator="{ on }">
                   <FcButton
-                    aria-label="Remove Study from Request"
+                    :aria-label="'Remove ' + locations[i].description + ' from Request'"
                     class="mr-4"
                     type="icon"
                     @click="$emit('remove-study', i)"
@@ -37,7 +39,7 @@
                     <v-icon>mdi-close</v-icon>
                   </FcButton>
                 </template>
-                <span>Remove Study from Request</span>
+                <span>Remove {{locations[i].description}} from Request</span>
               </v-tooltip>
             </div>
           </template>
@@ -85,9 +87,11 @@
       </v-expansion-panel>
     </v-expansion-panels>
 
-    <FcSummaryStudyRequest
-      :is-create="true"
-      :study-request="studyRequestBulk" />
+    <div class="mr-5 mt-4">
+      <FcSummaryStudyRequest
+        :is-create="true"
+        :study-request="studyRequestBulk" />
+    </div>
   </section>
 </template>
 
@@ -96,9 +100,11 @@ import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcCardStudyRequestConfirm from '@/web/components/requests/FcCardStudyRequestConfirm.vue';
 import FcSummaryStudyRequest from '@/web/components/requests/summary/FcSummaryStudyRequest.vue';
+import FcMixinInputAutofocus from '@/web/mixins/FcMixinInputAutofocus';
 
 export default {
   name: 'FcStudyRequestBulkConfirm',
+  mixins: [FcMixinInputAutofocus],
   components: {
     FcButton,
     FcCardStudyRequestConfirm,

--- a/web/components/requests/FcStudyRequestBulkDetails.vue
+++ b/web/components/requests/FcStudyRequestBulkDetails.vue
@@ -5,6 +5,7 @@
       <v-row>
         <v-col cols="8">
           <v-text-field
+            ref="autofocus"
             v-model="v.name.$model"
             :error-messages="errorMessagesName"
             label="Set Name for Bulk Request"
@@ -36,6 +37,7 @@ import { StudyRequestReason } from '@/lib/Constants';
 import { OPTIONAL } from '@/lib/i18n/Strings';
 import FcStudyRequestReason from '@/web/components/requests/fields/FcStudyRequestReason.vue';
 import FcStudyRequestUrgent from '@/web/components/requests/fields/FcStudyRequestUrgent.vue';
+import FcMixinInputAutofocus from '@/web/mixins/FcMixinInputAutofocus';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
 function mapWatchers(keys) {
@@ -57,7 +59,10 @@ function mapWatchers(keys) {
 
 export default {
   name: 'FcStudyRequestBulkDetails',
-  mixins: [FcMixinVModelProxy(Object)],
+  mixins: [
+    FcMixinInputAutofocus,
+    FcMixinVModelProxy(Object),
+  ],
   components: {
     FcStudyRequestReason,
     FcStudyRequestUrgent,

--- a/web/components/requests/fields/FcStudyRequestUrgent.vue
+++ b/web/components/requests/fields/FcStudyRequestUrgent.vue
@@ -14,7 +14,7 @@
             class="mt-3"
             :error-messages="errorMessagesDueDate"
             hide-details="auto"
-            label="Due Date"
+            label="Due Date (MM/DD/YYYY)"
             :max="maxDueDate"
             :min="minDueDate"
             :success="!v.dueDate.$invalid">

--- a/web/main.js
+++ b/web/main.js
@@ -57,6 +57,8 @@ const vuetify = new Vuetify({
         shading: '#fafafa',
         border: '#e0e0e0',
         unselected: '#acacac',
+        // status colors
+        error: '#df323b',
         // request status
         statusRequested: '#2ec3cc',
         statusChangesNeeded: '#404040',

--- a/web/main.js
+++ b/web/main.js
@@ -58,7 +58,8 @@ const vuetify = new Vuetify({
         border: '#e0e0e0',
         unselected: '#acacac',
         // status colors
-        error: '#df323b',
+        error: '#df323b', // in default Vuetify: 'error darken-1'
+        success: '#00791e', // in default Vuetify: 'success darken-2'
         // request status
         statusRequested: '#2ec3cc',
         statusChangesNeeded: '#404040',

--- a/web/mixins/FcMixinInputAutofocus.js
+++ b/web/mixins/FcMixinInputAutofocus.js
@@ -1,0 +1,16 @@
+const SELECTOR_INPUT = 'button, input';
+
+export default {
+  mounted() {
+    this.autofocus();
+  },
+  methods: {
+    autofocus() {
+      let $autofocus = this.$refs.autofocus.$el;
+      if (!$autofocus.matches(SELECTOR_INPUT)) {
+        $autofocus = $autofocus.querySelector(SELECTOR_INPUT);
+      }
+      $autofocus.focus();
+    },
+  },
+};


### PR DESCRIPTION
# Issue Addressed
This PR closes #633 and closes #634 .

# Description
We add autofocus-like behaviour on bulk request study wizard steps to help with keyboard navigation, improve contrast in a number of places, and add non-visual alternatives / tooltips to several icon buttons that were part of more complex inputs.  We also fix a small navigation bug in the wizard: in the last "step" (the one after submitting the request), leaving the page via anything except the "View Details" or "Close" buttons previously triggered the navigation `beforeRouteLeave` guard to show a warning dialog, even though the details have already been saved at that point (and therefore cannot be lost, as the dialog suggests).

# Tests
Tested in frontend.