### PR TITLE
Switch to SI date / time formats

### DIFF
--- a/lib/i18n/Strings.js
+++ b/lib/i18n/Strings.js
@@ -49,7 +49,7 @@ const REQUEST_STUDY_NOT_FOUND = {
  */
 const REQUEST_STUDY_PROVIDE_URGENT_DUE_DATE = {
   variant: 'info',
-  text: 'Please provide a due date in MM/DD/YYYY format for this request.',
+  text: 'Please provide a due date in YYYY-MM-DD format for this request.',
 };
 
 /*

--- a/lib/time/TimeFormatters.js
+++ b/lib/time/TimeFormatters.js
@@ -70,24 +70,21 @@ class TimeFormatters {
    * @returns {string} the formatted date string, or the empty string if `d === null`
    */
   static formatDefault(d) {
-    return TimeFormatters.format(d);
+    return TimeFormatters.formatCsvDate(d);
   }
 
   /**
-   * Format `d` for the `en-US` locale, showing both date and time.  Note that
+   * Format `d` as per ISO 8601 standards, showing both date and time.  Note that
    * {@link formatDefault} only shows date.
    *
    * @param {DateTime} d - date to format
    * @returns {string} the formatted date-time string, or the empty string if `d === null`
    */
   static formatDateTime(d) {
-    return TimeFormatters.format(d, {
-      year: 'numeric',
-      month: 'short',
-      day: '2-digit',
-      hour: 'numeric',
-      minute: '2-digit',
-    });
+    if (d === null) {
+      return '';
+    }
+    return d.toISO().slice(0, 16).replace('T', ' ');
   }
 
   /**
@@ -143,15 +140,10 @@ class TimeFormatters {
    * @returns {string} the formatted time of day, or the empty string if `d === null`
    */
   static formatTimeOfDay(d) {
-    const timeOfDay = TimeFormatters.format(d, {
-      hour12: false,
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-    if (timeOfDay === '24:00') {
-      return '00:00';
+    if (d === null) {
+      return '';
     }
-    return timeOfDay;
+    return d.toISO().slice(11, 16);
   }
 
   /**
@@ -179,19 +171,6 @@ class TimeFormatters {
     const startHuman = TimeFormatters.formatTimeOfDay(start);
     const endHuman = TimeFormatters.formatTimeOfDay(end);
     return `${startHuman}\u2013${endHuman}`;
-  }
-
-  /**
-   * Extract the year and month from `d` in `MMM YYYY` format.
-   *
-   * @param {DateTime} d - date to format
-   * @returns {string} the formatted year and month, or the empty string if `d === null`
-   */
-  static formatYearMonth(d) {
-    return TimeFormatters.format(d, {
-      year: 'numeric',
-      month: 'short',
-    });
   }
 }
 

--- a/tests/jest/unit/reports/format/MovePdfGenerator.spec.js
+++ b/tests/jest/unit/reports/format/MovePdfGenerator.spec.js
@@ -86,6 +86,8 @@ function setup_5_36781() {
     centrelineId: 13464586,
     centrelineType: CentrelineType.INTERSECTION,
     countGroupId: 36781,
+    endDate: DateTime.fromSQL('2018-02-27 00:00:00'),
+    startDate: DateTime.fromSQL('2018-02-27 00:00:00'),
     type: { id: 5, studyType: StudyType.TMC },
   };
   StudyDAO.byCategoryAndCountGroup.mockResolvedValue(study);
@@ -113,6 +115,8 @@ function setup_5_38661() {
     centrelineId: 13456854,
     centrelineType: CentrelineType.INTERSECTION,
     countGroupId: 38661,
+    endDate: DateTime.fromSQL('2019-04-13 00:00:00'),
+    startDate: DateTime.fromSQL('2019-04-13 00:00:00'),
     type: { id: 5, studyType: StudyType.TMC },
   };
   StudyDAO.byCategoryAndCountGroup.mockResolvedValue(study);

--- a/tests/jest/unit/time/TimeFormatters.spec.js
+++ b/tests/jest/unit/time/TimeFormatters.spec.js
@@ -28,10 +28,10 @@ test('TimeFormatters.formatDefault()', () => {
   expect(TimeFormatters.formatDefault(t)).toEqual('');
 
   t = DateTime.fromSQL('1986-07-31 21:16:00');
-  expect(TimeFormatters.formatDefault(t)).toEqual('7/31/1986');
+  expect(TimeFormatters.formatDefault(t)).toEqual('1986-07-31');
 
   t = DateTime.fromSQL('2000-01-01 01:23:45');
-  expect(TimeFormatters.formatDefault(t)).toEqual('1/1/2000');
+  expect(TimeFormatters.formatDefault(t)).toEqual('2000-01-01');
 });
 
 test('TimeFormatters.formatDateTime()', () => {
@@ -39,10 +39,10 @@ test('TimeFormatters.formatDateTime()', () => {
   expect(TimeFormatters.formatDateTime(t)).toEqual('');
 
   t = DateTime.fromSQL('1986-07-31 21:16:00');
-  expect(TimeFormatters.formatDateTime(t)).toEqual('Jul 31, 1986, 9:16 PM');
+  expect(TimeFormatters.formatDateTime(t)).toEqual('1986-07-31 21:16');
 
   t = DateTime.fromSQL('2000-01-01 01:23:45');
-  expect(TimeFormatters.formatDateTime(t)).toEqual('Jan 01, 2000, 1:23 AM');
+  expect(TimeFormatters.formatDateTime(t)).toEqual('2000-01-01 01:23');
 });
 
 test('TimeFormatters.formatDayOfWeek()', () => {
@@ -87,6 +87,16 @@ test('TimeFormatters.formatTimeOfDay()', () => {
   expect(TimeFormatters.formatTimeOfDay(t)).toEqual('01:23');
 });
 
+test('TimeFormatters.formatRangeDate()', () => {
+  let start = DateTime.fromSQL('1986-07-31 21:16:00');
+  let end = DateTime.fromSQL('1986-07-31 22:16:00');
+  expect(TimeFormatters.formatRangeDate({ start, end })).toEqual('1986-07-31');
+
+  start = DateTime.fromSQL('1986-07-31 00:00:00');
+  end = DateTime.fromSQL('2000-01-01 01:23:45');
+  expect(TimeFormatters.formatRangeDate({ start, end })).toEqual('1986-07-31 to 2000-01-01');
+});
+
 test('TimeFormatters.formatRangeTimeOfDay()', () => {
   let start = DateTime.fromSQL('1986-07-31 21:16:00');
   let end = DateTime.fromSQL('1986-07-31 22:16:00');
@@ -95,17 +105,6 @@ test('TimeFormatters.formatRangeTimeOfDay()', () => {
   start = DateTime.fromSQL('1986-07-31 00:00:00');
   end = DateTime.fromSQL('1986-07-31 01:23:45');
   expect(TimeFormatters.formatRangeTimeOfDay({ start, end })).toEqual('00:00\u201301:23');
-});
-
-test('TimeFormatters.formatYearMonth()', () => {
-  let t = null;
-  expect(TimeFormatters.formatYearMonth(t)).toEqual('');
-
-  t = DateTime.fromSQL('1986-07-31 21:16:00');
-  expect(TimeFormatters.formatYearMonth(t)).toEqual('Jul 1986');
-
-  t = DateTime.fromSQL('2000-01-01 01:23:45');
-  expect(TimeFormatters.formatYearMonth(t)).toEqual('Jan 2000');
 });
 
 test('TimeFormatters.DAYS_OF_WEEK', () => {

--- a/web/components/dialogs/FcDialogCollisionFilters.vue
+++ b/web/components/dialogs/FcDialogCollisionFilters.vue
@@ -37,7 +37,7 @@
           :disabled="!internalFilters.applyDateRange"
           :error-messages="errorMessagesDateRangeStart"
           hide-details="auto"
-          label="From (MM/DD/YYYY)"
+          label="From (YYYY-MM-DD)"
           :max="now">
         </FcDatePicker>
         <FcDatePicker
@@ -46,7 +46,7 @@
           :disabled="!internalFilters.applyDateRange"
           :error-messages="errorMessagesDateRangeEnd"
           hide-details="auto"
-          label="To (MM/DD/YYYY)"
+          label="To (YYYY-MM-DD)"
           :max="now">
         </FcDatePicker>
 
@@ -133,14 +133,14 @@ export default {
     errorMessagesDateRangeStart() {
       const errors = [];
       if (!this.$v.internalFilters.dateRangeStart.requiredIfApplyDateRange) {
-        errors.push('Please provide a date in MM/DD/YYYY format.');
+        errors.push('Please provide a date in YYYY-MM-DD format.');
       }
       return errors;
     },
     errorMessagesDateRangeEnd() {
       const errors = [];
       if (!this.$v.internalFilters.dateRangeEnd.requiredIfApplyDateRange) {
-        errors.push('Please provide a date in MM/DD/YYYY format.');
+        errors.push('Please provide a date in YYYY-MM-DD format.');
       }
       return errors;
     },

--- a/web/components/dialogs/FcDialogStudyFilters.vue
+++ b/web/components/dialogs/FcDialogStudyFilters.vue
@@ -47,7 +47,7 @@
           :disabled="!internalFilters.applyDateRange"
           :error-messages="errorMessagesDateRangeStart"
           hide-details="auto"
-          label="From (MM/DD/YYYY)"
+          label="From (YYYY-MM-DD)"
           :max="now">
         </FcDatePicker>
         <FcDatePicker
@@ -56,7 +56,7 @@
           :disabled="!internalFilters.applyDateRange"
           :error-messages="errorMessagesDateRangeEnd"
           hide-details="auto"
-          label="To (MM/DD/YYYY)"
+          label="To (YYYY-MM-DD)"
           :max="now">
         </FcDatePicker>
 
@@ -124,14 +124,14 @@ export default {
     errorMessagesDateRangeStart() {
       const errors = [];
       if (!this.$v.internalFilters.dateRangeStart.requiredIfApplyDateRange) {
-        errors.push('Please provide a date in MM/DD/YYYY format.');
+        errors.push('Please provide a date in YYYY-MM-DD format.');
       }
       return errors;
     },
     errorMessagesDateRangeEnd() {
       const errors = [];
       if (!this.$v.internalFilters.dateRangeEnd.requiredIfApplyDateRange) {
-        errors.push('Please provide a date in MM/DD/YYYY format.');
+        errors.push('Please provide a date in YYYY-MM-DD format.');
       }
       return errors;
     },

--- a/web/components/inputs/FcDatePicker.vue
+++ b/web/components/inputs/FcDatePicker.vue
@@ -63,7 +63,7 @@ function fromValueFormatted(valueFormatted) {
   if (valueFormatted === null) {
     return null;
   }
-  const dt = DateTime.fromLocaleString(valueFormatted);
+  const dt = DateTime.fromISO(valueFormatted);
   if (!dt.isValid) {
     return null;
   }

--- a/web/components/reports/FcReportParametersWarrantTrafficSignalControl.vue
+++ b/web/components/reports/FcReportParametersWarrantTrafficSignalControl.vue
@@ -32,7 +32,7 @@
     <FcDatePicker
       v-model="internalValue.startDate"
       class="mt-2"
-      label="Start Date (MM/DD/YYYY)">
+      label="Start Date (YYYY-MM-DD)">
     </FcDatePicker>
     <v-text-field
       v-for="i in 3"

--- a/web/components/requests/fields/FcStudyRequestUrgent.vue
+++ b/web/components/requests/fields/FcStudyRequestUrgent.vue
@@ -14,7 +14,7 @@
             class="mt-3"
             :error-messages="errorMessagesDueDate"
             hide-details="auto"
-            label="Due Date (MM/DD/YYYY)"
+            label="Due Date (YYYY-MM-DD)"
             :max="maxDueDate"
             :min="minDueDate"
             outlined


### PR DESCRIPTION
# Issue Addressed
This PR closes #708 .

# Description
We switch from MM/DD/YYYY format to the less ambiguous ISO 8601 YYYY-MM-DD format, as per federal standards for human-readable all-numeric dates.

# Tests
Ran `npm run ci:jest-coverage`.  Tested major flows quickly in frontend.
