### PR TITLE
Reduced session timeouts

### DIFF
--- a/lib/auth/SessionTimeouts.js
+++ b/lib/auth/SessionTimeouts.js
@@ -1,0 +1,20 @@
+export default {
+  /*
+   * For admin users, we override the default TTL with a much shorter duration.  This
+   * helps mitigate the risk of leaving an admin session open unattended.
+   *
+   * See the `onPostAuth` hook in `MoveServer`, and `login` in `AuthController`,
+   * for callsites.
+   */
+  TTL_ADMIN: 5 * 60 * 1000,
+
+  /*
+   * Default TTL for user sessions.
+   *
+   * This is deliberately set to the length of core business hours (8am-5pm) at the City
+   * of Toronto.  Sessions started by non-admin users at start-of-day are guaranteed to
+   * remain open through end-of-day, and are also guaranteed to expire before
+   * start-of-next-day.
+   */
+  TTL_NON_ADMIN: 9 * 60 * 60 * 1000,
+};

--- a/lib/controller/AuthController.js
+++ b/lib/controller/AuthController.js
@@ -1,5 +1,6 @@
 import { AuthScope } from '@/lib/Constants';
 import OpenIdClient from '@/lib/auth/OpenIdClient';
+import SessionTimeouts from '@/lib/auth/SessionTimeouts';
 import config from '@/lib/config/MoveConfig';
 import SessionDAO from '@/lib/db/SessionDAO';
 import UserDAO from '@/lib/db/UserDAO';
@@ -21,6 +22,9 @@ async function login(request, { email, sub, uniqueName }) {
   const session = await SessionDAO.create(user, { days: 1 });
   const { id: sessionId } = session;
   request.cookieAuth.set({ sessionId });
+  if (user.scope.includes(AuthScope.ADMIN)) {
+    request.cookieAuth.ttl(SessionTimeouts.TTL_ADMIN);
+  }
   return user;
 }
 

--- a/lib/server/MoveServer.js
+++ b/lib/server/MoveServer.js
@@ -5,6 +5,8 @@ import Good from '@hapi/good';
 import Hapi from '@hapi/hapi';
 import Joi from '@/lib/model/Joi';
 
+import { AuthScope } from '@/lib/Constants';
+import SessionTimeouts from '@/lib/auth/SessionTimeouts';
 import config from '@/lib/config/MoveConfig';
 import db from '@/lib/db/db';
 import UserDAO from '@/lib/db/UserDAO';
@@ -178,9 +180,14 @@ class MoveServer {
         isSecure: true,
         name: 'session',
         path: vueConfig.publicPath,
-        ttl: 24 * 60 * 60 * 1000,
+        ttl: SessionTimeouts.TTL_NON_ADMIN,
         ...config.session,
       },
+      /*
+       * Setting `keepAlive: true` renews the `ttl` expiry period on each request, so that
+       * the session expires after the given period of *inactivity*.
+       */
+      keepAlive: true,
       validateFunc: async (request, session) => {
         const { sessionId } = session;
         const user = await UserDAO.bySessionId(sessionId);
@@ -206,8 +213,12 @@ class MoveServer {
     // LIFECYCLE HOOKS
     this.server.ext('onPostAuth', async (request, h) => {
       if (request.auth.credentials !== null) {
+        const user = await User.read.validateAsync(request.auth.credentials);
+        if (user.scope.includes(AuthScope.ADMIN)) {
+          request.cookieAuth.ttl(SessionTimeouts.TTL_ADMIN);
+        }
         /* eslint-disable-next-line no-param-reassign */
-        request.auth.credentials = await User.read.validateAsync(request.auth.credentials);
+        request.auth.credentials = user;
       }
       return h.continue;
     });

--- a/lib/server/MoveServer.js
+++ b/lib/server/MoveServer.js
@@ -215,7 +215,17 @@ class MoveServer {
       if (request.auth.credentials !== null) {
         const user = await User.read.validateAsync(request.auth.credentials);
         if (user.scope.includes(AuthScope.ADMIN)) {
-          request.cookieAuth.ttl(SessionTimeouts.TTL_ADMIN);
+          if (config.ENV !== 'test') {
+            /*
+              * In test environments, we use `InjectBackendClient` to provide mock authentication
+              * credentials.  This bypasses the normal authentication process, which means that
+              * the authentication cookie is never set, and the `request.cookieAuth.ttl` call
+              * below fails.
+              *
+              * As such, we only perform this TTL update when not in a test environment.
+              */
+            request.cookieAuth.ttl(SessionTimeouts.TTL_ADMIN);
+          }
         }
         /* eslint-disable-next-line no-param-reassign */
         request.auth.credentials = user;


### PR DESCRIPTION
# Issue Addressed
This PR closes #711 .

# Description
We reduce the timeout for admin users to 5 minutes, and for non-admin users to 9 hours.  We also add `keepAlive: true` to our cookie authentication settings, so that these timeouts occur after the specified period of _inactivity_.

Since our CI tests don't actually set the authentication cookie, we also also disable this timeout setting when `config.ENV === 'test'`.

# Tests
Tested that users can still log in and out.  Tested that a non-admin user is given a session good for 9 hours, and that this period is renewed on each request while logged in.  Tested that an admin user is given a session good for 5 minutes, and that this period is renewed on each request while logged in.  Tested directly that leaving an admin session open for 5 minutes with no activity results in the session expiring.  Ran all unit, database, and REST API tests in CI to double-check that this doesn't break anything.
