### PR TITLE
Update MOVE web backend to use new centreline conflation target

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -586,6 +586,10 @@ ReportType.init({
  */
 class RoadIntersectionType extends Enum {}
 RoadIntersectionType.init({
+  UNKNOWN: {
+    featureCode: 0,
+    description: 'Intersection',
+  },
   EXPRESSWAY: {
     featureCode: 501100,
     description: 'Expressway Intersection',
@@ -601,6 +605,34 @@ RoadIntersectionType.init({
   LANEWAY: {
     featureCode: 501700,
     description: 'Laneway Intersection',
+  },
+  RAILWAY: {
+    featureCode: 502000,
+    description: 'Railway Intersection',
+  },
+  PEDESTRIAN: {
+    featureCode: 504000,
+    description: 'Pedestrian Intersection',
+  },
+  CUL_DE_SAC: {
+    featureCode: 509100,
+    description: 'Cul-de-sac Intersection',
+  },
+  PSEUDO: {
+    featureCode: 509200,
+    description: 'Pseudo-Intersection',
+  },
+  UTILITY: {
+    featureCode: 509300,
+    description: 'Utility Intersection',
+  },
+  RIVER: {
+    featureCode: 509400,
+    description: 'River Intersection',
+  },
+  NONE: {
+    featureCode: 509900,
+    description: 'No Intersection',
   },
 });
 
@@ -664,6 +696,14 @@ RoadSegmentType.init({
   PENDING: {
     featureCode: 201800,
     description: 'Pending',
+  },
+  BUSWAY: {
+    featureCode: 201801,
+    description: 'Busway',
+  },
+  ACCESS_ROAD: {
+    featureCode: 201803,
+    description: 'Access Road',
   },
 });
 

--- a/lib/controller/LocationController.js
+++ b/lib/controller/LocationController.js
@@ -2,8 +2,6 @@ import Boom from '@hapi/boom';
 
 import {
   CentrelineType,
-  FEATURE_CODES_INTERSECTION,
-  FEATURE_CODES_SEGMENT,
   HttpStatus,
   LocationSelectionType,
   LocationSearchType,
@@ -16,15 +14,6 @@ import CompositeId from '@/lib/io/CompositeId';
 import Joi from '@/lib/model/Joi';
 import CentrelineLocation from '@/lib/model/helpers/CentrelineLocation';
 import CentrelineSelection from '@/lib/model/helpers/CentrelineSelection';
-
-function filterLocations(locations) {
-  return locations.filter(({ centrelineType, featureCode }) => {
-    if (centrelineType === CentrelineType.INTERSECTION) {
-      return FEATURE_CODES_INTERSECTION.includes(featureCode);
-    }
-    return FEATURE_CODES_SEGMENT.includes(featureCode);
-  });
-}
 
 /**
  * Routes related to location suggestions and lookups.
@@ -84,8 +73,7 @@ LocationController.push({
   },
   handler: async (request) => {
     const { limit, q, types } = request.query;
-    const locations = await LocationSearchDAO.getSuggestions(types, q, limit);
-    return filterLocations(locations);
+    return LocationSearchDAO.getSuggestions(types, q, limit);
   },
 });
 
@@ -169,8 +157,7 @@ LocationController.push({
   handler: async (request) => {
     const { s1 } = request.query;
     const features = CompositeId.decode(s1);
-    const locations = await CentrelineDAO.byFeatures(features);
-    return filterLocations(locations);
+    return CentrelineDAO.byFeatures(features);
   },
 });
 
@@ -212,7 +199,13 @@ LocationController.push({
     try {
       const featuresResolved = await FeatureResolver.byFeaturesSelection(featuresSelection);
       const locations = await CentrelineDAO.byFeatures(featuresResolved);
-      return filterLocations(locations);
+      /*
+       * Our resolved features here are from the routing target, which may include intersections
+       * that are not in the conflation target.  During location lookup,
+       * `CentrelineDAO.byFeatures` will return `null` for such features, so we need to filter
+       * those out.
+       */
+      return locations.filter(location => location !== null);
     } catch (err) {
       if (err instanceof InvalidFeaturesSelectionError) {
         const { statusCode } = HttpStatus.BAD_REQUEST;

--- a/lib/db/CentrelineDAO.js
+++ b/lib/db/CentrelineDAO.js
@@ -66,6 +66,7 @@ WHERE fnode = $(intersectionId) OR tnode = $(intersectionId)`;
 SELECT
   "centrelineId",
   "centrelineType",
+  classification,
   description,
   "featureCode",
   ST_AsGeoJSON(geom)::json AS geom,
@@ -81,6 +82,7 @@ WHERE "centrelineId" IN ($(centrelineIds:csv))`;
 SELECT
   ci."centrelineId",
   ci."centrelineType",
+  ci.classification,
   ci.description,
   ci."featureCode",
   ST_AsGeoJSON(ci.geom)::json AS geom,

--- a/lib/db/CentrelineDAO.js
+++ b/lib/db/CentrelineDAO.js
@@ -4,10 +4,7 @@ import {
   CentrelineType,
 } from '@/lib/Constants';
 import { InvalidCentrelineTypeError } from '@/lib/error/MoveErrors';
-import {
-  intersectionToFeature,
-  segmentToFeature,
-} from '@/lib/model/helpers/NormalizeUtils';
+import { segmentToFeature } from '@/lib/model/helpers/NormalizeUtils';
 
 /**
  * Data access layer for centreline "features", which include both segments and
@@ -21,19 +18,19 @@ class CentrelineDAO {
     }
     const sql = `
 SELECT
-  gc.lf_name AS "midblockName",
-  lsi."fromIntersectionName",
-  lsi."toIntersectionName",
-  va.aadt,
-  CAST(gc.geo_id AS INT),
-  gc.lfn_id,
-  gc.fcode,
-  ST_AsGeoJSON(ST_ClosestPoint(gc.geom, ST_Centroid(gc.geom)))::json AS "geomPoint",
-  ST_AsGeoJSON(ST_LineMerge(gc.geom))::json AS geom
-  FROM gis.centreline gc
-  LEFT JOIN location_search.centreline lsi ON gc.geo_id = lsi.geo_id
-  LEFT JOIN volume.aadt va ON gc.geo_id = va.centreline_id
-  WHERE gc.geo_id IN ($(centrelineIds:csv))`;
+  aadt,
+  "centrelineId",
+  "centrelineType",
+  "featureCode",
+  "fromIntersectionName",
+  ST_AsGeoJSON(geom)::json AS geom,
+  lat,
+  lng,
+  "midblockName",
+  "roadId",
+  "toIntersectionName"
+FROM centreline.midblocks
+WHERE "centrelineId" IN ($(centrelineIds:csv))`;
     const rows = await db.manyOrNone(sql, { centrelineIds });
     return rows.map(segmentToFeature);
   }
@@ -41,19 +38,19 @@ SELECT
   static async segmentsIncidentTo(intersectionId) {
     const sql = `
 SELECT
-  gc.lf_name AS "midblockName",
-  lsi."fromIntersectionName",
-  lsi."toIntersectionName",
-  va.aadt,
-  CAST(gc.geo_id AS INT),
-  gc.lfn_id,
-  gc.fcode,
-  ST_AsGeoJSON(ST_ClosestPoint(gc.geom, ST_Centroid(gc.geom)))::json AS "geomPoint",
-  ST_AsGeoJSON(ST_lineMerge(gc.geom))::json AS geom
-  FROM gis.centreline gc
-  LEFT JOIN location_search.centreline lsi ON gc.geo_id = lsi.geo_id
-  LEFT JOIN volume.aadt va ON gc.geo_id = va.centreline_id
-  WHERE gc.fnode = $(intersectionId) OR gc.tnode = $(intersectionId)`;
+  aadt,
+  "centrelineId",
+  "centrelineType",
+  "featureCode",
+  "fromIntersectionName",
+  ST_AsGeoJSON(geom)::json AS geom,
+  lat,
+  lng,
+  "midblockName",
+  "roadId",
+  "toIntersectionName"
+FROM centreline.midblocks
+WHERE fnode = $(intersectionId) OR tnode = $(intersectionId)`;
     const rows = await db.manyOrNone(sql, { intersectionId });
     return rows.map(segmentToFeature);
   }
@@ -66,31 +63,33 @@ SELECT
       return [];
     }
     const sql = `
-SELECT DISTINCT ON (int_id)
-  int_id,
-  intersec5,
-  elevatio9,
-  ST_AsGeoJSON(geom)::json AS geom
-  FROM gis.centreline_intersection
-  WHERE int_id IN ($(centrelineIds:csv))
-  ORDER BY int_id ASC, elev_level ASC`;
-    const rows = await db.manyOrNone(sql, { centrelineIds });
-    return rows.map(intersectionToFeature);
+SELECT
+  "centrelineId",
+  "centrelineType",
+  description,
+  "featureCode",
+  ST_AsGeoJSON(geom)::json AS geom,
+  lat,
+  lng
+FROM centreline.intersections
+WHERE "centrelineId" IN ($(centrelineIds:csv))`;
+    return db.manyOrNone(sql, { centrelineIds });
   }
 
   static async intersectionsIncidentTo(segmentId) {
     const sql = `
-SELECT DISTINCT ON (int_id)
-  gci.int_id,
-  gci.intersec5,
-  gci.elevatio9,
-  ST_AsGeoJSON(gci.geom)::json AS geom
-  FROM gis.centreline_intersection gci
-  JOIN gis.centreline gc ON gci.int_id IN (gc.fnode, gc.tnode)
-  WHERE gc.geo_id = $(segmentId)
-  ORDER BY int_id ASC, elev_level ASC`;
-    const rows = await db.manyOrNone(sql, { segmentId });
-    return rows.map(intersectionToFeature);
+SELECT
+  ci."centrelineId",
+  ci."centrelineType",
+  ci.description,
+  ci."featureCode",
+  ST_AsGeoJSON(ci.geom)::json AS geom,
+  ci.lat,
+  ci.lng
+FROM centreline.intersections ci
+JOIN centreline.midblocks cm ON ci."centrelineId" IN (cm.fnode, cm.tnode)
+WHERE cm."centrelineId" = $(segmentId)`;
+    return db.manyOrNone(sql, { segmentId });
   }
 
   // COMBINED METHODS

--- a/lib/db/LocationSearchDAO.js
+++ b/lib/db/LocationSearchDAO.js
@@ -183,7 +183,7 @@ LIMIT $(limitApprox);`;
     // TODO: also include midblock conflation!
     const sql = `
 SELECT centreline_id AS "centrelineId"
-FROM location_search.traffic_signal
+FROM location_search.traffic_signal ts
 WHERE ts.px = $(px)`;
     const rows = await db.manyOrNone(sql, { px });
     const features = rows.map(({ centrelineId }) => ({

--- a/lib/db/LocationSearchDAO.js
+++ b/lib/db/LocationSearchDAO.js
@@ -1,7 +1,6 @@
-import { LocationSearchType } from '@/lib/Constants';
+import { CentrelineType, LocationSearchType } from '@/lib/Constants';
 import db from '@/lib/db/db';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
-import { intersectionToFeature } from '@/lib/model/helpers/NormalizeUtils';
 
 const REGEX_SPECIAL_TERM = /([A-Za-z]+):(\d*)/;
 const TERMS_ARTERY = ['artery'];
@@ -88,7 +87,7 @@ WHERE arterycode = $(arterycode)`;
     const sqlExact = `
 WITH candidates AS (
   SELECT
-    int_id,
+    int_id AS "centrelineId",
     ts_rank_cd(
       to_tsvector('english', intersec5),
       (plainto_tsquery($(query))::text || ':*')::tsquery,
@@ -103,30 +102,28 @@ WITH candidates AS (
   WHERE to_tsvector('english', intersec5) @@ (plainto_tsquery($(query))::text || ':*')::tsquery
 )
 SELECT
-  ci.int_id,
-  ci.intersec5,
-  ci.elevatio9,
-  ST_AsGeoJSON(ci.geom)::json AS geom,
+  "centrelineId",
   f_rank_cd * 20 + f_substring_match * 0.5 - abs(501245 - f_feature_code) / 100.0 AS score
-FROM candidates JOIN gis.centreline_intersection ci USING (int_id)
-ORDER BY score DESC, intersec5 ASC
+FROM candidates
+ORDER BY score DESC
 LIMIT $(limit);`;
     const rowsExact = await db.manyOrNone(sqlExact, { limit, query });
     /*
      * Although we don't currently surface the score anywhere in the frontend, we preserve
      * them in the results in case they prove helpful eventually.
      */
-    const intersectionsExact = rowsExact.map(
-      ({ score, ...intersection }) => intersectionToFeature(intersection),
-    );
+    const featuresExact = rowsExact.map(({ centrelineId }) => ({
+      centrelineId,
+      centrelineType: CentrelineType.INTERSECTION,
+    }));
 
     /*
      * If we have enough results, stop; otherwise, continue to approximate matching and
      * fill out the result list.
      */
-    const limitApprox = limit - intersectionsExact.length;
+    const limitApprox = limit - featuresExact.length;
     if (limitApprox <= 0) {
-      return intersectionsExact;
+      return CentrelineDAO.byFeatures(featuresExact);
     }
 
     /*
@@ -147,7 +144,7 @@ LIMIT $(limit);`;
 SET pg_trgm.word_similarity_threshold = 0.3;
 WITH candidates AS (
   SELECT
-    int_id,
+    int_id AS "centrelineId",
     word_similarity(
       replace(replace(plainto_tsquery($(query))::text, '''', ''), ' &', ''),
       intersec5
@@ -157,22 +154,18 @@ WITH candidates AS (
   WHERE replace(replace(plainto_tsquery($(query))::text, '''', ''), ' &', '') <% intersec5
 )
 SELECT
-  ci.int_id,
-  ci.intersec5,
-  ci.elevatio9,
-  ST_AsGeoJSON(ci.geom)::json AS geom,
+  "centrelineId",
   f_word_similarity * 2 - abs(501245 - f_feature_code) / 100.0 AS score
-FROM candidates JOIN gis.centreline_intersection ci USING (int_id)
-ORDER BY score DESC, intersec5 ASC
+FROM candidates
+ORDER BY score DESC
 LIMIT $(limitApprox);`;
-    const rowsApprox = await db.manyOrNone(sqlApprox, {
-      limitApprox,
-      query,
-    });
-    const intersectionsApprox = rowsApprox.map(
-      ({ score, ...intersection }) => intersectionToFeature(intersection),
-    );
-    return intersectionsExact.concat(intersectionsApprox);
+    const rowsApprox = await db.manyOrNone(sqlApprox, { limitApprox, query });
+    const featuresApprox = rowsApprox.map(({ centrelineId }) => ({
+      centrelineId,
+      centrelineType: CentrelineType.INTERSECTION,
+    }));
+    const features = featuresExact.concat(featuresApprox);
+    return CentrelineDAO.byFeatures(features);
   }
 
   /**
@@ -187,17 +180,17 @@ LIMIT $(limitApprox);`;
    * to the given signal if found, empty array otherwise
    */
   static async trafficSignalSuggestions(px) {
+    // TODO: also include midblock conflation!
     const sql = `
-SELECT
-  ci.int_id,
-  ci.intersec5,
-  ci.elevatio9,
-  ST_AsGeoJSON(ci.geom)::json AS geom
-FROM location_search.traffic_signal ts
-JOIN gis.centreline_intersection ci ON ts.centreline_id = ci.int_id
+SELECT centreline_id AS "centrelineId"
+FROM location_search.traffic_signal
 WHERE ts.px = $(px)`;
     const rows = await db.manyOrNone(sql, { px });
-    return rows.map(intersectionToFeature);
+    const features = rows.map(({ centrelineId }) => ({
+      centrelineId,
+      centrelineType: CentrelineType.INTERSECTION,
+    }));
+    return CentrelineDAO.byFeatures(features);
   }
 
   /**

--- a/lib/db/PoiDAO.js
+++ b/lib/db/PoiDAO.js
@@ -4,20 +4,10 @@ import { InvalidCentrelineTypeError } from '@/lib/error/MoveErrors';
 
 function getCentrelineTable(centrelineType) {
   if (centrelineType === CentrelineType.SEGMENT) {
-    return 'gis.centreline';
+    return 'centreline.midblocks';
   }
   if (centrelineType === CentrelineType.INTERSECTION) {
-    return 'gis.centreline_intersection';
-  }
-  throw new InvalidCentrelineTypeError(centrelineType);
-}
-
-function getCentrelineIdColumn(centrelineType) {
-  if (centrelineType === CentrelineType.SEGMENT) {
-    return 'geo_id';
-  }
-  if (centrelineType === CentrelineType.INTERSECTION) {
-    return 'int_id';
+    return 'centreline.intersections';
   }
   throw new InvalidCentrelineTypeError(centrelineType);
 }
@@ -25,7 +15,6 @@ function getCentrelineIdColumn(centrelineType) {
 class PoiDAO {
   static async byCentrelineAndType(type, centrelineId, centrelineType, radius) {
     const centrelineTable = getCentrelineTable(centrelineType);
-    const centrelineIdColumn = getCentrelineIdColumn(centrelineType);
     const poiTable = `gis.${type}`;
     const sql = `SELECT poi.objectid AS id, ST_Distance(
       ST_Transform(poi.geom, 2952),
@@ -33,7 +22,7 @@ class PoiDAO {
     ) AS geom_dist
     FROM ${centrelineTable} c, ${poiTable} poi
     WHERE
-      c.${centrelineIdColumn} = $(centrelineId)
+      c."centrelineId" = $(centrelineId)
       AND ST_DWithin(
         ST_Transform(poi.geom, 2952),
         ST_Transform(c.geom, 2952),

--- a/lib/db/RoutingDAO.js
+++ b/lib/db/RoutingDAO.js
@@ -39,7 +39,7 @@ class RoutingDAO {
   static async getIntersectionsBoundingBox(intersectionFrom, intersectionTo) {
     const sql = `
 SELECT ST_X(geom) AS x, ST_Y(geom) AS y
-FROM routing.centreline_vertices
+FROM centreline.routing_vertices
 WHERE id IN ($(intersectionFrom), $(intersectionTo))`;
     const rowsVertices = await db.manyOrNone(sql, { intersectionFrom, intersectionTo });
     if (rowsVertices.length !== 2) {
@@ -92,7 +92,7 @@ SELECT node, edge, agg_cost AS "aggCost"
 FROM pgr_astar(
   'WITH vertices AS (
     SELECT id
-    FROM routing.centreline_vertices
+    FROM centreline.routing_vertices
     WHERE ST_DWithin(
       geom,
       ST_MakeEnvelope(${xmin}, ${ymin}, ${xmax}, ${ymax}, 2952),
@@ -100,7 +100,7 @@ FROM pgr_astar(
     )
   )
   SELECT e.*
-  FROM routing.centreline_edges e
+  FROM centreline.routing_edges e
   JOIN vertices vs ON e.source = vs.id
   JOIN vertices vt ON e.target = vt.id',
   $(intersectionFrom),

--- a/lib/model/helpers/CentrelineFeature.js
+++ b/lib/model/helpers/CentrelineFeature.js
@@ -7,8 +7,8 @@ import Joi from '@/lib/model/Joi';
  *
  * A "feature" is essentially a key to a centreline location.  It consists of two fields:
  * a type (intersection or midblock segment) and an ID.  For intersections, this ID is equal to
- * the value of `gis.centreline_intersection.int_id` for the corresponding location.  For
- * midblocks, it is equal to the value of `gis.centreline.geo_id`.
+ * the value of `centreline.intersections.centrelineId` for the corresponding location.  For
+ * midblocks, it is equal to the value of `centreline.midblocks.centrelineId`.
  *
  * Features can be encoded into a {@link CompositeId}, which is then used to help build URLs
  * (either for frontend routes or REST API calls) that must look up information about one or

--- a/lib/model/helpers/CentrelineLocation.js
+++ b/lib/model/helpers/CentrelineLocation.js
@@ -22,6 +22,14 @@ export default {
       otherwise: Joi.number().positive().allow(null).required(),
     },
   ),
+  classification: Joi.any().when(
+    'centrelineType',
+    {
+      is: CentrelineType.INTERSECTION,
+      then: Joi.string().allow(null).required(),
+      otherwise: Joi.forbidden(),
+    },
+  ),
   description: Joi.string().allow(null).required(),
   featureCode: Joi.number().when(
     'centrelineType',

--- a/lib/model/helpers/NormalizeUtils.js
+++ b/lib/model/helpers/NormalizeUtils.js
@@ -1,26 +1,6 @@
-import { CentrelineType } from '@/lib/Constants';
 import MidblockDescription from '@/lib/geo/MidblockDescription';
 import JobMetadata from '@/lib/model/JobMetadata';
 import Joi from '@/lib/model/Joi';
-
-function intersectionToFeature({
-  geom,
-  intersec5: description,
-  elevatio9: featureCode,
-  int_id: intId,
-}) {
-  const centrelineId = parseInt(intId, 10);
-  const [lng, lat] = geom.coordinates;
-  return {
-    centrelineId,
-    centrelineType: CentrelineType.INTERSECTION,
-    description,
-    featureCode,
-    geom,
-    lat,
-    lng,
-  };
-}
 
 async function normalizeJobMetadata(jobMetadata) {
   const jobMetadataNormalized = await JobMetadata.read.validateAsync(jobMetadata);
@@ -44,50 +24,31 @@ async function normalizeJobMetadatas(jobMetadatas) {
   return jobMetadatasNormalized;
 }
 
+/**
+ * Only SEGMENT features have AADT estimates.  When using `aadt`, you should usually
+ * check `location.centrelineType === CentrelineType.SEGMENT` first.  You should also
+ * check whether `location.aadt === null`, as AADT cannot be reliably estimated for all
+ * segments.  (For instance, newer roads have no historical data to base this off of,
+ * and some small laneways have insufficient data.)
+ *
+ * Only SEGMENT features have road IDs.  When using `roadId`, you should usually
+ * check `location.centrelineType === CentrelineType.SEGMENT` first.
+ */
 function segmentToFeature({
-  aadt,
-  fcode: featureCode,
   fromIntersectionName,
   midblockName,
-  geo_id: geoId,
-  geom,
-  geomPoint,
-  lfn_id: roadId,
   toIntersectionName,
+  ...restSegment
 }) {
-  const centrelineId = parseInt(geoId, 10);
   const description = MidblockDescription.get(
     midblockName,
     fromIntersectionName,
     toIntersectionName,
   );
-  const [lng, lat] = geomPoint.coordinates;
-  return {
-    /*
-     * Only SEGMENT features have AADT estimates.  When using `aadt`, you should usually
-     * check `location.centrelineType === CentrelineType.SEGMENT` first.  You should also
-     * check whether `location.aadt === null`, as AADT cannot be reliably estimated for all
-     * segments.  (For instance, newer roads have no historical data to base this off of,
-     * and some small laneways have insufficient data.)
-     */
-    aadt,
-    centrelineId,
-    centrelineType: CentrelineType.SEGMENT,
-    description,
-    featureCode,
-    geom,
-    lat,
-    lng,
-    /*
-     * Only SEGMENT features have road IDs.  When using `roadId`, you should usually
-     * check `location.centrelineType === CentrelineType.SEGMENT` first.
-     */
-    roadId,
-  };
+  return { description, ...restSegment };
 }
 
 const NormalizeUtils = {
-  intersectionToFeature,
   normalizeJobMetadata,
   normalizeJobMetadatas,
   segmentToFeature,
@@ -95,7 +56,6 @@ const NormalizeUtils = {
 
 export {
   NormalizeUtils as default,
-  intersectionToFeature,
   normalizeJobMetadata,
   normalizeJobMetadatas,
   segmentToFeature,

--- a/tests/jest/api/LocationController.spec.js
+++ b/tests/jest/api/LocationController.spec.js
@@ -25,7 +25,7 @@ function expectSuggestionsContain(result, centrelineId) {
 
 test('LocationController.getCompositeId', async () => {
   const features = [
-    { centrelineId: 30000549, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 13441579, centrelineType: CentrelineType.INTERSECTION },
     { centrelineId: 111569, centrelineType: CentrelineType.SEGMENT },
   ];
   const data = {
@@ -40,7 +40,7 @@ test('LocationController.getCompositeId', async () => {
 
 test('LocationController.getCompositeId [length mismatch]', async () => {
   const data = {
-    centrelineId: [30000549, 111569],
+    centrelineId: [13441579, 111569],
     centrelineType: [CentrelineType.SEGMENT],
   };
   const response = await client.fetch('/locations/compositeId', { data });
@@ -103,6 +103,7 @@ test('LocationController.getLocationsByCorridor [short corridor]', async () => {
   const locations = response.result;
   s1 = CompositeId.encode(locations);
   expect(CompositeId.decode(s1)).toEqual([
+    { centrelineId: 13456067, centrelineType: CentrelineType.INTERSECTION },
     { centrelineId: 445623, centrelineType: CentrelineType.SEGMENT },
     { centrelineId: 13455700, centrelineType: CentrelineType.INTERSECTION },
     { centrelineId: 445346, centrelineType: CentrelineType.SEGMENT },

--- a/tests/jest/db/CentrelineDAO.spec.js
+++ b/tests/jest/db/CentrelineDAO.spec.js
@@ -9,10 +9,10 @@ afterAll(() => {
 
 test('CentrelineDAO.byFeature', async () => {
   // intersection
-  let feature = { centrelineId: 30000549, centrelineType: CentrelineType.INTERSECTION };
+  let feature = { centrelineId: 13441579, centrelineType: CentrelineType.INTERSECTION };
   let result = await CentrelineDAO.byFeature(feature);
   expect(result).not.toBeNull();
-  expect(result.centrelineId).toEqual(30000549);
+  expect(result.centrelineId).toEqual(13441579);
   expect(result.centrelineType).toEqual(CentrelineType.INTERSECTION);
 
   // segment
@@ -58,7 +58,7 @@ test('CentrelineDAO.byFeatures', async () => {
 
   // single valid intersection
   query = [
-    { centrelineId: 30000549, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 13441579, centrelineType: CentrelineType.INTERSECTION },
   ];
   results = await CentrelineDAO.byFeatures(query);
   expectFeaturesResults(results, query);
@@ -72,15 +72,15 @@ test('CentrelineDAO.byFeatures', async () => {
 
   // duplicate value
   query = [
-    { centrelineId: 30000549, centrelineType: CentrelineType.INTERSECTION },
-    { centrelineId: 30000549, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 13441579, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 13441579, centrelineType: CentrelineType.INTERSECTION },
   ];
   results = await CentrelineDAO.byFeatures(query);
   expectFeaturesResults(results, query);
 
   // intersection + segment
   query = [
-    { centrelineId: 30000549, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 13441579, centrelineType: CentrelineType.INTERSECTION },
     { centrelineId: 111569, centrelineType: CentrelineType.SEGMENT },
   ];
   results = await CentrelineDAO.byFeatures(query);

--- a/tests/jest/unit/io/CompositeId.spec.js
+++ b/tests/jest/unit/io/CompositeId.spec.js
@@ -85,7 +85,7 @@ test('CompositeId [empty feature set]', () => {
 
 test('CompositeId [encode / decode]', () => {
   let features = [
-    { centrelineId: 30000549, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 13441579, centrelineType: CentrelineType.INTERSECTION },
   ];
   let compositeId = CompositeId.encode(features);
   expect(CompositeId.decode(compositeId)).toEqual(features);
@@ -97,7 +97,7 @@ test('CompositeId [encode / decode]', () => {
   expect(CompositeId.decode(compositeId)).toEqual(features);
 
   features = [
-    { centrelineId: 30000549, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 13441579, centrelineType: CentrelineType.INTERSECTION },
     { centrelineId: 111569, centrelineType: CentrelineType.SEGMENT },
   ];
   compositeId = CompositeId.encode(features);

--- a/web/config/FrontendEnv.js
+++ b/web/config/FrontendEnv.js
@@ -29,7 +29,7 @@ FrontendEnv.init({
   },
   QA: {
     appClass: 'is-qa',
-    appTitle: 'MOVE (dev)',
+    appTitle: 'MOVE (QA)',
   },
   PROD: {
     appClass: 'is-prod',


### PR DESCRIPTION
# Issue Addressed
This PR makes progress on #695 .

# Description
We update the web application backend to use our new centreline conflation target and routing target, rather than raw joins using `gis`, `volume`, and `location_search`.  This should provide a performance benefit by reducing joins in `CentrelineDAO`, which is used in several places throughout MOVE.

# Tests
Tested quickly in frontend.