### PR TITLE
Add topbar back in for local, dev, QA environments

### DIFF
--- a/web/App.vue
+++ b/web/App.vue
@@ -1,5 +1,7 @@
 <template>
-  <v-app id="fc_app">
+  <v-app
+    id="fc_app"
+    :class="frontendEnv.appClass">
     <component
       v-if="hasDialog"
       v-model="hasDialog"
@@ -25,7 +27,15 @@
       </template>
     </v-navigation-drawer>
     <v-main>
-      <router-view></router-view>
+      <v-container
+        class="d-flex fill-height flex-column pa-0"
+        fluid>
+        <FcDashboardNavInDevelopment
+          v-if="frontendEnv !== FrontendEnv.PROD" />
+        <div class="flex-grow-1" style="width: 100%;">
+          <router-view></router-view>
+        </div>
+      </v-container>
     </v-main>
   </v-app>
 </template>
@@ -51,13 +61,16 @@ import FcToastInfo from '@/web/components/dialogs/FcToastInfo.vue';
 import FcToastJob from '@/web/components/dialogs/FcToastJob.vue';
 import FcDashboardNav from '@/web/components/nav/FcDashboardNav.vue';
 import FcDashboardNavBrand from '@/web/components/nav/FcDashboardNavBrand.vue';
+import FcDashboardNavInDevelopment from '@/web/components/nav/FcDashboardNavInDevelopment.vue';
 import FcDashboardNavUser from '@/web/components/nav/FcDashboardNavUser.vue';
