### PR TITLE
Add "tcs:" as special term for signal search

### DIFF
--- a/lib/db/LocationSearchDAO.js
+++ b/lib/db/LocationSearchDAO.js
@@ -5,7 +5,7 @@ import { intersectionToFeature } from '@/lib/model/helpers/NormalizeUtils';
 
 const REGEX_SPECIAL_TERM = /([A-Za-z]+):(\d*)/;
 const TERMS_ARTERY = ['artery'];
-const TERMS_SIGNAL = ['px', 'signal'];
+const TERMS_SIGNAL = ['px', 'signal', 'tcs'];
 
 /**
  * Data access layer for location search, which looks up centreline features matching a given

--- a/tests/jest/db/LocationSearchDAO.spec.js
+++ b/tests/jest/db/LocationSearchDAO.spec.js
@@ -22,7 +22,6 @@ test('LocationSearchDAO.arterySuggestions', async () => {
   expectSuggestionsContain(result, CentrelineType.SEGMENT, 908372);
 });
 
-
 test('LocationSearchDAO.getSuggestions', async () => {
   let result = await LocationSearchDAO.getSuggestions(null, 'Danforth and Main', 3);
   expectSuggestionsContain(result, CentrelineType.INTERSECTION, 13460034);
@@ -54,10 +53,16 @@ test('LocationSearchDAO.getSuggestions', async () => {
   result = await LocationSearchDAO.getSuggestions(null, 'signal:1234', 3);
   expectSuggestionsContain(result, CentrelineType.INTERSECTION, 13448866);
 
+  result = await LocationSearchDAO.getSuggestions(null, 'tcs:1234', 3);
+  expectSuggestionsContain(result, CentrelineType.INTERSECTION, 13448866);
+
   result = await LocationSearchDAO.getSuggestions(null, 'p:1234', 3);
   expectSuggestionsContain(result, CentrelineType.INTERSECTION, 13448866);
 
   result = await LocationSearchDAO.getSuggestions(null, 'sig:1234', 3);
+  expectSuggestionsContain(result, CentrelineType.INTERSECTION, 13448866);
+
+  result = await LocationSearchDAO.getSuggestions(null, 'tc:1234', 3);
   expectSuggestionsContain(result, CentrelineType.INTERSECTION, 13448866);
 
   result = await LocationSearchDAO.getSuggestions([LocationSearchType.ARTERY], 'artery:1234', 3);


### PR DESCRIPTION
# Issue Addressed
This PR closes #683 .

# Description
We add "tcs:" alongside "px:" and "signal:" as a special search term for traffic control signals.

# Tests
Updated `LocationSearchDAO.spec.js` and ran tests.
