### PR TITLE
Fetch map tiles and glyphs from current web environment

### DIFF
--- a/lib/geo/GeoStyle.js
+++ b/lib/geo/GeoStyle.js
@@ -4,6 +4,20 @@ import metadataDark from '@/lib/geo/theme/dark/metadata.json';
 import rootStyleLight from '@/lib/geo/theme/light/root.json';
 import metadataLight from '@/lib/geo/theme/light/metadata.json';
 
+// MAP ASSETS ORIGIN
+
+/**
+ * @returns {string} origin for map tiles and glyphs
+ */
+function getStaticMapAssetsOrigin() {
+  if (window.document.domain === 'localhost') {
+    return 'https://move.intra.dev-toronto.ca';
+  }
+  return window.location.origin;
+}
+
+const ORIGIN_STATIC_MAP_ASSETS = getStaticMapAssetsOrigin();
+
 // BASEMAP LAYERS
 
 /**
@@ -179,7 +193,7 @@ function addTippecanoeSource(style, id, minLevel, maxLevel, crossfade = 0) {
   /* eslint-disable-next-line no-param-reassign */
   style.sources[id] = {
     type: 'vector',
-    tiles: [`https://flashcrow-etladmin.intra.dev-toronto.ca/tiles/${id}/{z}/{x}/{y}.pbf`],
+    tiles: [`${ORIGIN_STATIC_MAP_ASSETS}/tiles/${id}/{z}/{x}/{y}.pbf`],
     minzoom: minLevel.minzoom,
     maxzoom: maxLevel.maxzoomSource + crossfade,
   };
@@ -806,7 +820,7 @@ class GeoStyle {
 
     const style = {
       ...baseStyle,
-      glyphs: 'https://flashcrow-etladmin.intra.dev-toronto.ca/glyphs/{fontstack}/{range}.pbf',
+      glyphs: `${ORIGIN_STATIC_MAP_ASSETS}/glyphs/{fontstack}/{range}.pbf`,
     };
     style.layers = [
       ...nonSymbolLayers,

--- a/tests/unitSetup.js
+++ b/tests/unitSetup.js
@@ -4,6 +4,9 @@ import Blob from 'node-blob';
 global.Blob = Blob;
 global.URL.createObjectURL = jest.fn();
 global.window = {
+  document: {
+    domain: 'localhost',
+  },
   location: {
     origin: 'https://localhost:8100',
   },


### PR DESCRIPTION
# Issue Addressed
This PR closes #679 .

# Description
We stop fetching these from DEV0 ETL, and start fetching them from the appropriate web environment.

# Tests
Ran coverage tests, including `GeoStyle.spec.js`.
