### PR TITLE
a11y: keyboard navigability

### DIFF
--- a/web/App.vue
+++ b/web/App.vue
@@ -13,6 +13,7 @@
       v-bind="toastData" />
     <v-navigation-drawer
       app
+      class="fc-navigation-drawer"
       mini-variant
       permanent>
       <template v-slot:prepend>
@@ -117,6 +118,10 @@ export default {
   font-size: 0.875rem;
   font-weight: normal;
   line-height: 1.25rem;
+
+  & .fc-navigation-drawer {
+    overflow: visible;
+  }
 
   & .v-input--selection-controls__input + .v-label {
     color: var(--v-default-base);

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -456,6 +456,7 @@ export default {
     ]),
     ...mapGetters([
       'legendOptionsForMode',
+      'locationActive',
       'locationsForMode',
       'locationsRouteParams',
       'locationsSelectionForMode',
@@ -558,6 +559,24 @@ export default {
     hoveredFeature: debounce(function watchHoveredFeature() {
       this.featureKeyHoveredPopup = this.featureKeyHovered;
     }, 200),
+    locationActive() {
+      if (this.locationActive === null || this.locationMode !== LocationMode.SINGLE) {
+        return;
+      }
+      const { description, geom, ...locationActiveRest } = this.locationActive;
+      const properties = {
+        ...locationActiveRest,
+        name: description,
+      };
+      const layerId = properties.centrelineType === CentrelineType.INTERSECTION
+        ? 'intersections'
+        : 'midblocks';
+      this.selectedFeature = {
+        geometry: geom,
+        layer: { id: layerId },
+        properties,
+      };
+    },
     mapStyle() {
       this.map.setStyle(this.mapStyle);
       this.updateLocationsSource();

--- a/web/components/FcPaneMapPopup.vue
+++ b/web/components/FcPaneMapPopup.vue
@@ -402,7 +402,6 @@ export default {
     this.createPopup();
   },
   mounted() {
-    this.createPopup();
     this.popup.setLngLat(this.coordinates);
     this.popup.setDOMContent(this.$refs.content.$el);
     this.popup.addTo(this.map);

--- a/web/components/inputs/FcDatePicker.vue
+++ b/web/components/inputs/FcDatePicker.vue
@@ -1,19 +1,20 @@
 <template>
-  <div>
+  <div class="fc-date-picker">
     <v-menu
       v-model="showMenu"
+      :attach="$el"
       :close-on-content-click="false"
       max-width="290px"
       min-width="290px"
       offset-y
       transition="scale-transition">
-      <template v-slot:activator="{ on: onMenu }">
+      <template v-slot:activator="{ attrs, on: onMenu }">
         <v-text-field
           v-model="valueFormatted"
           append-icon="mdi-calendar"
           offset-y
           outlined
-          v-bind="$attrs"
+          v-bind="{ ...attrs, ...$attrs }"
           @blur="resetValueFormatted"
           @input="updateValueFormatted"
           @click:append="showMenu = !showMenu"
@@ -141,3 +142,9 @@ export default {
   },
 };
 </script>
+
+<style lang="scss">
+.fc-date-picker {
+  position: relative;
+}
+</style>

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -8,7 +8,7 @@
       :close-on-content-click="false"
       :offset-y="true"
       :open-on-click="false">
-      <template v-slot:activator="{ on: onMenu }">
+      <template v-slot:activator="{ attrs, on: onMenu }">
         <v-text-field
           v-model="query"
           :aria-label="query"
@@ -19,7 +19,10 @@
           label="Choose location or click on the map"
           :loading="loading"
           solo
-          v-bind="$attrs"
+          v-bind="{
+            ...attrs,
+            ...$attrs,
+          }"
           @blur="actionBlur"
           @focus="actionFocus"
           @input="actionInput"

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -18,6 +18,7 @@
             @location-remove="actionRemove" />
           <FcInputLocationSearch
             v-if="!locationsEditFull"
+            ref="autofocus"
             v-model="locationToAdd"
             :location-index="-1"
             @focus="setLocationsEditIndex(-1)"
@@ -185,9 +186,11 @@ import FcInputLocationSearch from '@/web/components/inputs/FcInputLocationSearch
 import FcDisplayLocationMulti from '@/web/components/location/FcDisplayLocationMulti.vue';
 import FcHeaderSingleLocation from '@/web/components/location/FcHeaderSingleLocation.vue';
 import FcSummaryPoi from '@/web/components/location/FcSummaryPoi.vue';
+import FcMixinInputAutofocus from '@/web/mixins/FcMixinInputAutofocus';
 
 export default {
   name: 'FcSelectorMultiLocation',
+  mixins: [FcMixinInputAutofocus],
   components: {
     FcButton,
     FcButtonAria,

--- a/web/components/nav/FcDashboardNavUser.vue
+++ b/web/components/nav/FcDashboardNavUser.vue
@@ -18,13 +18,18 @@
     </div>
     <v-menu
       v-if="auth.loggedIn"
-      top>
-      <template v-slot:activator="{ on: onMenu }">
+      :attach="$el"
+      :min-width="140"
+      top
+      :z-index="100">
+      <template v-slot:activator="{ attrs, on: onMenu }">
         <v-tooltip right>
           <template v-slot:activator="{ on: onTooltip }">
             <FcButton
+              ref="btn"
               :aria-label="username"
               type="fab-icon"
+              v-bind="attrs"
               v-on="{ ...onMenu, ...onTooltip }">
               <v-icon>mdi-account-circle</v-icon>
             </FcButton>
@@ -32,18 +37,14 @@
           <span>{{username}}</span>
         </v-tooltip>
       </template>
-      <v-list>
-        <template
-          v-if="hasAuthScope(AuthScope.ADMIN)">
-          <v-list-item
-            link
-            :to="{ name: 'admin' }">
-            <v-list-item-title>Admin Console</v-list-item-title>
-          </v-list-item>
-          <v-divider></v-divider>
-        </template>
+      <v-list class="text-left" id="fc_menu_user">
         <v-list-item
-          @click="actionSignOut()">
+          v-if="hasAuthScope(AuthScope.ADMIN)"
+          @click="actionAdmin">
+          <v-list-item-title>Admin Console</v-list-item-title>
+        </v-list-item>
+        <v-list-item
+          @click="actionSignOut">
           <v-list-item-title>Sign out</v-list-item-title>
         </v-list-item>
       </v-list>
@@ -86,6 +87,9 @@ export default {
     ...mapGetters(['username']),
   },
   methods: {
+    actionAdmin() {
+      this.$router.push({ name: 'admin' });
+    },
     actionSignIn() {
       Vue.nextTick(async () => {
         const event = this.$analytics.signInEvent();
@@ -104,3 +108,9 @@ export default {
   },
 };
 </script>
+
+<style lang="scss">
+#fc_menu_user {
+  background: white;
+}
+</style>

--- a/web/components/requests/FcCreateStudyRequestBulk.vue
+++ b/web/components/requests/FcCreateStudyRequestBulk.vue
@@ -6,6 +6,8 @@
       <FcStepperStudyRequestBulk
         v-if="step !== null"
         v-model="step"
+        :indices-intersections="indicesIntersections"
+        :indices-midblocks="indicesMidblocks"
         class="mb-2" />
 
       <div class="px-5">
@@ -96,7 +98,7 @@
         <v-spacer></v-spacer>
 
         <FcButton
-          v-if="step === 1"
+          v-if="step === 1 || (step === 2 && indicesIntersections.length === 0)"
           class="mr-2"
           type="tertiary"
           @click="$emit('action-navigate-back')">
@@ -106,7 +108,7 @@
           v-else-if="step !== null"
           class="mr-2"
           type="tertiary"
-          @click="step -= 1">
+          @click="actionBack">
           Back
         </FcButton>
 
@@ -114,7 +116,7 @@
           v-if="step !== null && step < 4"
           :disabled="disabledNext"
           type="primary"
-          @click="step += 1">
+          @click="actionNext">
           Continue
         </FcButton>
         <FcButton
@@ -199,13 +201,15 @@ export default {
 
     const indicesIntersectionsSelected = [...indicesIntersections];
     const indicesMidblocksSelected = [...indicesMidblocks];
+
+    const step = indicesIntersections.length > 0 ? 1 : 2;
     return {
       indicesIntersections,
       indicesIntersectionsSelected,
       indicesMidblocks,
       indicesMidblocksSelected,
       loadingSubmit: false,
-      step: 1,
+      step,
       studyRequests,
     };
   },
@@ -294,6 +298,20 @@ export default {
     this.setLocationsIndicesDeselected([]);
   },
   methods: {
+    actionBack() {
+      if (this.step === 3 && this.indicesMidblocks.length === 0) {
+        this.step = 1;
+      } else {
+        this.step -= 1;
+      }
+    },
+    actionNext() {
+      if (this.step === 1 && this.indicesMidblocks.length === 0) {
+        this.step = 3;
+      } else {
+        this.step += 1;
+      }
+    },
     actionRemoveStudy(i) {
       let j = this.indicesIntersectionsSelected.indexOf(i);
       if (j !== -1) {

--- a/web/components/requests/FcDetailsStudyRequest.vue
+++ b/web/components/requests/FcDetailsStudyRequest.vue
@@ -10,6 +10,7 @@
           <v-row>
             <v-col cols="8">
               <FcStudyRequestStudyType
+                ref="autofocus"
                 :location="location"
                 :v="$v.internalValue" />
             </v-col>
@@ -121,11 +122,15 @@ import FcStudyRequestNotes from '@/web/components/requests/fields/FcStudyRequest
 import FcStudyRequestReason from '@/web/components/requests/fields/FcStudyRequestReason.vue';
 import FcStudyRequestStudyType from '@/web/components/requests/fields/FcStudyRequestStudyType.vue';
 import FcStudyRequestUrgent from '@/web/components/requests/fields/FcStudyRequestUrgent.vue';
+import FcMixinInputAutofocus from '@/web/mixins/FcMixinInputAutofocus';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
 export default {
   name: 'FcDetailsStudyRequest',
-  mixins: [FcMixinVModelProxy(Object)],
+  mixins: [
+    FcMixinInputAutofocus,
+    FcMixinVModelProxy(Object),
+  ],
   components: {
     FcButton,
     FcStudyRequestDaysOfWeek,

--- a/web/components/requests/FcStepperStudyRequestBulk.vue
+++ b/web/components/requests/FcStepperStudyRequestBulk.vue
@@ -5,9 +5,11 @@
     alt-labels>
     <v-stepper-header class="elevation-0 px-3 pt-1">
       <v-stepper-step
+        :aria-disabled="!hasIntersections"
         class="pa-2"
-        :complete="internalValue > 1"
-        :editable="internalValue > 1"
+        :class="{ disabled: !hasIntersections }"
+        :complete="hasIntersections && internalValue > 1"
+        :editable="hasIntersections > 0 && internalValue > 1"
         :step="1">
         Select intersections
       </v-stepper-step>
@@ -15,9 +17,11 @@
       <v-icon small>mdi-chevron-right</v-icon>
 
       <v-stepper-step
+        :aria-disabled="!hasMidblocks"
         class="pa-2"
-        :complete="internalValue > 2"
-        :editable="internalValue > 2"
+        :class="{ disabled: !hasMidblocks }"
+        :complete="hasMidblocks && internalValue > 2"
+        :editable="hasMidblocks && internalValue > 2"
         :step="2">
         Select midblocks
       </v-stepper-step>
@@ -49,6 +53,18 @@ import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 export default {
   name: 'FcStepperStudyRequestBulk',
   mixins: [FcMixinVModelProxy(Number)],
+  props: {
+    indicesIntersections: Array,
+    indicesMidblocks: Array,
+  },
+  computed: {
+    hasIntersections() {
+      return this.indicesIntersections.length > 0;
+    },
+    hasMidblocks() {
+      return this.indicesMidblocks.length > 0;
+    },
+  },
 };
 </script>
 
@@ -58,6 +74,10 @@ export default {
     flex-basis: auto;
     & > .v-stepper__label {
       color: var(--v-default-base);
+    }
+    &.disabled {
+      opacity: 0.38;
+      pointer-events: none;
     }
     &.v-stepper__step--inactive {
       & > .v-stepper__step__step {

--- a/web/mixins/FcMixinInputAutofocus.js
+++ b/web/mixins/FcMixinInputAutofocus.js
@@ -6,7 +6,11 @@ export default {
   },
   methods: {
     autofocus() {
-      let $autofocus = this.$refs.autofocus.$el;
+      const { autofocus } = this.$refs;
+      if (autofocus === undefined) {
+        return;
+      }
+      let $autofocus = autofocus.$el;
       if (!$autofocus.matches(SELECTOR_INPUT)) {
         $autofocus = $autofocus.querySelector(SELECTOR_INPUT);
       }

--- a/web/mixins/FcMixinInputAutofocus.js
+++ b/web/mixins/FcMixinInputAutofocus.js
@@ -1,8 +1,10 @@
+import Vue from 'vue';
+
 const SELECTOR_INPUT = 'button, input';
 
 export default {
   mounted() {
-    this.autofocus();
+    Vue.nextTick(() => this.autofocus());
   },
   methods: {
     autofocus() {


### PR DESCRIPTION
# Issue Addressed
This PR closes #632 .

# Description
We make several parts of MOVE much more easily navigable by keyboard: the user menu, map popups, bulk and non-bulk request study flows, the location search bar and multi-location selector.

We also address a small bug in the bulk request flow where it would show an empty list for selections that contain no intersections / midblocks in the corresponding wizard step.  Those steps are now disabled in the stepper at top, and are skipped by both forward and backward navigation.

# Tests
Tested changes in frontend.