+import FrontendEnv from '@/web/config/FrontendEnv';
 
 export default {
   name: 'App',
   components: {
     FcDashboardNav,
     FcDashboardNavBrand,
+    FcDashboardNavInDevelopment,
     FcDashboardNavUser,
     FcDialogAlertStudyRequestUrgent,
     FcDialogAlertStudyRequestsUnactionable,
@@ -67,6 +80,9 @@ export default {
     FcToastError,
     FcToastInfo,
     FcToastJob,
+  },
+  data() {
+    return { FrontendEnv };
   },
   computed: {
     hasDialog: {
@@ -93,6 +109,7 @@ export default {
       'auth',
       'dialog',
       'dialogData',
+      'frontendEnv',
       'toast',
       'toastData',
       'toastKey',
@@ -106,10 +123,16 @@ export default {
 
 <style lang="scss">
 #fc_app {
+  --full-height: calc(100vh - 52px);
+
   color: var(--v-default-base);
   font-size: 0.875rem;
   font-weight: normal;
   line-height: 1.25rem;
+
+  &.is-prod {
+    --full-height: 100vh;
+  }
 
   & .fc-navigation-drawer {
     overflow: visible;

--- a/web/components/nav/FcDashboardNavBrand.vue
+++ b/web/components/nav/FcDashboardNavBrand.vue
@@ -15,17 +15,22 @@
             src="/logo_square.png"></v-img>
         </v-list-item-icon>
         <v-list-item-content>
-          <v-list-item-title>MOVE</v-list-item-title>
+          <v-list-item-title>{{frontendEnv.appTitle}}</v-list-item-title>
         </v-list-item-content>
       </v-list-item>
     </template>
-    <span>MOVE</span>
+    <span>{{frontendEnv.appTitle}}</span>
   </v-tooltip>
 </template>
 
 <script>
+import { mapState } from 'vuex';
+
 export default {
   name: 'FcDashboardNavBrand',
+  computed: {
+    ...mapState(['frontendEnv']),
+  },
   methods: {
     actionClick() {
       const event = this.$analytics.buttonEvent('MOVE', this.$el);

--- a/web/components/nav/FcDashboardNavInDevelopment.vue
+++ b/web/components/nav/FcDashboardNavInDevelopment.vue
@@ -1,0 +1,75 @@
+<template>
+  <div
+    class="fc-dashboard-nav-in-development align-center d-flex px-5 py-2"
+    :class="classesEnv">
+    <h1 class="headline">
+      This is the {{textEnv}} version of MOVE.  To open this page in the latest release version,
+      click the button at right.
+    </h1>
+    <v-spacer></v-spacer>
+    <FcButton
+      type="secondary"
+      @click="actionProd">
+      <v-icon left>mdi-open-in-new</v-icon>
+      Open in release version
+    </FcButton>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+
+import FcButton from '@/web/components/inputs/FcButton.vue';
+import FrontendEnv from '@/web/config/FrontendEnv';
+
+export default {
+  name: 'FcDashboardNavInDevelopment',
+  components: {
+    FcButton,
+  },
+  data() {
+    return { FrontendEnv };
+  },
+  computed: {
+    classesEnv() {
+      if (this.frontendEnv === FrontendEnv.LOCAL) {
+        return 'light-green lighten-2';
+      }
+      if (this.frontendEnv === FrontendEnv.DEV) {
+        return 'amber lighten-2';
+      }
+      if (this.frontendEnv === FrontendEnv.QA) {
+        return 'light-blue lighten-3';
+      }
+      return '';
+    },
+    textEnv() {
+      if (this.frontendEnv === FrontendEnv.LOCAL) {
+        return 'local';
+      }
+      if (this.frontendEnv === FrontendEnv.DEV) {
+        return 'development';
+      }
+      if (this.frontendEnv === FrontendEnv.QA) {
+        return 'QA';
+      }
+      return '';
+    },
+    urlProd() {
+      return `https://move.intra.prod-toronto.ca${this.$route.fullPath}`;
+    },
+    ...mapState(['frontendEnv']),
+  },
+  methods: {
+    actionProd() {
+      window.open(this.urlProd, '_blank');
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+.fc-dashboard-nav-in-development {
+  width: 100%;
+}
+</style>

--- a/web/config/FrontendEnv.js
+++ b/web/config/FrontendEnv.js
@@ -1,0 +1,40 @@
+import { Enum } from '@/lib/ClassUtils';
+import { EnumValueError } from '@/lib/error/MoveErrors';
+
+class FrontendEnv extends Enum {
+  static get() {
+    if (window.document.domain === 'localhost') {
+      return FrontendEnv.LOCAL;
+    }
+    if (window.location.origin === 'https://move.intra.dev-toronto.ca') {
+      return FrontendEnv.DEV;
+    }
+    if (window.location.origin === 'https://move.intra.qa-toronto.ca') {
+      return FrontendEnv.QA;
+    }
+    if (window.location.origin === 'https://move.intra.prod-toronto.ca') {
+      return FrontendEnv.PROD;
+    }
+    throw new EnumValueError('could not determine frontend environment');
+  }
+}
+FrontendEnv.init({
+  LOCAL: {
+    appClass: 'is-local',
+    appTitle: 'MOVE (local)',
+  },
+  DEV: {
+    appClass: 'is-dev',
+    appTitle: 'MOVE (dev)',
+  },
+  QA: {
+    appClass: 'is-qa',
+    appTitle: 'MOVE (dev)',
+  },
+  PROD: {
+    appClass: 'is-prod',
+    appTitle: 'MOVE',
+  },
+});
+
+export default FrontendEnv;

--- a/web/css/main.scss
+++ b/web/css/main.scss
@@ -117,8 +117,6 @@
 
   --border-default: 1px solid var(--base);
 
-  --full-height: 100vh;
-
   --z-index-controls: 99;
 }
 

--- a/web/router.js
+++ b/web/router.js
@@ -300,13 +300,13 @@ router.beforeEach(async (to, from, next) => {
 function afterEachSetTitle(to) {
   let title = routeMetaKey(to, 'title', undefined);
   if (title === undefined) {
-    document.title = 'MOVE';
+    document.title = store.state.frontendEnv.appTitle;
     return;
   }
   if (title instanceof Function) {
     title = title(to);
   }
-  title = `MOVE \u00b7 ${title}`;
+  title = `${store.state.frontendEnv.appTitle} \u00b7 ${title}`;
   document.title = title;
 }
 

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -24,6 +24,7 @@ import {
 } from '@/lib/i18n/Strings';
 import CompositeId from '@/lib/io/CompositeId';
 import DateTime from '@/lib/time/DateTime';
+import FrontendEnv from '@/web/config/FrontendEnv';
 import viewData from '@/web/store/modules/viewData';
 
 Vue.use(Vuex);
@@ -40,6 +41,7 @@ export default new Vuex.Store({
       loggedIn: false,
       user: null,
     },
+    frontendEnv: FrontendEnv.get(),
     now: DateTime.local(),
     // TOP-LEVEL UI
     dialog: null,


### PR DESCRIPTION
# Issue Addressed
This PR closes #727 .

# Description
We restore `<FcDashboardNavInDevelopment>`, add some environment-specific cues (colour, text), and change the action button to link to production.  In the process, we introduce `FrontendEnv`, a general-purpose way to introduce environment-specific changes in the frontend.

# Tests
Tested quickly in browser, will be rolling out to dev / QA to test there.