### PR TITLE
Chunked and null-safe fetching of locations in Track Requests

### DIFF
--- a/lib/ArrayUtils.js
+++ b/lib/ArrayUtils.js
@@ -34,6 +34,22 @@ class ArrayUtils {
     return [...Array(n).keys()].map(i => loActual + i);
   }
 
+  /**
+   *
+   * @param {Array} xs - array to split into chunks
+   * @param {number} k - maximum chunk size
+   * @returns {Array<Array>} `xs`, split into chunks of size at most `k`
+   */
+  static chunk(xs, k) {
+    const chunks = [];
+    const n = xs.length;
+    for (let i = 0; i < n; i += k) {
+      const chunk = xs.slice(i, i + k);
+      chunks.push(chunk);
+    }
+    return chunks;
+  }
+
   // AGGREGATION
 
   /**

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -1,3 +1,4 @@
+import ArrayUtils from '@/lib/ArrayUtils';
 import {
   centrelineKey,
   POI_RADIUS,
@@ -313,12 +314,14 @@ async function fetchStudyRequestsMetadata(studyRequests, studyRequestComments) {
   });
   userIds = Array.from(userIds);
 
-  const promiseLocations = getLocationsByCentreline(features);
   const promiseUsers = getUsersByIds(userIds);
+  const featureChunks = ArrayUtils.chunk(features, CompositeId.MAX_FEATURES);
+  const promisesLocationChunks = featureChunks.map(getLocationsByCentreline);
   const [
-    studyRequestLocations,
     studyRequestUsers,
-  ] = await Promise.all([promiseLocations, promiseUsers]);
+    ...studyRequestLocationChunks
+  ] = await Promise.all([promiseUsers, ...promisesLocationChunks]);
+  const studyRequestLocations = studyRequestLocationChunks.flat();
   const studyRequestLocationsMap = mapBy(studyRequestLocations, centrelineKey);
 
   return {

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -111,7 +111,9 @@ async function getLocationsByCentreline(features) {
   const data = { s1 };
   const options = { data };
   const locations = await apiClient.fetch('/locations/byCentreline', options);
-  const locationsSchema = Joi.array().items(CentrelineLocation);
+  const locationsSchema = Joi.array().items(
+    Joi.object().keys(CentrelineLocation).allow(null),
+  );
   return locationsSchema.validateAsync(locations);
 }
 
@@ -321,7 +323,9 @@ async function fetchStudyRequestsMetadata(studyRequests, studyRequestComments) {
     studyRequestUsers,
     ...studyRequestLocationChunks
   ] = await Promise.all([promiseUsers, ...promisesLocationChunks]);
-  const studyRequestLocations = studyRequestLocationChunks.flat();
+  const studyRequestLocations = studyRequestLocationChunks
+    .flat()
+    .filter(location => location !== null);
   const studyRequestLocationsMap = mapBy(studyRequestLocations, centrelineKey);
 
   return {

--- a/lib/controller/LocationController.js
+++ b/lib/controller/LocationController.js
@@ -157,7 +157,8 @@ LocationController.push({
   handler: async (request) => {
     const { s1 } = request.query;
     const features = CompositeId.decode(s1);
-    return CentrelineDAO.byFeatures(features);
+    const locations = await CentrelineDAO.byFeatures(features);
+    return locations.filter(location => location !== null);
   },
 });
 

--- a/lib/controller/LocationController.js
+++ b/lib/controller/LocationController.js
@@ -148,7 +148,9 @@ LocationController.push({
   options: {
     auth: { mode: 'try' },
     response: {
-      schema: Joi.array().items(CentrelineLocation),
+      schema: Joi.array().items(
+        Joi.object().keys(CentrelineLocation).allow(null),
+      ),
     },
     validate: {
       query: CentrelineSelection,
@@ -157,8 +159,7 @@ LocationController.push({
   handler: async (request) => {
     const { s1 } = request.query;
     const features = CompositeId.decode(s1);
-    const locations = await CentrelineDAO.byFeatures(features);
-    return locations.filter(location => location !== null);
+    return CentrelineDAO.byFeatures(features);
   },
 });
 

--- a/lib/db/CentrelineDAO.js
+++ b/lib/db/CentrelineDAO.js
@@ -74,7 +74,6 @@ WHERE fnode = $(intersectionId) OR tnode = $(intersectionId)`;
    * @returns {Promise<Array<CentrelineLocation>>}
    */
   static async intersectionsByIds(centrelineIds) {
-    // TODO: how do users select overpasses on the map?
     if (centrelineIds.length === 0) {
       return [];
     }

--- a/lib/db/CentrelineDAO.js
+++ b/lib/db/CentrelineDAO.js
@@ -7,11 +7,17 @@ import { InvalidCentrelineTypeError } from '@/lib/error/MoveErrors';
 import { segmentToFeature } from '@/lib/model/helpers/NormalizeUtils';
 
 /**
- * Data access layer for centreline "features", which include both segments and
+ * Data access layer for centreline "features", which include both midblocks and
  * intersections under a common interface.
  */
 class CentrelineDAO {
   // SEGMENTS
+
+  /**
+   *
+   * @param {Array<number>} centrelineIds
+   * @returns {Promise<Array<CentrelineLocation>>}
+   */
   static async segmentsByIds(centrelineIds) {
     if (centrelineIds.length === 0) {
       return [];
@@ -35,6 +41,11 @@ WHERE "centrelineId" IN ($(centrelineIds:csv))`;
     return rows.map(segmentToFeature);
   }
 
+  /**
+   *
+   * @param {number} intersectionId
+   * @returns {Promise<Array<CentrelineLocation>>}
+   */
   static async segmentsIncidentTo(intersectionId) {
     const sql = `
 SELECT
@@ -57,6 +68,11 @@ WHERE fnode = $(intersectionId) OR tnode = $(intersectionId)`;
 
   // INTERSECTIONS
 
+  /**
+   *
+   * @param {Array<number>} centrelineIds
+   * @returns {Promise<Array<CentrelineLocation>>}
+   */
   static async intersectionsByIds(centrelineIds) {
     // TODO: how do users select overpasses on the map?
     if (centrelineIds.length === 0) {
@@ -77,6 +93,11 @@ WHERE "centrelineId" IN ($(centrelineIds:csv))`;
     return db.manyOrNone(sql, { centrelineIds });
   }
 
+  /**
+   *
+   * @param {number} segmentId
+   * @returns {Promise<Array<CentrelineLocation>>}
+   */
   static async intersectionsIncidentTo(segmentId) {
     const sql = `
 SELECT
@@ -96,12 +117,22 @@ WHERE cm."centrelineId" = $(segmentId)`;
 
   // COMBINED METHODS
 
+  /**
+   *
+   * @param {CentrelineFeature} feature
+   * @returns {Promise<CentrelineLocation?>}
+   */
   static async byFeature(feature) {
     const locations = await CentrelineDAO.byFeatures([feature]);
     const [location] = locations;
     return location;
   }
 
+  /**
+   *
+   * @param {Array<CentrelineFeature>} features
+   * @returns {Promise<Array<CentrelineLocation?>>}
+   */
   static async byFeatures(features) {
     const segmentIds = new Set();
     const intersectionIds = new Set();
@@ -153,7 +184,7 @@ WHERE cm."centrelineId" = $(segmentId)`;
    *
    * @param {CentrelineType} centrelineType - type of centreline feature
    * @param {number} centrelineId - ID of centreline feature
-   * @returns {Array} incident features
+   * @returns {Promise<Array<CentrelineLocation>>} incident features
    */
   static async featuresIncidentTo(centrelineType, centrelineId) {
     if (centrelineType === CentrelineType.SEGMENT) {

--- a/lib/db/LocationSearchDAO.js
+++ b/lib/db/LocationSearchDAO.js
@@ -41,6 +41,9 @@ WHERE arterycode = $(arterycode)`;
     const { centrelineId, centrelineType } = row;
     const feature = { centrelineId, centrelineType };
     const location = await CentrelineDAO.byFeature(feature);
+    if (location === null) {
+      return [];
+    }
     return [location];
   }
 

--- a/lib/db/LocationSearchDAO.js
+++ b/lib/db/LocationSearchDAO.js
@@ -126,7 +126,8 @@ LIMIT $(limit);`;
      */
     const limitApprox = limit - featuresExact.length;
     if (limitApprox <= 0) {
-      return CentrelineDAO.byFeatures(featuresExact);
+      const locations = await CentrelineDAO.byFeatures(featuresExact);
+      return locations.filter(location => location !== null);
     }
 
     /*
@@ -168,7 +169,8 @@ LIMIT $(limitApprox);`;
       centrelineType: CentrelineType.INTERSECTION,
     }));
     const features = featuresExact.concat(featuresApprox);
-    return CentrelineDAO.byFeatures(features);
+    const locations = await CentrelineDAO.byFeatures(features);
+    return locations.filter(location => location !== null);
   }
 
   /**
@@ -188,7 +190,8 @@ SELECT "centrelineId", "centrelineType"
 FROM location_search.traffic_signal
 WHERE px = $(px)`;
     const features = await db.manyOrNone(sql, { px });
-    return CentrelineDAO.byFeatures(features);
+    const locations = await CentrelineDAO.byFeatures(features);
+    return locations.filter(location => location !== null);
   }
 
   /**

--- a/lib/email/EmailStudyRequestBulkConfirmation.js
+++ b/lib/email/EmailStudyRequestBulkConfirmation.js
@@ -39,7 +39,8 @@ class EmailStudyRequestBulkConfirmation extends EmailBase {
     const features = this.studyRequestBulk.studyRequests.map(
       ({ centrelineId, centrelineType }) => ({ centrelineId, centrelineType }),
     );
-    this.locations = await CentrelineDAO.byFeatures(features);
+    const locations = await CentrelineDAO.byFeatures(features);
+    this.locations = locations.filter(location => location !== null);
   }
 
   getRecipients() {

--- a/lib/email/EmailStudyRequestConfirmation.js
+++ b/lib/email/EmailStudyRequestConfirmation.js
@@ -7,8 +7,11 @@ import TimeFormatters from '@/lib/time/TimeFormatters';
 const TEMPLATE = `
 <div>
   <p>
-    We received your request for the following study to be conducted at
-    {{location}}:
+    We received your request for the following study
+    {{#location}}
+      to be conducted at {{location}}
+    {{/location}}
+    :
   </p>
   <ul>
     <li><strong>{{studyType}}</strong>: {{hours}}</li>
@@ -45,6 +48,9 @@ class EmailStudyRequestConfirmation extends EmailBase {
   }
 
   getSubject() {
+    if (this.location === null) {
+      return 'Request received - validation in progress';
+    }
     const { description } = this.location;
     return `Request received for ${description} - validation in progress`;
   }
@@ -68,7 +74,19 @@ class EmailStudyRequestConfirmation extends EmailBase {
     const { id } = this.studyRequest;
     const href = EmailBase.getUrl(`requests/study/${id}`);
 
-    const { description: location } = this.location;
+    /*
+     * If this study somehow refers to a centreline feature that no longer exists, we can
+     * still send out the email without crashing.
+     *
+     * In this particular case, this is *extremely* unlikely.  The centreline would have to
+     * be updated by our pipelines sometime between when the user starts the new study request
+     * flow and when the email is sent out, and that update would have to remove the centreline
+     * feature that the user has selected.
+     */
+    let location = null;
+    if (this.location !== null) {
+      location = this.location.description;
+    }
 
     const hours = EmailStudyRequestConfirmation.renderHours(this.studyRequest);
     const { studyType: { label: studyType } } = this.studyRequest;

