### PR TITLE
Simplify user scopes, fix preparedBy warrant report bug

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -398,11 +398,6 @@ ReportParameter.init({
       return [0, 0, 0];
     },
   },
-  USERNAME: {
-    defaultValue({ getters }) {
-      return getters.username;
-    },
-  },
 });
 
 /**
@@ -543,7 +538,6 @@ ReportType.init({
     label: 'Warrant: Traffic Signal Control',
     options: {
       adequateTrial: ReportParameter.BOOLEAN,
-      preparedBy: ReportParameter.USERNAME,
       preventablesByYear: ReportParameter.PREVENTABLE_COLLISIONS,
       startYear: ReportParameter.DATE_YEAR,
     },

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -14,13 +14,10 @@ AuthScope.init({
     description: 'Admin MOVE',
   },
   STUDY_REQUESTS: {
-    description: 'View Study Requests',
+    description: 'Study Requests',
   },
   STUDY_REQUESTS_ADMIN: {
     description: 'Admin Study Requests',
-  },
-  STUDY_REQUESTS_EDIT: {
-    description: 'Create and Edit Study Requests',
   },
 });
 

--- a/lib/controller/ReportController.js
+++ b/lib/controller/ReportController.js
@@ -42,9 +42,6 @@ function getSchemaForReportParameter(reportParameter) {
       Joi.number().integer().min(0).required(),
     ).required();
   }
-  if (reportParameter === ReportParameter.USERNAME) {
-    return Joi.string().required();
-  }
   throw new EnumValueError(reportParameter);
 }
 

--- a/lib/controller/StudyRequestBulkController.js
+++ b/lib/controller/StudyRequestBulkController.js
@@ -36,7 +36,7 @@ StudyRequestBulkController.push({
   path: '/requests/study/bulk',
   options: {
     auth: {
-      scope: [AuthScope.STUDY_REQUESTS_EDIT.name],
+      scope: [AuthScope.STUDY_REQUESTS.name],
     },
     response: {
       schema: StudyRequestBulk.read,
@@ -179,7 +179,7 @@ StudyRequestBulkController.push({
   path: '/requests/study/bulk/{id}',
   options: {
     auth: {
-      scope: [AuthScope.STUDY_REQUESTS_EDIT.name],
+      scope: [AuthScope.STUDY_REQUESTS.name],
     },
     response: {
       schema: StudyRequestBulk.read,

--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -43,7 +43,7 @@ StudyRequestController.push({
   path: '/requests/study',
   options: {
     auth: {
-      scope: [AuthScope.STUDY_REQUESTS_EDIT.name],
+      scope: [AuthScope.STUDY_REQUESTS.name],
     },
     response: {
       schema: StudyRequest.read,
@@ -178,7 +178,7 @@ StudyRequestController.push({
   path: '/requests/study/{id}',
   options: {
     auth: {
-      scope: [AuthScope.STUDY_REQUESTS_EDIT.name],
+      scope: [AuthScope.STUDY_REQUESTS.name],
     },
     response: {
       schema: StudyRequest.read,

--- a/lib/requests/RequestActions.js
+++ b/lib/requests/RequestActions.js
@@ -58,7 +58,7 @@ class RequestActions {
     if (hasAuthScope(user, AuthScope.STUDY_REQUESTS_ADMIN)) {
       return true;
     }
-    if (hasAuthScope(user, AuthScope.STUDY_REQUESTS_EDIT)) {
+    if (hasAuthScope(user, AuthScope.STUDY_REQUESTS)) {
       return user.id === studyRequest.userId;
     }
     return false;

--- a/scripts/db/schema-17.down.sql
+++ b/scripts/db/schema-17.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+UPDATE "users"
+SET "scope" = array_append("scope", 'STUDY_REQUESTS_EDIT')
+WHERE 'STUDY_REQUESTS' = ANY("scope");
+
+UPDATE "APP_META"."DB_UPDATE" SET "currentVersion" = 16;
+COMMIT;

--- a/scripts/db/schema-17.up.sql
+++ b/scripts/db/schema-17.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+UPDATE "users" SET "scope" = array_remove("scope", 'STUDY_REQUESTS_EDIT');
+
+UPDATE "APP_META"."DB_UPDATE" SET "currentVersion" = 17;
+COMMIT;

--- a/tests/jest/api/RestApi.spec.js
+++ b/tests/jest/api/RestApi.spec.js
@@ -429,32 +429,21 @@ test('StudyRequestController', async () => {
   expect(client.csrf).not.toBeNull();
 
   // requester can create requests and edit their own requests
-  const transientRequester = generateUser([
-    AuthScope.STUDY_REQUESTS,
-    AuthScope.STUDY_REQUESTS_EDIT,
-  ]);
+  const transientRequester = generateUser([AuthScope.STUDY_REQUESTS]);
   const requester = await UserDAO.create(transientRequester);
 
   // supervisors can manage all requests
   const transientSupervisor = generateUser([
     AuthScope.STUDY_REQUESTS,
     AuthScope.STUDY_REQUESTS_ADMIN,
-    AuthScope.STUDY_REQUESTS_EDIT,
   ]);
   const supervisor = await UserDAO.create(transientSupervisor);
 
   // other ETT1s have edit powers, but only on their own requests
   const transientETT1 = generateUser([
     AuthScope.STUDY_REQUESTS,
-    AuthScope.STUDY_REQUESTS_EDIT,
   ]);
   const ett1 = await UserDAO.create(transientETT1);
-
-  // other staff can only view requests; they cannot create or edit them
-  const transientStaff = generateUser([
-    AuthScope.STUDY_REQUESTS,
-  ]);
-  const staff = await UserDAO.create(transientStaff);
 
   const now = DateTime.local();
   const transientStudyRequest = {
@@ -481,14 +470,6 @@ test('StudyRequestController', async () => {
     { centrelineId: 13459445, centrelineType: CentrelineType.INTERSECTION },
   ];
   const s1 = CompositeId.encode(features);
-
-  // creating requests requires `STUDY_REQUESTS_EDIT` permission
-  client.setUser(staff);
-  response = await client.fetch('/requests/study', {
-    method: 'POST',
-    data: transientStudyRequest,
-  });
-  expect(response.statusCode).toBe(HttpStatus.FORBIDDEN.statusCode);
 
   // requester can create request
   client.setUser(requester);

--- a/tests/jest/db/UserDAO.spec.js
+++ b/tests/jest/db/UserDAO.spec.js
@@ -34,7 +34,7 @@ test('UserDAO', async () => {
   Object.assign(persistedUser1, { email, uniqueName });
   await expect(UserDAO.update(persistedUser1)).resolves.toEqual(persistedUser1);
   Object.assign(persistedUser1, {
-    scope: [AuthScope.STUDY_REQUESTS, AuthScope.STUDY_REQUESTS_EDIT],
+    scope: [AuthScope.STUDY_REQUESTS],
   });
   await expect(UserDAO.update(persistedUser1)).resolves.toEqual(persistedUser1);
   await expect(UserDAO.bySub(transientUser1.sub)).resolves.toEqual(persistedUser1);

--- a/tests/jest/unit/Constants.spec.js
+++ b/tests/jest/unit/Constants.spec.js
@@ -17,9 +17,6 @@ test('ReportParameter#defaultValue', () => {
     state: { now: { year: 2020 } },
   })).toEqual(2017);
   expect(ReportParameter.PREVENTABLE_COLLISIONS.defaultValue()).toEqual([0, 0, 0]);
-  expect(ReportParameter.USERNAME.defaultValue({
-    getters: { username: 'foo' },
-  })).toEqual('foo');
 });
 
 test('StudyHours#hint', () => {

--- a/tests/jest/unit/auth/ScopeMatcher.spec.js
+++ b/tests/jest/unit/auth/ScopeMatcher.spec.js
@@ -5,41 +5,37 @@ test('ScopeMatcher.hasAuthScope', () => {
   let user = null;
   expect(hasAuthScope(user, [])).toBe(false);
   expect(hasAuthScope(user, [AuthScope.STUDY_REQUESTS])).toBe(false);
-  expect(hasAuthScope(user, [
-    AuthScope.STUDY_REQUESTS,
-    AuthScope.STUDY_REQUESTS_EDIT,
-  ])).toBe(false);
 
   user = {
     scope: [AuthScope.STUDY_REQUESTS],
   };
   expect(hasAuthScope(user, [])).toBe(true);
   expect(hasAuthScope(user, [AuthScope.STUDY_REQUESTS])).toBe(true);
-  expect(hasAuthScope(user, [AuthScope.STUDY_REQUESTS_EDIT])).toBe(false);
+  expect(hasAuthScope(user, [AuthScope.STUDY_REQUESTS_ADMIN])).toBe(false);
   expect(hasAuthScope(user, [
     AuthScope.STUDY_REQUESTS,
-    AuthScope.STUDY_REQUESTS_EDIT,
+    AuthScope.STUDY_REQUESTS_ADMIN,
   ])).toBe(true);
   expect(hasAuthScope(user, [
     AuthScope.STUDY_REQUESTS_ADMIN,
-    AuthScope.STUDY_REQUESTS_EDIT,
+    AuthScope.ADMIN,
   ])).toBe(false);
 
   user = {
     scope: [
       AuthScope.STUDY_REQUESTS,
-      AuthScope.STUDY_REQUESTS_EDIT,
+      AuthScope.STUDY_REQUESTS_ADMIN,
     ],
   };
   expect(hasAuthScope(user, [])).toBe(true);
   expect(hasAuthScope(user, [AuthScope.STUDY_REQUESTS])).toBe(true);
-  expect(hasAuthScope(user, [AuthScope.STUDY_REQUESTS_EDIT])).toBe(true);
+  expect(hasAuthScope(user, [AuthScope.STUDY_REQUESTS_ADMIN])).toBe(true);
   expect(hasAuthScope(user, [
     AuthScope.STUDY_REQUESTS,
-    AuthScope.STUDY_REQUESTS_EDIT,
+    AuthScope.STUDY_REQUESTS_ADMIN,
   ])).toBe(true);
   expect(hasAuthScope(user, [
     AuthScope.STUDY_REQUESTS_ADMIN,
-    AuthScope.STUDY_REQUESTS_EDIT,
+    AuthScope.ADMIN,
   ])).toBe(true);
 });

--- a/tests/jest/unit/reports/ReportWarrantTrafficSignalControl.spec.js
+++ b/tests/jest/unit/reports/ReportWarrantTrafficSignalControl.spec.js
@@ -125,7 +125,6 @@ test('ReportWarrantTrafficSignalControl#transformData [Overlea and Thorncliffe: 
   } = setup_5_38661();
   const options = {
     adequateTrial: true,
-    preparedBy: 'Foo Bar',
     preventablesByYear: [3, 5, 10],
     startYear: 2016,
   };
@@ -162,7 +161,6 @@ test('ReportWarrantTrafficSignalControl#generateCsv [Overlea and Thorncliffe: 5/
   } = setup_5_38661();
   const options = {
     adequateTrial: true,
-    preparedBy: 'Foo Bar',
     preventablesByYear: [3, 5, 10],
     startYear: 2016,
   };

--- a/tests/jest/unit/reports/format/MovePdfGenerator.spec.js
+++ b/tests/jest/unit/reports/format/MovePdfGenerator.spec.js
@@ -241,7 +241,6 @@ test('WARRANT_TRAFFIC_SIGNAL_CONTROL', async () => {
   const reportInstance = ReportFactory.getInstance(ReportType.WARRANT_TRAFFIC_SIGNAL_CONTROL);
   const doc = await reportInstance.generate('5/38661', ReportFormat.PDF, {
     adequateTrial: true,
-    preparedBy: 'Foo Bar',
     preventablesByYear: [3, 5, 10],
     startYear: 2016,
   });

--- a/web/components/requests/nav/FcNavStudyRequest.vue
+++ b/web/components/requests/nav/FcNavStudyRequest.vue
@@ -78,7 +78,7 @@ export default {
       if (this.hasAuthScope(AuthScope.STUDY_REQUESTS_ADMIN)) {
         return true;
       }
-      if (this.studyRequest !== null && this.hasAuthScope(AuthScope.STUDY_REQUESTS_EDIT)) {
+      if (this.studyRequest !== null && this.hasAuthScope(AuthScope.STUDY_REQUESTS)) {
         return this.auth.user.id === this.studyRequest.userId;
       }
       return false;

--- a/web/router.js
+++ b/web/router.js
@@ -159,7 +159,7 @@ const router = new Router({
         name: 'requestStudyNew',
         meta: {
           auth: {
-            scope: [AuthScope.STUDY_REQUESTS_EDIT],
+            scope: [AuthScope.STUDY_REQUESTS],
           },
           title: 'New Request',
         },
@@ -173,7 +173,7 @@ const router = new Router({
         name: 'requestStudyEdit',
         meta: {
           auth: {
-            scope: [AuthScope.STUDY_REQUESTS_EDIT],
+            scope: [AuthScope.STUDY_REQUESTS],
           },
           title({ params: { id } }) {
             return `Edit Request #${id}`;
@@ -189,7 +189,7 @@ const router = new Router({
         name: 'requestStudyBulkEdit',
         meta: {
           auth: {
-            scope: [AuthScope.STUDY_REQUESTS_EDIT],
+            scope: [AuthScope.STUDY_REQUESTS],
           },
           title({ params: { id } }) {
             return `Edit Bulk Request #${id}`;

--- a/web/views/FcRequestStudyBulkView.vue
+++ b/web/views/FcRequestStudyBulkView.vue
@@ -145,7 +145,7 @@ export default {
       if (this.hasAuthScope(AuthScope.STUDY_REQUESTS_ADMIN)) {
         return true;
       }
-      if (this.studyRequestBulk !== null && this.hasAuthScope(AuthScope.STUDY_REQUESTS_EDIT)) {
+      if (this.studyRequestBulk !== null && this.hasAuthScope(AuthScope.STUDY_REQUESTS)) {
         return this.auth.user.id === this.studyRequestBulk.userId;
       }
       return false;


### PR DESCRIPTION
# Issue Addressed
This PR closes #660 , and addresses a bug filed through our bug report form.

# Description
We update `AuthScope`, getting rid of the `STUDY_REQUEST_EDIT` scope and adding its permissions to `STUDY_REQUEST`.  

# Tests
Ran `npm run ci:jest-coverage` locally to exercise all REST API, DAO, and unit tests and ensure that this permissions change doesn't break anything there.  Testing briefly in frontend; will also QA internally leading up to beta.
