### PR TITLE
User-friendly report naming

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -415,6 +415,8 @@ ReportParameter.init({
  * @param {string} label - human-readable name of this report type
  * @param {Object?} options - user-supplied options for this report type
  * @param {PageOrientation} orientation - page orientation for PDF documents
+ * @param {ReportExportMode} reportExportMode - whether this is collision-related
+ * or study-related
  * @param {boolean} tmcRelated - does this report type require TMC data?
  * @param {PageSize} size - page size for PDF documents
  * @param {boolean} speedRelated - does this report type require speed data?
@@ -427,6 +429,7 @@ ReportType.init({
     formats: [ReportFormat.CSV, ReportFormat.PDF],
     label: 'Directory Report',
     orientation: PageOrientation.LANDSCAPE,
+    reportExportMode: ReportExportMode.COLLISIONS,
     size: PageSize.LEGAL,
     suffix: 'CollisionDirectory',
   },
@@ -435,6 +438,7 @@ ReportType.init({
     formats: [ReportFormat.PDF],
     label: 'Tabulation Report',
     orientation: PageOrientation.LANDSCAPE,
+    reportExportMode: ReportExportMode.COLLISIONS,
     size: PageSize.LETTER,
     suffix: 'CollisionTabulation',
   },
@@ -443,6 +447,7 @@ ReportType.init({
     formats: [ReportFormat.CSV, ReportFormat.PDF],
     label: '24-Hour Summary Report',
     orientation: PageOrientation.LANDSCAPE,
+    reportExportMode: ReportExportMode.STUDIES,
     tmcRelated: false,
     size: PageSize.LETTER,
     speedRelated: false,
@@ -453,6 +458,7 @@ ReportType.init({
     formats: [ReportFormat.CSV, ReportFormat.PDF],
     label: '24-Hour Detailed Report',
     orientation: PageOrientation.PORTRAIT,
+    reportExportMode: ReportExportMode.STUDIES,
     tmcRelated: false,
     size: PageSize.LETTER,
     speedRelated: false,
@@ -463,6 +469,7 @@ ReportType.init({
     formats: [ReportFormat.CSV, ReportFormat.PDF],
     label: '24-Hour Graphical Report',
     orientation: PageOrientation.LANDSCAPE,
+    reportExportMode: ReportExportMode.STUDIES,
     tmcRelated: false,
     size: PageSize.LETTER,
     speedRelated: false,
@@ -473,6 +480,7 @@ ReportType.init({
     formats: [ReportFormat.CSV, ReportFormat.PDF],
     label: 'TMC Summary Report',
     orientation: PageOrientation.LANDSCAPE,
+    reportExportMode: ReportExportMode.STUDIES,
     tmcRelated: true,
     size: PageSize.LETTER,
     speedRelated: false,
@@ -483,6 +491,7 @@ ReportType.init({
     formats: [ReportFormat.CSV, ReportFormat.PDF],
     label: 'TMC Detailed Report',
     orientation: PageOrientation.PORTRAIT,
+    reportExportMode: ReportExportMode.STUDIES,
     tmcRelated: true,
     size: PageSize.LETTER,
     speedRelated: false,
@@ -493,6 +502,7 @@ ReportType.init({
     formats: [],
     label: 'TMC Illustrated Report',
     orientation: PageOrientation.PORTRAIT,
+    reportExportMode: ReportExportMode.STUDIES,
     tmcRelated: true,
     size: PageSize.LETTER,
     speedRelated: false,
@@ -503,6 +513,7 @@ ReportType.init({
     formats: [ReportFormat.CSV, ReportFormat.PDF],
     label: 'Crosswalk Observation Report',
     orientation: PageOrientation.LANDSCAPE,
+    reportExportMode: ReportExportMode.STUDIES,
     tmcRelated: false,
     size: PageSize.LETTER,
     speedRelated: false,
@@ -513,6 +524,7 @@ ReportType.init({
     formats: [ReportFormat.CSV, ReportFormat.PDF],
     label: 'Intersection Summary Report',
     orientation: PageOrientation.LANDSCAPE,
+    reportExportMode: ReportExportMode.STUDIES,
     tmcRelated: true,
     size: PageSize.LETTER,
     speedRelated: false,
@@ -523,6 +535,7 @@ ReportType.init({
     formats: [],
     label: 'Ped Delay Summary',
     orientation: PageOrientation.LANDSCAPE,
+    reportExportMode: ReportExportMode.STUDIES,
     tmcRelated: false,
     size: PageSize.LETTER,
     speedRelated: false,
@@ -533,6 +546,7 @@ ReportType.init({
     formats: [ReportFormat.CSV, ReportFormat.PDF],
     label: 'Speed Percentile Report',
     orientation: PageOrientation.LANDSCAPE,
+    reportExportMode: ReportExportMode.STUDIES,
     tmcRelated: false,
     size: PageSize.LETTER,
     speedRelated: true,
@@ -548,6 +562,7 @@ ReportType.init({
       startYear: ReportParameter.DATE_YEAR,
     },
     orientation: PageOrientation.PORTRAIT,
+    reportExportMode: ReportExportMode.STUDIES,
     tmcRelated: true,
     size: PageSize.LETTER,
     speedRelated: false,

--- a/lib/api/AxiosBackendClient.js
+++ b/lib/api/AxiosBackendClient.js
@@ -73,8 +73,6 @@ class AxiosBackendClient {
   download(url, options = {}) {
     const uriDownload = this.getUri(url, options);
     const $a = document.createElement('a');
-    /* eslint-disable-next-line no-console */
-    console.log(uriDownload);
     $a.setAttribute('download', '');
     $a.setAttribute('href', uriDownload);
     $a.setAttribute('target', '_blank');

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -461,10 +461,12 @@ async function postJobGenerateCollisionReports(csrf, locationsSelection, filters
   return normalizeJobMetadata(jobMetadata);
 }
 
-async function postJobGenerateStudyReports(csrf, features, filters, reportFormat) {
-  const s1 = CompositeId.encode(features);
+async function postJobGenerateStudyReports(csrf, locationsSelection, filters, reportFormat) {
+  const { locations, selectionType } = locationsSelection;
+  const s1 = CompositeId.encode(locations);
   const data = {
     s1,
+    selectionType,
     ...filters,
     reportFormat,
   };

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -443,10 +443,12 @@ async function getUsers() {
   return usersSchema.validateAsync(users);
 }
 
-async function postJobGenerateCollisionReports(csrf, features, filters, reportFormat) {
-  const s1 = CompositeId.encode(features);
+async function postJobGenerateCollisionReports(csrf, locationsSelection, filters, reportFormat) {
+  const { locations, selectionType } = locationsSelection;
+  const s1 = CompositeId.encode(locations);
   const data = {
     s1,
+    selectionType,
     ...filters,
     reportFormat,
   };

--- a/lib/controller/JobController.js
+++ b/lib/controller/JobController.js
@@ -2,9 +2,12 @@ import Boom from '@hapi/boom';
 
 import {
   HttpStatus,
+  LocationSelectionType,
+  MAX_LOCATIONS,
   ReportExportMode,
   ReportFormat,
 } from '@/lib/Constants';
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import JobMetadataDAO from '@/lib/db/JobMetadataDAO';
 import ReportDAO from '@/lib/db/ReportDAO';
 import CompositeId from '@/lib/io/CompositeId';
@@ -50,6 +53,7 @@ JobController.push({
     validate: {
       payload: {
         ...CentrelineSelection,
+        selectionType: Joi.enum().ofType(LocationSelectionType),
         ...CollisionFilters,
         reportFormat: Joi.enum().ofType(ReportFormat).required(),
       },
@@ -59,13 +63,21 @@ JobController.push({
     const user = request.auth.credentials;
     const {
       s1,
+      selectionType,
       reportFormat,
       ...collisionQuery
     } = request.payload;
-    const features = CompositeId.decode(s1);
+
     try {
+      const features = CompositeId.decode(s1);
+      if (features.length > MAX_LOCATIONS) {
+        return Boom.badRequest(`cannot fetch reports on more than ${MAX_LOCATIONS} locations`);
+      }
+      const locations = await CentrelineDAO.byFeatures(features);
+      const locationsSelection = { locations, selectionType };
+
       const reports = await ReportDAO.byCentrelineAndCollisionQuery(
-        features,
+        locationsSelection,
         collisionQuery,
         reportFormat,
       );

--- a/lib/controller/JobController.js
+++ b/lib/controller/JobController.js
@@ -7,7 +7,6 @@ import {
   ReportExportMode,
   ReportFormat,
 } from '@/lib/Constants';
-import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import JobMetadataDAO from '@/lib/db/JobMetadataDAO';
 import ReportDAO from '@/lib/db/ReportDAO';
 import CompositeId from '@/lib/io/CompositeId';
@@ -53,9 +52,9 @@ JobController.push({
     validate: {
       payload: {
         ...CentrelineSelection,
-        selectionType: Joi.enum().ofType(LocationSelectionType),
         ...CollisionFilters,
         reportFormat: Joi.enum().ofType(ReportFormat).required(),
+        selectionType: Joi.enum().ofType(LocationSelectionType).required(),
       },
     },
   },
@@ -73,11 +72,10 @@ JobController.push({
       if (features.length > MAX_LOCATIONS) {
         return Boom.badRequest(`cannot fetch reports on more than ${MAX_LOCATIONS} locations`);
       }
-      const locations = await CentrelineDAO.byFeatures(features);
-      const locationsSelection = { locations, selectionType };
+      const featuresSelection = { features, selectionType };
 
       const reports = await ReportDAO.byCentrelineAndCollisionQuery(
-        locationsSelection,
+        featuresSelection,
         collisionQuery,
         reportFormat,
       );
@@ -88,6 +86,7 @@ JobController.push({
         reportExportMode: ReportExportMode.COLLISIONS,
         reports,
         s1,
+        selectionType,
       };
       const jobMetadata = await JobManager.publish(JobType.GENERATE_REPORTS, data, user);
       return jobMetadata;
@@ -123,6 +122,7 @@ JobController.push({
         ...StudyFilters,
         mostRecent: Joi.number().integer().min(1).default(null),
         reportFormat: Joi.enum().ofType(ReportFormat).required(),
+        selectionType: Joi.enum().ofType(LocationSelectionType).required(),
       },
     },
   },
@@ -130,13 +130,20 @@ JobController.push({
     const user = request.auth.credentials;
     const {
       s1,
+      selectionType,
       reportFormat,
       ...studyQuery
     } = request.payload;
-    const features = CompositeId.decode(s1);
+
     try {
+      const features = CompositeId.decode(s1);
+      if (features.length > MAX_LOCATIONS) {
+        return Boom.badRequest(`cannot fetch reports on more than ${MAX_LOCATIONS} locations`);
+      }
+      const featuresSelection = { features, selectionType };
+
       const reports = await ReportDAO.byCentrelineAndStudyQuery(
-        features,
+        featuresSelection,
         studyQuery,
         reportFormat,
       );
@@ -147,6 +154,7 @@ JobController.push({
         reportExportMode: ReportExportMode.STUDIES,
         reports,
         s1,
+        selectionType,
       };
       const jobMetadata = await JobManager.publish(JobType.GENERATE_REPORTS, data, user);
       return jobMetadata;

--- a/lib/controller/LocationController.js
+++ b/lib/controller/LocationController.js
@@ -4,12 +4,14 @@ import {
   CentrelineType,
   FEATURE_CODES_INTERSECTION,
   FEATURE_CODES_SEGMENT,
+  HttpStatus,
+  LocationSelectionType,
   LocationSearchType,
-  MAX_LOCATIONS,
 } from '@/lib/Constants';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import LocationSearchDAO from '@/lib/db/LocationSearchDAO';
-import RoutingDAO from '@/lib/db/RoutingDAO';
+import { InvalidFeaturesSelectionError } from '@/lib/error/MoveErrors';
+import FeatureResolver from '@/lib/geo/FeatureResolver';
 import CompositeId from '@/lib/io/CompositeId';
 import Joi from '@/lib/model/Joi';
 import CentrelineLocation from '@/lib/model/helpers/CentrelineLocation';
@@ -203,20 +205,21 @@ LocationController.push({
   handler: async (request) => {
     const { s1 } = request.query;
     const features = CompositeId.decode(s1);
-    if (features.length > MAX_LOCATIONS) {
-      return Boom.badRequest(`cannot route corridor on more than ${MAX_LOCATIONS} locations`);
+    const featuresSelection = {
+      features,
+      selectionType: LocationSelectionType.CORRIDOR,
+    };
+    try {
+      const featuresResolved = await FeatureResolver.byFeaturesSelection(featuresSelection);
+      const locations = await CentrelineDAO.byFeatures(featuresResolved);
+      return filterLocations(locations);
+    } catch (err) {
+      if (err instanceof InvalidFeaturesSelectionError) {
+        const { statusCode } = HttpStatus.BAD_REQUEST;
+        return Boom.boomify(err, { statusCode, override: false });
+      }
+      throw err;
     }
-    const corridor = await RoutingDAO.routeCorridor(features);
-    if (corridor === null) {
-      return Boom.notFound('no corridor found on the given location selection');
-    }
-    if (corridor.length > CompositeId.MAX_FEATURES) {
-      return Boom.badRequest(
-        `cannot return corridor with more than ${CompositeId.MAX_FEATURES} locations`,
-      );
-    }
-    const locations = await CentrelineDAO.byFeatures(corridor);
-    return filterLocations(locations);
   },
 });
 

--- a/lib/controller/ReportController.js
+++ b/lib/controller/ReportController.js
@@ -129,7 +129,7 @@ ReportController.push({
         format: reportFormat,
         ...reportOptions,
       };
-      const { key } = StoragePath.forReport(report);
+      const { key } = await StoragePath.forReport(report);
       response.header('Content-Disposition', `attachment; filename="${key}"`);
     }
 

--- a/lib/db/ReportDAO.js
+++ b/lib/db/ReportDAO.js
@@ -1,5 +1,6 @@
 import { ReportType } from '@/lib/Constants';
 import StudyDAO from '@/lib/db/StudyDAO';
+import FeatureResolver from '@/lib/geo/FeatureResolver';
 import CompositeId from '@/lib/io/CompositeId';
 import ArrayStats from '@/lib/math/ArrayStats';
 
@@ -28,9 +29,9 @@ class ReportDAO {
       }));
   }
 
-  static async byCentrelineAndCollisionQuery(locationsSelection, collisionQuery, reportFormat) {
-    const { locations, selectionType } = locationsSelection;
-    const s1 = CompositeId.encode(locations);
+  static async byCentrelineAndCollisionQuery(featuresSelection, collisionQuery, reportFormat) {
+    const { features, selectionType } = featuresSelection;
+    const s1 = CompositeId.encode(features);
     const id = `${s1}/${selectionType.name}`;
 
     return REPORT_TYPES_COLLISION
@@ -43,7 +44,9 @@ class ReportDAO {
       }));
   }
 
-  static async byCentrelineAndStudyQuery(features, studyQuery, reportFormat) {
+  static async byCentrelineAndStudyQuery(featuresSelection, studyQuery, reportFormat) {
+    const features = await FeatureResolver.byFeaturesSelection(featuresSelection);
+
     const reports = [];
 
     const studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);

--- a/lib/db/ReportDAO.js
+++ b/lib/db/ReportDAO.js
@@ -28,8 +28,11 @@ class ReportDAO {
       }));
   }
 
-  static async byCentrelineAndCollisionQuery(features, collisionQuery, reportFormat) {
-    const id = CompositeId.encode(features);
+  static async byCentrelineAndCollisionQuery(locationsSelection, collisionQuery, reportFormat) {
+    const { locations, selectionType } = locationsSelection;
+    const s1 = CompositeId.encode(locations);
+    const id = `${s1}/${selectionType.name}`;
+
     return REPORT_TYPES_COLLISION
       .filter(reportType => reportType.formats.includes(reportFormat))
       .map(reportType => ({

--- a/lib/db/StudyDataDAO.js
+++ b/lib/db/StudyDataDAO.js
@@ -1,4 +1,5 @@
 import { StudyType } from '@/lib/Constants';
+import { mapBy } from '@/lib/MapUtils';
 import db from '@/lib/db/db';
 import ArteryDAO from '@/lib/db/ArteryDAO';
 import CountDAO from '@/lib/db/CountDAO';
@@ -87,9 +88,7 @@ class StudyDataDAO {
       ArteryDAO.byStudy(study),
       CountDAO.byStudy(study),
     ]);
-    const arteriesByCode = new Map(
-      arteries.map(artery => [artery.arteryCode, artery]),
-    );
+    const arteriesByCode = mapBy(arteries, ({ arteryCode }) => arteryCode);
 
     const dataRows = await StudyDataDAO.dataRowsByCounts(study, counts);
     const studyData = StudyDataDAO.groupDataRows(counts, dataRows);

--- a/lib/error/MoveErrors.js
+++ b/lib/error/MoveErrors.js
@@ -83,6 +83,13 @@ class InvalidCssVariableError extends Error {}
 class InvalidDynamicTileLayerError extends Error {}
 
 /**
+ * Thrown by {@link FeatureResolver.byFeaturesSelection} methods for selections
+ * that contain too many features, that cannot be resolved, or that resolve to
+ * too many features.
+ */
+class InvalidFeaturesSelectionError extends Error {}
+
+/**
  * Thrown by {@link OpenIdClient#callback} for invalid OpenID Connect identity tokens.
  *
  * @memberof MoveErrors
@@ -141,6 +148,7 @@ const MoveErrors = {
   InvalidCompositeIdError,
   InvalidCssVariableError,
   InvalidDynamicTileLayerError,
+  InvalidFeaturesSelectionError,
   InvalidOpenIdTokenError,
   InvalidReportFormatError,
   InvalidReportIdError,
@@ -160,6 +168,7 @@ export {
   InvalidCompositeIdError,
   InvalidCssVariableError,
   InvalidDynamicTileLayerError,
+  InvalidFeaturesSelectionError,
   InvalidOpenIdTokenError,
   InvalidReportFormatError,
   InvalidReportIdError,

--- a/lib/error/MoveErrors.js
+++ b/lib/error/MoveErrors.js
@@ -86,6 +86,9 @@ class InvalidDynamicTileLayerError extends Error {}
  * Thrown by {@link FeatureResolver.byFeaturesSelection} methods for selections
  * that contain too many features, that cannot be resolved, or that resolve to
  * too many features.
+ *
+ * @memberof MoveErrors
+ * @see FeatureResolver.byFeaturesSelection
  */
 class InvalidFeaturesSelectionError extends Error {}
 
@@ -96,6 +99,14 @@ class InvalidFeaturesSelectionError extends Error {}
  * @see OpenIdClient#callback
  */
 class InvalidOpenIdTokenError extends Error {}
+
+/**
+ * Thrown by {@link StoragePath} methods for invalid report export modes.
+ *
+ * @memberof MoveErrors
+ * @see StoragePath
+ */
+class InvalidReportExportModeError extends Error {}
 
 /**
  * Thrown by {@link ReportBase#generate} for invalid report formats.
@@ -150,6 +161,7 @@ const MoveErrors = {
   InvalidDynamicTileLayerError,
   InvalidFeaturesSelectionError,
   InvalidOpenIdTokenError,
+  InvalidReportExportModeError,
   InvalidReportFormatError,
   InvalidReportIdError,
   InvalidReportTypeError,
@@ -170,6 +182,7 @@ export {
   InvalidDynamicTileLayerError,
   InvalidFeaturesSelectionError,
   InvalidOpenIdTokenError,
+  InvalidReportExportModeError,
   InvalidReportFormatError,
   InvalidReportIdError,
   InvalidReportTypeError,

--- a/lib/geo/FeatureResolver.js
+++ b/lib/geo/FeatureResolver.js
@@ -1,0 +1,34 @@
+import { LocationSelectionType, MAX_LOCATIONS } from '@/lib/Constants';
+import RoutingDAO from '@/lib/db/RoutingDAO';
+import { InvalidFeaturesSelectionError } from '@/lib/error/MoveErrors';
+import CompositeId from '@/lib/io/CompositeId';
+
+class FeatureResolver {
+  static async byFeaturesSelection(featuresSelection) {
+    const { features, selectionType } = featuresSelection;
+    if (features.length > MAX_LOCATIONS) {
+      throw new InvalidFeaturesSelectionError(
+        `cannot route corridor on more than ${MAX_LOCATIONS} locations`,
+      );
+    }
+
+    if (selectionType === LocationSelectionType.CORRIDOR) {
+      const corridor = await RoutingDAO.routeCorridor(features);
+      if (corridor === null) {
+        throw new InvalidFeaturesSelectionError(
+          'no corridor found on the given location selection',
+        );
+      }
+      if (corridor.length > CompositeId.MAX_FEATURES) {
+        throw new InvalidFeaturesSelectionError(
+          `cannot return corridor with more than ${CompositeId.MAX_FEATURES} locations`,
+        );
+      }
+      return corridor;
+    }
+
+    return features;
+  }
+}
+
+export default FeatureResolver;

--- a/lib/io/storage/StoragePath.js
+++ b/lib/io/storage/StoragePath.js
@@ -46,15 +46,15 @@ class StoragePath {
   /**
    *
    * @param {Array<Object>} reports
+   * @param {Array<StoragePathResponse>} storagePaths - storage paths previously generated via
+   * {@link StoragePath.forReport}
    * @returns {StoragePathResponse} storage path for given report ZIP archive
    */
-  static async forReportZip(reports) {
+  static async forReportZip(reports, storagePaths) {
     const hashBuilder = crypto.createHash('md5');
     const n = reports.length;
     for (let i = 0; i < n; i++) {
-      const report = reports[i];
-      /* eslint-disable-next-line no-await-in-loop */
-      const { key: reportKey } = await StoragePath.forReport(report);
+      const { key: reportKey } = storagePaths[i];
       hashBuilder.update(reportKey, 'utf8');
     }
     const hash = hashBuilder.digest('hex');

--- a/lib/io/storage/StoragePath.js
+++ b/lib/io/storage/StoragePath.js
@@ -20,7 +20,7 @@ class StoragePath {
    * @param {Object} report
    * @returns {StoragePathResponse} storage path for given report
    */
-  static forReport(report) {
+  static async forReport(report) {
     let {
       type,
       id,
@@ -48,12 +48,15 @@ class StoragePath {
    * @param {Array<Object>} reports
    * @returns {StoragePathResponse} storage path for given report ZIP archive
    */
-  static forReportZip(reports) {
+  static async forReportZip(reports) {
     const hashBuilder = crypto.createHash('md5');
-    reports.forEach((report) => {
-      const { key: reportKey } = StoragePath.forReport(report);
+    const n = reports.length;
+    for (let i = 0; i < n; i++) {
+      const report = reports[i];
+      /* eslint-disable-next-line no-await-in-loop */
+      const { key: reportKey } = await StoragePath.forReport(report);
       hashBuilder.update(reportKey, 'utf8');
-    });
+    }
     const hash = hashBuilder.digest('hex');
     const key = `${hash}.zip`;
     return { namespace: StoragePath.NAMESPACE_REPORTS, key };

--- a/lib/io/storage/StoragePath.js
+++ b/lib/io/storage/StoragePath.js
@@ -1,6 +1,20 @@
 import crypto from 'crypto';
 
+import {
+  CardinalDirection,
+  CentrelineType,
+  ReportExportMode,
+} from '@/lib/Constants';
+import { mapBy } from '@/lib/MapUtils';
 import ObjectUtils from '@/lib/ObjectUtils';
+import ArteryDAO from '@/lib/db/ArteryDAO';
+import CountDAO from '@/lib/db/CountDAO';
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import { InvalidReportExportModeError } from '@/lib/error/MoveErrors';
+import { getLocationsSelectionDescription } from '@/lib/geo/CentrelineUtils';
+import CompositeId from '@/lib/io/CompositeId';
+import { parseCollisionReportId, parseStudyReportId } from '@/lib/reports/ReportIdParser';
+import TimeFormatters from '@/lib/time/TimeFormatters';
 
 /**
  * @typedef {Object} StoragePathResponse
@@ -13,7 +27,190 @@ import ObjectUtils from '@/lib/ObjectUtils';
  * methods.
  */
 class StoragePath {
+  // HELPERS
+
+  /**
+   *
+   * @param {DateTime} dt
+   * @returns {string}
+   */
+  static getDate(dt) {
+    return TimeFormatters.formatCsvDate(dt);
+  }
+
+  /**
+   *
+   * @param {Object} study
+   * @returns {string}
+   */
+  static async getDirectionsFromStudy(study) {
+    const [arteries, counts] = await Promise.all([
+      ArteryDAO.byStudy(study),
+      CountDAO.byStudy(study),
+    ]);
+    const arteriesByCode = mapBy(arteries, ({ arteryCode }) => arteryCode);
+    const countDirections = counts.map(({ arteryCode }) => {
+      const artery = arteriesByCode.get(arteryCode);
+      return artery.approachDir;
+    });
+    const directions = CardinalDirection.enumValues.filter(
+      direction => countDirections.some(countDirection => countDirection === direction),
+    );
+    return directions
+      .map(({ short }) => `${short}B`)
+      .join('_');
+  }
+
+  /**
+   *
+   * @param {string} id
+   * @returns {string}
+   */
+  static getId(id) {
+    return id.replace('/', '_');
+  }
+
+  /**
+   *
+   * @param {Object} study
+   * @returns {string}
+   */
+  static async getLocationFromStudy(study) {
+    const location = await CentrelineDAO.byFeature(study);
+    const description = StoragePath.sanitizeLocationDescription(location.description);
+    if (location.centrelineType === CentrelineType.SEGMENT) {
+      const partDirections = await StoragePath.getDirectionsFromStudy(study);
+      return `${description}_${partDirections}`;
+    }
+    return description;
+  }
+
+  /**
+   *
+   * @param {Object} data
+   * @returns {string}
+   */
+  static async getLocationsSelection(data) {
+    const { s1, selectionType } = data;
+    const features = CompositeId.decode(s1);
+    const locations = await CentrelineDAO.byFeatures(features);
+    const locationsSelection = { locations, selectionType };
+    const description = getLocationsSelectionDescription(locationsSelection);
+    return StoragePath.sanitizeLocationDescription(description);
+  }
+
+  /**
+   *
+   * @param {Object} options
+   * @returns {string}
+   */
+  static getOptionsHash(options) {
+    if (ObjectUtils.isEmpty(options)) {
+      return '';
+    }
+    const hashBuilder = crypto.createHash('md5');
+    hashBuilder.update(JSON.stringify(options));
+    const hash = hashBuilder.digest('hex').slice(0, 8);
+    return `_${hash}`;
+  }
+
+  /**
+   *
+   * @param {Array<StoragePathResponse>} storagePaths
+   * @returns {string}
+   */
+  static getReportHash(storagePaths) {
+    const hashBuilder = crypto.createHash('md5');
+    const n = storagePaths.length;
+    for (let i = 0; i < n; i++) {
+      const { key: reportKey } = storagePaths[i];
+      hashBuilder.update(reportKey, 'utf8');
+    }
+    return hashBuilder.digest('hex').slice(0, 8);
+  }
+
+  /**
+   *
+   * @param {ReportType} type
+   * @returns {string}
+   */
+  static getReportType(type) {
+    return type.name;
+  }
+
+  /**
+   *
+   * @param {Array<StoragePathResponse>} storagePaths
+   * @returns {string}
+   */
+  static getTotalReports(storagePaths) {
+    return `${storagePaths.length}_TOTAL`;
+  }
+
+  /**
+   *
+   * @param {string} description
+   * @returns {string}
+   */
+  static sanitizeLocationDescription(description) {
+    return description
+      .replace('+', 'plus')
+      .replace(' \u2013 ', '-')
+      .replace(' \u2192 ', '--')
+      .replace(/[^a-zA-Z0-9-]+/g, '_')
+      .toUpperCase();
+  }
+
+  // REPORT PATH GENERATORS
+
   // TODO: add MVCR here
+
+  /**
+   *
+   * @param {Object} report
+   * @returns {StoragePathResponse} storage path for given collision report
+   */
+  static async forCollisionReport(report) {
+    const {
+      type,
+      id,
+      format,
+      ...options
+    } = report;
+
+    const partReportType = StoragePath.getReportType(type);
+    const { s1, selectionType } = await parseCollisionReportId(id);
+    const partLocationsSelection = await StoragePath.getLocationsSelection({ s1, selectionType });
+    const partId = StoragePath.getId(id);
+    const partOptionsHash = StoragePath.getOptionsHash(options);
+    const { extension } = format;
+    const key = `${partReportType}_${partLocationsSelection}_${partId}${partOptionsHash}.${extension}`;
+    return { namespace: StoragePath.NAMESPACE_REPORTS_COLLISION, key };
+  }
+
+  /**
+   *
+   * @param {Object} report
+   * @returns {StoragePathResponse} storage path for given study report
+   */
+  static async forStudyReport(report) {
+    const {
+      type,
+      id,
+      format,
+      ...options
+    } = report;
+
+    const partReportType = StoragePath.getReportType(type);
+    const { study } = await parseStudyReportId(type, id);
+    const partLocation = await StoragePath.getLocationFromStudy(study);
+    const partStartDate = StoragePath.getDate(study.startDate);
+    const partId = StoragePath.getId(id);
+    const partOptionsHash = StoragePath.getOptionsHash(options);
+    const { extension } = format;
+    const key = `${partReportType}_${partLocation}_${partStartDate}_${partId}${partOptionsHash}.${extension}`;
+    return { namespace: StoragePath.NAMESPACE_REPORTS_STUDY, key };
+  }
 
   /**
    *
@@ -21,50 +218,69 @@ class StoragePath {
    * @returns {StoragePathResponse} storage path for given report
    */
   static async forReport(report) {
-    let {
-      type,
-      id,
-      format,
-      ...options
-    } = report;
-    type = type.name;
-    id = id.replace('/', '_');
-    format = format.extension;
-    if (ObjectUtils.isEmpty(options)) {
-      options = '';
-    } else {
-      const hashBuilder = crypto.createHash('md5');
-      hashBuilder.update(JSON.stringify(options));
-      const hash = hashBuilder.digest('hex');
-      options = `_${hash}`;
+    const { type } = report;
+    if (type.reportExportMode === ReportExportMode.COLLISIONS) {
+      return StoragePath.forCollisionReport(report);
     }
-
-    const key = `${type}_${id}${options}.${format}`;
-    return { namespace: StoragePath.NAMESPACE_REPORTS, key };
+    if (type.reportExportMode === ReportExportMode.STUDIES) {
+      return StoragePath.forStudyReport(report);
+    }
+    throw new InvalidReportExportModeError(type.reportExportMode);
   }
 
   /**
    *
-   * @param {Array<Object>} reports
+   * @param {Object} data
+   * @param {Array<StoragePathResponse>} storagePaths
+   * @returns {StoragePathResponse} storage path for given collision report archive
+   */
+  static async forCollisionReportZip(data, storagePaths) {
+    const partLocationsSelection = await StoragePath.getLocationsSelection(data);
+    const partReportHash = StoragePath.getReportHash(storagePaths);
+    const key = `COLLISION_${partLocationsSelection}_${partReportHash}.zip`;
+    return { namespace: StoragePath.NAMESPACE_REPORTS_COLLISION, key };
+  }
+
+  /**
+   *
+   * @param {Object} data
+   * @param {Array<StoragePathResponse>} storagePaths
+   * @returns {StoragePathResponse} storage path for given study report archive
+   */
+  static async forStudyReportZip(data, storagePaths) {
+    const partLocationsSelection = await StoragePath.getLocationsSelection(data);
+    const partTotalReports = StoragePath.getTotalReports(storagePaths);
+    const partReportHash = StoragePath.getReportHash(storagePaths);
+    const key = `STUDY_${partLocationsSelection}_${partTotalReports}_${partReportHash}.zip`;
+    return { namespace: StoragePath.NAMESPACE_REPORTS_STUDY, key };
+  }
+
+  /**
+   *
+   * @param {Object} data - data provided during job creation
    * @param {Array<StoragePathResponse>} storagePaths - storage paths previously generated via
    * {@link StoragePath.forReport}
    * @returns {StoragePathResponse} storage path for given report ZIP archive
    */
-  static async forReportZip(reports, storagePaths) {
-    const hashBuilder = crypto.createHash('md5');
-    const n = reports.length;
-    for (let i = 0; i < n; i++) {
-      const { key: reportKey } = storagePaths[i];
-      hashBuilder.update(reportKey, 'utf8');
+  static async forReportZip(data, storagePaths) {
+    const { reportExportMode } = data;
+    if (reportExportMode === ReportExportMode.COLLISIONS) {
+      return StoragePath.forCollisionReportZip(data, storagePaths);
     }
-    const hash = hashBuilder.digest('hex');
-    const key = `${hash}.zip`;
-    return { namespace: StoragePath.NAMESPACE_REPORTS, key };
+    if (reportExportMode === ReportExportMode.STUDIES) {
+      return StoragePath.forStudyReportZip(data, storagePaths);
+    }
+    throw new InvalidReportExportModeError(reportExportMode);
   }
 }
 /**
  * @type {string}
  */
-StoragePath.NAMESPACE_REPORTS = 'reports';
+StoragePath.NAMESPACE_REPORTS_COLLISION = 'reportsCollision';
+
+/**
+ * @type {string}
+ */
+StoragePath.NAMESPACE_REPORTS_STUDY = 'reportsStudy';
 
 export default StoragePath;

--- a/lib/jobs/JobDescription.js
+++ b/lib/jobs/JobDescription.js
@@ -1,15 +1,16 @@
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import { InvalidJobTypeError } from '@/lib/error/JobErrors';
-import { getLocationsDescription } from '@/lib/geo/CentrelineUtils';
+import { getLocationsSelectionDescription } from '@/lib/geo/CentrelineUtils';
 import CompositeId from '@/lib/io/CompositeId';
 import JobType from '@/lib/jobs/JobType';
 
 class JobDescription {
-  static async getGenerateReports({ reportExportMode, s1 }) {
+  static async getGenerateReports({ reportExportMode, s1, selectionType }) {
     const features = CompositeId.decode(s1);
     const locations = await CentrelineDAO.byFeatures(features);
-    const locationsDescription = getLocationsDescription(locations);
-    return `${reportExportMode.description}: ${locationsDescription}`;
+    const locationsSelection = { locations, selectionType };
+    const description = getLocationsSelectionDescription(locationsSelection);
+    return `${reportExportMode.description}: ${description}`;
   }
 
   static async get(type, data) {

--- a/lib/jobs/JobRunnerGenerateReports.js
+++ b/lib/jobs/JobRunnerGenerateReports.js
@@ -62,7 +62,7 @@ class JobRunnerGenerateReports extends JobRunnerBase {
   }
 
   async zipReports(reports, storagePaths) {
-    const { namespace, key } = await StoragePath.forReportZip(reports);
+    const { namespace, key } = await StoragePath.forReportZip(reports, storagePaths);
     const reportZipExists = await storageStrategy.has(namespace, key);
     if (reportZipExists) {
       return { namespace, key };

--- a/lib/jobs/JobRunnerGenerateReports.js
+++ b/lib/jobs/JobRunnerGenerateReports.js
@@ -45,8 +45,12 @@ class JobRunnerGenerateReports extends JobRunnerBase {
     return reporterClient.fetch('/reports', options);
   }
 
-  async saveReport(report) {
-    const { namespace, key } = StoragePath.forReport(report);
+  async getStoragePaths(reports) {
+    const tasks = reports.map(StoragePath.forReport);
+    return Promise.all(tasks);
+  }
+
+  async saveReport(report, { namespace, key }) {
     const reportExists = await storageStrategy.has(namespace, key);
     if (reportExists) {
       return false;
@@ -57,8 +61,8 @@ class JobRunnerGenerateReports extends JobRunnerBase {
     return true;
   }
 
-  async zipReports(reports) {
-    const { namespace, key } = StoragePath.forReportZip(reports);
+  async zipReports(reports, storagePaths) {
+    const { namespace, key } = await StoragePath.forReportZip(reports);
     const reportZipExists = await storageStrategy.has(namespace, key);
     if (reportZipExists) {
       return { namespace, key };
@@ -73,8 +77,8 @@ class JobRunnerGenerateReports extends JobRunnerBase {
         .on('end', () => resolve({ namespace, key }));
       archive.pipe(valueStream);
 
-      reports.forEach((report) => {
-        const { namespace: namespaceReport, key: keyReport } = StoragePath.forReport(report);
+      reports.forEach((report, i) => {
+        const { namespace: namespaceReport, key: keyReport } = storagePaths[i];
         const valueStreamReport = storageStrategy.getStream(namespaceReport, keyReport)
           .on('error', reject);
         archive.append(valueStreamReport, { name: keyReport });
@@ -96,11 +100,14 @@ class JobRunnerGenerateReports extends JobRunnerBase {
    * @param {Array<Object>} data.reports - reports to be generated
    */
   async runImpl({ reports }) {
+    const storagePaths = await this.getStoragePaths(reports);
+
     const n = reports.length;
     for (let i = 0; i < n; i++) {
       const report = reports[i];
+      const storagePath = storagePaths[i];
       /* eslint-disable-next-line no-await-in-loop */
-      const savedNew = await this.saveReport(report);
+      const savedNew = await this.saveReport(report, storagePath);
 
       if (savedNew) {
         // Random delay strategy; see `DELAY_MIN` / `DELAY_MAX` above.
@@ -117,7 +124,7 @@ class JobRunnerGenerateReports extends JobRunnerBase {
       /* eslint-disable-next-line no-await-in-loop */
       await this.incrProgressCurrent();
     }
-    return this.zipReports(reports);
+    return this.zipReports(reports, storagePaths);
   }
 }
 

--- a/lib/jobs/JobRunnerGenerateReports.js
+++ b/lib/jobs/JobRunnerGenerateReports.js
@@ -61,8 +61,8 @@ class JobRunnerGenerateReports extends JobRunnerBase {
     return true;
   }
 
-  async zipReports(reports, storagePaths) {
-    const { namespace, key } = await StoragePath.forReportZip(reports, storagePaths);
+  async zipReports(data, storagePaths) {
+    const { namespace, key } = await StoragePath.forReportZip(data, storagePaths);
     const reportZipExists = await storageStrategy.has(namespace, key);
     if (reportZipExists) {
       return { namespace, key };
@@ -77,8 +77,7 @@ class JobRunnerGenerateReports extends JobRunnerBase {
         .on('end', () => resolve({ namespace, key }));
       archive.pipe(valueStream);
 
-      reports.forEach((report, i) => {
-        const { namespace: namespaceReport, key: keyReport } = storagePaths[i];
+      storagePaths.forEach(({ namespace: namespaceReport, key: keyReport }) => {
         const valueStreamReport = storageStrategy.getStream(namespaceReport, keyReport)
           .on('error', reject);
         archive.append(valueStreamReport, { name: keyReport });
@@ -90,16 +89,17 @@ class JobRunnerGenerateReports extends JobRunnerBase {
   }
 
   /**
-   * Generates the given `reports`, storing each using the configured `storageStrategy`.
-   * Once all reports have been generated and stored, ZIPs those reports into a single
-   * archive, and stores that ZIP as well.
+   * Generates the reports specified in `data`, storing each using the configured
+   * `storageStrategy`.  Once all reports have been generated and stored, ZIPs those reports into
+   * a single archive, and stores that ZIP as well.
    *
    * Resolves to the `{ namespace, key }` storage parameters for this ZIP archive.
    *
    * @param {Object} data - data provided during job creation
-   * @param {Array<Object>} data.reports - reports to be generated
+   * @returns {Promise<StoragePathResponse>} storage path of the final ZIP archive
    */
-  async runImpl({ reports }) {
+  async runImpl(data) {
+    const { reports } = data;
     const storagePaths = await this.getStoragePaths(reports);
 
     const n = reports.length;
@@ -124,7 +124,7 @@ class JobRunnerGenerateReports extends JobRunnerBase {
       /* eslint-disable-next-line no-await-in-loop */
       await this.incrProgressCurrent();
     }
-    return this.zipReports(reports, storagePaths);
+    return this.zipReports(data, storagePaths);
   }
 }
 

--- a/lib/jobs/JobType.js
+++ b/lib/jobs/JobType.js
@@ -1,5 +1,10 @@
 import { Enum } from '@/lib/ClassUtils';
-import { ReportExportMode, ReportFormat, ReportType } from '@/lib/Constants';
+import {
+  LocationSelectionType,
+  ReportExportMode,
+  ReportFormat,
+  ReportType,
+} from '@/lib/Constants';
 import Joi from '@/lib/model/Joi';
 import CentrelineSelection from '@/lib/model/helpers/CentrelineSelection';
 
@@ -20,6 +25,7 @@ JobType.init({
           format: Joi.enum().ofType(ReportFormat).required(),
         }).unknown(),
       ),
+      selectionType: Joi.enum().ofType(LocationSelectionType).required(),
     }),
     getMetadata({ reportExportMode, s1 }) {
       return { reportExportMode, s1 };

--- a/lib/jobs/JobType.js
+++ b/lib/jobs/JobType.js
@@ -27,8 +27,8 @@ JobType.init({
       ),
       selectionType: Joi.enum().ofType(LocationSelectionType).required(),
     }),
-    getMetadata({ reportExportMode, s1 }) {
-      return { reportExportMode, s1 };
+    getMetadata({ reportExportMode, s1, selectionType }) {
+      return { reportExportMode, s1, selectionType };
     },
     getProgressTotal({ reports }) {
       return reports.length;
@@ -36,6 +36,7 @@ JobType.init({
     metadataSchema: Joi.object().keys({
       ...CentrelineSelection,
       reportExportMode: Joi.enum().ofType(ReportExportMode),
+      selectionType: Joi.enum().ofType(LocationSelectionType).required(),
     }),
   },
 });

--- a/lib/reports/ReportBaseCrash.js
+++ b/lib/reports/ReportBaseCrash.js
@@ -41,16 +41,18 @@ class ReportBaseCrash extends ReportBase {
   }
 
   async generateLayoutHeader({ locationsSelection }) {
-    let info = getLocationsSelectionDescription(locationsSelection);
+    const description = getLocationsSelectionDescription(locationsSelection);
     /*
      * `pdfmake` only supports ANSI characters:
      *
      * https://pdfmake.github.io/docs/0.1/fonts/standard-14-fonts/
      *
-     * To work around this, we replace the Unicode arrow used in corridor descriptions
-     * with a more ANSI-friendly equivalent here.
+     * To work around this, we replace the Unicode arrows and dashes used in corridor
+     * descriptions with more ANSI-friendly equivalents here.
      */
-    info = info.replace('\u2192', '-');
+    const info = description
+      .replace('\u2013', '-')
+      .replace('\u2192', '--');
     return { info, subinfo: '' };
   }
 

--- a/lib/reports/ReportBaseCrash.js
+++ b/lib/reports/ReportBaseCrash.js
@@ -1,13 +1,19 @@
 /* eslint-disable class-methods-use-this */
-import { ReportBlock } from '@/lib/Constants';
+import {
+  LocationSelectionType,
+  MAX_LOCATIONS,
+  ReportBlock,
+} from '@/lib/Constants';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import CollisionDAO from '@/lib/db/CollisionDAO';
 import CollisionFactorDAO from '@/lib/db/CollisionFactorDAO';
+import RoutingDAO from '@/lib/db/RoutingDAO';
 import {
+  EnumValueError,
   InvalidCompositeIdError,
   InvalidReportIdError,
 } from '@/lib/error/MoveErrors';
-import { getLocationsDescription } from '@/lib/geo/CentrelineUtils';
+import { getLocationsSelectionDescription } from '@/lib/geo/CentrelineUtils';
 import CompositeId from '@/lib/io/CompositeId';
 import ReportBase from '@/lib/reports/ReportBase';
 
@@ -21,39 +27,83 @@ class ReportBaseCrash extends ReportBase {
   }
 
   /**
-   * Parses a `CompositeId`, and returns it as an array of centreline locations from
-   * {@link CentrelineDAO} for further processing.
+   * Parses an ID in the format `{s1}/{selectionType}`, where `{ s1, selectionType }` identifies
+   * a location selection.  Returns this as an object `{ locations, selectionType }`: `locations`
+   * is an array of centreline locations from {@link CentrelineDAO}, while `selectionType` is a
+   * {@link LocationSelectionType}.
    *
-   * @param {string} s1 - `CompositeId` to parse
+   * @param {string} rawId - ID to parse
    * @throws {InvalidReportIdError}
    */
-  async parseId(s1) {
+  async parseId(rawId) {
+    const parts = rawId.split('/');
+    if (parts.length !== 2) {
+      throw new InvalidReportIdError(rawId);
+    }
+
+    const s1 = parts.shift();
+    let locations;
     try {
       const features = CompositeId.decode(s1);
-      const locations = await CentrelineDAO.byFeatures(features);
-      return Array.from(locations.values());
+      if (features.length > MAX_LOCATIONS) {
+        throw new InvalidReportIdError(rawId);
+      }
+      locations = await CentrelineDAO.byFeatures(features);
     } catch (err) {
       if (err instanceof InvalidCompositeIdError) {
-        throw new InvalidReportIdError(s1);
+        throw new InvalidReportIdError(rawId);
       }
       throw err;
     }
+
+    const selectionTypeStr = parts.shift();
+    let selectionType;
+    try {
+      selectionType = LocationSelectionType.enumValueOf(selectionTypeStr);
+    } catch (err) {
+      if (err instanceof EnumValueError) {
+        throw new InvalidReportIdError(rawId);
+      }
+      throw err;
+    }
+
+    const locationsSelection = { locations, selectionType };
+    if (selectionType === LocationSelectionType.CORRIDOR) {
+      const features = await RoutingDAO.routeCorridor(locations);
+      if (features === null) {
+        throw new InvalidReportIdError(rawId);
+      }
+      if (features.length > CompositeId.MAX_FEATURES) {
+        throw new InvalidReportIdError(rawId);
+      }
+      locations = await CentrelineDAO.byFeatures(features);
+    }
+
+    return { locations, locationsSelection };
   }
 
-  async fetchRawData(features, collisionQuery) {
+  async fetchRawData({ locations }, collisionQuery) {
     if (this.collisionFactors === null) {
       this.collisionFactors = await CollisionFactorDAO.all();
     }
     const [collisions, collisionSummary] = await Promise.all([
-      CollisionDAO.byCentreline(features, collisionQuery),
-      CollisionDAO.byCentrelineSummary(features, collisionQuery),
+      CollisionDAO.byCentreline(locations, collisionQuery),
+      CollisionDAO.byCentrelineSummary(locations, collisionQuery),
     ]);
     return { collisions, collisionSummary };
   }
 
-  async generateLayoutHeader(features) {
-    const locations = await CentrelineDAO.byFeatures(features);
-    const info = getLocationsDescription(locations);
+  async generateLayoutHeader({ locationsSelection }) {
+    let info = getLocationsSelectionDescription(locationsSelection);
+    /*
+     * `pdfmake` only supports ANSI characters:
+     *
+     * https://pdfmake.github.io/docs/0.1/fonts/standard-14-fonts/
+     *
+     * To work around this, we replace the Unicode arrow used in corridor descriptions
+     * with a more ANSI-friendly equivalent here.
+     */
+    info = info.replace('\u2192', 'to');
     return { info, subinfo: '' };
   }
 

--- a/lib/reports/ReportBaseCrash.js
+++ b/lib/reports/ReportBaseCrash.js
@@ -1,19 +1,16 @@
 /* eslint-disable class-methods-use-this */
-import {
-  LocationSelectionType,
-  MAX_LOCATIONS,
-  ReportBlock,
-} from '@/lib/Constants';
+import { LocationSelectionType, ReportBlock } from '@/lib/Constants';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import CollisionDAO from '@/lib/db/CollisionDAO';
 import CollisionFactorDAO from '@/lib/db/CollisionFactorDAO';
-import RoutingDAO from '@/lib/db/RoutingDAO';
 import {
   EnumValueError,
   InvalidCompositeIdError,
+  InvalidFeaturesSelectionError,
   InvalidReportIdError,
 } from '@/lib/error/MoveErrors';
 import { getLocationsSelectionDescription } from '@/lib/geo/CentrelineUtils';
+import FeatureResolver from '@/lib/geo/FeatureResolver';
 import CompositeId from '@/lib/io/CompositeId';
 import ReportBase from '@/lib/reports/ReportBase';
 
@@ -42,13 +39,9 @@ class ReportBaseCrash extends ReportBase {
     }
 
     const s1 = parts.shift();
-    let locations;
+    let features;
     try {
-      const features = CompositeId.decode(s1);
-      if (features.length > MAX_LOCATIONS) {
-        throw new InvalidReportIdError(rawId);
-      }
-      locations = await CentrelineDAO.byFeatures(features);
+      features = CompositeId.decode(s1);
     } catch (err) {
       if (err instanceof InvalidCompositeIdError) {
         throw new InvalidReportIdError(rawId);
@@ -67,28 +60,29 @@ class ReportBaseCrash extends ReportBase {
       throw err;
     }
 
+    const locations = await CentrelineDAO.byFeatures(features);
     const locationsSelection = { locations, selectionType };
-    if (selectionType === LocationSelectionType.CORRIDOR) {
-      const features = await RoutingDAO.routeCorridor(locations);
-      if (features === null) {
+
+    const featuresSelection = { features, selectionType };
+    try {
+      features = await FeatureResolver.byFeaturesSelection(featuresSelection);
+    } catch (err) {
+      if (err instanceof InvalidFeaturesSelectionError) {
         throw new InvalidReportIdError(rawId);
       }
-      if (features.length > CompositeId.MAX_FEATURES) {
-        throw new InvalidReportIdError(rawId);
-      }
-      locations = await CentrelineDAO.byFeatures(features);
+      throw err;
     }
 
-    return { locations, locationsSelection };
+    return { features, locationsSelection };
   }
 
-  async fetchRawData({ locations }, collisionQuery) {
+  async fetchRawData({ features }, collisionQuery) {
     if (this.collisionFactors === null) {
       this.collisionFactors = await CollisionFactorDAO.all();
     }
     const [collisions, collisionSummary] = await Promise.all([
-      CollisionDAO.byCentreline(locations, collisionQuery),
-      CollisionDAO.byCentrelineSummary(locations, collisionQuery),
+      CollisionDAO.byCentreline(features, collisionQuery),
+      CollisionDAO.byCentrelineSummary(features, collisionQuery),
     ]);
     return { collisions, collisionSummary };
   }
@@ -103,7 +97,7 @@ class ReportBaseCrash extends ReportBase {
      * To work around this, we replace the Unicode arrow used in corridor descriptions
      * with a more ANSI-friendly equivalent here.
      */
-    info = info.replace('\u2192', 'to');
+    info = info.replace('\u2192', '-');
     return { info, subinfo: '' };
   }
 

--- a/lib/reports/ReportBaseCrash.js
+++ b/lib/reports/ReportBaseCrash.js
@@ -1,18 +1,10 @@
 /* eslint-disable class-methods-use-this */
-import { LocationSelectionType, ReportBlock } from '@/lib/Constants';
-import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import { ReportBlock } from '@/lib/Constants';
 import CollisionDAO from '@/lib/db/CollisionDAO';
 import CollisionFactorDAO from '@/lib/db/CollisionFactorDAO';
-import {
-  EnumValueError,
-  InvalidCompositeIdError,
-  InvalidFeaturesSelectionError,
-  InvalidReportIdError,
-} from '@/lib/error/MoveErrors';
 import { getLocationsSelectionDescription } from '@/lib/geo/CentrelineUtils';
-import FeatureResolver from '@/lib/geo/FeatureResolver';
-import CompositeId from '@/lib/io/CompositeId';
 import ReportBase from '@/lib/reports/ReportBase';
+import { parseCollisionReportId } from '@/lib/reports/ReportIdParser';
 
 /**
  * Base class for all CRASH-related reports, i.e. those reports that deal with collision data.
@@ -33,46 +25,7 @@ class ReportBaseCrash extends ReportBase {
    * @throws {InvalidReportIdError}
    */
   async parseId(rawId) {
-    const parts = rawId.split('/');
-    if (parts.length !== 2) {
-      throw new InvalidReportIdError(rawId);
-    }
-
-    const s1 = parts.shift();
-    let features;
-    try {
-      features = CompositeId.decode(s1);
-    } catch (err) {
-      if (err instanceof InvalidCompositeIdError) {
-        throw new InvalidReportIdError(rawId);
-      }
-      throw err;
-    }
-
-    const selectionTypeStr = parts.shift();
-    let selectionType;
-    try {
-      selectionType = LocationSelectionType.enumValueOf(selectionTypeStr);
-    } catch (err) {
-      if (err instanceof EnumValueError) {
-        throw new InvalidReportIdError(rawId);
-      }
-      throw err;
-    }
-
-    const locations = await CentrelineDAO.byFeatures(features);
-    const locationsSelection = { locations, selectionType };
-
-    const featuresSelection = { features, selectionType };
-    try {
-      features = await FeatureResolver.byFeaturesSelection(featuresSelection);
-    } catch (err) {
-      if (err instanceof InvalidFeaturesSelectionError) {
-        throw new InvalidReportIdError(rawId);
-      }
-      throw err;
-    }
-
+    const { features, locationsSelection } = await parseCollisionReportId(rawId);
     return { features, locationsSelection };
   }
 

--- a/lib/reports/ReportBaseFlow.js
+++ b/lib/reports/ReportBaseFlow.js
@@ -1,10 +1,8 @@
 /* eslint-disable class-methods-use-this */
-import { StudyType } from '@/lib/Constants';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
-import StudyDAO from '@/lib/db/StudyDAO';
 import StudyDataDAO from '@/lib/db/StudyDataDAO';
-import { InvalidReportIdError } from '@/lib/error/MoveErrors';
 import ReportBase from '@/lib/reports/ReportBase';
+import { parseStudyReportId } from '@/lib/reports/ReportIdParser';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 
 /**
@@ -20,52 +18,7 @@ class ReportBaseFlow extends ReportBase {
    * @throws {InvalidReportIdError}
    */
   async parseId(rawId) {
-    const parts = rawId.split('/');
-    if (parts.length !== 2) {
-      throw new InvalidReportIdError(rawId);
-    }
-
-    let categoryId = parts.shift();
-    categoryId = parseInt(categoryId, 10);
-    if (Number.isNaN(categoryId)) {
-      throw new InvalidReportIdError(rawId);
-    }
-
-    let countGroupId = parts.shift();
-    countGroupId = parseInt(countGroupId, 10);
-    if (Number.isNaN(countGroupId)) {
-      throw new InvalidReportIdError(rawId);
-    }
-
-    const study = await StudyDAO.byCategoryAndCountGroup(categoryId, countGroupId);
-    if (study === null) {
-      throw new InvalidReportIdError(rawId);
-    }
-    const { studyType } = study.type;
-    const { speedRelated, tmcRelated } = this.type();
-    if (speedRelated) {
-      /*
-       * Speed reports MUST have speed data, as the speed class calculations depend on it.
-       * Without that, many of those calculations will return `NaN`.
-       */
-      if (studyType !== StudyType.ATR_SPEED_VOLUME) {
-        throw new InvalidReportIdError(rawId);
-      }
-    } else if (tmcRelated) {
-      /*
-       * TMC reports MUST have TMC data, as the various turning movement totals depend on it.
-       * Without that, many of those calculations will return `NaN`.
-       */
-      if (studyType !== StudyType.TMC) {
-        throw new InvalidReportIdError(rawId);
-      }
-    } else if (studyType === StudyType.TMC) {
-      /*
-       * Other reports MUST NOT have TMC data, as they expect data in the volume-data format
-       * in `"TRAFFIC"."CNT_DET"`.
-       */
-      throw new InvalidReportIdError(rawId);
-    }
+    const { study } = await parseStudyReportId(this.type(), rawId);
     return study;
   }
 

--- a/lib/reports/ReportCollisionDirectory.js
+++ b/lib/reports/ReportCollisionDirectory.js
@@ -208,7 +208,7 @@ class ReportCollisionDirectory extends ReportBaseCrash {
     };
   }
 
-  generateLayoutContent(location, { collisions, collisionSummary }) {
+  generateLayoutContent(parsedId, { collisions, collisionSummary }) {
     const collisionSummaryBlock = ReportBaseCrash.getCollisionsSummaryBlock(collisionSummary);
     const tableOptions = this.getTableOptions(collisions);
     return [

--- a/lib/reports/ReportCollisionTabulation.js
+++ b/lib/reports/ReportCollisionTabulation.js
@@ -457,7 +457,7 @@ class ReportCollisionTabulation extends ReportBaseCrash {
     });
   }
 
-  generateLayoutContent(location, { collisions, collisionSummary }) {
+  generateLayoutContent(parsedId, { collisions, collisionSummary }) {
     const collisionSummaryBlock = ReportBaseCrash.getCollisionsSummaryBlock(collisionSummary);
     const dimAccdateYear = ReportCollisionTabulation.getDimAccdateYear(collisions);
     return [

--- a/lib/reports/ReportIdParser.js
+++ b/lib/reports/ReportIdParser.js
@@ -1,0 +1,129 @@
+/* eslint-disable class-methods-use-this */
+import { LocationSelectionType, StudyType } from '@/lib/Constants';
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import StudyDAO from '@/lib/db/StudyDAO';
+import {
+  EnumValueError,
+  InvalidCompositeIdError,
+  InvalidFeaturesSelectionError,
+  InvalidReportIdError,
+} from '@/lib/error/MoveErrors';
+import FeatureResolver from '@/lib/geo/FeatureResolver';
+import CompositeId from '@/lib/io/CompositeId';
+
+async function parseCollisionReportId(rawId) {
+  const parts = rawId.split('/');
+  if (parts.length !== 2) {
+    throw new InvalidReportIdError(rawId);
+  }
+
+  const s1 = parts.shift();
+  let features;
+  try {
+    features = CompositeId.decode(s1);
+  } catch (err) {
+    if (err instanceof InvalidCompositeIdError) {
+      throw new InvalidReportIdError(rawId);
+    }
+    throw err;
+  }
+
+  const selectionTypeStr = parts.shift();
+  let selectionType;
+  try {
+    selectionType = LocationSelectionType.enumValueOf(selectionTypeStr);
+  } catch (err) {
+    if (err instanceof EnumValueError) {
+      throw new InvalidReportIdError(rawId);
+    }
+    throw err;
+  }
+
+  const locations = await CentrelineDAO.byFeatures(features);
+  const locationsSelection = { locations, selectionType };
+
+  const featuresSelection = { features, selectionType };
+  try {
+    features = await FeatureResolver.byFeaturesSelection(featuresSelection);
+  } catch (err) {
+    if (err instanceof InvalidFeaturesSelectionError) {
+      throw new InvalidReportIdError(rawId);
+    }
+    throw err;
+  }
+
+  return {
+    features,
+    locationsSelection,
+    s1,
+    selectionType,
+  };
+}
+
+async function parseStudyReportId(type, rawId) {
+  const parts = rawId.split('/');
+  if (parts.length !== 2) {
+    throw new InvalidReportIdError(rawId);
+  }
+
+  let categoryId = parts.shift();
+  categoryId = parseInt(categoryId, 10);
+  if (Number.isNaN(categoryId)) {
+    throw new InvalidReportIdError(rawId);
+  }
+
+  let countGroupId = parts.shift();
+  countGroupId = parseInt(countGroupId, 10);
+  if (Number.isNaN(countGroupId)) {
+    throw new InvalidReportIdError(rawId);
+  }
+
+  const study = await StudyDAO.byCategoryAndCountGroup(categoryId, countGroupId);
+  if (study === null) {
+    throw new InvalidReportIdError(rawId);
+  }
+  const { studyType } = study.type;
+  const { speedRelated, tmcRelated } = type;
+  if (speedRelated) {
+    /*
+     * Speed reports MUST have speed data, as the speed class calculations depend on it.
+     * Without that, many of those calculations will return `NaN`.
+     */
+    if (studyType !== StudyType.ATR_SPEED_VOLUME) {
+      throw new InvalidReportIdError(rawId);
+    }
+  } else if (tmcRelated) {
+    /*
+     * TMC reports MUST have TMC data, as the various turning movement totals depend on it.
+     * Without that, many of those calculations will return `NaN`.
+     */
+    if (studyType !== StudyType.TMC) {
+      throw new InvalidReportIdError(rawId);
+    }
+  } else if (studyType === StudyType.TMC) {
+    /*
+     * Other reports MUST NOT have TMC data, as they expect data in the volume-data format
+     * in `"TRAFFIC"."CNT_DET"`.
+     */
+    throw new InvalidReportIdError(rawId);
+  }
+  return {
+    categoryId,
+    countGroupId,
+    study,
+  };
+}
+
+/**
+ * @namespace
+ */
+const ReportIdParser = {
+  parseCollisionReportId,
+  parseStudyReportId,
+};
+
+export {
+  ReportIdParser as default,
+  parseCollisionReportId,
+  parseStudyReportId,
+};

--- a/tests/jest/api/LocationController.spec.js
+++ b/tests/jest/api/LocationController.spec.js
@@ -147,5 +147,5 @@ test('LocationController.getLocationsByCorridor [no corridor found]', async () =
   const s1 = CompositeId.encode(features);
   const data = { s1 };
   const response = await client.fetch('/locations/byCorridor', { data });
-  expect(response.statusCode).toBe(HttpStatus.NOT_FOUND.statusCode);
+  expect(response.statusCode).toBe(HttpStatus.BAD_REQUEST.statusCode);
 });

--- a/tests/jest/db/JobDAO.spec.js
+++ b/tests/jest/db/JobDAO.spec.js
@@ -1,7 +1,7 @@
 import PgBoss from 'pg-boss';
 import { v4 as uuidv4 } from 'uuid';
 
-import { ReportFormat, ReportType } from '@/lib/Constants';
+import { LocationSelectionType, ReportFormat, ReportType } from '@/lib/Constants';
 import db from '@/lib/db/db';
 import JobDAO from '@/lib/db/JobDAO';
 import JobType from '@/lib/jobs/JobType';
@@ -33,6 +33,8 @@ test('JobDAO', async () => {
         { type: ReportType.SPEED_PERCENTILE, id: '4/12345', format: ReportFormat.PDF },
         { type: ReportType.SPEED_PERCENTILE, id: '4/67890', format: ReportFormat.PDF },
       ],
+      s1: 's1:AMgvmB8PvmB',
+      selectionType: LocationSelectionType.POINTS,
     },
     createdon: DateTimeZone.utc(),
   };

--- a/tests/jest/db/JobMetadataDAO.spec.js
+++ b/tests/jest/db/JobMetadataDAO.spec.js
@@ -1,6 +1,11 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import { ReportExportMode, ReportFormat, ReportType } from '@/lib/Constants';
+import {
+  LocationSelectionType,
+  ReportExportMode,
+  ReportFormat,
+  ReportType,
+} from '@/lib/Constants';
 import db from '@/lib/db/db';
 import JobMetadataDAO from '@/lib/db/JobMetadataDAO';
 import UserDAO from '@/lib/db/UserDAO';
@@ -24,6 +29,7 @@ test('JobMetadataDAO', async () => {
         { type: ReportType.SPEED_PERCENTILE, id: '4/67890', format: ReportFormat.PDF },
       ],
       s1: 's1:AMgvmB8PvmB',
+      selectionType: LocationSelectionType.POINTS,
     },
     createdon: DateTimeZone.utc(),
   };
@@ -47,6 +53,7 @@ test('JobMetadataDAO', async () => {
     metadata: {
       reportExportMode: ReportExportMode.STUDIES,
       s1: 's1:AMgvmB8PvmB',
+      selectionType: LocationSelectionType.POINTS,
     },
     result: null,
   });
@@ -80,12 +87,13 @@ test('JobMetadataDAO', async () => {
     id: jobId2,
     name: JobType.GENERATE_REPORTS.jobName,
     data: {
-      s1: 's1:AMgvmB8PvmB',
       reportExportMode: ReportExportMode.STUDIES,
       reports: [
         { type: ReportType.COUNT_SUMMARY_24H, id: '1/4321', format: ReportFormat.CSV },
         { type: ReportType.COUNT_SUMMARY_24H, id: '1/8765', format: ReportFormat.CSV },
       ],
+      s1: 's1:AMgvmB8PvmB',
+      selectionType: LocationSelectionType.POINTS,
     },
     createdon: DateTimeZone.utc(),
   };

--- a/tests/jest/db/StoragePathDb.spec.js
+++ b/tests/jest/db/StoragePathDb.spec.js
@@ -1,0 +1,96 @@
+import {
+  LocationSelectionType,
+  MAX_LOCATIONS,
+  ReportExportMode,
+  ReportType,
+} from '@/lib/Constants';
+import Random from '@/lib/Random';
+import db from '@/lib/db/db';
+import CategoryDAO from '@/lib/db/CategoryDAO';
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import CompositeId from '@/lib/io/CompositeId';
+import StoragePath from '@/lib/io/storage/StoragePath';
+
+afterAll(() => {
+  db.$pool.end();
+});
+
+function generateLocationsSelection(locationsAll) {
+  const k = Random.range(1, MAX_LOCATIONS + 1);
+  const locations = Random.sample(locationsAll, k);
+  return { locations, selectionType: LocationSelectionType.POINTS };
+}
+
+function generateReportFormat(reportType) {
+  return Random.choice(reportType.formats);
+}
+
+function generateCollisionReportType() {
+  const reportTypes = ReportType.enumValues
+    .filter(({ reportExportMode }) => reportExportMode === ReportExportMode.COLLISIONS);
+  return Random.choice(reportTypes);
+}
+
+function generateStudyReportType(studyType) {
+  const reportTypes = studyType.reportTypes
+    .filter(reportType => !Object.prototype.hasOwnProperty.call(reportType, 'options'));
+  return Random.choice(reportTypes);
+}
+
+test('StoragePath.forReport [collision fuzz test]', async () => {
+  const sql = `
+SELECT centreline_id, centreline_type
+FROM counts.studies TABLESAMPLE BERNOULLI (1)`;
+  const rows = await db.manyOrNone(sql);
+  const features = rows.map(({ centreline_id: centrelineId, centreline_type: centrelineType }) => ({
+    centrelineId,
+    centrelineType,
+  }));
+  const locationsAll = await CentrelineDAO.byFeatures(features);
+
+  const n = 25;
+  for (let i = 0; i < n; i++) {
+    const locationsSelection = generateLocationsSelection(locationsAll);
+    const { locations, selectionType } = locationsSelection;
+    const s1 = CompositeId.encode(locations);
+    const id = `${s1}/${selectionType.name}`;
+    const type = generateCollisionReportType();
+    const format = generateReportFormat(type);
+
+    const report = { type, id, format };
+    /* eslint-disable-next-line no-await-in-loop */
+    const { namespace, key } = await StoragePath.forReport(report);
+    expect(namespace).toEqual(StoragePath.NAMESPACE_REPORTS_COLLISION);
+    expect(key.length).toBeLessThan(200);
+    expect(key).toMatch(/[A-Z0-9-]+/);
+  }
+});
+
+test('StoragePath.forReport [study fuzz test]', async () => {
+  const categories = await CategoryDAO.all();
+
+  const sql = `
+SELECT "CATEGORY_ID", count_group_id
+FROM counts.studies TABLESAMPLE BERNOULLI (1)`;
+  const rows = await db.manyOrNone(sql);
+
+  const n = rows.length;
+  for (let i = 0; i < n; i++) {
+    const { CATEGORY_ID: categoryId, count_group_id: countGroupId } = rows[i];
+    const id = `${categoryId}/${countGroupId}`;
+    const { studyType } = categories.get(categoryId);
+    if (studyType === null) {
+      /* eslint-disable-next-line no-continue */
+      continue;
+    }
+    const type = generateStudyReportType(studyType);
+    const format = generateReportFormat(type);
+
+    const report = { type, id, format };
+    /* eslint-disable-next-line no-await-in-loop */
+    const { namespace, key } = await StoragePath.forReport(report);
+    expect(namespace).toEqual(StoragePath.NAMESPACE_REPORTS_STUDY);
+    expect(key.length).toBeLessThan(200);
+    expect(key).toMatch(/[A-Z0-9-]+/);
+  }
+});

--- a/tests/jest/unit/io/storage/StoragePath.spec.js
+++ b/tests/jest/unit/io/storage/StoragePath.spec.js
@@ -32,7 +32,8 @@ test('StoragePath.forReportZip', async () => {
     id: '1/2345',
     format: ReportFormat.CSV,
   };
-  const { namespace, key } = await StoragePath.forReportZip([report]);
+  const storagePath = await StoragePath.forReport(report);
+  const { namespace, key } = await StoragePath.forReportZip([report], [storagePath]);
   expect(namespace).toEqual(StoragePath.NAMESPACE_REPORTS);
   expect(key).toMatch(/[a-f0-9]+\.zip/);
 });

--- a/tests/jest/unit/io/storage/StoragePath.spec.js
+++ b/tests/jest/unit/io/storage/StoragePath.spec.js
@@ -1,13 +1,13 @@
 import { ReportFormat, ReportType } from '@/lib/Constants';
 import StoragePath from '@/lib/io/storage/StoragePath';
 
-test('StoragePath.forReport', () => {
+test('StoragePath.forReport', async () => {
   let report = {
     type: ReportType.SPEED_PERCENTILE,
     id: '1/2345',
     format: ReportFormat.CSV,
   };
-  expect(StoragePath.forReport(report)).toEqual({
+  await expect(StoragePath.forReport(report)).resolves.toEqual({
     namespace: StoragePath.NAMESPACE_REPORTS,
     key: 'SPEED_PERCENTILE_1_2345.csv',
   });
@@ -20,19 +20,19 @@ test('StoragePath.forReport', () => {
     foo: 1,
     bar: 'baz',
   };
-  expect(StoragePath.forReport(report)).toEqual({
+  await expect(StoragePath.forReport(report)).resolves.toEqual({
     namespace: StoragePath.NAMESPACE_REPORTS,
     key: 'COLLISION_DIRECTORY_s1:AkttmBoXtmB_204c1293209bcf240d71f87d91f3f0eb.pdf',
   });
 });
 
-test('StoragePath.forReportZip', () => {
+test('StoragePath.forReportZip', async () => {
   const report = {
     type: ReportType.SPEED_PERCENTILE,
     id: '1/2345',
     format: ReportFormat.CSV,
   };
-  const { namespace, key } = StoragePath.forReportZip([report]);
+  const { namespace, key } = await StoragePath.forReportZip([report]);
   expect(namespace).toEqual(StoragePath.NAMESPACE_REPORTS);
   expect(key).toMatch(/[a-f0-9]+\.zip/);
 });

--- a/tests/jest/unit/io/storage/StoragePath.spec.js
+++ b/tests/jest/unit/io/storage/StoragePath.spec.js
@@ -1,39 +1,145 @@
-import { ReportFormat, ReportType } from '@/lib/Constants';
+import {
+  CardinalDirection,
+  CentrelineType,
+  LocationSelectionType,
+  ReportExportMode,
+  ReportFormat,
+  ReportType,
+  StudyType,
+} from '@/lib/Constants';
+import ArteryDAO from '@/lib/db/ArteryDAO';
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import CountDAO from '@/lib/db/CountDAO';
+import StudyDAO from '@/lib/db/StudyDAO';
 import StoragePath from '@/lib/io/storage/StoragePath';
+import DateTime from '@/lib/time/DateTime';
 
-test('StoragePath.forReport', async () => {
-  let report = {
-    type: ReportType.SPEED_PERCENTILE,
-    id: '1/2345',
-    format: ReportFormat.CSV,
-  };
-  await expect(StoragePath.forReport(report)).resolves.toEqual({
-    namespace: StoragePath.NAMESPACE_REPORTS,
-    key: 'SPEED_PERCENTILE_1_2345.csv',
-  });
+jest.mock('@/lib/db/ArteryDAO');
+jest.mock('@/lib/db/CentrelineDAO');
+jest.mock('@/lib/db/CountDAO');
+jest.mock('@/lib/db/StudyDAO');
 
-  report = {
+test('StoragePath.forReport [collision]', async () => {
+  CentrelineDAO.byFeatures.mockResolvedValue([
+    { description: 'St Clair Ave W / Hounslow Heath Rd / Silverthorn Ave' },
+    { description: 'Old Weston Rd / Turnberry Ave' },
+  ]);
+
+  const report = {
     type: ReportType.COLLISION_DIRECTORY,
-    id: 's1:AkttmBoXtmB',
+    id: 's1:AkttmBoXtmB/POINTS',
     format: ReportFormat.PDF,
     // options
     foo: 1,
     bar: 'baz',
   };
   await expect(StoragePath.forReport(report)).resolves.toEqual({
-    namespace: StoragePath.NAMESPACE_REPORTS,
-    key: 'COLLISION_DIRECTORY_s1:AkttmBoXtmB_204c1293209bcf240d71f87d91f3f0eb.pdf',
+    namespace: StoragePath.NAMESPACE_REPORTS_COLLISION,
+    key: 'COLLISION_DIRECTORY_ST_CLAIR_AVE_W_HOUNSLOW_HEATH_RD_SILVERTHORN_AVE_PLUS_1_LOCATION_s1:AkttmBoXtmB_POINTS_204c1293.pdf',
   });
 });
 
-test('StoragePath.forReportZip', async () => {
+test('StoragePath.forReport [study, intersection]', async () => {
+  CentrelineDAO.byFeature.mockResolvedValue({
+    centrelineType: CentrelineType.INTERSECTION,
+    description: 'Caledonia Rd / Rogers Rd',
+  });
+  StudyDAO.byCategoryAndCountGroup.mockResolvedValue({
+    startDate: DateTime.fromObject({ year: 2018, month: 3, day: 24 }),
+    type: { studyType: StudyType.TMC },
+  });
+
   const report = {
-    type: ReportType.SPEED_PERCENTILE,
-    id: '1/2345',
+    type: ReportType.COUNT_SUMMARY_TURNING_MOVEMENT,
+    id: '5/36853',
     format: ReportFormat.CSV,
   };
-  const storagePath = await StoragePath.forReport(report);
-  const { namespace, key } = await StoragePath.forReportZip([report], [storagePath]);
-  expect(namespace).toEqual(StoragePath.NAMESPACE_REPORTS);
-  expect(key).toMatch(/[a-f0-9]+\.zip/);
+  await expect(StoragePath.forReport(report)).resolves.toEqual({
+    namespace: StoragePath.NAMESPACE_REPORTS_STUDY,
+    key: 'COUNT_SUMMARY_TURNING_MOVEMENT_CALEDONIA_RD_ROGERS_RD_2018-03-24_5_36853.csv',
+  });
+});
+
+test('StoragePath.forReport [study, midblock]', async () => {
+  // /reporter/reports?type=SPEED_PERCENTILE&id=4%2F1349804&format=WEB
+  ArteryDAO.byStudy.mockResolvedValue([
+    { arteryCode: 11744, approachDir: CardinalDirection.SOUTH },
+    { arteryCode: 37691, approachDir: CardinalDirection.NORTH },
+  ]);
+  CentrelineDAO.byFeature.mockResolvedValue({
+    centrelineType: CentrelineType.SEGMENT,
+    description: 'Silverthorn Ave: Rockwell Ave \u2013 Turnberry Ave',
+  });
+  CountDAO.byStudy.mockResolvedValue([
+    { arteryCode: 11744 },
+  ]);
+  StudyDAO.byCategoryAndCountGroup.mockResolvedValue({
+    startDate: DateTime.fromObject({ year: 2011, month: 3, day: 1 }),
+    type: { studyType: StudyType.ATR_SPEED_VOLUME },
+  });
+
+  const report = {
+    type: ReportType.SPEED_PERCENTILE,
+    id: '4/1349804',
+    format: ReportFormat.PDF,
+  };
+  await expect(StoragePath.forReport(report)).resolves.toEqual({
+    namespace: StoragePath.NAMESPACE_REPORTS_STUDY,
+    key: 'SPEED_PERCENTILE_SILVERTHORN_AVE_ROCKWELL_AVE-TURNBERRY_AVE_SB_2011-03-01_4_1349804.pdf',
+  });
+});
+
+test('StoragePath.forReportZip [collision]', async () => {
+  CentrelineDAO.byFeatures.mockResolvedValue([
+    { description: 'St Clair Ave W / Hounslow Heath Rd / Silverthorn Ave' },
+    { description: 'Old Weston Rd / Turnberry Ave' },
+  ]);
+
+  const report = {
+    type: ReportType.COLLISION_DIRECTORY,
+    id: 's1:AkttmBoXtmB/POINTS',
+    format: ReportFormat.PDF,
+    // options
+    foo: 1,
+    bar: 'baz',
+  };
+  const storagePath = {
+    namespace: StoragePath.NAMESPACE_REPORTS_COLLISION,
+    key: 'COLLISION_DIRECTORY_ST_CLAIR_AVE_W_HOUNSLOW_HEATH_RD_SILVERTHORN_AVE_PLUS_1_LOCATION_s1:AkttmBoXtmB_POINTS_204c1293.pdf',
+  };
+  await expect(StoragePath.forReportZip({
+    reportExportMode: ReportExportMode.COLLISIONS,
+    reports: [report],
+    s1: 's1:AkttmBoXtmB',
+    selectionType: LocationSelectionType.POINTS,
+  }, [storagePath])).resolves.toEqual({
+    namespace: StoragePath.NAMESPACE_REPORTS_COLLISION,
+    key: 'COLLISION_ST_CLAIR_AVE_W_HOUNSLOW_HEATH_RD_SILVERTHORN_AVE_PLUS_1_LOCATION_9de06bf8.zip',
+  });
+});
+
+test('StoragePath.forReportZip [study]', async () => {
+  CentrelineDAO.byFeatures.mockResolvedValue([{
+    centrelineType: CentrelineType.SEGMENT,
+    description: 'Silverthorn Ave: Rockwell Ave \u2013 Turnberry Ave',
+  }]);
+
+  const report = {
+    type: ReportType.SPEED_PERCENTILE,
+    id: '4/1349804',
+    format: ReportFormat.PDF,
+  };
+  const storagePath = {
+    namespace: StoragePath.NAMESPACE_REPORTS_STUDY,
+    key: 'SPEED_PERCENTILE_SILVERTHORN_AVE_ROCKWELL_AVE-TURNBERRY_AVE_SB_2011-03-01_4_1349804.pdf',
+  };
+  await expect(StoragePath.forReportZip({
+    reportExportMode: ReportExportMode.STUDIES,
+    reports: [report],
+    s1: 's1:ANHtIA',
+    selectionType: LocationSelectionType.POINTS,
+  }, [storagePath])).resolves.toEqual({
+    namespace: StoragePath.NAMESPACE_REPORTS_STUDY,
+    key: 'STUDY_SILVERTHORN_AVE_ROCKWELL_AVE-TURNBERRY_AVE_1_TOTAL_76976bae.zip',
+  });
 });

--- a/tests/jest/unit/reports/ReportIdParser.spec.js
+++ b/tests/jest/unit/reports/ReportIdParser.spec.js
@@ -1,0 +1,130 @@
+import {
+  CentrelineType,
+  LocationSelectionType,
+  ReportType,
+  StudyType,
+} from '@/lib/Constants';
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import StudyDAO from '@/lib/db/StudyDAO';
+import { InvalidReportIdError } from '@/lib/error/MoveErrors';
+import { parseCollisionReportId, parseStudyReportId } from '@/lib/reports/ReportIdParser';
+
+jest.mock('@/lib/db/CentrelineDAO');
+jest.mock('@/lib/db/StudyDAO');
+
+test('ReportIdParser.parseCollisionReportId [invalid]', async () => {
+  expect(parseCollisionReportId('')).rejects.toBeInstanceOf(InvalidReportIdError);
+  expect(parseCollisionReportId('/')).rejects.toBeInstanceOf(InvalidReportIdError);
+  expect(parseCollisionReportId('abc')).rejects.toBeInstanceOf(InvalidReportIdError);
+  expect(parseCollisionReportId('s1:AkttmBoXtmB')).rejects.toBeInstanceOf(InvalidReportIdError);
+  expect(parseCollisionReportId('s1:AkttmBoXtmB/')).rejects.toBeInstanceOf(InvalidReportIdError);
+  expect(parseCollisionReportId('/CORRIDOR')).rejects.toBeInstanceOf(InvalidReportIdError);
+  expect(
+    parseCollisionReportId('s1:AkttmBoXtmB/blargl'),
+  ).rejects.toBeInstanceOf(InvalidReportIdError);
+  expect(parseCollisionReportId('s1:/POINTS')).rejects.toBeInstanceOf(InvalidReportIdError);
+  expect(parseCollisionReportId('5/36853')).rejects.toBeInstanceOf(InvalidReportIdError);
+});
+
+test('ReportIdParser.parseCollisionReportId', async () => {
+  const resolvedValue = [{ a: 42 }, { b: 'foo' }];
+  CentrelineDAO.byFeatures.mockResolvedValue(resolvedValue);
+  expect(parseCollisionReportId('s1:AkttmBoXtmB/POINTS')).resolves.toEqual({
+    features: [
+      { centrelineId: 13462962, centrelineType: CentrelineType.SEGMENT },
+      { centrelineId: 13462260, centrelineType: CentrelineType.SEGMENT },
+    ],
+    locationsSelection: {
+      locations: resolvedValue,
+      selectionType: LocationSelectionType.POINTS,
+    },
+    s1: 's1:AkttmBoXtmB',
+    selectionType: LocationSelectionType.POINTS,
+  });
+});
+
+test('ReportIdParser.parseStudyReportId [invalid]', async () => {
+  expect(
+    parseStudyReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, ''),
+  ).rejects.toBeInstanceOf(InvalidReportIdError);
+  expect(
+    parseStudyReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, '/'),
+  ).rejects.toBeInstanceOf(InvalidReportIdError);
+  expect(
+    parseStudyReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, 'abc'),
+  ).rejects.toBeInstanceOf(InvalidReportIdError);
+  expect(
+    parseStudyReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, '5'),
+  ).rejects.toBeInstanceOf(InvalidReportIdError);
+  expect(
+    parseStudyReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, '5/'),
+  ).rejects.toBeInstanceOf(InvalidReportIdError);
+  expect(
+    parseStudyReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, '/36583'),
+  ).rejects.toBeInstanceOf(InvalidReportIdError);
+  expect(
+    parseStudyReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, '5/blargl'),
+  ).rejects.toBeInstanceOf(InvalidReportIdError);
+  expect(
+    parseStudyReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, 'foo/36583'),
+  ).rejects.toBeInstanceOf(InvalidReportIdError);
+  expect(
+    parseStudyReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, 's1:AkttmBoXtmB/POINTS'),
+  ).rejects.toBeInstanceOf(InvalidReportIdError);
+});
+
+test('ReportIdParser.parseStudyReportId [speed-related]', async () => {
+  let resolvedValue = {
+    type: { studyType: StudyType.ATR_SPEED_VOLUME },
+  };
+  StudyDAO.byCategoryAndCountGroup.mockResolvedValue(resolvedValue);
+  expect(
+    parseCollisionReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, '5/36583'),
+  ).rejects.toBeInstanceOf(InvalidReportIdError);
+  expect(
+    parseCollisionReportId(ReportType.SPEED_PERCENTILE, '4/1234'),
+  ).resolves.toEqual({
+    categoryId: 4,
+    countGroupId: 1234,
+    study: resolvedValue,
+  });
+
+  resolvedValue = {
+    type: { studyType: StudyType.ATR_VOLUME },
+  };
+  StudyDAO.byCategoryAndCountGroup.mockResolvedValue(resolvedValue);
+  expect(
+    parseCollisionReportId(ReportType.SPEED_PERCENTILE, '4/1234'),
+  ).rejects.toBeInstanceOf(InvalidReportIdError);
+});
+
+test('ReportIdParser.parseStudyReportId [TMC-related]', async () => {
+  const resolvedValue = {
+    type: { studyType: StudyType.TMC },
+  };
+  StudyDAO.byCategoryAndCountGroup.mockResolvedValue(resolvedValue);
+  expect(
+    parseCollisionReportId(ReportType.SPEED_PERCENTILE, '4/1234'),
+  ).rejects.toBeInstanceOf(InvalidReportIdError);
+  expect(
+    parseCollisionReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, '5/36583'),
+  ).resolves.toEqual({
+    categoryId: 5,
+    countGroupId: 36853,
+    study: resolvedValue,
+  });
+});
+
+test('ReportIdParser.parseStudyReportId [neither speed- nor TMC-related]', async () => {
+  const resolvedValue = {
+    type: { studyType: StudyType.ATR_VOLUME },
+  };
+  StudyDAO.byCategoryAndCountGroup.mockResolvedValue(resolvedValue);
+  expect(
+    parseCollisionReportId(ReportType.COUNT_SUMMARY_24H_GRAPHICAL, '1/5678'),
+  ).resolves.toEqual({
+    categoryId: 1,
+    countGroupId: 5678,
+    study: resolvedValue,
+  });
+});

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -174,7 +174,9 @@ export default {
   },
   computed: {
     activeReportId() {
-      return CompositeId.encode(this.locationsActive);
+      const { locations, selectionType } = this.locationsSelection;
+      const s1 = CompositeId.encode(locations);
+      return `${s1}/${selectionType.name}`;
     },
     activeReportType() {
       const { indexActiveReportType, reportTypes } = this;

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -265,7 +265,7 @@ export default {
     async actionDownloadReportFormatStudies(reportFormat) {
       const job = await postJobGenerateStudyReports(
         this.auth.csrf,
-        this.locations,
+        this.locationsSelection,
         this.filterParamsStudy,
         reportFormat,
       );

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -250,7 +250,7 @@ export default {
     async actionDownloadReportFormatCollisions(reportFormat) {
       const job = await postJobGenerateCollisionReports(
         this.auth.csrf,
-        this.locations,
+        this.locationsSelection,
         this.filterParamsCollision,
         reportFormat,
       );


### PR DESCRIPTION
# Issue Addressed
This PR closes #639 .

# Description
We refactor `StoragePath` considerably, making the `forXXX` methods async so that we can fetch information from database to build filenames here.  To help with that, we add `selectionType` to `GENERATE_REPORTS` jobs in `scheduler`, and update the whole report stack to use this plus `RoutingDAO` (via the new `FeatureResolver`) instead of a pre-resolved set of locations.

# Tests
Ran `npm run ci:jest-coverage` to test, which includes revamped `StoragePath` testing.  Generated several reports, both single and bulk, and both web and download, to ensure this doesn't break anything.
