### PR TITLE
Add day of week to TMC reports, study popups, View Data

### DIFF
--- a/lib/geo/CentrelineUtils.js
+++ b/lib/geo/CentrelineUtils.js
@@ -47,6 +47,7 @@ function getLocationStudyTypes(location) {
       StudyType.ATR_VOLUME_BICYCLE,
       StudyType.PED_DELAY,
       StudyType.PXO_OBSERVE,
+      StudyType.TMC,
       StudyType.RESCU,
     ];
   }
@@ -56,6 +57,7 @@ function getLocationStudyTypes(location) {
     StudyType.ATR_VOLUME_BICYCLE,
     StudyType.PED_DELAY,
     StudyType.PXO_OBSERVE,
+    StudyType.TMC,
   ];
 }
 

--- a/lib/reports/ReportCountSummaryTurningMovement.js
+++ b/lib/reports/ReportCountSummaryTurningMovement.js
@@ -181,12 +181,17 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
       return [];
     }
     const [count] = counts;
-    const { hours, id } = count;
+    const { date, hours, id } = count;
     const px = ReportCountSummaryTurningMovement.getTrafficSignalId(count);
     const countData = studyData.get(id);
     const stats = ReportCountSummaryTurningMovement.transformCountData(countData);
 
-    return { hours, px, stats };
+    return {
+      date,
+      hours,
+      px,
+      stats,
+    };
   }
 
   generateCsv(count, { stats }) {
@@ -465,22 +470,31 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
     };
   }
 
