### PR TITLE
Signal warrant: use average for combination, copy update

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -555,7 +555,7 @@ ReportType.init({
   WARRANT_TRAFFIC_SIGNAL_CONTROL: {
     disabled: false,
     formats: [ReportFormat.PDF],
-    label: 'Warrant: Traffic Signal Control',
+    label: 'Warrant: Traffic Control Signal',
     options: {
       adequateTrial: ReportParameter.BOOLEAN,
       isTwoLane: ReportParameter.BOOLEAN,
@@ -840,7 +840,7 @@ StudyRequestReason.init({
     text: 'Signal Timing',
   },
   TSC: {
-    text: 'Traffic Signal Control',
+    text: 'Traffic Control Signal',
   },
   OTHER: {
     text: 'Other',

--- a/lib/reports/ReportWarrantTrafficSignalControl.js
+++ b/lib/reports/ReportWarrantTrafficSignalControl.js
@@ -327,22 +327,17 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
    */
   static evaluateCombinationWarrant(minVolume, delayToCross) {
     /*
-     * Note that the combination warrant only passes if sections 1A, 1B, 2A, and 2B are met
-     * *for every hour*.
+     * Note that the combination warrant passes if sections 1 and 2 both have 80% or better
+     * compliance.  Section-wide compliance is determined by averaging across the study
+     * period.
+     *
+     * Previously, this applied a stricter requirement: sections 1A, 1B, 2A, and 2B all had
+     * to meet the 80% threshold in every hour.  Users remarked that they had been using
+     * an average-based process, hence the change here.
      */
-    const met1A = minVolume.a.hourly.every(
-      ({ compliance }) => compliance >= ReportWarrantTrafficSignalControl.COMPLIANCE_PARTIAL,
-    );
-    const met1B = minVolume.b.hourly.every(
-      ({ compliance }) => compliance >= ReportWarrantTrafficSignalControl.COMPLIANCE_PARTIAL,
-    );
-    const met2A = delayToCross.a.hourly.every(
-      ({ compliance }) => compliance >= ReportWarrantTrafficSignalControl.COMPLIANCE_PARTIAL,
-    );
-    const met2B = delayToCross.b.hourly.every(
-      ({ compliance }) => compliance >= ReportWarrantTrafficSignalControl.COMPLIANCE_PARTIAL,
-    );
-    return met1A && met1B && met2A && met2B;
+    const met1 = minVolume.compliance >= ReportWarrantTrafficSignalControl.COMPLIANCE_PARTIAL;
+    const met2 = delayToCross.compliance >= ReportWarrantTrafficSignalControl.COMPLIANCE_PARTIAL;
+    return met1 && met2;
   }
 
   /**
@@ -380,7 +375,7 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
     } = ReportWarrantTrafficSignalControl.getThresholds(options);
 
     /*
-     * Traffic Signal Control warrants depend on hourly values computed as part of the
+     * Traffic Control Signal warrants depend on hourly values computed as part of the
      * Intersection Summary Report.  As such, we can reuse that logic here!
      */
     const hourlyTotals = hourlyData.map(
@@ -598,8 +593,8 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
           },
           {
             value: `Have both of warrants #1, #2
-            been satisfied to the extent of
-            80% at least for every hour?`,
+            been 80% satisfied on average over
+            the study period?`,
             header: true,
             style: { bt: true, shade: true },
           },

--- a/tests/jest/unit/reports/ReportWarrantTrafficSignalControl.spec.js
+++ b/tests/jest/unit/reports/ReportWarrantTrafficSignalControl.spec.js
@@ -23,6 +23,7 @@ function setup_5_38661() {
   };
 
   const count = {
+    date: DateTime.fromSQL('2019-04-13 00:00:00'),
     hours: StudyHours.ROUTINE,
     id: 38661,
     locationDesc: 'OVERLEA BLVD AT THORNCLIFFE PARK DR & E TCS (PX 679)',

--- a/tests/jest/unit/reports/data/transformedData_WARRANT_TRAFFIC_SIGNAL_CONTROL_5_38661.json
+++ b/tests/jest/unit/reports/data/transformedData_WARRANT_TRAFFIC_SIGNAL_CONTROL_5_38661.json
@@ -211,5 +211,6 @@
     "b": true,
     "compliance": 100
   },
-  "combination": false
+  "combination": true,
+  "date": "2019-04-13 00:00:00.000"
 }


### PR DESCRIPTION
# Issue Addressed
This PR makes progress on #682 .

# Description
Turns out that "Traffic Signal Control" should be "Traffic Control Signal", and that divisional practice for the combination warrant (Section 4) is to use the average compliance over the study period - not the minimum compliance of any hour.

# Tests
Tested quickly in frontend, and updated reporting unit tests accordingly so that those still pass.
