### PR TITLE
Update CodeDeploy scripts: remove nvm, switch to app user

### DIFF
--- a/deploy_scripts/install.sh
+++ b/deploy_scripts/install.sh
@@ -1,31 +1,5 @@
 #!/bin/bash
-# shellcheck disable=SC1090,SC1091
 
 set -euo pipefail
 
-set +u
-source /home/ec2-user/.bash_profile
-set -u
-
-# section: pre_install_flashcrow
-## /install_node.sh
-if command -v nvm > /dev/null 2>&1; then
-  echo "nvm already installed, skipping..."
-else
-  echo "installing nvm..."
-  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.36.0/install.sh | bash
-  # ensure that nvm shims are available in current shell session
-  export NVM_DIR="$HOME/.nvm"
-  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-  [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-fi
-
-# confirm
-echo "$NVM_DIR"
-
-# install correct version of node
-echo "installing node@lts/*..."
-nvm install lts/*
-echo "lts/*" > /home/ec2-user/.nvmrc
-nvm use lts/*
 npm install -g forever

--- a/deploy_scripts/install.sh
+++ b/deploy_scripts/install.sh
@@ -2,4 +2,4 @@
 
 set -euo pipefail
 
-npm install -g forever
+echo "Nothing to install."

--- a/deploy_scripts/start.sh
+++ b/deploy_scripts/start.sh
@@ -10,7 +10,6 @@ sudo cp -R ~ec2-user/flashcrow /var/app
 # copy private / forever configs to /var/app/flashcrow
 sudo chown -R ec2-user:ec2-user /var/app/flashcrow
 cp -r /home/ec2-user/flashcrow.config.js /var/app/flashcrow/lib/config/private.js
-cp /var/app/flashcrow/scripts/deployment/web/forever.json /var/app/flashcrow/forever.json
 
 # copy nginx configs to /etc/nginx
 sudo cp /home/ec2-user/flashcrow/scripts/deployment/web/nginx/nginx.conf /etc/nginx/
@@ -23,6 +22,7 @@ sudo mkdir -p /var/app/log
 cd /var/app/flashcrow
 export PATH="/var/app/nodejs/bin:$PATH"
 npm ci
+npm install -g forever
 
 # build static files into dist
 npm run frontend:build
@@ -40,7 +40,7 @@ sudo cp -r /home/ec2-user/flashcrow/dist /usr/share/nginx/html/flashcrow
 # start flashcrow
 cd /var/app/flashcrow
 # shellcheck disable=SC2046
-sudo -u appsvc env $(xargs < /var/app/config/cot-env.config) PATH="$PATH" NODE_ENV=production NODE_EXTRA_CA_CERTS=/var/app/ssl/extra-ca-certs.cer forever start /var/app/flashcrow/forever.json
+sudo -u appsvc env $(xargs < /var/app/config/cot-env.config) PATH="$PATH" NODE_ENV=production NODE_EXTRA_CA_CERTS=/var/app/ssl/extra-ca-certs.cer forever start /var/app/flashcrow/scripts/deployment/web/forever.json
 
 # need to restart nginx
 sudo service nginx restart

--- a/deploy_scripts/stop.sh
+++ b/deploy_scripts/stop.sh
@@ -2,14 +2,4 @@
 
 set -euo pipefail
 
-set +u
-source /home/ec2-user/.bash_profile
-set -u
-
-if NODE_ENV=production forever list | grep 'No forever'; then
-    echo "forever is not running."
-else
-    NODE_ENV=production forever stopall
-    echo "forever stopped."
-fi
-echo "end."
+sudo -u appsvc env NODE_ENV=production PATH=/var/app/nodejs/bin forever stopall

--- a/scripts/deployment/web/forever.json
+++ b/scripts/deployment/web/forever.json
@@ -5,11 +5,11 @@
     "watch": false,
     "command": "node -r ./globalWindowShim -r esm -r module-alias/register",
     "script": "web/web.js",
-    "sourceDir": "/home/ec2-user/flashcrow",
-    "pidFile": "/home/ec2-user/log/flashcrow/web.pid",
-    "logFile": "/home/ec2-user/log/flashcrow/web.log",
-    "outFile": "/home/ec2-user/log/flashcrow/web.out",
-    "errFile": "/home/ec2-user/log/flashcrow/web.err"
+    "sourceDir": "/var/app/flashcrow",
+    "pidFile": "/var/app/log/web.pid",
+    "logFile": "/var/app/log/web.log",
+    "outFile": "/var/app/log/web.out",
+    "errFile": "/var/app/log/web.err"
   },
   {
     "id": "reporter-0",
@@ -17,12 +17,12 @@
     "watch": false,
     "command": "node -r ./globalWindowShim -r esm -r module-alias/register",
     "script": "reporter/reporter.js",
-    "sourceDir": "/home/ec2-user/flashcrow",
+    "sourceDir": "/var/app/flashcrow",
     "args": ["--port", 8200],
-    "pidFile": "/home/ec2-user/log/flashcrow/reporter-0.pid",
-    "logFile": "/home/ec2-user/log/flashcrow/reporter.log",
-    "outFile": "/home/ec2-user/log/flashcrow/reporter.out",
-    "errFile": "/home/ec2-user/log/flashcrow/reporter.err"
+    "pidFile": "/var/app/log/reporter-0.pid",
+    "logFile": "/var/app/log/reporter.log",
+    "outFile": "/var/app/log/reporter.out",
+    "errFile": "/var/app/log/reporter.err"
   },
   {
     "id": "reporter-1",
@@ -30,12 +30,12 @@
     "watch": false,
     "command": "node -r ./globalWindowShim -r esm -r module-alias/register",
     "script": "reporter/reporter.js",
-    "sourceDir": "/home/ec2-user/flashcrow",
+    "sourceDir": "/var/app/flashcrow",
     "args": ["--port", 8201],
-    "pidFile": "/home/ec2-user/log/flashcrow/reporter-1.pid",
-    "logFile": "/home/ec2-user/log/flashcrow/reporter.log",
-    "outFile": "/home/ec2-user/log/flashcrow/reporter.out",
-    "errFile": "/home/ec2-user/log/flashcrow/reporter.err"
+    "pidFile": "/var/app/log/reporter-1.pid",
+    "logFile": "/var/app/log/reporter.log",
+    "outFile": "/var/app/log/reporter.out",
+    "errFile": "/var/app/log/reporter.err"
   },
   {
     "id": "reporter-2",
@@ -43,12 +43,12 @@
     "watch": false,
     "command": "node -r ./globalWindowShim -r esm -r module-alias/register",
     "script": "reporter/reporter.js",
-    "sourceDir": "/home/ec2-user/flashcrow",
+    "sourceDir": "/var/app/flashcrow",
     "args": ["--port", 8202],
-    "pidFile": "/home/ec2-user/log/flashcrow/reporter-2.pid",
-    "logFile": "/home/ec2-user/log/flashcrow/reporter.log",
-    "outFile": "/home/ec2-user/log/flashcrow/reporter.out",
-    "errFile": "/home/ec2-user/log/flashcrow/reporter.err"
+    "pidFile": "/var/app/log/reporter-2.pid",
+    "logFile": "/var/app/log/reporter.log",
+    "outFile": "/var/app/log/reporter.out",
+    "errFile": "/var/app/log/reporter.err"
   },
   {
     "id": "reporter-3",
@@ -56,12 +56,12 @@
     "watch": false,
     "command": "node -r ./globalWindowShim -r esm -r module-alias/register",
     "script": "reporter/reporter.js",
-    "sourceDir": "/home/ec2-user/flashcrow",
+    "sourceDir": "/var/app/flashcrow",
     "args": ["--port", 8203],
-    "pidFile": "/home/ec2-user/log/flashcrow/reporter-3.pid",
-    "logFile": "/home/ec2-user/log/flashcrow/reporter.log",
-    "outFile": "/home/ec2-user/log/flashcrow/reporter.out",
-    "errFile": "/home/ec2-user/log/flashcrow/reporter.err"
+    "pidFile": "/var/app/log/reporter-3.pid",
+    "logFile": "/var/app/log/reporter.log",
+    "outFile": "/var/app/log/reporter.out",
+    "errFile": "/var/app/log/reporter.err"
   },
   {
     "id": "scheduler",
@@ -69,11 +69,11 @@
     "watch": false,
     "command": "node -r ./globalWindowShim -r esm -r module-alias/register",
     "script": "scheduler/scheduler.js",
-    "sourceDir": "/home/ec2-user/flashcrow",
+    "sourceDir": "/var/app/flashcrow",
     "args": ["--port", 8300],
-    "pidFile": "/home/ec2-user/log/flashcrow/scheduler.pid",
-    "logFile": "/home/ec2-user/log/flashcrow/scheduler.log",
-    "outFile": "/home/ec2-user/log/flashcrow/scheduler.out",
-    "errFile": "/home/ec2-user/log/flashcrow/scheduler.err"
+    "pidFile": "/var/app/log/scheduler.pid",
+    "logFile": "/var/app/log/scheduler.log",
+    "outFile": "/var/app/log/scheduler.out",
+    "errFile": "/var/app/log/scheduler.err"
   }
 ]


### PR DESCRIPTION
# Issue Addressed
This PR makes further progress on #696 .

# Description
We remove `nvm` to rely instead on pinned LTS versions of `node` and `npm`, and switch over to using an unprivileged app-specific service user.

# Tests
Will test by deploying to dev (and possibly follow up with a couple of quick config changes on `master` before going to QA).
