### PR TITLE
Use Content-Disposition header to set filename in backend

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -353,24 +353,30 @@ ReportExportMode.init({
 /**
  * Report formats available from MOVE Reporter.
  *
+ * @param {boolean} download - whether reports of this format should be downloaded; used to
+ * set `Content-Disposition` header.
  * @param {string} extension - file extension for type
  * @param {string} mimeType - MIME type to return results under
  */
 class ReportFormat extends Enum {}
 ReportFormat.init({
   CSV: {
+    download: true,
     extension: 'csv',
     mimeType: 'text/csv',
   },
   JSON: {
+    download: false,
     extension: 'json',
     mimeType: 'application/json',
   },
   PDF: {
+    download: true,
     extension: 'pdf',
     mimeType: 'application/pdf',
   },
   WEB: {
+    download: false,
     extension: 'json',
     mimeType: 'application/json',
   },

--- a/lib/api/AxiosBackendClient.js
+++ b/lib/api/AxiosBackendClient.js
@@ -15,14 +15,16 @@ import QueryString from '@/lib/api/QueryString';
  */
 class AxiosBackendClient {
   constructor(baseURL, options = {}) {
-    this.axiosClient = axios.create({
+    const defaultOptions = {
       baseURL,
       paramsSerializer: QueryString.get,
       withCredentials: true,
       xsrfCookieName: 'csrf',
       xsrfHeaderName: 'X-CSRF-Token',
       ...options,
-    });
+    };
+    this.axiosClient = axios.create(defaultOptions);
+    this.defaultOptions = defaultOptions;
   }
 
   static getAxiosOptions(options) {
@@ -55,6 +57,33 @@ class AxiosBackendClient {
     return axiosOptions;
   }
 
+  /**
+   * Issues the given request and downloads the result using the `<a href="..." download>`
+   * trick.
+   *
+   * This will only work in browser contexts!  Do *not* call this method from node.js services,
+   * as `document.createElement` will fail there.  In node.js, you should instead use
+   * {@link AxiosBackendClient#fetch} or {@link AxiosBackendClient#getUri}, then process the
+   * resulting response stream; see {@link JobRunnerGenerateReports#runImpl} for an example.
+   *
+   * @param {string} url - URL to download
+   * @param {Object} options - additional options (e.g. GET parameters, POST payload,
+   * credentials, CSRF tokens, etc.)
+   */
+  download(url, options = {}) {
+    const uriDownload = this.getUri(url, options);
+    const $a = document.createElement('a');
+    /* eslint-disable-next-line no-console */
+    console.log(uriDownload);
+    $a.setAttribute('download', '');
+    $a.setAttribute('href', uriDownload);
+    $a.setAttribute('target', '_blank');
+    $a.click();
+    /*
+     * Note that $a has not been added to the DOM, and is garbage collected here.
+     */
+  }
+
   async fetch(url, options = {}) {
     const axiosOptions = AxiosBackendClient.getAxiosOptions(options);
     const response = await this.axiosClient.request({
@@ -62,6 +91,19 @@ class AxiosBackendClient {
       ...axiosOptions,
     });
     return response.data;
+  }
+
+  getUri(url, options = {}) {
+    const axiosOptions = AxiosBackendClient.getAxiosOptions(options);
+    const uri = this.axiosClient.getUri({
+      url,
+      ...axiosOptions,
+    });
+    /*
+     * The `getUri` method in `axios` doesn't prepend `baseURL`, so we have to do that
+     * manually here.
+     */
+    return `${this.defaultOptions.baseURL}${uri}`;
   }
 }
 

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -155,9 +155,9 @@ async function getPoiByCentrelineSummary(feature) {
   return apiClient.fetch('/poi/byCentreline/summary', options);
 }
 
-async function getReport(type, id, format, reportParameters) {
+function getReportOptions(type, id, format, reportParameters) {
   const responseType = format.mimeType === 'application/json' ? 'json' : 'blob';
-  const options = {
+  return {
     method: 'GET',
     data: {
       type,
@@ -167,7 +167,16 @@ async function getReport(type, id, format, reportParameters) {
     },
     responseType,
   };
+}
+
+async function getReport(type, id, format, reportParameters) {
+  const options = getReportOptions(type, id, format, reportParameters);
   return reporterClient.fetch('/reports', options);
+}
+
+function getReportDownload(type, id, format, reportParameters) {
+  const options = getReportOptions(type, id, format, reportParameters);
+  reporterClient.download('/reports', options);
 }
 
 async function getReportWeb(type, id, reportParameters) {
@@ -596,6 +605,7 @@ const WebApi = {
   getLocationSuggestions,
   getPoiByCentrelineSummary,
   getReport,
+  getReportDownload,
   getReportWeb,
   getStorage,
   getStudiesByCentreline,
@@ -641,6 +651,7 @@ export {
   getLocationSuggestions,
   getPoiByCentrelineSummary,
   getReport,
+  getReportDownload,
   getReportWeb,
   getStorage,
   getStudiesByCentreline,

--- a/lib/controller/ReportController.js
+++ b/lib/controller/ReportController.js
@@ -7,6 +7,7 @@ import {
   ReportType,
 } from '@/lib/Constants';
 import { EnumValueError } from '@/lib/error/MoveErrors';
+import StoragePath from '@/lib/io/storage/StoragePath';
 import CollisionFilters from '@/lib/model/CollisionFilters';
 import Joi from '@/lib/model/Joi';
 import ReportFactory from '@/lib/reports/ReportFactory';
@@ -118,8 +119,21 @@ ReportController.push({
 
     const reportInstance = ReportFactory.getInstance(reportType);
     const reportStream = await reportInstance.generate(id, reportFormat, reportOptions);
-    return h.response(reportStream)
+    const response = h.response(reportStream)
       .type(reportType.mimeType);
+
+    if (reportFormat.download) {
+      const report = {
+        type: reportType,
+        id,
+        format: reportFormat,
+        ...reportOptions,
+      };
+      const { key } = StoragePath.forReport(report);
+      response.header('Content-Disposition', `attachment; filename="${key}"`);
+    }
+
+    return response;
   },
 });
 

--- a/lib/jobs/JobRunnerBase.js
+++ b/lib/jobs/JobRunnerBase.js
@@ -1,6 +1,13 @@
 import JobMetadataDAO from '@/lib/db/JobMetadataDAO';
 import { NotImplementedError } from '@/lib/error/MoveErrors';
 
+/**
+ * Base class for all background job runners.  Runners execute background jobs via their
+ * implementations of {@link JobRunnerBase.runImpl}. During execution, they can optionally
+ * update progress via {@link JobRunnerBase.incrProgressCurrent}; this is used to help
+ * display progress notifications in the frontend, and for failed jobs can also provide
+ * more information on where the failure occurred.
+ */
 class JobRunnerBase {
   constructor(job, jobMetadata) {
     this.job = job;
@@ -14,6 +21,12 @@ class JobRunnerBase {
     this.data = await type.dataSchema.validateAsync(data);
   }
 
+  /**
+   * Increments the `progressCurrent` field of the `JobMetadata` record associated with this job.
+   * For instance, {@link JobRunnerGenerateReports} calls this for each report generated.
+   *
+   * @param {number} n - amount to increment progress by (default 1)
+   */
   async incrProgressCurrent(n = 1) {
     this.jobMetadata.progressCurrent += n;
     await JobMetadataDAO.update(this.jobMetadata);
@@ -26,6 +39,12 @@ class JobRunnerBase {
     return this.runImpl(this.data);
   }
 
+  /**
+   * Runs the given job.  This method is responsible for ensuring that any resources opened /
+   * acquired are closed / released before exiting.
+   *
+   * @param {Object} data - data provided during job creation
+   */
   /* eslint-disable-next-line class-methods-use-this, no-unused-vars */
   async runImpl(data) {
     throw new NotImplementedError();

--- a/lib/jobs/JobRunnerGenerateReports.js
+++ b/lib/jobs/JobRunnerGenerateReports.js
@@ -32,6 +32,9 @@ const reporterClient = new AxiosBackendClient(config.reporter, reporterClientOpt
 const DELAY_MIN = 2000;
 const DELAY_MAX = 4000;
 
+/**
+ * Job runner for report generation jobs.
+ */
 class JobRunnerGenerateReports extends JobRunnerBase {
   static async fetchReportStream(report) {
     const options = {
@@ -82,6 +85,16 @@ class JobRunnerGenerateReports extends JobRunnerBase {
     });
   }
 
+  /**
+   * Generates the given `reports`, storing each using the configured `storageStrategy`.
+   * Once all reports have been generated and stored, ZIPs those reports into a single
+   * archive, and stores that ZIP as well.
+   *
+   * Resolves to the `{ namespace, key }` storage parameters for this ZIP archive.
+   *
+   * @param {Object} data - data provided during job creation
+   * @param {Array<Object>} data.reports - reports to be generated
+   */
   async runImpl({ reports }) {
     const n = reports.length;
     for (let i = 0; i < n; i++) {

--- a/lib/reports/format/MoveCsvGenerator.js
+++ b/lib/reports/format/MoveCsvGenerator.js
@@ -1,3 +1,5 @@
+import stream from 'stream';
+
 import csvStringify from 'csv-stringify';
 
 import DateTime from '@/lib/time/DateTime';
@@ -14,18 +16,38 @@ class MoveCsvGenerator {
   }
 
   async generate() {
-    return csvStringify(this.rows, {
+    const csvStream = csvStringify(this.rows, {
       cast: {
         object(value) {
           if (value instanceof DateTime) {
             return TimeFormatters.formatCsv(value);
           }
-          return JSON.stringify(value);
+          return value.toString();
         },
       },
       columns: this.columns,
       header: true,
     });
+
+    /*
+     * The stream returned by `csvStringify` doesn't `pipe` correctly (see
+     * https://github.com/adaltas/node-csv-stringify/issues/66 for more details).  In particular,
+     * it handles close-during-write incorrectly, so that `curl` can be used to crash MOVE
+     * Reporter as follows:
+     *
+     * ```
+     * curl -k -I "https://localhost:8200/reports?type=SPEED_PERCENTILE&id=4%2F2010692&format=CSV"
+     * ```
+     *
+     * This is because `curl -I` fetches headers, then closes the stream before fetching the
+     * response body: a perfect close-during-write example!
+     *
+     * To work around this, we pipe the CSV stream through an instance of `stream.PassThrough`
+     * here.  This properly handles close-during-write, preventing the crash.
+     */
+    const duplexStream = new stream.PassThrough();
+    csvStream.pipe(duplexStream);
+    return duplexStream;
   }
 }
 

--- a/tests/jest/unit/api/AxiosBackendClient.spec.js
+++ b/tests/jest/unit/api/AxiosBackendClient.spec.js
@@ -53,3 +53,17 @@ test('AxiosBackendClient.getAxiosOptions()', () => {
     responseType: 'json',
   });
 });
+
+test('AxiosBackendClient.getUri', () => {
+  const client = new AxiosBackendClient('/foo');
+  expect(client.getUri('')).toEqual('/foo');
+  expect(client.getUri('/bar')).toEqual('/foo/bar');
+  expect(client.getUri('/bar', {
+    data: { a: '1', b: ['2', '3'] },
+  })).toEqual('/foo/bar?a=1&b=2&b=3');
+  expect(client.getUri('/bar', {
+    csrf: 'f00bar',
+    data: { a: '1', b: ['2', '3'] },
+    method: 'POST',
+  })).toEqual('/foo/bar');
+});

--- a/tests/jest/unit/reports/format/MoveCsvGenerator.spec.js
+++ b/tests/jest/unit/reports/format/MoveCsvGenerator.spec.js
@@ -60,16 +60,16 @@ test('MoveCsvGenerator#generate [DateTime]', async () => {
     hour: 7,
     minute: 45,
   });
-  const columns = ['Time', 'Count', 'Flag', 'Notes', 'JSON'];
+  const columns = ['Time', 'Count', 'Flag', 'Notes'];
   const rows = [
-    [dt, 42, true, 'foo', { x: 2 }],
-    [dt.plus({ minutes: 15 }), 1729, false, 'bar baz', { y: 'pi' }],
+    [dt, 42, true, 'foo'],
+    [dt.plus({ minutes: 15 }), 1729, false, 'bar baz'],
   ];
   const generator = new MoveCsvGenerator(columns, rows);
   const readableStream = await generator.generate();
   const str = await readableStreamToString(readableStream);
-  expect(str).toEqual(`Time,Count,Flag,Notes,JSON
-2000-01-01 07:45,42,1,foo,"{""x"":2}"
-2000-01-01 08:00,1729,,bar baz,"{""y"":""pi""}"
+  expect(str).toEqual(`Time,Count,Flag,Notes
+2000-01-01 07:45,42,1,foo
+2000-01-01 08:00,1729,,bar baz
 `);
 });

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -116,7 +116,6 @@
 </template>
 
 <script>
-import { saveAs } from 'file-saver';
 import {
   mapActions,
   mapGetters,
@@ -132,7 +131,7 @@ import {
 } from '@/lib/Constants';
 import {
   getCollisionsByCentrelineSummaryPerLocation,
-  getReport,
+  getReportDownload,
   getReportWeb,
 } from '@/lib/api/WebApi';
 import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
@@ -144,11 +143,6 @@ import FcIconLocationMulti from '@/web/components/location/FcIconLocationMulti.v
 import FcListLocationMulti from '@/web/components/location/FcListLocationMulti.vue';
 import FcReport from '@/web/components/reports/FcReport.vue';
 import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
-
-const DOWNLOAD_FORMATS_SUPPORTED = [
-  ReportFormat.CSV,
-  ReportFormat.PDF,
-];
 
 export default {
   name: 'FcDrawerViewCollisionReports',
@@ -196,7 +190,8 @@ export default {
       if (this.loadingDownload || this.loadingReportLayout) {
         return [];
       }
-      return DOWNLOAD_FORMATS_SUPPORTED
+      return ReportFormat.enumValues
+        .filter(reportFormat => reportFormat.download)
         .filter(reportFormat => this.activeReportType.formats.includes(reportFormat))
         .map(({ name }) => ({ label: name, value: name }));
     },
@@ -262,16 +257,12 @@ export default {
         return;
       }
       this.loadingDownload = true;
-
-      const reportData = await getReport(
+      getReportDownload(
         this.activeReportType,
         this.activeReportId,
         format,
         this.filterParamsCollision,
       );
-      const filename = `report.${format}`;
-      saveAs(reportData, filename);
-
       this.loadingDownload = false;
     },
     actionLeave() {

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -160,7 +160,6 @@
 </template>
 
 <script>
-import { saveAs } from 'file-saver';
 import {
   mapActions,
   mapGetters,
@@ -176,7 +175,7 @@ import {
   StudyType,
 } from '@/lib/Constants';
 import {
-  getReport,
+  getReportDownload,
   getReportWeb,
   getStudiesByCentreline,
   getStudiesByCentrelineSummaryPerLocation,
@@ -192,11 +191,6 @@ import FcIconLocationMulti from '@/web/components/location/FcIconLocationMulti.v
 import FcListLocationMulti from '@/web/components/location/FcListLocationMulti.vue';
 import FcReport from '@/web/components/reports/FcReport.vue';
 import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
-
-const DOWNLOAD_FORMATS_SUPPORTED = [
-  ReportFormat.CSV,
-  ReportFormat.PDF,
-];
 
 export default {
   name: 'FcDrawerViewStudyReports',
@@ -286,7 +280,8 @@ export default {
       if (this.loadingDownload || this.loadingReportLayout) {
         return [];
       }
-      return DOWNLOAD_FORMATS_SUPPORTED
+      return ReportFormat.enumValues
+        .filter(reportFormat => reportFormat.download)
         .filter(reportFormat => this.activeReportType.formats.includes(reportFormat))
         .map(({ name }) => ({ label: name, value: name }));
     },
@@ -391,16 +386,12 @@ export default {
         return;
       }
       this.loadingDownload = true;
-
-      const reportData = await getReport(
+      getReportDownload(
         activeReportType,
         activeReportId,
         format,
         reportParameters,
       );
-      const filename = `report.${format}`;
-      saveAs(reportData, filename);
-
       this.loadingDownload = false;
     },
     actionLeave() {


### PR DESCRIPTION
# Issue Addressed
This PR makes further progress on #639 .

# Description
We centralize the generation of filenames in `StoragePath`, and return the filename via the `Content-Disposition` header.  We then refactor the frontend to use that header by dynamically creating and "clicking" an `<a href="..." download>` link.  This allows us to remove `file-saver` from 2 of 3 callsites (it's still used in Track Requests to download requests).

In the process, we also fix a bug where a `curl -I` request for a CSV report would crash MOVE Reporter - this turned out to be a small issue with how `csv-stringify` handles streams.

# Tests
Tested quickly in local development: CSV and PDF reports both work; this change doesn't break bulk report generation; these reports can be fetched via `curl`; `curl -I` requests work properly for all report formats.
