### PR TITLE
CSV formats for collision reports

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -435,7 +435,7 @@ ReportType.init({
   },
   COLLISION_TABULATION: {
     disabled: false,
-    formats: [ReportFormat.PDF],
+    formats: [ReportFormat.CSV, ReportFormat.PDF],
     label: 'Tabulation Report',
     orientation: PageOrientation.LANDSCAPE,
     reportExportMode: ReportExportMode.COLLISIONS,

--- a/lib/db/CollisionFactorDAO.js
+++ b/lib/db/CollisionFactorDAO.js
@@ -1,6 +1,14 @@
 import db from '@/lib/db/db';
 
 /**
+ * @typedef {Object} CollisionFactorEntry
+ * @property {string} code - abbreviated description of the value, suitable for display in
+ * small table cells
+ * @property {string} description - human-readable description, suitable for display in larger
+ * table cells, headings, etc.
+ */
+
+/**
  * Since the set of collision factors is small and static, we cache it here to reduce DB load.
  */
 let CACHE = null;
@@ -37,11 +45,22 @@ AND "${tableName}" ~ '^[0-9]+$'`,
   });
 }
 
+/**
+ * Data access layer for collision factors.  Collision records use numeric codes for many of
+ * their fields, as described on the MVCR reference sheet from the Ministry of Transportation
+ * of Ontario (MTO).  A collision factor is the mapping from those numeric codes to
+ * human-readable descriptions, so that the collision records can be more easily interpreted
+ * without needing to consult that reference sheet.
+ */
 class CollisionFactorDAO {
   static isInited() {
     return CACHE !== null;
   }
 
+  /**
+   * @returns {Map<string, Map<number, CollisionFactorEntry>>} map with field names as keys, and
+   * maps from numeric codes to {@link CollisionFactorEntry} entries as values
+   */
   static async all() {
     if (!CollisionFactorDAO.isInited()) {
       await init();

--- a/lib/reports/ReportCollisionDirectory.js
+++ b/lib/reports/ReportCollisionDirectory.js
@@ -69,21 +69,112 @@ class ReportCollisionDirectory extends ReportBaseCrash {
      * TODO: this violates the "no shared references" invariant in `ReportBase#transformData`.
      * We should address that eventually, but there isn't time right now.
      */
-    const rawCollisions = rawData.collisions;
-    const collisions = rawCollisions.map(
+    const collisions = rawData.collisions.map(
       ReportCollisionDirectory.getCollisionDirectoryEntry,
     );
     const collisionSummary = { ...rawData.collisionSummary };
-    return { collisions, collisionSummary, rawCollisions };
+    return { collisions, collisionSummary };
   }
 
-  generateCsv(location, { rawCollisions }) {
-    if (rawCollisions.length === 0) {
-      return { columns: [], rows: [] };
-    }
-    const columns = Object.keys(rawCollisions[0])
-      .map(key => ({ key, header: key }));
-    return { columns, rows: rawCollisions };
+  getCsvDriverCells({
+    drivact = null,
+    drivcond = null,
+    initdir = null,
+    invage = null,
+    manoeuver = null,
+  }) {
+    return {
+      drivact: this.getCollisionFactorCode('drivact', drivact),
+      drivcond: this.getCollisionFactorCode('drivcond', drivcond),
+      initdir: this.getCollisionFactorCode('initdir', initdir),
+      invage: this.getCollisionFactorCode('invage', invage),
+      manoeuver: this.getCollisionFactorCode('manoeuver', manoeuver),
+    };
+  }
+
+  getCsvCollisionRow({
+    accnb,
+    accdate,
+    acclass,
+    traffictl,
+    rdsfcond,
+    visible,
+    impactype,
+    drivers,
+    pedestrians,
+    cyclists,
+    injured,
+    verified,
+    hasMvaImage,
+  }) {
+    const [driver1 = {}, driver2 = {}] = drivers;
+    const driver1Cells = this.getCsvDriverCells(driver1);
+    const driver2Cells = this.getCsvDriverCells(driver2);
+    return {
+      accnb,
+      accdate: TimeFormatters.formatCsv(accdate),
+      acclass: this.getCollisionFactorCode('acclass', acclass),
+      traffictl: this.getCollisionFactorCode('traffictl', traffictl),
+      rdsfcond: this.getCollisionFactorCode('rdsfcond', rdsfcond),
+      visible: this.getCollisionFactorCode('visible', visible),
+      impactype: this.getCollisionFactorCode('impactype', impactype),
+      initdir1: driver1Cells.initdir,
+      manoeuver1: driver1Cells.manoeuver,
+      drivact1: driver1Cells.drivact,
+      drivcond1: driver1Cells.drivcond,
+      invage1: driver1Cells.invage,
+      initdir2: driver2Cells.initdir,
+      manoeuver2: driver2Cells.manoeuver,
+      drivact2: driver2Cells.drivact,
+      drivcond2: driver2Cells.drivcond,
+      invage2: driver2Cells.invage,
+      drivers: drivers.length,
+      pedestrians: pedestrians.length,
+      cyclists: cyclists.length,
+      injured0: injured[0],
+      injured1: injured[1],
+      injured2: injured[2],
+      injured3: injured[3],
+      injured4: injured[4],
+      injured5: injured[5],
+      verified,
+      hasMvaImage,
+    };
+  }
+
+  generateCsv(location, { collisions }) {
+    const columns = [
+      { key: 'accnb', header: 'MVA Number' },
+      { key: 'accdate', header: 'Date Time' },
+      { key: 'acclass', header: 'Acc Cla' },
+      { key: 'traffictl', header: 'Traffic Control' },
+      { key: 'rdsfcond', header: 'Rd Surf' },
+      { key: 'visible', header: 'Visib' },
+      { key: 'impactype', header: 'Impact' },
+      { key: 'initdir1', header: 'Dir 1' },
+      { key: 'manoeuver1', header: 'Manoeuver 1' },
+      { key: 'drivact1', header: 'Action 1' },
+      { key: 'drivcond1', header: 'Cond 1' },
+      { key: 'invage1', header: 'Age 1' },
+      { key: 'initdir2', header: 'Dir 2' },
+      { key: 'manoeuver2', header: 'Manoeuver 2' },
+      { key: 'drivact2', header: 'Action 2' },
+      { key: 'drivcond2', header: 'Cond 2' },
+      { key: 'invage2', header: 'Age 2' },
+      { key: 'drivers', header: '# Driver' },
+      { key: 'pedestrians', header: '# Ped' },
+      { key: 'cyclists', header: '# Cyclist' },
+      { key: 'injured0', header: 'Injury NO' },
+      { key: 'injured1', header: 'Injury MI' },
+      { key: 'injured2', header: 'Injury MR' },
+      { key: 'injured3', header: 'Injury MJ' },
+      { key: 'injured4', header: 'Injury FA' },
+      { key: 'injured5', header: 'Injury OT' },
+      { key: 'verified', header: 'Verified' },
+      { key: 'hasMvaImage', header: 'MVA Img' },
+    ];
+    const rows = collisions.map(this.getCsvCollisionRow.bind(this));
+    return { columns, rows };
   }
 
   getTableDriverCells({

--- a/lib/reports/ReportCollisionDirectory.js
+++ b/lib/reports/ReportCollisionDirectory.js
@@ -65,10 +65,6 @@ class ReportCollisionDirectory extends ReportBaseCrash {
   }
 
   transformData(location, rawData) {
-    /*
-     * TODO: this violates the "no shared references" invariant in `ReportBase#transformData`.
-     * We should address that eventually, but there isn't time right now.
-     */
     const collisions = rawData.collisions.map(
       ReportCollisionDirectory.getCollisionDirectoryEntry,
     );

--- a/lib/reports/ReportCollisionTabulation.js
+++ b/lib/reports/ReportCollisionTabulation.js
@@ -2,178 +2,16 @@
 import ArrayUtils from '@/lib/ArrayUtils';
 import { ReportBlock, ReportType, SortDirection } from '@/lib/Constants';
 import ReportBaseCrash from '@/lib/reports/ReportBaseCrash';
+import {
+  CollisionDimension,
+  EventCrossTabulation,
+  InvolvedCrossTabulation,
+} from '@/lib/reports/tabulation/CollisionTabulation';
 import TimeFormatters from '@/lib/time/TimeFormatters';
-
-class CollisionDimension {
-  constructor({
-    description,
-    entries,
-    event,
-    fn,
-    nullValue = null,
-    otherDescriptionFn = values => `${values.length} other values`,
-  }) {
-    this.description = description;
-    this.entries = entries;
-    this.event = event;
-    this.fn = fn;
-    this.nullValue = nullValue;
-    if (!this.entries.has(this.nullValue)) {
-      this.entries.set(this.nullValue, { description: 'Unknown' });
-    }
-    this.otherDescriptionFn = otherDescriptionFn;
-  }
-}
-
-class CrossTabulation {
-  constructor(dimX, dimY) {
-    this.dimX = dimX;
-    this.dimY = dimY;
-    this.table = new Map();
-    this.total = 0;
-    this.dimY.entries.forEach((valueY, y) => {
-      const values = new Map();
-      this.dimX.entries.forEach((valueX, x) => {
-        values.set(x, 0);
-      });
-      this.table.set(y, { total: 0, values });
-    });
-  }
-
-  incr(x0, y0) {
-    let y = y0;
-    if (y === null || !this.table.has(y)) {
-      y = this.dimY.nullValue;
-    }
-    const tableY = this.table.get(y);
-
-    let x = x0;
-    if (x === null || !tableY.values.has(x)) {
-      x = this.dimX.nullValue;
-    }
-    const valueX = tableY.values.get(x);
-    this.total += 1;
-    tableY.total += 1;
-    tableY.values.set(x, valueX + 1);
-  }
-
-  getOrderX() {
-    const { entries, nullValue } = this.dimX;
-    const keys = Array.from(entries.keys());
-    const keysNoNull = keys.filter(x => x !== nullValue);
-    const orderX = ArrayUtils.sortBy(keysNoNull, x => x);
-    orderX.push(nullValue);
-    return orderX;
-  }
-
-  getOrderY({
-    hideNull = false,
-    hideOther = false,
-    limit = 10,
-    sortByTotal = true,
-    sortDirection = SortDirection.DESC,
-  }) {
-    const { entries, nullValue } = this.dimY;
-    const keys = Array.from(entries.keys());
-    const keysNoNull = keys.filter(y => y !== nullValue);
-    let sortKey;
-    if (sortByTotal) {
-      sortKey = y => this.table.get(y).total;
-    } else {
-      sortKey = y => y;
-    }
-    const orderY = ArrayUtils.sortBy(keysNoNull, sortKey, sortDirection);
-    const n = hideNull ? keysNoNull.length : keys.length;
-    if (n <= limit) {
-      if (!hideNull) {
-        orderY.push(nullValue);
-      }
-      return orderY;
-    }
-    const hasNull = this.table.get(nullValue).total > 0;
-    if (!hideNull && hasNull) {
-      const orderYRest = orderY.slice(limit - 2);
-      const orderYLimit = orderY.slice(0, limit - 2);
-      orderYLimit.push(nullValue);
-      if (!hideOther) {
-        orderYLimit.push(orderYRest);
-      }
-      return orderYLimit;
-    }
-    const orderYRest = orderY.slice(limit - 1);
-    const orderYLimit = orderY.slice(0, limit - 1);
-    if (!hideOther) {
-      orderYLimit.push(orderYRest);
-    }
-    return orderYLimit;
-  }
-
-  getOrderedTable(orderX, orderY) {
-    const nx = orderX.length;
-    const ny = orderY.length;
-    const orderedTable = orderY.map((y) => {
-      const row = new Array(nx + 1).fill(0);
-      const ys = Array.isArray(y) ? y : [y];
-      ys.forEach((yy) => {
-        const { total, values } = this.table.get(yy);
-        orderX.forEach((x, j) => {
-          row[j] += values.get(x);
-        });
-        row[nx] += total;
-      });
-      return row;
-    });
-    const rowTotals = new Array(nx + 1).fill(0);
-    for (let i = 0; i < ny; i++) {
-      for (let j = 0; j <= nx; j++) {
-        rowTotals[j] += orderedTable[i][j];
-      }
-    }
-    orderedTable.push(rowTotals);
-    return orderedTable;
-  }
-}
-
-class EventCrossTabulation extends CrossTabulation {
-  constructor(dimX, dimY) {
-    super(dimX, dimY);
-    if (!dimX.event || !dimY.event) {
-      throw new Error('expected event-level dimensions!');
-    }
-  }
-
-  tabulate(collisions) {
-    collisions.forEach((event) => {
-      const x = this.dimX.fn(event);
-      const y = this.dimY.fn(event);
-      this.incr(x, y);
-    });
-  }
-}
-
-class InvolvedCrossTabulation extends CrossTabulation {
-  constructor(dimX, dimY) {
-    super(dimX, dimY);
-    if (dimX.event || dimY.event) {
-      throw new Error('expected involved-level dimensions!');
-    }
-  }
-
-  tabulate(collisions) {
-    collisions.forEach(({ involved, ...event }) => {
-      involved.forEach((person) => {
-        const x = this.dimX.fn(event, person);
-        const y = this.dimY.fn(event, person);
-        this.incr(x, y);
-      });
-    });
-  }
-}
 
 class ReportCollisionTabulation extends ReportBaseCrash {
   constructor() {
     super();
-    // TODO: proper initialization system for report modules
     this.initedDims = false;
   }
 
@@ -349,6 +187,10 @@ class ReportCollisionTabulation extends ReportBaseCrash {
 
       orderedTable[i].forEach((value, j) => {
         if (j >= nx) {
+          /*
+           * Each `orderedTable[i]` has an element at index `nx` containing the total across
+           * all `dimX` values.  We skip that here.
+           */
           return;
         }
 

--- a/lib/reports/ReportCollisionTabulation.js
+++ b/lib/reports/ReportCollisionTabulation.js
@@ -331,6 +331,119 @@ class ReportCollisionTabulation extends ReportBaseCrash {
     return crossTabulation;
   }
 
+  getCsvRows(crossTabulation, type, options) {
+    const { dimX, dimY } = crossTabulation;
+    const orderX = crossTabulation.getOrderX();
+    const orderY = crossTabulation.getOrderY(options);
+    const orderedTable = crossTabulation.getOrderedTable(orderX, orderY);
+    const nx = orderX.length;
+
+    const rows = [];
+    orderY.forEach((y, i) => {
+      let valueY;
+      if (Array.isArray(y)) {
+        valueY = dimY.otherDescriptionFn(y);
+      } else {
+        valueY = dimY.entries.get(y).description;
+      }
+
+      orderedTable[i].forEach((value, j) => {
+        if (j >= nx) {
+          return;
+        }
+
+        const x = orderX[j];
+        const valueX = dimX.entries.get(x).description;
+
+        const row = {
+          dimX: dimX.description,
+          x: valueX,
+          dimY: dimY.description,
+          y: valueY,
+          type,
+          value,
+        };
+        rows.push(row);
+      });
+    });
+    return rows;
+  }
+
+  getEventCsvRows(collisions, dimX, dimY, options = {}) {
+    const crossTabulation = this.getEventCrossTabulation(collisions, dimX, dimY);
+    return this.getCsvRows(crossTabulation, 'EVENT', options);
+  }
+
+  getInvolvedCsvRows(collisions, dimX, dimY, options = {}) {
+    const crossTabulation = this.getInvolvedCrossTabulation(collisions, dimX, dimY);
+    return this.getCsvRows(crossTabulation, 'INVOLVED', options);
+  }
+
+  getDayOfWeekCsvRows(collisions) {
+    const { data } = this.getDayOfWeekBarChartOptions(collisions);
+    return data.map(({ value }, i) => ({
+      dimX: 'Day of Week',
+      x: TimeFormatters.DAYS_OF_WEEK[i],
+      dimY: null,
+      y: null,
+      type: 'EVENT',
+      value,
+    }));
+  }
+
+  getHourOfDayCsvRows(collisions) {
+    const { data } = this.getHourOfDayBarChartOptions(collisions);
+    return data.map(({ value }, i) => ({
+      dimX: 'Hour of Day',
+      x: i,
+      dimY: null,
+      y: null,
+      type: 'EVENT',
+      value,
+    }));
+  }
+
+  generateCsv(location, { collisions }) {
+    const dimAccdateYear = ReportCollisionTabulation.getDimAccdateYear(collisions);
+    const columns = [
+      { key: 'dimX', label: 'Dim 1' },
+      { key: 'x', label: 'Dim 1 Value' },
+      { key: 'dimY', label: 'Dim 2' },
+      { key: 'y', label: 'Dim 2 Value' },
+      { key: 'type', label: 'Value Type' },
+      { key: 'value', label: 'Value' },
+    ];
+    const rows = [
+      ...this.getInvolvedCsvRows(collisions, this.dimInjury, this.dimInvtype),
+      ...this.getInvolvedCsvRows(collisions, this.dimAge, this.dimInvtype),
+      ...this.getInvolvedCsvRows(collisions, this.dimInitdir, this.dimManoeuver),
+      ...this.getInvolvedCsvRows(collisions, this.dimInitdir, this.dimImpactype),
+      ...this.getInvolvedCsvRows(collisions, this.dimInjury, this.dimDrivcond),
+      ...this.getInvolvedCsvRows(collisions, this.dimInjury, this.dimDrivact),
+      ...this.getEventCsvRows(
+        collisions,
+        this.dimInjuryEvent,
+        dimAccdateYear,
+        { limit: 11, sortByTotal: false },
+      ),
+      ...this.getEventCsvRows(
+        collisions,
+        this.dimInjuryEvent,
+        this.dimAccdateMonth,
+        {
+          hideNull: true,
+          hideOther: true,
+          limit: 12,
+          sortByTotal: false,
+          sortDirection: SortDirection.ASC,
+        },
+      ),
+      ...this.getDayOfWeekCsvRows(collisions),
+      ...this.getHourOfDayCsvRows(collisions),
+    ];
+    return { columns, rows };
+  }
+
   getTableOptions(crossTabulation, options) {
     const { dimX, dimY } = crossTabulation;
     const orderX = crossTabulation.getOrderX();

--- a/lib/reports/tabulation/CollisionTabulation.js
+++ b/lib/reports/tabulation/CollisionTabulation.js
@@ -1,0 +1,271 @@
+import ArrayUtils from '@/lib/ArrayUtils';
+import { SortDirection } from '@/lib/Constants';
+
+/**
+ * @typedef {Object} CollisionDimensionOptions
+ * @property {string} description - human-readable description of the dimension
+ * @property {Map<number, CollisionFactorEntry>} entries - values for the dimension
+ * @property {boolean} event - `true` if this is a dimension of collision events, `false`
+ * if it's a dimension of persons involved in a collision
+ * @property {Function} fn - function that takes a collision event (and, if `!event`, a person
+ * involved in that collision), and returns the value of this dimension
+ * @property {number?} nullValue - value to be interpreted as the `null` (i.e. missing) value
+ * here; useful for events or involved persons with missing field values, as well as for
+ * fields that have an explicit numeric value for "unknown"
+ * @property {Function} otherDescriptionFn - function that takes an array of "other" values,
+ * and returns a human-readable description for that array of values
+ *
+ */
+
+/**
+ * @typedef {Object} CrossTabulationOptions
+ * @property {boolean} hideNull - whether to hide the `nullValue`
+ * @property {boolean} hideOther - whether to hide other values at end (e.g. for months of year
+ * and other dimensions where all values are shown)
+ * @property {number} limit - maximum number of entries in `dimY` ordering
+ * @property {boolean} sortByTotal - whether to sort `dimY` ordering by `dimY` totals
+ * @property {number} sortDirection - either 1 or -1, for ascending or descending order
+ */
+
+/**
+ * Represents a dimension on which collisions or persons involved in them can be measured.
+ * For instance, injury severity and age are measures related to persons involved in
+ * collisions, while road surface condition is a measure of the collision event as a whole.
+ *
+ * These are used in pairs to form cross-tabulations.
+ *
+ * @param {CollisionDimensionOptions} options - dimension options
+ */
+class CollisionDimension {
+  constructor({
+    description,
+    entries,
+    event,
+    fn,
+    nullValue = null,
+    otherDescriptionFn = values => `${values.length} other values`,
+  }) {
+    this.description = description;
+    this.entries = entries;
+    this.event = event;
+    this.fn = fn;
+    this.nullValue = nullValue;
+    if (!this.entries.has(this.nullValue)) {
+      this.entries.set(this.nullValue, { description: 'Unknown' });
+    }
+    this.otherDescriptionFn = otherDescriptionFn;
+  }
+}
+
+/**
+ * Represents the cross-tabulation of two {@link CollisionDimension} dimensions.
+ * A cross-tabulation is essentially a two-dimensional histogram: each of `dimX`,
+ * `dimY` has a number of possible values, and each `(x, y)` bucket contains a
+ * count of items for which the `dimX` value is `x` and the `dimY` value is `y`.
+ *
+ * @param {CollisionDimension} dimX - horizontal dimension in table (first row)
+ * @param {CollisionDimension} dimY - vertical dimension in table (first column)
+ */
+class CrossTabulation {
+  constructor(dimX, dimY) {
+    this.dimX = dimX;
+    this.dimY = dimY;
+    this.table = new Map();
+    this.total = 0;
+    this.dimY.entries.forEach((valueY, y) => {
+      const values = new Map();
+      this.dimX.entries.forEach((valueX, x) => {
+        values.set(x, 0);
+      });
+      this.table.set(y, { total: 0, values });
+    });
+  }
+
+  /**
+   * Increment the `(x0, y0)` bucket by 1.  This also increments the overall
+   * total, as well as the corresponding `dimY` total.
+   *
+   * @param {number?} x0 - value of `dimX`
+   * @param {number?} y0 - value of `dimY`
+   */
+  incr(x0, y0) {
+    let y = y0;
+    if (y === null || !this.table.has(y)) {
+      y = this.dimY.nullValue;
+    }
+    const tableY = this.table.get(y);
+
+    let x = x0;
+    if (x === null || !tableY.values.has(x)) {
+      x = this.dimX.nullValue;
+    }
+    const valueX = tableY.values.get(x);
+    this.total += 1;
+    tableY.total += 1;
+    tableY.values.set(x, valueX + 1);
+  }
+
+  /**
+   * @returns {Array<number?>} array of possible `dimX` values, including the `nullValue`
+   */
+  getOrderX() {
+    const { entries, nullValue } = this.dimX;
+    const keys = Array.from(entries.keys());
+    const keysNoNull = keys.filter(x => x !== nullValue);
+    const orderX = ArrayUtils.sortBy(keysNoNull, x => x);
+    orderX.push(nullValue);
+    return orderX;
+  }
+
+  /**
+   *
+   * @param {CrossTabulationOptions} options - cross tabulation options
+   * @returns {Array<number?|Array<number?>>} array of possible `dimY` values; includes
+   * `nullValue` if `!options.hideNull`; includes other values if `!options.hideOther`; sorted by
+   * `dimY` total if `options.sortByTotal`, with direction depending on `options.sortDirection`
+   */
+  getOrderY({
+    hideNull = false,
+    hideOther = false,
+    limit = 10,
+    sortByTotal = true,
+    sortDirection = SortDirection.DESC,
+  }) {
+    const { entries, nullValue } = this.dimY;
+    const keys = Array.from(entries.keys());
+    const keysNoNull = keys.filter(y => y !== nullValue);
+    let sortKey;
+    if (sortByTotal) {
+      sortKey = y => this.table.get(y).total;
+    } else {
+      sortKey = y => y;
+    }
+    const orderY = ArrayUtils.sortBy(keysNoNull, sortKey, sortDirection);
+    const n = hideNull ? keysNoNull.length : keys.length;
+    if (n <= limit) {
+      if (!hideNull) {
+        orderY.push(nullValue);
+      }
+      return orderY;
+    }
+    const hasNull = this.table.get(nullValue).total > 0;
+    if (!hideNull && hasNull) {
+      const orderYRest = orderY.slice(limit - 2);
+      const orderYLimit = orderY.slice(0, limit - 2);
+      orderYLimit.push(nullValue);
+      if (!hideOther) {
+        orderYLimit.push(orderYRest);
+      }
+      return orderYLimit;
+    }
+    const orderYRest = orderY.slice(limit - 1);
+    const orderYLimit = orderY.slice(0, limit - 1);
+    if (!hideOther) {
+      orderYLimit.push(orderYRest);
+    }
+    return orderYLimit;
+  }
+
+  /**
+   *
+   * @param {Array<number?>} orderX - ordering of `dimX` values
+   * @param {Array<number?|Array<number?>>} orderY - ordering of `dimY` values
+   * @returns {Array<Array<number>>} tabular counts of buckets, where row `i` and
+   * column `j` contains the count for `(orderX[j], orderY[i])`, and with totals
+   * appended to each row
+   */
+  getOrderedTable(orderX, orderY) {
+    const nx = orderX.length;
+    const ny = orderY.length;
+    const orderedTable = orderY.map((y) => {
+      const row = new Array(nx + 1).fill(0);
+      const ys = Array.isArray(y) ? y : [y];
+      ys.forEach((yy) => {
+        const { total, values } = this.table.get(yy);
+        orderX.forEach((x, j) => {
+          row[j] += values.get(x);
+        });
+        row[nx] += total;
+      });
+      return row;
+    });
+    const rowTotals = new Array(nx + 1).fill(0);
+    for (let i = 0; i < ny; i++) {
+      for (let j = 0; j <= nx; j++) {
+        rowTotals[j] += orderedTable[i][j];
+      }
+    }
+    orderedTable.push(rowTotals);
+    return orderedTable;
+  }
+}
+
+/**
+ * Subclass of {@link CrossTabulation} for cross-tabulations on collision events.
+ */
+class EventCrossTabulation extends CrossTabulation {
+  constructor(dimX, dimY) {
+    super(dimX, dimY);
+    if (!dimX.event || !dimY.event) {
+      throw new Error('expected event-level dimensions!');
+    }
+  }
+
+  /**
+   * Tabulates the given collision events.
+   *
+   * @param {Array<Object>} collisions - collisions to tabulate
+   */
+  tabulate(collisions) {
+    collisions.forEach((event) => {
+      const x = this.dimX.fn(event);
+      const y = this.dimY.fn(event);
+      this.incr(x, y);
+    });
+  }
+}
+
+/**
+ * Subclass of {@link CrossTabulation} for cross-tabulations on persons involved in collisions.
+ */
+class InvolvedCrossTabulation extends CrossTabulation {
+  constructor(dimX, dimY) {
+    super(dimX, dimY);
+    if (dimX.event || dimY.event) {
+      throw new Error('expected involved-level dimensions!');
+    }
+  }
+
+  /**
+   * Tabulates the persons involved in the given collision events.
+   *
+   * @param {Array<Object>} collisions - collisions to tabulate
+   */
+  tabulate(collisions) {
+    collisions.forEach(({ involved, ...event }) => {
+      involved.forEach((person) => {
+        const x = this.dimX.fn(event, person);
+        const y = this.dimY.fn(event, person);
+        this.incr(x, y);
+      });
+    });
+  }
+}
+
+/**
+ * @namespace
+ */
+const CollisionTabulation = {
+  CollisionDimension,
+  CrossTabulation,
+  EventCrossTabulation,
+  InvolvedCrossTabulation,
+};
+
+export {
+  CollisionTabulation as default,
+  CollisionDimension,
+  CrossTabulation,
+  EventCrossTabulation,
+  InvolvedCrossTabulation,
+};


### PR DESCRIPTION
# Issue Addressed
This PR closes #743 .

# Description
We implement the CSV download format for tabulation reports, and revamp the CSV format for collision directory reports to match the layout of web / PDF reports there.

# Tests
Tested quickly in frontend.