--- a/lib/io/storage/StoragePath.js
+++ b/lib/io/storage/StoragePath.js
@@ -90,10 +90,18 @@ class StoragePath {
    */
   static async getLocationFromStudy(study) {
     const location = await CentrelineDAO.byFeature(study);
-    const description = StoragePath.sanitizeLocationDescription(
-      location.description,
-      StoragePath.MAX_LOCATION_LENGTH,
-    );
+
+    let description;
+    if (location === null) {
+      const { centrelineId, centrelineType } = study;
+      description = `${centrelineType}_${centrelineId}`;
+    } else {
+      description = StoragePath.sanitizeLocationDescription(
+        location.description,
+        StoragePath.MAX_LOCATION_LENGTH,
+      );
+    }
+
     if (location.centrelineType === CentrelineType.SEGMENT) {
       const partDirections = await StoragePath.getDirectionsFromStudy(study);
       return `${description}_${partDirections}`;

--- a/lib/io/storage/StoragePath.js
+++ b/lib/io/storage/StoragePath.js
@@ -117,9 +117,17 @@ class StoragePath {
   static async getLocationsSelection(data) {
     const { s1, selectionType } = data;
     const features = CompositeId.decode(s1);
-    const locations = await CentrelineDAO.byFeatures(features);
+    let locations = await CentrelineDAO.byFeatures(features);
+    locations = locations.filter(location => location !== null);
 
     const n = locations.length;
+    if (n === 0) {
+      /*
+       * Fallback in case no locations could be fetched (i.e. all features in the selection
+       * refer to centreline features that have since been removed).
+       */
+      return `${s1}_${selectionType.name}`;
+    }
     let descriptionFirst = StoragePath.sanitizeLocationDescription(
       locations[0].description,
       StoragePath.MAX_LOCATION_LENGTH,

--- a/lib/jobs/JobDescription.js
+++ b/lib/jobs/JobDescription.js
@@ -7,9 +7,17 @@ import JobType from '@/lib/jobs/JobType';
 class JobDescription {
   static async getGenerateReports({ reportExportMode, s1, selectionType }) {
     const features = CompositeId.decode(s1);
-    const locations = await CentrelineDAO.byFeatures(features);
+    let locations = await CentrelineDAO.byFeatures(features);
+    locations = locations.filter(location => location !== null);
     const locationsSelection = { locations, selectionType };
     const description = getLocationsSelectionDescription(locationsSelection);
+    if (description === null) {
+      /*
+       * Fallback if all locations have been removed from the centreline since the job was
+       * created.  This is *extremely* unlikely, but should still be handled.
+       */
+      return `${reportExportMode.description}: locations not found`;
+    }
     return `${reportExportMode.description}: ${description}`;
   }
 

--- a/lib/model/helpers/CentrelineLocation.js
+++ b/lib/model/helpers/CentrelineLocation.js
@@ -12,6 +12,20 @@ import {
   Point,
 } from '@/lib/model/helpers/GeoJson';
 
+/**
+ * @typedef {Object} CentrelineLocation
+ * @property {number?} aadt - annual average daily traffic (AADT, midblocks only)
+ * @property {number} centrelineId - ID of location
+ * @property {number} centrelineType - type of location
+ * @property {string?} classification - intersection classification (intersections only)
+ * @property {string} description - human-readable description
+ * @property {number} featureCode - code identifying intersection or midblock type
+ * @property {Object} geom - GeoJSON representation of intersection or midblock geometry
+ * @property {number} lat - latitude of intersection, or of midblock centroid
+ * @property {number} lng - longitude of intersection, or of midblock centroid
+ * @property {number?} roadId - identifies midblocks belonging to the same road (midblocks only)
+ */
+
 export default {
   ...CentrelineFeature,
   aadt: Joi.any().when(

--- a/lib/reports/ReportBaseFlow.js
+++ b/lib/reports/ReportBaseFlow.js
@@ -28,7 +28,18 @@ class ReportBaseFlow extends ReportBase {
 
   async generateLayoutHeader(study) {
     const location = await CentrelineDAO.byFeature(study);
-    const info = location.description;
+
+    let info;
+    if (location === null) {
+      /*
+       * Fallback in case this study refers to an old centreline feature that no longer exists.
+       */
+      const { centrelineId, centrelineType } = study;
+      info = `${centrelineType}_${centrelineId}`;
+    } else {
+      info = location.description;
+    }
+
     const { startDate: start, endDate: end } = study;
     const subinfo = TimeFormatters.formatRangeDate({ start, end });
     return { info, subinfo };

--- a/lib/reports/ReportBaseFlowDirectional.js
+++ b/lib/reports/ReportBaseFlowDirectional.js
@@ -281,6 +281,18 @@ class ReportBaseFlowDirectional extends ReportBaseFlow {
    * an array of "X-bound" directions from `intersection` for that road
    */
   static getRoadDirections(intersection, segments) {
+    if (intersection === null || segments.length === 0) {
+      /*
+       * If the underlying centreline locations cannot be found (e.g. because this study refers
+       * to locations that no longer exist in the centreline), default to north-south and
+       * east-west roads.
+       */
+      return [
+        [CardinalDirection.NORTH, CardinalDirection.SOUTH],
+        [CardinalDirection.EAST, CardinalDirection.WEST],
+      ];
+    }
+
     /*
      * Figure out which `segments` lie in which directions from `intersection`.  By combining
      * this information with `roads` (which `segments` belong to which roads), we can figure
@@ -355,21 +367,12 @@ class ReportBaseFlowDirectional extends ReportBaseFlow {
       ),
     );
 
-    /*
-     * While `minFeatureCode` is no longer used to determine major and minor directions, it is
-     * still useful in the warrant process, as it allows us to set the correct volume thresholds.
-     */
-    const minFeatureCode = Math.min(
-      ...segments.map(({ featureCode }) => featureCode),
-    );
-
     return {
       countData,
       hourlyData,
       hourlyMajorDirections,
       hourlyMinorDirections,
       intersection,
-      minFeatureCode,
       segments,
     };
   }

--- a/lib/reports/ReportIdParser.js
+++ b/lib/reports/ReportIdParser.js
@@ -39,7 +39,8 @@ async function parseCollisionReportId(rawId) {
     throw err;
   }
 
-  const locations = await CentrelineDAO.byFeatures(features);
+  let locations = await CentrelineDAO.byFeatures(features);
+  locations = locations.filter(location => location !== null);
   const locationsSelection = { locations, selectionType };
 
   const featuresSelection = { features, selectionType };

--- a/lib/reports/ReportWarrantTrafficSignalControl.js
+++ b/lib/reports/ReportWarrantTrafficSignalControl.js
@@ -46,16 +46,11 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
   }
 
   /**
-   *
-   * @param {FeatureCode} minFeatureCode - minimum feature code, as computed by
-   * {@link ReportBaseFlowDirectional}
-   * @param {Array<Object>} segments - segments incident to intersection under
-   * study, as computed by {@link ReportBaseFlowDirectional}
    * @param {Object} options - extra report-specific options parsed from
    * {@link ReportController#getReport}
    * @returns thresholds for warrant sections 1A, 1B, 2A, 2B
    */
-  static getThresholds(minFeatureCode, segments, options) {
+  static getThresholds(options) {
     /*
      * As per the City of Toronto Road Classification System p.9, all major arterials and
      * expressways are guaranteed to have at least 4 lanes.
@@ -365,7 +360,6 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
       hourlyData,
       hourlyMajorDirections,
       hourlyMinorDirections,
-      minFeatureCode,
     } = ReportBaseFlowDirectional.getDirectionalStats(study, {
       countData: rawData,
       intersection,
@@ -383,7 +377,7 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
       threshold2A,
       threshold2B,
       threshold3A,
-    } = ReportWarrantTrafficSignalControl.getThresholds(minFeatureCode, segments, options);
+    } = ReportWarrantTrafficSignalControl.getThresholds(options);
 
     /*
      * Traffic Signal Control warrants depend on hourly values computed as part of the

--- a/tests/jest/api/LocationController.spec.js
+++ b/tests/jest/api/LocationController.spec.js
@@ -80,6 +80,20 @@ test('LocationController.getLocationsByCentreline', async () => {
   response.result.forEach(({ centrelineId, centrelineType }, i) => {
     expect({ centrelineId, centrelineType }).toEqual(features[i]);
   });
+
+  // valid multi-fetch: non-existent intersection, existent segment
+  features = [
+    { centrelineId: 1, centrelineType: CentrelineType.INTERSECTION },
+    { centrelineId: 111569, centrelineType: CentrelineType.SEGMENT },
+  ];
+  s1 = CompositeId.encode(features);
+  data = { s1 };
+  response = await client.fetch('/locations/byCentreline', { data });
+  expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
+  expect(response.result.length).toEqual(features.length);
+  expect(response.result[0]).toBeNull();
+  expect(response.result[1].centrelineId).toEqual(features[1].centrelineId);
+  expect(response.result[1].centrelineType).toEqual(features[1].centrelineType);
 });
 
 test('LocationController.getLocationsByCorridor [empty]', async () => {

--- a/tests/jest/unit/ArrayUtils.spec.js
+++ b/tests/jest/unit/ArrayUtils.spec.js
@@ -27,6 +27,21 @@ test('ArrayUtils.range()', () => {
   }
 });
 
+test('ArrayUtils.chunk()', () => {
+  expect(ArrayUtils.chunk([], 2)).toEqual([]);
+  expect(ArrayUtils.chunk(['a'], 2)).toEqual([['a']]);
+  expect(ArrayUtils.chunk(['a', 'b'], 2)).toEqual([['a', 'b']]);
+  expect(ArrayUtils.chunk(['a', 'b', 'c'], 2)).toEqual([
+    ['a', 'b'],
+    ['c'],
+  ]);
+  expect(ArrayUtils.chunk(ArrayUtils.range(11), 4)).toEqual([
+    [0, 1, 2, 3],
+    [4, 5, 6, 7],
+    [8, 9, 10],
+  ]);
+});
+
 test('ArrayUtils.sumObjects()', () => {
   const xs = [
     { a: 1, b: 2 },

--- a/tests/jest/unit/time/DateTime.spec.js
+++ b/tests/jest/unit/time/DateTime.spec.js
@@ -50,7 +50,7 @@ test('DateTime [SQL parsing]', () => {
     const t = Random.range(TIME_MIN, TIME_MAX);
     const dt = DateTime.fromMillis(t);
     const dt2 = DateTime.fromSQL(dt.toSQL());
-    expect(dt.equals(dt2)).toBe(true);
+    expect(dt2.toMillis()).toBe(t);
   }
 });
 
@@ -59,7 +59,7 @@ test('DateTime [JSON parsing]', () => {
     const t = Random.range(TIME_MIN, TIME_MAX);
     const dt = DateTime.fromMillis(t);
     const dt2 = DateTime.fromJSON(dt.toJSON());
-    expect(dt.equals(dt2)).toBe(true);
+    expect(dt2.toMillis()).toBe(t);
   }
 });
 
@@ -68,6 +68,6 @@ test('DateTime [string parsing]', () => {
     const t = Random.range(TIME_MIN, TIME_MAX);
     const dt = DateTime.fromMillis(t);
     const dt2 = DateTime.fromString(dt.toString());
-    expect(dt.equals(dt2)).toBe(true);
+    expect(dt2.toMillis()).toBe(t);
   }
 });

--- a/web/components/FcPaneMapPopup.vue
+++ b/web/components/FcPaneMapPopup.vue
@@ -53,6 +53,8 @@ import CompositeId from '@/lib/io/CompositeId';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 
+const MSG_LOCATION_REMOVED = 'Location removed from centreline';
+
 const SELECTABLE_LAYERS = [
   'studies',
   'intersections',
@@ -118,6 +120,13 @@ async function getCentrelineDetails(feature, centrelineType) {
 }
 
 function getCentrelineDescription(feature, { location }) {
+  if (location === null) {
+    /*
+     * Fallback if the centreline feature the user is hovering over has just been removed by a
+     * centreline update.  This is *extremely* unlikely to happen.
+     */
+    return [MSG_LOCATION_REMOVED];
+  }
   const description = [location.description];
 
   const locationFeatureType = getLocationFeatureType(location);
@@ -186,10 +195,20 @@ function getStudyDescription(feature, { location, studySummary }) {
     description.push(studyStr);
   });
 
-  const locationFeatureType = getLocationFeatureType(location);
-  if (locationFeatureType !== null) {
-    const locationStr = `${locationFeatureType.description} \u00b7 ${location.description}`;
-    description.push(locationStr);
+  if (location === null) {
+    /*
+     * Fallback in case this study refers to a location that has been removed from the
+     * centreline.
+     */
+    description.push(MSG_LOCATION_REMOVED);
+  } else {
+    const locationFeatureType = getLocationFeatureType(location);
+    if (locationFeatureType === null) {
+      description.push(location.description);
+    } else {
+      const locationStr = `${locationFeatureType.description} \u00b7 ${location.description}`;
+      description.push(locationStr);
+    }
   }
 
   return description;

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -411,6 +411,12 @@ export default new Vuex.Store({
       }
 
       let locationsNext = await getLocationsByCentreline(features);
+      /*
+       * Since this endpoint can return `null` values, we filter those out here.  If this does
+       * change the list of features, it should trigger an update of the route parameters.
+       */
+      locationsNext = locationsNext.filter(location => location !== null);
+
       const locationsSelection = {
         locations: locationsNext,
         selectionType: selectionTypeNext,


### PR DESCRIPTION
# Issue Addressed
This PR closes #750 .

# Description
We introduce `ArrayUtils.chunk`, and use it to break the locations list into chunks of no more than `CompositeId.MAX_FEATURES` features.  We also update `/api/locations/byCentreline` to filter out `null` values.

# Tests
Added unit test for `ArrayUtils.chunk`.  Tested quickly in frontend.
