### PR TITLE
Time range filters for View Data

### DIFF
--- a/lib/validation/ValidationsFilters.js
+++ b/lib/validation/ValidationsFilters.js
@@ -1,0 +1,12 @@
+import { requiredIf } from 'vuelidate/lib/validators';
+
+const ValidationsFilters = {
+  dateRangeStart: {
+    requiredIfApplyDateRange: requiredIf(({ applyDateRange }) => applyDateRange),
+  },
+  dateRangeEnd: {
+    requiredIfApplyDateRange: requiredIf(({ applyDateRange }) => applyDateRange),
+  },
+};
+
+export default ValidationsFilters;

--- a/web/components/data/FcHeaderCollisions.vue
+++ b/web/components/data/FcHeaderCollisions.vue
@@ -9,7 +9,7 @@
       <FcDialogCollisionFilters
         v-if="showFiltersCollision"
         v-model="showFiltersCollision"
-        v-bind="filtersCollision"
+        :filters="filtersCollision"
         @set-filters="setFiltersCollision">
       </FcDialogCollisionFilters>
       <FcButton

--- a/web/components/data/FcHeaderStudies.vue
+++ b/web/components/data/FcHeaderStudies.vue
@@ -9,7 +9,7 @@
       <FcDialogStudyFilters
         v-if="showFiltersStudy"
         v-model="showFiltersStudy"
-        v-bind="filtersStudy"
+        :filters="filtersStudy"
         @set-filters="setFiltersStudy">
       </FcDialogStudyFilters>
       <FcButton

--- a/web/components/dialogs/FcDialogCollisionFilters.vue
+++ b/web/components/dialogs/FcDialogCollisionFilters.vue
@@ -19,32 +19,42 @@
         <v-checkbox
           v-for="emphasisArea in CollisionEmphasisArea.enumValues"
           :key="emphasisArea.name"
-          v-model="internalEmphasisAreas"
+          v-model="internalFilters.emphasisAreas"
           class="mt-2"
           hide-details
           :label="emphasisArea.text"
           :value="emphasisArea"></v-checkbox>
 
-        <FcRadioGroup
-          v-model="internalDatesFrom"
-          class="mt-4"
+        <h2 class="body-1 mt-4">Dates</h2>
+        <v-checkbox
+          v-model="internalFilters.applyDateRange"
+          class="mt-2"
           hide-details
-          :items="[
-            { label: '3 years', value: 3 },
-            { label: '5 years', value: 5 },
-            { label: '10 years', value: 10 },
-            { label: 'All', value: -1 },
-          ]">
-          <template v-slot:legend>
-            <h2 class="body-1 secondary--text">Dates from</h2>
-          </template>
-        </FcRadioGroup>
+          label="Filter by date?"></v-checkbox>
+        <FcDatePicker
+          v-model="$v.internalFilters.dateRangeStart.$model"
+          class="mt-2"
+          :disabled="!internalFilters.applyDateRange"
+          :error-messages="errorMessagesDateRangeStart"
+          hide-details="auto"
+          label="From (MM/DD/YYYY)"
+          :max="now">
+        </FcDatePicker>
+        <FcDatePicker
+          v-model="$v.internalFilters.dateRangeEnd.$model"
+          class="mt-2"
+          :disabled="!internalFilters.applyDateRange"
+          :error-messages="errorMessagesDateRangeEnd"
+          hide-details="auto"
+          label="To (MM/DD/YYYY)"
+          :max="now">
+        </FcDatePicker>
 
         <h2 class="body-1 mt-4">Days of the Week</h2>
         <v-checkbox
           v-for="(label, i) in DAYS_OF_WEEK"
           :key="i"
-          v-model="internalDaysOfWeek"
+          v-model="internalFilters.daysOfWeek"
           class="mt-2"
           hide-details
           :label="label"
@@ -52,7 +62,7 @@
 
         <h2 class="body-1 mt-4">Time of Day</h2>
         <v-range-slider
-          v-model="internalHoursOfDay"
+          v-model="internalFilters.hoursOfDay"
           class="mt-11"
           hide-details
           :max="24"
@@ -63,7 +73,7 @@
         <v-checkbox
           v-for="roadSurfaceCondition in CollisionRoadSurfaceCondition.enumValues"
           :key="roadSurfaceCondition.name"
-          v-model="internalRoadSurfaceConditions"
+          v-model="internalFilters.roadSurfaceConditions"
           class="mt-2"
           hide-details
           :label="roadSurfaceCondition.text"
@@ -78,6 +88,7 @@
           Cancel
         </FcButton>
         <FcButton
