### PR TITLE
Add refs/heads prefix to CD script

### DIFF
--- a/scripts/deployment/code-commit/deploy_code_commit.sh
+++ b/scripts/deployment/code-commit/deploy_code_commit.sh
@@ -15,4 +15,4 @@ fi
 # notify prj_move on Slack
 curl -H "Content-Type: application/json; charset=utf-8" -d "{\"text\": \"<!here> MOVE down for deployment: ${CI_COMMIT_REF_NAME} @ ${CI_COMMIT_SHORT_SHA} -> ${TARGET_ENV}\"}" "$SLACK_WEBHOOK_URL"
 
-git push https://git-codecommit.ca-central-1.amazonaws.com/v1/repos/bdit_flashcrow "HEAD:${CI_COMMIT_REF_NAME}"
+git push https://git-codecommit.ca-central-1.amazonaws.com/v1/repos/bdit_flashcrow "HEAD:refs/heads/${CI_COMMIT_REF_NAME}"


### PR DESCRIPTION
# Issue Addressed
This PR makes progress on #671 .

# Description
We update `deploy_code_commit.sh` to use the full `refs/heads/{branch}` specifier for the target, so that this will work for newly-formed environments as well.

# Tests
Need to test by deploying to dev.