### PR TITLE
a11y: misc cleanup

### DIFF
--- a/web/components/FcDataTableRequests.vue
+++ b/web/components/FcDataTableRequests.vue
@@ -166,7 +166,7 @@
         <FcButtonAria
           :aria-label="item.ariaLabel"
           button-class="btn-show-request"
-          top
+          left
           type="secondary"
           @click="actionShowItem(item)">
           <v-icon>mdi-open-in-new</v-icon>

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -158,6 +158,14 @@ function getFeatureKey(feature) {
   return `${layerId}:${id}`;
 }
 
+function getFeatureKeyLocation(location) {
+  if (location === null) {
+    return null;
+  }
+  const { centrelineType, centrelineId } = location;
+  return `c:${centrelineType}:${centrelineId}`;
+}
+
 function getFeatureKeyRoute($route, locationMode) {
   if (locationMode.multi) {
     return null;
@@ -559,11 +567,15 @@ export default {
     hoveredFeature: debounce(function watchHoveredFeature() {
       this.featureKeyHoveredPopup = this.featureKeyHovered;
     }, 200),
-    locationActive() {
-      if (this.locationActive === null || this.locationMode.multi) {
+    locationActive(locationActive, locationActivePrev) {
+      if (locationActive === null) {
+        const featureKeyLocationActivePrev = getFeatureKeyLocation(locationActivePrev);
+        if (this.featureKeySelected === featureKeyLocationActivePrev) {
+          this.selectedFeature = null;
+        }
         return;
       }
-      const { description, geom, ...locationActiveRest } = this.locationActive;
+      const { description, geom, ...locationActiveRest } = locationActive;
       const properties = {
         ...locationActiveRest,
         name: description,

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -560,7 +560,7 @@ export default {
       this.featureKeyHoveredPopup = this.featureKeyHovered;
     }, 200),
     locationActive() {
-      if (this.locationActive === null || this.locationMode !== LocationMode.SINGLE) {
+      if (this.locationActive === null || this.locationMode.multi) {
         return;
       }
       const { description, geom, ...locationActiveRest } = this.locationActive;
@@ -576,6 +576,11 @@ export default {
         layer: { id: layerId },
         properties,
       };
+    },
+    locationMode() {
+      if (this.locationMode.multi) {
+        this.selectedFeature = null;
+      }
     },
     mapStyle() {
       this.map.setStyle(this.mapStyle);
@@ -860,6 +865,9 @@ export default {
         transition-duration: 0.28s;
         transition-property: background-color;
         transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+        &:focus {
+          background-color: #c1c1c1;
+        }
       }
     }
     & > .mapboxgl-ctrl-scale {

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -52,7 +52,11 @@
                 <span>Clear Location</span>
               </v-tooltip>
               <v-divider vertical />
-              <v-icon right>mdi-magnify</v-icon>
+              <v-icon
+                :color="hasFocus ? 'primary' : null"
+                right>
+                mdi-magnify
+              </v-icon>
             </template>
           </template>
         </v-text-field>
@@ -246,6 +250,9 @@ export default {
 
 <style lang="scss">
 .fc-input-location-search {
+  & > .v-input--is-focused {
+    box-shadow: 0 0 0 2px var(--v-primary-base);
+  }
   &.v-select .v-input__append-inner .v-input__icon--append .v-icon {
     margin-top: 0;
   }

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -22,7 +22,7 @@
             v-model="locationToAdd"
             :location-index="-1"
             @focus="setLocationsEditIndex(-1)"
-            @location-add="addLocationEdit" />
+            @location-add="actionAdd" />
         </div>
         <v-messages
           class="mt-2"
@@ -161,6 +161,7 @@
 </template>
 
 <script>
+import Vue from 'vue';
 import {
   mapActions,
   mapGetters,
@@ -311,6 +312,7 @@ export default {
         this.loading = true;
         try {
           await this.syncLocationsEdit();
+          Vue.nextTick(() => this.autofocus());
           this.hasError = false;
         } catch (err) {
           this.setToastBackendError(err);
@@ -321,6 +323,10 @@ export default {
     },
   },
   methods: {
+    actionAdd(location) {
+      this.addLocationEdit(location);
+      Vue.nextTick(() => this.autofocus());
+    },
     actionLocationNext() {
       if (this.locationsIndex <= this.locations.length - 1) {
         this.setLocationsIndex(this.locationsIndex + 1);
@@ -334,6 +340,7 @@ export default {
     actionRemove(i) {
       this.setLocationsEditIndex(-1);
       this.removeLocationEdit(i);
+      Vue.nextTick(() => this.autofocus());
     },
     ...mapActions(['syncLocationsEdit']),
     ...mapMutations([

--- a/web/components/inputs/FcSelectorSingleLocation.vue
+++ b/web/components/inputs/FcSelectorSingleLocation.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="fc-selector-single-location">
     <FcInputLocationSearch
+      ref="autofocus"
       v-model="internalLocation"
       class="elevation-2" />
   </div>
@@ -11,9 +12,11 @@ import { mapGetters, mapMutations } from 'vuex';
 
 import { LocationSelectionType } from '@/lib/Constants';
 import FcInputLocationSearch from '@/web/components/inputs/FcInputLocationSearch.vue';
+import FcMixinInputAutofocus from '@/web/mixins/FcMixinInputAutofocus';
 
 export default {
   name: 'FcSelectorSingleLocation',
+  mixins: [FcMixinInputAutofocus],
   components: {
     FcInputLocationSearch,
   },

--- a/web/components/location/FcDisplayLocationMulti.vue
+++ b/web/components/location/FcDisplayLocationMulti.vue
@@ -12,7 +12,8 @@
         flat
         hide-details
         readonly
-        solo>
+        solo
+        tabindex="-1">
         <template v-slot:append>
           <div class="align-center d-flex">
             <FcIconLocationMulti

--- a/web/components/nav/FcDashboardNavBrand.vue
+++ b/web/components/nav/FcDashboardNavBrand.vue
@@ -38,5 +38,8 @@ export default {
 <style lang="scss">
 .v-application a.fc-nav-brand {
   color: transparent;
+  &:focus {
+    background-color: #e0e0e0;
+  }
 }
 </style>

--- a/web/components/requests/nav/FcBreadcrumbsStudyRequest.vue
+++ b/web/components/requests/nav/FcBreadcrumbsStudyRequest.vue
@@ -2,7 +2,16 @@
   <v-breadcrumbs
     class="pa-0"
     :divider="divider"
-    :items="items" />
+    :items="items">
+    <template v-slot:item="{ item }">
+      <v-breadcrumbs-item
+        :aria-disabled="item.disabled.toString()"
+        :disabled="item.disabled"
+        :to="item.to">
+        {{item.text}}
+      </v-breadcrumbs-item>
+    </template>
+  </v-breadcrumbs>
 </template>
 
 <script>
@@ -32,6 +41,7 @@ export default {
       const { name } = this.$route;
       if (name === 'requestStudyBulkView') {
         return {
+          disabled: true,
           text: this.studyRequest.name,
           to: {
             name: 'requestStudyBulkView',
@@ -42,6 +52,7 @@ export default {
       if (name === 'requestStudyView') {
         const text = getLocationsDescription(this.locationsSelection.locations);
         return {
+          disabled: true,
           text,
           to: {
             name: 'requestStudyView',
@@ -64,6 +75,7 @@ export default {
           return null;
         }
         return {
+          disabled: false,
           text: this.studyRequestBulkName,
           to: {
             name: 'requestStudyBulkView',
@@ -75,6 +87,7 @@ export default {
     },
     items() {
       const items = [{
+        disabled: false,
         text: this.labelBackViewRequest,
         to: this.routeBackViewRequest,
       }];


### PR DESCRIPTION
# Issue Addressed
This issue closes #637 .

# Description
We fix a few last low-hanging a11y issues: marking disabled breadcrumbs in View Request flows with `aria-disabled`, initial focus on the location search bar, better popup handling, better focus management in location selection.

# Tests
Tested quickly in frontend.
