### PR TITLE
Fill in unused directions to fix offset intersection warrants

### DIFF
--- a/lib/reports/ReportBaseFlowDirectional.js
+++ b/lib/reports/ReportBaseFlowDirectional.js
@@ -207,28 +207,80 @@ class ReportBaseFlowDirectional extends ReportBaseFlow {
   }
 
   /**
-   * @param {Array<Array>} roads - `segments`, grouped into roads by `roadId`
-   * @param {Object} intersection - intersection to get directions from
-   * @param {Array} segments - segments incident to `intersection`
-   * @returns {Array<Array<CardinalDirection>>} for each road grouping `roads[i]`, an array of
-   * "X-bound" directions from `intersection` for the `segments` in `roads[i]`
+   *
+   * @param {Array<Object>} segments - segments incident to `intersection`
+   * @returns {Array<Array<number>>} arrays of indices from `segments`, with each such
+   * array representing a single road
    */
-  static getRoadDirections(roads, intersection, segments) {
+  static getRoads(segments) {
+    const segmentRoadIndices = segments.map(({ roadId }, i) => ({ i, roadId }));
+    return ArrayUtils.groupBy(segmentRoadIndices, ({ roadId }) => roadId)
+      .map(road => road.map(({ i }) => i));
+  }
+
+  /**
+   * @param {Array<Array<number>>} roads - arrays of indices from `segments`, with each such
+   * array representing a single road
+   * @param {Map<CardinalDirection, number>} directionCandidates - mapping from
+   * `CardinalDirection` values to indices from `segments` representing best directional
+   * candidates
+   * @returns {Array<Array<CardinalDirection>>} array of roads, each containing
+   * an array of "X-bound" directions from `intersection` for that road
+   */
+  static inferRoadDirections(roads, directionCandidates) {
     /*
-     * `GeometryUtils.getDirectionCandidatesFrom` returns a map from directions to indices
-     * (in this case, into `segments`).  We need this mapping to link segments in `roads`
-     * to `segments`.
+     * `indexToDirection` here is the "inverse" mapping of `directionCandidates`.  Using this,
+     * we can map indices into `segments` into directions.
      */
-    const centrelineIdToSegmentIndex = new Map();
-    segments.forEach(({ centrelineId }, i) => {
-      centrelineIdToSegmentIndex.set(centrelineId, i);
+    const indexToDirection = new Map();
+    directionCandidates.forEach((i, dir) => {
+      indexToDirection.set(i, dir.opposing);
     });
-    const roadsIndices = roads.map(
-      roadSegments => roadSegments.map(
-        ({ centrelineId }) => centrelineIdToSegmentIndex.get(centrelineId),
-      ),
+
+    const roadDirections = roads.map(
+      road => road
+        .filter(i => indexToDirection.has(i))
+        .map(i => indexToDirection.get(i)),
     );
 
+    /*
+     * We now attempt to assign any unused directions to roads.
+     *
+     * This is mainly useful for "offset intersections", where looking at the geometry of
+     * `intersection` and incident `segments` alone will miss one of the offset legs.  If
+     * a road exists with one identified leg in the opposing direction of the missing offset
+     * leg, we add the missing offset leg to that road.
+     *
+     * In the case of T-intersections, the missing leg will have zero volume in the count data,
+     * so we can apply this same heuristic without issue.
+     *
+     * If no such road can be found, we instead add the unused direction to its own road, to
+     * ensure that the data for that leg can at least be included in approach totals.
+     */
+    const unusedDirections = CardinalDirection.enumValues
+      .filter(dir => !directionCandidates.has(dir))
+      .map(dir => dir.opposing);
+    unusedDirections.forEach((dir) => {
+      const road = roadDirections.find(
+        roadCandidate => roadCandidate.length === 1 && roadCandidate.includes(dir.opposing),
+      );
+      if (road === undefined) {
+        roadDirections.push([dir]);
+      } else {
+        road.push(dir);
+      }
+    });
+
+    return roadDirections;
+  }
+
+  /**
+   * @param {Object} intersection - intersection to get directions from
+   * @param {Array<Object>} segments - segments incident to `intersection`
+   * @returns {Array<Array<CardinalDirection>>} array of roads, each containing
+   * an array of "X-bound" directions from `intersection` for that road
+   */
+  static getRoadDirections(intersection, segments) {
     /*
      * Figure out which `segments` lie in which directions from `intersection`.  By combining
      * this information with `roads` (which `segments` belong to which roads), we can figure
@@ -238,23 +290,8 @@ class ReportBaseFlowDirectional extends ReportBaseFlow {
     const intersectionPoint = intersection.geom.coordinates;
     const directionCandidates = getDirectionCandidatesFrom(segmentLineStrings, intersectionPoint);
 
-    /*
-     * `indexToDirection` here is the "inverse" mapping of `directionCandidates`.  Using this,
-     * we can map:
-     *
-     * - roads to road segments;
-     * - road segments to indices into `segments`,
-     * - indices into `segments` into directions.
-     */
-    const indexToDirection = new Map();
-    directionCandidates.forEach((i, dir) => {
-      indexToDirection.set(i, dir.opposing);
-    });
-    return roadsIndices.map(
-      roadIndices => roadIndices
-        .filter(i => indexToDirection.has(i))
-        .map(i => indexToDirection.get(i)),
-    );
+    const roads = ReportBaseFlowDirectional.getRoads(segments);
+    return ReportBaseFlowDirectional.inferRoadDirections(roads, directionCandidates);
   }
 
   /**
@@ -283,9 +320,6 @@ class ReportBaseFlowDirectional extends ReportBaseFlow {
   static getDirectionalStats(study, { countData: rawData, intersection, segments }) {
     const countData = ReportBaseFlowDirectional.computeAllMovementAndVehicleTotals(rawData);
 
-    // We use `roadId` to group incident segments into roads.
-    const roads = ArrayUtils.groupBy(segments, ({ roadId }) => roadId);
-
     /*
      * As per OTM Book 12, p. 77:
 
@@ -298,14 +332,10 @@ class ReportBaseFlowDirectional extends ReportBaseFlow {
      * reflects actual road usage.  As such, MOVE Reporter incorporates this refinement here.
      */
     const hourlyData = ReportBaseFlowDirectional.sumHourly(countData);
-    const roadDirections = ReportBaseFlowDirectional.getRoadDirections(
-      roads,
-      intersection,
-      segments,
-    );
+    const roadDirections = ReportBaseFlowDirectional.getRoadDirections(intersection, segments);
     const hourlyRoadVolumes = hourlyData.map(
-      hourData => roads.map(
-        (_, i) => ReportBaseFlowDirectional.getRoadVolume(roadDirections[i], hourData),
+      hourData => roadDirections.map(
+        directions => ReportBaseFlowDirectional.getRoadVolume(directions, hourData),
       ),
     );
 

--- a/tests/jest/unit/reports/ReportBaseFlowDirectional.spec.js
+++ b/tests/jest/unit/reports/ReportBaseFlowDirectional.spec.js
@@ -31,3 +31,70 @@ test('ReportBaseFlowDirectional.computeMovementAndVehicleTotals', () => {
     expect(sumVehicleExits).toBe(sumVehicleEnters);
   }
 });
+
+test('ReportBaseFlowDirectional.getRoads', () => {
+  let segments = [];
+  expect(ReportBaseFlowDirectional.getRoads(segments)).toEqual([]);
+
+  segments = [{ roadId: 42 }];
+  expect(ReportBaseFlowDirectional.getRoads(segments)).toEqual([[0]]);
+
+  segments = [{ roadId: 42 }, { roadId: 42 }];
+  expect(ReportBaseFlowDirectional.getRoads(segments)).toEqual([[0, 1]]);
+
+  segments = [{ roadId: 42 }, { roadId: 1729 }];
+  expect(ReportBaseFlowDirectional.getRoads(segments)).toEqual([[0], [1]]);
+
+  segments = [{ roadId: 42 }, { roadId: 1729 }, { roadId: 42 }, { roadId: 73 }];
+  expect(ReportBaseFlowDirectional.getRoads(segments)).toEqual([[0, 2], [3], [1]]);
+});
+
+test('ReportBaseFlowDirectional.inferRoadDirections', () => {
+  let roads = [];
+  let directionCandidates = new Map();
+  expect(ReportBaseFlowDirectional.inferRoadDirections(roads, directionCandidates)).toEqual([
+    [CardinalDirection.SOUTH, CardinalDirection.NORTH],
+    [CardinalDirection.WEST, CardinalDirection.EAST],
+  ]);
+
+  roads = [[0]];
+  directionCandidates = new Map([[CardinalDirection.WEST, 0]]);
+  expect(ReportBaseFlowDirectional.inferRoadDirections(roads, directionCandidates)).toEqual([
+    [CardinalDirection.EAST, CardinalDirection.WEST],
+    [CardinalDirection.SOUTH, CardinalDirection.NORTH],
+  ]);
+
+  roads = [[0, 3], [2, 1]];
+  directionCandidates = new Map([
+    [CardinalDirection.WEST, 0],
+    [CardinalDirection.NORTH, 1],
+    [CardinalDirection.SOUTH, 2],
+    [CardinalDirection.EAST, 3],
+  ]);
+  expect(ReportBaseFlowDirectional.inferRoadDirections(roads, directionCandidates)).toEqual([
+    [CardinalDirection.EAST, CardinalDirection.WEST],
+    [CardinalDirection.NORTH, CardinalDirection.SOUTH],
+  ]);
+
+  roads = [[0, 2], [1]];
+  directionCandidates = new Map([
+    [CardinalDirection.SOUTH, 0],
+    [CardinalDirection.EAST, 1],
+    [CardinalDirection.NORTH, 2],
+  ]);
+  expect(ReportBaseFlowDirectional.inferRoadDirections(roads, directionCandidates)).toEqual([
+    [CardinalDirection.NORTH, CardinalDirection.SOUTH],
+    [CardinalDirection.WEST, CardinalDirection.EAST],
+  ]);
+
+  roads = [[0, 3], [2, 1]];
+  directionCandidates = new Map([
+    [CardinalDirection.NORTH, 1],
+    [CardinalDirection.SOUTH, 2],
+    [CardinalDirection.EAST, 3],
+  ]);
+  expect(ReportBaseFlowDirectional.inferRoadDirections(roads, directionCandidates)).toEqual([
+    [CardinalDirection.WEST, CardinalDirection.EAST],
+    [CardinalDirection.NORTH, CardinalDirection.SOUTH],
+  ]);
+});


### PR DESCRIPTION
# Issue Addressed
This PR closes #740 .

# Description
We ensure that all cardinal directions are accounted for when grouping directions into logical "roads" in `ReportBaseFlowDirectional`.

# Tests
Added unit tests for part of this, CI / CD testing.  Will test with a variety of known offset intersections in AWS dev.
