### PR TITLE
Fix text entry bug in date picker

### DIFF
--- a/web/components/inputs/FcDatePicker.vue
+++ b/web/components/inputs/FcDatePicker.vue
@@ -52,6 +52,8 @@
 import DateTime from '@/lib/time/DateTime';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 
+const REGEX_VALUE_FORMATTED = /[0-9]{4}-[0-9]{2}-[0-9]{2}/;
+
 function fromInternalValue(internalValue) {
   if (internalValue === null) {
     return null;
@@ -61,6 +63,10 @@ function fromInternalValue(internalValue) {
 
 function fromValueFormatted(valueFormatted) {
   if (valueFormatted === null) {
+    return null;
+  }
+  const match = REGEX_VALUE_FORMATTED.exec(valueFormatted);
+  if (match === null) {
     return null;
   }
   const dt = DateTime.fromISO(valueFormatted);


### PR DESCRIPTION
# Issue Addressed
This PR closes #729 .

# Description
It turns out that `19` is a valid ISO datetime string, which is interpreted as "today at 19:00".  This meant that, whenever the user entered the first two digits of a year, it would detect that as a valid date and fill in the date picker with today's date.

Checking this against a full date regex fixes the issue.

# Tests
Tested quickly in frontend.