### PR TITLE
Allow user to override auto-detected intersection type and road width

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -394,9 +394,14 @@ ReportParameter.init({
       return true;
     },
   },
-  DATE_YEAR: {
+  BOOLEAN_NULLABLE: {
+    defaultValue() {
+      return null;
+    },
+  },
+  DATE: {
     defaultValue({ state }) {
-      return state.now.year - 3;
+      return state.now.minus({ years: 3 });
     },
   },
   PREVENTABLE_COLLISIONS: {
@@ -558,8 +563,10 @@ ReportType.init({
     label: 'Warrant: Traffic Signal Control',
     options: {
       adequateTrial: ReportParameter.BOOLEAN,
+      isTwoLane: ReportParameter.BOOLEAN_NULLABLE,
+      isXIntersection: ReportParameter.BOOLEAN_NULLABLE,
       preventablesByYear: ReportParameter.PREVENTABLE_COLLISIONS,
-      startYear: ReportParameter.DATE_YEAR,
+      startDate: ReportParameter.DATE,
     },
     orientation: PageOrientation.PORTRAIT,
     reportExportMode: ReportExportMode.STUDIES,

--- a/lib/controller/ReportController.js
+++ b/lib/controller/ReportController.js
@@ -32,11 +32,11 @@ function getSchemaForReportParameter(reportParameter) {
   if (reportParameter === ReportParameter.BOOLEAN) {
     return Joi.boolean().required();
   }
-  if (reportParameter === ReportParameter.DATE_YEAR) {
-    return Joi.number().integer().positive().required();
+  if (reportParameter === ReportParameter.BOOLEAN_NULLABLE) {
+    return Joi.boolean().default(null);
   }
-  if (reportParameter === ReportParameter.INTEGER_NON_NEGATIVE) {
-    return Joi.number().integer().min(0).required();
+  if (reportParameter === ReportParameter.DATE) {
+    return Joi.dateTime().required();
   }
   if (reportParameter === ReportParameter.PREVENTABLE_COLLISIONS) {
     return Joi.array().length(3).items(

--- a/lib/reports/ReportWarrantTrafficSignalControl.js
+++ b/lib/reports/ReportWarrantTrafficSignalControl.js
@@ -9,6 +9,7 @@ import ArrayStats from '@/lib/math/ArrayStats';
 import ReportBaseFlowDirectional from '@/lib/reports/ReportBaseFlowDirectional';
 import ReportCountSummaryTurningMovement from '@/lib/reports/ReportCountSummaryTurningMovement';
 import ReportIntersectionSummary from '@/lib/reports/ReportIntersectionSummary';
+import TimeFormatters from '@/lib/time/TimeFormatters';
 
 /**
  * Full and partial thresholds for compliance, as used in warrant sections 1A, 1B, 2A, and 2B.
@@ -51,9 +52,11 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
    * {@link ReportBaseFlowDirectional}
    * @param {Array<Object>} segments - segments incident to intersection under
    * study, as computed by {@link ReportBaseFlowDirectional}
+   * @param {Object} options - extra report-specific options parsed from
+   * {@link ReportController#getReport}
    * @returns thresholds for warrant sections 1A, 1B, 2A, 2B, and 3C
    */
-  static getThresholds(minFeatureCode, segments) {
+  static getThresholds(minFeatureCode, segments, options) {
     /*
      * As per the City of Toronto Road Classification System p.9, all major arterials and
      * expressways are guaranteed to have at least 4 lanes.
@@ -62,7 +65,9 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
      * feature codes here.  (This also makes intuitive sense, in that the goal of the
      * Road Classification System is to distinguish road types by intended use.)
      */
-    const isTwoLane = minFeatureCode >= FeatureCode.MINOR_ARTERIAL;
+    const isTwoLane = options.isTwoLane === null
+      ? minFeatureCode >= FeatureCode.MINOR_ARTERIAL
+      : options.isTwoLane;
 
     /*
      * For purposes of this report, we consider a "T" intersection to be any intersection
@@ -72,7 +77,9 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
      * here is "Intersection Configuration" as the number of approaches to the intersection.
      * This strongly suggests that this road segment counting approach is appropriate here.
      */
-    const isXIntersection = segments.length >= 4;
+    const isXIntersection = options.isXIntersection === null
+      ? segments.length >= 4
+      : options.isXIntersection;
 
     /*
      * For 1A (total approaches), the threshold depends on whether the road has two
@@ -299,7 +306,7 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
     const {
       adequateTrial: compliance3B,
       preventablesByYear: annual3A,
-      startYear,
+      startDate,
     } = options;
 
     const total3A = ArrayStats.sum(annual3A);
@@ -323,7 +330,7 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
       a: {
         annual: annual3A,
         compliance: compliance3A,
-        startYear,
+        startDate,
         threshold: threshold3A,
         value: value3A,
       },
@@ -393,7 +400,7 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
       threshold2A,
       threshold2B,
       threshold3A,
-    } = ReportWarrantTrafficSignalControl.getThresholds(minFeatureCode, segments);
+    } = ReportWarrantTrafficSignalControl.getThresholds(minFeatureCode, segments, options);
 
     /*
      * Traffic Signal Control warrants depend on hourly values computed as part of the
@@ -770,18 +777,25 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
   }
 
   static getPreventableCollisionsTableOptions(sectionData) {
-    const { startYear } = sectionData;
-    const startYearPlusOne = startYear + 1;
-    const startYearPlusTwo = startYear + 2;
+    const { startDate } = sectionData;
+
+    const startDateRanges = new Array(3);
+    for (let i = 0; i < 3; i++) {
+      const start = startDate.plus({ years: i });
+      const end = startDate.plus({ days: -1, years: i + 1 });
+      const dateRangeStr = TimeFormatters.formatRangeDate({ start, end });
+      startDateRanges[i] = `Year ${i + 1}: ${dateRangeStr}`;
+    }
+
     return {
       title: 'Warrant 3 \u2013 Collision Hazard',
       caption: '3A. Preventable Collisions Per Year',
       header: [
         [
-          { value: startYear.toString() },
-          { value: startYearPlusOne.toString() },
+          { value: startDateRanges[0] },
+          { value: startDateRanges[1] },
           {
-            value: startYearPlusTwo.toString(),
+            value: startDateRanges[2],
             style: { br: true },
           },
           { value: 'Total' },
@@ -841,10 +855,10 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
     const hoursStr = hours === null ? null : hours.description;
     const pxStr = px === null ? null : px.toString();
     const intersectionTypeStr = isXIntersection ? 'X (4-way)' : 'T (3-way)';
-    const lanesStr = isTwoLane ? '2' : '3 or more';
+    const lanesStr = isTwoLane ? '1-2 lanes' : '3+ lanes';
     const entries = [
       { cols: 3, name: 'Intersection Type', value: intersectionTypeStr },
-      { cols: 3, name: 'Lanes', value: lanesStr },
+      { cols: 3, name: 'Road Width', value: lanesStr },
       { cols: 3, name: 'Study Hours', value: hoursStr },
       { cols: 3, name: 'Traffic Signal #', value: pxStr },
     ];

--- a/lib/time/TimeFormatters.js
+++ b/lib/time/TimeFormatters.js
@@ -166,7 +166,7 @@ class TimeFormatters {
     if (startHuman === endHuman) {
       return startHuman;
     }
-    return `${startHuman}\u2013${endHuman}`;
+    return `${startHuman} to ${endHuman}`;
   }
 
   /**

--- a/tests/jest/unit/Constants.spec.js
+++ b/tests/jest/unit/Constants.spec.js
@@ -5,6 +5,7 @@ import {
   StudyRequestStatus,
 } from '@/lib/Constants';
 import { STUDY_HOURS_HINT_OTHER } from '@/lib/i18n/Strings';
+import DateTime from '@/lib/time/DateTime';
 
 test('HttpStatus#isOk', () => {
   expect(HttpStatus.OK.isOk()).toBe(true);
@@ -13,9 +14,14 @@ test('HttpStatus#isOk', () => {
 
 test('ReportParameter#defaultValue', () => {
   expect(ReportParameter.BOOLEAN.defaultValue()).toEqual(true);
-  expect(ReportParameter.DATE_YEAR.defaultValue({
-    state: { now: { year: 2020 } },
-  })).toEqual(2017);
+  expect(ReportParameter.BOOLEAN_NULLABLE.defaultValue()).toEqual(null);
+  const defaultValueDate = ReportParameter.DATE.defaultValue({
+    state: {
+      now: DateTime.fromObject({ year: 2020, month: 3, day: 17 }),
+    },
+  });
+  const defaultValueDateExpected = DateTime.fromObject({ year: 2017, month: 3, day: 17 });
+  expect(defaultValueDate.equals(defaultValueDateExpected)).toBe(true);
   expect(ReportParameter.PREVENTABLE_COLLISIONS.defaultValue()).toEqual([0, 0, 0]);
 });
 

--- a/tests/jest/unit/reports/ReportWarrantTrafficSignalControl.spec.js
+++ b/tests/jest/unit/reports/ReportWarrantTrafficSignalControl.spec.js
@@ -5,6 +5,7 @@ import { CentrelineType, StudyHours, StudyType } from '@/lib/Constants';
 import { NotImplementedError } from '@/lib/error/MoveErrors';
 import ReportWarrantTrafficSignalControl from '@/lib/reports/ReportWarrantTrafficSignalControl';
 import { loadJsonSync } from '@/lib/test/TestDataLoader';
+import DateTime from '@/lib/time/DateTime';
 
 const countData_5_38661 = loadJsonSync(
   path.resolve(__dirname, './data/countData_5_38661.json'),
@@ -125,8 +126,10 @@ test('ReportWarrantTrafficSignalControl#transformData [Overlea and Thorncliffe: 
   } = setup_5_38661();
   const options = {
     adequateTrial: true,
+    isTwoLane: null,
+    isXIntersection: null,
     preventablesByYear: [3, 5, 10],
-    startYear: 2016,
+    startDate: DateTime.fromObject({ year: 2012, month: 4, day: 1 }),
   };
 
   let transformedData = reportInstance.transformData(study, {

--- a/tests/jest/unit/reports/data/transformedData_WARRANT_TRAFFIC_SIGNAL_CONTROL_5_38661.json
+++ b/tests/jest/unit/reports/data/transformedData_WARRANT_TRAFFIC_SIGNAL_CONTROL_5_38661.json
@@ -201,7 +201,7 @@
         10
       ],
       "compliance": 100,
-      "startYear": 2016,
+      "startDate": "2012-04-01 00:00:00.000",
       "threshold": 5,
       "value": {
         "avg": 6,

--- a/tests/jest/unit/reports/format/MovePdfGenerator.spec.js
+++ b/tests/jest/unit/reports/format/MovePdfGenerator.spec.js
@@ -276,8 +276,10 @@ test('WARRANT_TRAFFIC_SIGNAL_CONTROL', async () => {
   const reportInstance = ReportFactory.getInstance(ReportType.WARRANT_TRAFFIC_SIGNAL_CONTROL);
   const doc = await reportInstance.generate('5/38661', ReportFormat.PDF, {
     adequateTrial: true,
+    isTwoLane: null,
+    isXIntersection: null,
     preventablesByYear: [3, 5, 10],
-    startYear: 2016,
+    startDate: DateTime.fromObject({ year: 2012, month: 4, day: 1 }),
   });
   expect(getNumPages(doc)).toBe(2);
 });

--- a/web/components/dialogs/FcDialogReportParameters.vue
+++ b/web/components/dialogs/FcDialogReportParameters.vue
@@ -1,7 +1,7 @@
 <template>
   <v-dialog
     v-model="internalValue"
-    max-width="300"
+    max-width="336"
     scrollable>
     <v-card role="dialog">
       <v-card-title>Set Parameters</v-card-title>
@@ -27,6 +27,7 @@
 
 <script>
 import { ReportType } from '@/lib/Constants';
+import { reviver } from '@/lib/JsonUtils';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcReportParametersWarrantTrafficSignalControl
   from '@/web/components/reports/FcReportParametersWarrantTrafficSignalControl.vue';
@@ -44,7 +45,11 @@ export default {
     reportType: ReportType,
   },
   data() {
-    const internalReportParameters = JSON.parse(JSON.stringify(this.reportParameters));
+    const internalReportParameters = JSON.parse(
+      JSON.stringify(this.reportParameters),
+      reviver,
+    );
+
     return {
       internalReportParameters,
     };

--- a/web/components/reports/FcReportParametersWarrantTrafficSignalControl.vue
+++ b/web/components/reports/FcReportParametersWarrantTrafficSignalControl.vue
@@ -2,7 +2,8 @@
   <div class="fc-report-parameters fc-report-parameters-warrant-traffic-signal-control">
     <v-checkbox
       name="adequateTrial"
-      v-model="internalValue.adequateTrial">
+      v-model="internalValue.adequateTrial"
+      hide-details>
       <template v-slot:label>
         <span>
           <abbr
@@ -12,30 +13,86 @@
         </span>
       </template>
     </v-checkbox>
-    <v-text-field
-      v-model.number="internalValue.startYear"
-      label="Collisions: Start Year"
-      min="1985"
-      type="number"></v-text-field>
+
+    <h2 class="headline mt-4">Road Geometry Parameters</h2>
+    <v-select
+      v-model="internalValue.isTwoLane"
+      class="mt-2"
+      hide-details
+      :items="itemsIsTwoLane"
+      label="Road Width" />
+    <v-select
+      v-model="internalValue.isXIntersection"
+      class="mt-2"
+      hide-details
+      :items="itemsIsXIntersection"
+      label="Intersection Type" />
+
+    <h2 class="headline mt-4">Collision Parameters</h2>
+    <FcDatePicker
+      v-model="internalValue.startDate"
+      class="mt-2"
+      label="Start Date (MM/DD/YYYY)">
+    </FcDatePicker>
     <v-text-field
       v-for="i in 3"
-      :key="internalValue.startYear + i - 1"
+      :key="i"
       v-model.number="internalValue.preventablesByYear[i - 1]"
+      :disabled="internalValue.startDate === null"
       min="0"
       :name="'preventablesByYear' + (i - 1)"
       type="number">
       <template v-slot:label>
-        <span>Collisions: Preventable, {{internalValue.startYear + i - 1}}</span>
+        <span>Year {{i}}: {{startDateRanges[i - 1]}}</span>
       </template>
     </v-text-field>
   </div>
 </template>
 
 <script>
+import TimeFormatters from '@/lib/time/TimeFormatters';
+import FcDatePicker from '@/web/components/inputs/FcDatePicker.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
 export default {
   name: 'FcReportParametersWarrantTrafficSignalControl',
   mixins: [FcMixinVModelProxy(Object)],
+  components: {
+    FcDatePicker,
+  },
+  data() {
+    const itemsIsTwoLane = [
+      { text: 'Auto-detect', value: null },
+      { text: '1-2 lanes', value: true },
+      { text: '3+ lanes', value: false },
+    ];
+    const itemsIsXIntersection = [
+      { text: 'Auto-detect', value: null },
+      { text: 'T (3-way)', value: false },
+      { text: 'X (4-way)', value: true },
+    ];
+
+    return {
+      itemsIsTwoLane,
+      itemsIsXIntersection,
+    };
+  },
+  computed: {
+    startDateRanges() {
+      const startDateRanges = new Array(3);
+      if (this.internalStartValue === null) {
+        for (let i = 0; i < 3; i++) {
+          startDateRanges[i] = `Year ${i + 1}`;
+        }
+      } else {
+        for (let i = 0; i < 3; i++) {
+          const start = this.internalValue.startDate.plus({ years: i });
+          const end = this.internalValue.startDate.plus({ days: -1, years: i + 1 });
+          startDateRanges[i] = TimeFormatters.formatRangeDate({ start, end });
+        }
+      }
+      return startDateRanges;
+    },
+  },
 };
 </script>


### PR DESCRIPTION
# Issue Addressed
This PR closes #684 .

# Description
Our current auto-detection misses several key cases, such as minor arterials and midblock intersections with private driveways - so we offer a way for users to bypass it, by adding new parameters to the traffic control signal warrant report type.  Also changed the `startYear` parameter to `startDate`, following user feedback that they'd prefer this level of control over time ranges here.

# Tests
Updated relevant tests and ran as part of pre-commit.  Tested new and changed parameters manually via frontend.