-  static getCountMetadataOptions({ hours, px, stats }) {
+  static getCountMetadataOptions({
+    date,
+    hours,
+    px,
+    stats,
+  }) {
+    const dateStr = TimeFormatters.formatDefault(date);
+    const dayOfWeekStr = TimeFormatters.formatDayOfWeek(date);
+    const fullDateStr = `${dateStr} (${dayOfWeekStr})`;
+    const hoursStr = hours === null ? null : hours.description;
+    const pxStr = px === null ? null : px.toString();
     const {
       BIKE_TOTAL,
       PEDS_TOTAL,
       TOTAL,
       VEHICLE_TOTAL,
     } = stats.all.sum;
-    const hoursStr = hours === null ? null : hours.description;
-    const pxStr = px === null ? null : px.toString();
     const entries = [
+      { cols: 3, name: 'Date', value: fullDateStr },
+      { cols: 3, name: 'Study Hours', value: hoursStr },
+      { cols: 6, name: 'Traffic Signal #', value: pxStr },
       { cols: 3, name: '8 Hr Volume', value: TOTAL },
       { cols: 3, name: '8 Hr Vehicles', value: VEHICLE_TOTAL },
       { cols: 3, name: '8 Hr Cyclists', value: BIKE_TOTAL },
       { cols: 3, name: '8 Hr Pedestrians', value: PEDS_TOTAL },
-      { cols: 3, name: 'Study Hours', value: hoursStr },
-      { cols: 3, name: 'Traffic Signal #', value: pxStr },
     ];
     return { entries };
   }

--- a/lib/reports/ReportCountSummaryTurningMovementDetailed.js
+++ b/lib/reports/ReportCountSummaryTurningMovementDetailed.js
@@ -21,7 +21,7 @@ class ReportCountSummaryTurningMovementDetailed extends ReportBaseFlow {
       return [];
     }
     const [count] = counts;
-    const { hours, id } = count;
+    const { date, hours, id } = count;
     const px = ReportCountSummaryTurningMovement.getTrafficSignalId(count);
     const countData = studyData.get(id);
 
@@ -36,6 +36,7 @@ class ReportCountSummaryTurningMovementDetailed extends ReportBaseFlow {
 
     return {
       all,
+      date,
       hours,
       px,
       raw,
@@ -192,22 +193,31 @@ class ReportCountSummaryTurningMovementDetailed extends ReportBaseFlow {
     };
   }
 
-  static getCountMetadataOptions({ all, hours, px }) {
+  static getCountMetadataOptions({
+    all,
+    date,
+    hours,
+    px,
+  }) {
+    const dateStr = TimeFormatters.formatDefault(date);
+    const dayOfWeekStr = TimeFormatters.formatDayOfWeek(date);
+    const fullDateStr = `${dateStr} (${dayOfWeekStr})`;
+    const hoursStr = hours === null ? null : hours.description;
+    const pxStr = px === null ? null : px.toString();
     const {
       BIKE_TOTAL,
       PEDS_TOTAL,
       TOTAL,
       VEHICLE_TOTAL,
     } = all;
-    const hoursStr = hours === null ? null : hours.description;
-    const pxStr = px === null ? null : px.toString();
     const entries = [
+      { cols: 3, name: 'Date', value: fullDateStr },
+      { cols: 3, name: 'Study Hours', value: hoursStr },
+      { cols: 6, name: 'Traffic Signal #', value: pxStr },
       { cols: 3, name: '8 Hr Volume', value: TOTAL },
       { cols: 3, name: '8 Hr Vehicles', value: VEHICLE_TOTAL },
       { cols: 3, name: '8 Hr Cyclists', value: BIKE_TOTAL },
       { cols: 3, name: '8 Hr Pedestrians', value: PEDS_TOTAL },
-      { cols: 3, name: 'Study Hours', value: hoursStr },
-      { cols: 3, name: 'Traffic Signal #', value: pxStr },
     ];
     return { entries };
   }

--- a/lib/reports/ReportIntersectionSummary.js
+++ b/lib/reports/ReportIntersectionSummary.js
@@ -177,9 +177,10 @@ class ReportIntersectionSummary extends ReportBaseFlowDirectional {
     );
     const totalsRounded = ObjectUtils.map(totals, value => Math.round(value));
 
-    const { hours } = count;
+    const { date, hours } = count;
     const px = ReportCountSummaryTurningMovement.getTrafficSignalId(count);
     return {
+      date,
       hourlyTotals: hourlyTotalsRounded,
       hours,
       px,
@@ -297,22 +298,31 @@ class ReportIntersectionSummary extends ReportBaseFlowDirectional {
     };
   }
 
-  static getCountMetadataOptions({ hours, px, totals }) {
+  static getCountMetadataOptions({
+    date,
+    hours,
+    px,
+    totals,
+  }) {
+    const dateStr = TimeFormatters.formatDefault(date);
+    const dayOfWeekStr = TimeFormatters.formatDayOfWeek(date);
+    const fullDateStr = `${dateStr} (${dayOfWeekStr})`;
+    const hoursStr = hours === null ? null : hours.description;
+    const pxStr = px === null ? null : px.toString();
     const {
       MAJOR_APPROACHES,
       MAJOR_CROSSING_TOTAL,
       MINOR_APPROACHES,
       TOTAL,
     } = totals;
-    const hoursStr = hours === null ? null : hours.description;
-    const pxStr = px === null ? null : px.toString();
     const entries = [
+      { cols: 3, name: 'Date', value: fullDateStr },
+      { cols: 3, name: 'Study Hours', value: hoursStr },
+      { cols: 6, name: 'Traffic Signal #', value: pxStr },
       { cols: 3, name: '8 Hr Total Approaches', value: TOTAL },
       { cols: 3, name: '8 Hr Major Approaches', value: MAJOR_APPROACHES },
       { cols: 3, name: '8 Hr Minor Approaches', value: MINOR_APPROACHES },
       { cols: 3, name: '8 Hr Major Crossings', value: MAJOR_CROSSING_TOTAL },
-      { cols: 3, name: 'Study Hours', value: hoursStr },
-      { cols: 3, name: 'Traffic Signal #', value: pxStr },
     ];
     return { entries };
   }

--- a/lib/reports/ReportWarrantTrafficSignalControl.js
+++ b/lib/reports/ReportWarrantTrafficSignalControl.js
@@ -415,9 +415,10 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
       delayToCross,
     );
 
-    const { hours } = count;
+    const { date, hours } = count;
     const px = ReportCountSummaryTurningMovement.getTrafficSignalId(count);
     return {
+      date,
       minVolume,
       delayToCross,
       collisionHazard,
@@ -807,20 +808,25 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
   }
 
   static getCountMetadataOptions({
+    date,
     hours,
     isTwoLane,
     isXIntersection,
     px,
   }) {
+    const dateStr = TimeFormatters.formatDefault(date);
+    const dayOfWeekStr = TimeFormatters.formatDayOfWeek(date);
+    const fullDateStr = `${dateStr} (${dayOfWeekStr})`;
     const hoursStr = hours === null ? null : hours.description;
     const pxStr = px === null ? null : px.toString();
     const intersectionTypeStr = isXIntersection ? 'X (4-way)' : 'T (3-way)';
     const lanesStr = isTwoLane ? '1-2 lanes' : '3+ lanes';
     const entries = [
+      { cols: 3, name: 'Date', value: fullDateStr },
+      { cols: 3, name: 'Study Hours', value: hoursStr },
+      { cols: 6, name: 'Traffic Signal #', value: pxStr },
       { cols: 3, name: 'Intersection Type', value: intersectionTypeStr },
       { cols: 3, name: 'Road Width', value: lanesStr },
-      { cols: 3, name: 'Study Hours', value: hoursStr },
-      { cols: 3, name: 'Traffic Signal #', value: pxStr },
     ];
     return { entries };
   }

--- a/tests/jest/unit/geo/CentrelineUtils.spec.js
+++ b/tests/jest/unit/geo/CentrelineUtils.spec.js
@@ -60,7 +60,6 @@ test('CentrelineUtils.getLocationStudyTypes', () => {
     };
     const studyTypes = getLocationStudyTypes(location);
     expect(studyTypes).toBeInstanceOf(Array);
-    expect(studyTypes).not.toContain(StudyType.TMC);
   });
   let location = {
     centrelineType: CentrelineType.SEGMENT,

--- a/tests/jest/unit/reports/format/MovePdfGenerator.spec.js
+++ b/tests/jest/unit/reports/format/MovePdfGenerator.spec.js
@@ -93,6 +93,7 @@ function setup_5_36781() {
   StudyDAO.byCategoryAndCountGroup.mockResolvedValue(study);
 
   const counts = [{
+    date: DateTime.fromSQL('2018-02-27 00:00:00'),
     hours: StudyHours.SCHOOL,
     id: 36781,
     locationDesc: 'GERRARD ST AT SUMACH ST (PX 1390)',
@@ -122,6 +123,7 @@ function setup_5_38661() {
   StudyDAO.byCategoryAndCountGroup.mockResolvedValue(study);
 
   const counts = [{
+    date: DateTime.fromSQL('2019-04-13 00:00:00'),
     hours: StudyHours.ROUTINE,
     id: 38661,
     locationDesc: 'OVERLEA BLVD AT THORNCLIFFE PARK DR & E TCS (PX 679)',

--- a/web/components/FcPaneMapPopup.vue
+++ b/web/components/FcPaneMapPopup.vue
@@ -14,7 +14,7 @@
           <div
             v-for="(line, i) in description"
             :key="i"
-            class="body-1">
+            class="body-1 mb-1">
             {{line}}
           </div>
         </template>
@@ -119,20 +119,26 @@ async function getCentrelineDetails(feature, centrelineType) {
   return { location };
 }
 
-function getCentrelineDescription(feature, { location }) {
+function getLocationDescription(location) {
   if (location === null) {
     /*
-     * Fallback if the centreline feature the user is hovering over has just been removed by a
-     * centreline update.  This is *extremely* unlikely to happen.
+     * Fallback in case this study refers to a location that has been removed from the
+     * centreline.
      */
-    return [MSG_LOCATION_REMOVED];
+    return MSG_LOCATION_REMOVED;
   }
-  const description = [location.description];
-
   const locationFeatureType = getLocationFeatureType(location);
-  if (locationFeatureType !== null) {
-    description.push(locationFeatureType.description);
+  if (locationFeatureType === null) {
+    return location.description;
   }
+  return `${locationFeatureType.description} \u00b7 ${location.description}`;
+}
+
+function getCentrelineDescription(feature, { location }) {
+  const description = [];
+
+  const locationStr = getLocationDescription(location);
+  description.push(locationStr);
 
   const { centrelineType } = feature.properties;
   if (centrelineType === CentrelineType.SEGMENT) {
@@ -191,25 +197,13 @@ function getStudyDescription(feature, { location, studySummary }) {
     }
     const { startDate } = mostRecent;
     const startDateStr = TimeFormatters.formatDefault(startDate);
-    const studyStr = `${label} (${startDateStr})`;
+    const dayOfWeek = TimeFormatters.formatDayOfWeek(startDate);
+    const studyStr = `${label}: ${startDateStr} (${dayOfWeek})`;
     description.push(studyStr);
   });
 
-  if (location === null) {
-    /*
-     * Fallback in case this study refers to a location that has been removed from the
-     * centreline.
-     */
-    description.push(MSG_LOCATION_REMOVED);
-  } else {
-    const locationFeatureType = getLocationFeatureType(location);
-    if (locationFeatureType === null) {
-      description.push(location.description);
-    } else {
-      const locationStr = `${locationFeatureType.description} \u00b7 ${location.description}`;
-      description.push(locationStr);
-    }
-  }
+  const locationStr = getLocationDescription(location);
+  description.push(locationStr);
 
   return description;
 }

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -257,7 +257,8 @@ export default {
         ...this.studySummary.map(({ mostRecent: { startDate } }) => startDate),
       );
       const mostRecentDateStr = TimeFormatters.formatDefault(mostRecentDate);
-      return `${nStr} (${mostRecentDateStr})`;
+      const dayOfWeek = TimeFormatters.formatDayOfWeek(mostRecentDate);
+      return `${nStr}: ${mostRecentDateStr} (${dayOfWeek})`;
     },
     textLocationsSelectionIncludes() {
       if (this.locationsSelection.selectionType !== LocationSelectionType.CORRIDOR) {

--- a/web/components/location/FcHeaderSingleLocation.vue
+++ b/web/components/location/FcHeaderSingleLocation.vue
@@ -50,7 +50,8 @@ export default {
         ...this.studySummary.map(({ mostRecent: { startDate } }) => startDate),
       );
       const mostRecentDateStr = TimeFormatters.formatDefault(mostRecentDate);
-      return `${nStr} (${mostRecentDateStr})`;
+      const dayOfWeek = TimeFormatters.formatDayOfWeek(mostRecentDate);
+      return `${nStr}: ${mostRecentDateStr} (${dayOfWeek})`;
     },
   },
   watch: {


### PR DESCRIPTION
# Issue Addressed
This PR closes #745 .

# Description
We add the day of week in brackets to several places where the date of a study is shown.  We also change `CentrelineUtils` to allow requesting new TMCs at midblocks, in keeping with recent conflation updates that allow existing TMC studies to be placed on midblocks.

# Tests
Ran CI tests, tested quickly in frontend.