+          :disabled="$v.internalFilters.$invalid"
           type="tertiary"
           @click="actionSave">
           Save
@@ -88,13 +99,16 @@
 </template>
 
 <script>
+import { mapState } from 'vuex';
+
 import {
   CollisionEmphasisArea,
   CollisionRoadSurfaceCondition,
 } from '@/lib/Constants';
 import TimeFormatters from '@/lib/time/TimeFormatters';
+import ValidationsFilters from '@/lib/validation/ValidationsFilters';
 import FcButton from '@/web/components/inputs/FcButton.vue';
-import FcRadioGroup from '@/web/components/inputs/FcRadioGroup.vue';
+import FcDatePicker from '@/web/components/inputs/FcDatePicker.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
 export default {
@@ -102,45 +116,50 @@ export default {
   mixins: [FcMixinVModelProxy(Boolean)],
   components: {
     FcButton,
-    FcRadioGroup,
+    FcDatePicker,
   },
   props: {
-    datesFrom: Number,
-    daysOfWeek: Array,
-    emphasisAreas: Array,
-    hoursOfDay: Array,
-    roadSurfaceConditions: Array,
+    filters: Object,
   },
   data() {
     return {
       CollisionEmphasisArea,
       CollisionRoadSurfaceCondition,
       DAYS_OF_WEEK: TimeFormatters.DAYS_OF_WEEK,
-      internalDatesFrom: this.datesFrom,
-      internalDaysOfWeek: this.daysOfWeek,
-      internalEmphasisAreas: this.emphasisAreas,
-      internalHoursOfDay: this.hoursOfDay,
-      internalRoadSurfaceConditions: this.roadSurfaceConditions,
+      internalFilters: { ...this.filters },
     };
   },
   computed: {
-    internalFilters() {
-      return {
-        datesFrom: this.internalDatesFrom,
-        daysOfWeek: this.internalDaysOfWeek,
-        emphasisAreas: this.internalEmphasisAreas,
-        hoursOfDay: this.internalHoursOfDay,
-        roadSurfaceConditions: this.internalRoadSurfaceConditions,
-      };
+    errorMessagesDateRangeStart() {
+      const errors = [];
+      if (!this.$v.internalFilters.dateRangeStart.requiredIfApplyDateRange) {
+        errors.push('Please provide a date in MM/DD/YYYY format.');
+      }
+      return errors;
     },
+    errorMessagesDateRangeEnd() {
+      const errors = [];
+      if (!this.$v.internalFilters.dateRangeEnd.requiredIfApplyDateRange) {
+        errors.push('Please provide a date in MM/DD/YYYY format.');
+      }
+      return errors;
+    },
+    ...mapState(['now']),
+  },
+  validations: {
+    internalFilters: ValidationsFilters,
   },
   methods: {
     actionClearAll() {
-      this.internalDatesFrom = -1;
-      this.internalDaysOfWeek = [];
-      this.internalEmphasisAreas = [];
-      this.internalHoursOfDay = [0, 24];
-      this.internalRoadSurfaceConditions = [];
+      this.internalFilters = {
+        applyDateRange: false,
+        dateRangeStart: null,
+        dateRangeEnd: null,
+        daysOfWeek: [],
+        emphasisAreas: [],
+        hoursOfDay: [0, 24],
+        roadSurfaceConditions: [],
+      };
     },
     actionSave() {
       this.$emit('set-filters', this.internalFilters);

--- a/web/components/inputs/FcDatePicker.vue
+++ b/web/components/inputs/FcDatePicker.vue
@@ -13,7 +13,6 @@
           v-model="valueFormatted"
           append-icon="mdi-calendar"
           offset-y
-          outlined
           v-bind="{ ...attrs, ...$attrs }"
           @blur="resetValueFormatted"
           @input="updateValueFormatted"
@@ -99,6 +98,9 @@ export default {
   },
   computed: {
     color() {
+      if (this.$attrs.disabled) {
+        return 'unselected';
+      }
       if (this.$attrs.success) {
         return 'success';
       }

--- a/web/components/requests/fields/FcStudyRequestUrgent.vue
+++ b/web/components/requests/fields/FcStudyRequestUrgent.vue
@@ -17,6 +17,7 @@
             label="Due Date (MM/DD/YYYY)"
             :max="maxDueDate"
             :min="minDueDate"
+            outlined
             :success="!v.dueDate.$invalid">
           </FcDatePicker>
         </v-col>

--- a/web/store/modules/viewData.js
+++ b/web/store/modules/viewData.js
@@ -6,14 +6,18 @@ export default {
   state: {
     detailView: false,
     filtersCollision: {
-      datesFrom: -1,
+      applyDateRange: false,
+      dateRangeStart: null,
+      dateRangeEnd: null,
       daysOfWeek: [],
       emphasisAreas: [],
       hoursOfDay: [0, 24],
       roadSurfaceConditions: [],
     },
     filtersStudy: {
-      datesFrom: -1,
+      applyDateRange: false,
+      dateRangeStart: null,
+      dateRangeEnd: null,
       daysOfWeek: [],
       hours: [],
       studyTypes: [],
@@ -22,7 +26,8 @@ export default {
   getters: {
     filterChipsCollision(state) {
       const {
-        datesFrom,
+        dateRangeStart,
+        dateRangeEnd,
         daysOfWeek,
         emphasisAreas,
         hoursOfDay,
@@ -35,10 +40,13 @@ export default {
         const filterChip = { filter: 'emphasisAreas', label, value };
         filterChipsCollision.push(filterChip);
       });
-      if (datesFrom !== -1) {
-        const label = `Collisions \u2264 ${datesFrom} years`;
-        const value = datesFrom;
-        const filterChip = { filter: 'datesFrom', label, value };
+      if (dateRangeStart !== null && dateRangeEnd !== null) {
+        const label = TimeFormatters.formatRangeDate({
+          start: dateRangeStart,
+          end: dateRangeEnd,
+        });
+        const value = { dateRangeStart, dateRangeEnd };
+        const filterChip = { filter: 'dateRange', label, value };
         filterChipsCollision.push(filterChip);
       }
       daysOfWeek.forEach((value) => {
@@ -63,7 +71,8 @@ export default {
     },
     filterChipsStudy(state) {
       const {
-        datesFrom,
+        dateRangeStart,
+        dateRangeEnd,
         daysOfWeek,
         hours,
         studyTypes,
@@ -79,10 +88,13 @@ export default {
         const filterChip = { filter: 'daysOfWeek', label, value };
         filterChipsStudy.push(filterChip);
       });
-      if (datesFrom !== -1) {
-        const label = `Studies \u2264 ${datesFrom} years`;
-        const value = datesFrom;
-        const filterChip = { filter: 'datesFrom', label, value };
+      if (dateRangeStart !== null && dateRangeEnd !== null) {
+        const label = TimeFormatters.formatRangeDate({
+          start: dateRangeStart,
+          end: dateRangeEnd,
+        });
+        const value = { dateRangeStart, dateRangeEnd };
+        const filterChip = { filter: 'dateRange', label, value };
         filterChipsStudy.push(filterChip);
       }
       hours.forEach((studyHours) => {
@@ -92,19 +104,19 @@ export default {
       });
       return filterChipsStudy;
     },
-    filterParamsCollision(state, getters, rootState) {
+    filterParamsCollision(state) {
       const {
-        datesFrom,
+        dateRangeStart,
+        dateRangeEnd,
         daysOfWeek,
         emphasisAreas,
         hoursOfDay: [hoursOfDayStart, hoursOfDayEnd],
         roadSurfaceConditions,
       } = state.filtersCollision;
       const params = {};
-      if (datesFrom !== -1) {
-        const { now } = rootState;
-        params.dateRangeStart = now.minus({ years: datesFrom });
-        params.dateRangeEnd = now;
+      if (dateRangeStart !== null && dateRangeEnd !== null) {
+        params.dateRangeStart = dateRangeStart;
+        params.dateRangeEnd = dateRangeEnd;
       }
       if (daysOfWeek.length > 0) {
         params.daysOfWeek = daysOfWeek;
@@ -121,18 +133,18 @@ export default {
       }
       return params;
     },
-    filterParamsStudy(state, getters, rootState) {
+    filterParamsStudy(state) {
       const {
-        datesFrom,
+        dateRangeStart,
+        dateRangeEnd,
         daysOfWeek,
         hours,
         studyTypes,
       } = state.filtersStudy;
       const params = {};
-      if (datesFrom !== -1) {
-        const { now } = rootState;
-        params.dateRangeStart = now.minus({ years: datesFrom });
-        params.dateRangeEnd = now;
+      if (dateRangeStart !== null && dateRangeEnd !== null) {
+        params.dateRangeStart = dateRangeStart;
+        params.dateRangeEnd = dateRangeEnd;
       }
       if (daysOfWeek.length > 0) {
         params.daysOfWeek = daysOfWeek;
@@ -154,8 +166,9 @@ export default {
   },
   mutations: {
     removeFilterCollision(state, { filter, value }) {
-      if (filter === 'datesFrom') {
-        state.filtersCollision.datesFrom = -1;
+      if (filter === 'dateRange') {
+        state.filtersCollision.dateRangeStart = null;
+        state.filtersCollision.dateRangeEnd = null;
       } else if (filter === 'hoursOfDay') {
         state.filtersCollision.hoursOfDay = [0, 24];
       } else {
@@ -167,8 +180,9 @@ export default {
       }
     },
     removeFilterStudy(state, { filter, value }) {
-      if (filter === 'datesFrom') {
-        state.filtersStudy.datesFrom = -1;
+      if (filter === 'dateRange') {
+        state.filtersCollision.dateRangeStart = null;
+        state.filtersCollision.dateRangeEnd = null;
       } else {
         const values = state.filtersStudy[filter];
         const i = values.indexOf(value);

--- a/web/store/modules/viewData.js
+++ b/web/store/modules/viewData.js
@@ -26,6 +26,7 @@ export default {
   getters: {
     filterChipsCollision(state) {
       const {
+        applyDateRange,
         dateRangeStart,
         dateRangeEnd,
         daysOfWeek,
@@ -40,7 +41,7 @@ export default {
         const filterChip = { filter: 'emphasisAreas', label, value };
         filterChipsCollision.push(filterChip);
       });
-      if (dateRangeStart !== null && dateRangeEnd !== null) {
+      if (applyDateRange) {
         const label = TimeFormatters.formatRangeDate({
           start: dateRangeStart,
           end: dateRangeEnd,
@@ -71,6 +72,7 @@ export default {
     },
     filterChipsStudy(state) {
       const {
+        applyDateRange,
         dateRangeStart,
         dateRangeEnd,
         daysOfWeek,
@@ -88,7 +90,7 @@ export default {
         const filterChip = { filter: 'daysOfWeek', label, value };
         filterChipsStudy.push(filterChip);
       });
-      if (dateRangeStart !== null && dateRangeEnd !== null) {
+      if (applyDateRange) {
         const label = TimeFormatters.formatRangeDate({
           start: dateRangeStart,
           end: dateRangeEnd,
@@ -106,6 +108,7 @@ export default {
     },
     filterParamsCollision(state) {
       const {
+        applyDateRange,
         dateRangeStart,
         dateRangeEnd,
         daysOfWeek,
@@ -114,7 +117,7 @@ export default {
         roadSurfaceConditions,
       } = state.filtersCollision;
       const params = {};
-      if (dateRangeStart !== null && dateRangeEnd !== null) {
+      if (applyDateRange) {
         params.dateRangeStart = dateRangeStart;
         params.dateRangeEnd = dateRangeEnd;
       }
@@ -135,6 +138,7 @@ export default {
     },
     filterParamsStudy(state) {
       const {
+        applyDateRange,
         dateRangeStart,
         dateRangeEnd,
         daysOfWeek,
@@ -142,7 +146,7 @@ export default {
         studyTypes,
       } = state.filtersStudy;
       const params = {};
-      if (dateRangeStart !== null && dateRangeEnd !== null) {
+      if (applyDateRange) {
         params.dateRangeStart = dateRangeStart;
         params.dateRangeEnd = dateRangeEnd;
       }
@@ -167,6 +171,7 @@ export default {
   mutations: {
     removeFilterCollision(state, { filter, value }) {
       if (filter === 'dateRange') {
+        state.filtersCollision.applyDateRange = false;
         state.filtersCollision.dateRangeStart = null;
         state.filtersCollision.dateRangeEnd = null;
       } else if (filter === 'hoursOfDay') {
@@ -181,8 +186,9 @@ export default {
     },
     removeFilterStudy(state, { filter, value }) {
       if (filter === 'dateRange') {
-        state.filtersCollision.dateRangeStart = null;
-        state.filtersCollision.dateRangeEnd = null;
+        state.filtersStudy.applyDateRange = false;
+        state.filtersStudy.dateRangeStart = null;
+        state.filtersStudy.dateRangeEnd = null;
       } else {
         const values = state.filtersStudy[filter];
         const i = values.indexOf(value);


### PR DESCRIPTION
# Issue Addressed
This PR closes #698 .

# Description
We replace `datesFrom` in our collision and study filters with three filter parameters: `applyDateRange`, which is used to flag whether a date range is being applied, and `dateRangeStart` / `dateRangeEnd` for the date range itself.  We then update the filter dialog UI and surrounding logic to match.

# Tests
Tested different filter groups in frontend to ensure that filter UI works correctly, that chips are shown correctly, that GET params are sent correctly, and that clicking filters removes them correctly.