### PR TITLE
Remove help center link from navbar

### DIFF
--- a/web/components/nav/FcDashboardNav.vue
+++ b/web/components/nav/FcDashboardNav.vue
@@ -31,11 +31,6 @@
       label="Report a Bug"
       :href="urlReportBug"
       target="_blank" />
-    <FcDashboardNavItem
-      icon="help-circle"
-      label="MOVE Help Centre"
-      href="https://www.notion.so/bditto/MOVE-Help-Centre-8a345a510b1a4119a1ddef5aa03e1bdc"
-      target="_blank" />
   </v-list>
 </template>
 


### PR DESCRIPTION
# Issue Addressed
This PR closes #717 .

# Description
As per discussion - this will be placed on our intranet page instead.

# Tests
Ran MOVE, verified that help center link is no longer in navbar.
