### PR TITLE
Email notification revamp

### DIFF
--- a/lib/controller/StudyRequestBulkController.js
+++ b/lib/controller/StudyRequestBulkController.js
@@ -4,9 +4,9 @@ import { canUpdateStudyRequestBulk } from '@/lib/auth/StudyRequestPermissions';
 import { AuthScope, LocationSelectionType } from '@/lib/Constants';
 import StudyRequestBulkDAO from '@/lib/db/StudyRequestBulkDAO';
 import StudyRequestChangeDAO from '@/lib/db/StudyRequestChangeDAO';
-import EmailStudyRequestBulkConfirmation from '@/lib/email/EmailStudyRequestBulkConfirmation';
-import Mailer from '@/lib/email/Mailer';
-import LogTag from '@/lib/log/LogTag';
+import EmailStudyRequestBulkRequested from '@/lib/email/EmailStudyRequestBulkRequested';
+import EmailStudyRequestBulkRequestedAdmin from '@/lib/email/EmailStudyRequestBulkRequestedAdmin';
+import { sendEmailSafe } from '@/lib/email/MailUtils';
 import Joi from '@/lib/model/Joi';
 import StudyRequestBulk from '@/lib/model/StudyRequestBulk';
 import StudyRequestChange from '@/lib/model/StudyRequestChange';
@@ -56,14 +56,12 @@ StudyRequestBulkController.push({
   handler: async (request) => {
     const user = request.auth.credentials;
     const studyRequestBulk = await StudyRequestBulkDAO.create(request.payload, user);
-    try {
-      const email = new EmailStudyRequestBulkConfirmation(user, studyRequestBulk);
-      const emailOptions = await email.getOptions();
-      const emailResponse = await Mailer.send(emailOptions);
-      request.log(LogTag.DEBUG, emailResponse);
-    } catch (err) {
-      request.log(LogTag.ERROR, err);
-    }
+    const emailRequestedAdmin = new EmailStudyRequestBulkRequestedAdmin(studyRequestBulk);
+    const emailRequested = new EmailStudyRequestBulkRequested(studyRequestBulk);
+    await Promise.all([
+      sendEmailSafe(emailRequestedAdmin),
+      sendEmailSafe(emailRequested),
+    ]);
     return studyRequestBulk;
   },
 });

--- a/lib/controller/StudyRequestBulkController.js
+++ b/lib/controller/StudyRequestBulkController.js
@@ -59,8 +59,8 @@ StudyRequestBulkController.push({
     const emailRequestedAdmin = new EmailStudyRequestBulkRequestedAdmin(studyRequestBulk);
     const emailRequested = new EmailStudyRequestBulkRequested(studyRequestBulk);
     await Promise.all([
-      sendEmailSafe(emailRequestedAdmin),
-      sendEmailSafe(emailRequested),
+      sendEmailSafe(request, emailRequestedAdmin),
+      sendEmailSafe(request, emailRequested),
     ]);
     return studyRequestBulk;
   },

--- a/lib/controller/StudyRequestBulkController.js
+++ b/lib/controller/StudyRequestBulkController.js
@@ -6,7 +6,7 @@ import StudyRequestBulkDAO from '@/lib/db/StudyRequestBulkDAO';
 import StudyRequestChangeDAO from '@/lib/db/StudyRequestChangeDAO';
 import EmailStudyRequestBulkRequested from '@/lib/email/EmailStudyRequestBulkRequested';
 import EmailStudyRequestBulkRequestedAdmin from '@/lib/email/EmailStudyRequestBulkRequestedAdmin';
-import { sendEmailSafe } from '@/lib/email/MailUtils';
+import { sendEmailSafe, sendStudyRequestBulkUpdateEmailsSafe } from '@/lib/email/MailUtils';
 import Joi from '@/lib/model/Joi';
 import StudyRequestBulk from '@/lib/model/StudyRequestBulk';
 import StudyRequestChange from '@/lib/model/StudyRequestChange';
@@ -228,7 +228,9 @@ StudyRequestBulkController.push({
       return err;
     }
 
-    const tasks = [StudyRequestBulkDAO.update(studyRequestBulkNew, user)];
+    const tasks = [
+      StudyRequestBulkDAO.update(studyRequestBulkNew, user),
+    ];
     const n = studyRequestBulkNew.studyRequests.length;
     for (let i = 0; i < n; i++) {
       const studyRequestNew = studyRequestBulkNew.studyRequests[i];
@@ -238,6 +240,9 @@ StudyRequestBulkController.push({
       }
     }
     const [studyRequestBulk] = await Promise.all(tasks);
+
+    await sendStudyRequestBulkUpdateEmailsSafe(request, studyRequestBulkNew, studyRequestBulkOld);
+
     return studyRequestBulk;
   },
 });

--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -9,7 +9,7 @@ import StudyRequestCommentDAO from '@/lib/db/StudyRequestCommentDAO';
 import EmailStudyRequestNewComment from '@/lib/email/EmailStudyRequestNewComment';
 import EmailStudyRequestRequested from '@/lib/email/EmailStudyRequestRequested';
 import EmailStudyRequestRequestedAdmin from '@/lib/email/EmailStudyRequestRequestedAdmin';
-import { sendEmailSafe } from '@/lib/email/MailUtils';
+import { sendEmailSafe, sendStudyRequestUpdateEmailsSafe } from '@/lib/email/MailUtils';
 import CompositeId from '@/lib/io/CompositeId';
 import Joi from '@/lib/model/Joi';
 import StudyRequest from '@/lib/model/StudyRequest';
@@ -226,7 +226,9 @@ StudyRequestController.push({
       return err;
     }
 
-    const tasks = [StudyRequestDAO.update(studyRequestNew, user)];
+    const tasks = [
+      StudyRequestDAO.update(studyRequestNew, user),
+    ];
     if (studyRequestNew.status !== studyRequestOld.status) {
       /*
        * At one point, we had planned to log all changes in `study_request_changes`.
@@ -237,6 +239,9 @@ StudyRequestController.push({
       tasks.push(StudyRequestChangeDAO.create(studyRequestNew, user));
     }
     const [studyRequest] = await Promise.all(tasks);
+
+    await sendStudyRequestUpdateEmailsSafe(request, studyRequestNew, studyRequestOld);
+
     return studyRequest;
   },
 });

--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -66,8 +66,8 @@ StudyRequestController.push({
     const emailRequestedAdmin = new EmailStudyRequestRequestedAdmin(studyRequest);
     const emailRequested = new EmailStudyRequestRequested(studyRequest);
     await Promise.all([
-      sendEmailSafe(emailRequestedAdmin),
-      sendEmailSafe(emailRequested),
+      sendEmailSafe(request, emailRequestedAdmin),
+      sendEmailSafe(request, emailRequested),
     ]);
     return studyRequest;
   },
@@ -337,7 +337,7 @@ StudyRequestController.push({
       studyRequestUpdated,
       studyRequestComment,
     );
-    await sendEmailSafe(emailNewComment);
+    await sendEmailSafe(request, emailNewComment);
 
     return {
       studyRequest: studyRequestUpdated,

--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -6,10 +6,11 @@ import StudyRequestDAO from '@/lib/db/StudyRequestDAO';
 import StudyRequestBulkDAO from '@/lib/db/StudyRequestBulkDAO';
 import StudyRequestChangeDAO from '@/lib/db/StudyRequestChangeDAO';
 import StudyRequestCommentDAO from '@/lib/db/StudyRequestCommentDAO';
-import EmailStudyRequestConfirmation from '@/lib/email/EmailStudyRequestConfirmation';
-import Mailer from '@/lib/email/Mailer';
+import EmailStudyRequestNewComment from '@/lib/email/EmailStudyRequestNewComment';
+import EmailStudyRequestRequested from '@/lib/email/EmailStudyRequestRequested';
+import EmailStudyRequestRequestedAdmin from '@/lib/email/EmailStudyRequestRequestedAdmin';
+import { sendEmailSafe } from '@/lib/email/MailUtils';
 import CompositeId from '@/lib/io/CompositeId';
-import LogTag from '@/lib/log/LogTag';
 import Joi from '@/lib/model/Joi';
 import StudyRequest from '@/lib/model/StudyRequest';
 import StudyRequestBulk from '@/lib/model/StudyRequestBulk';
@@ -62,14 +63,12 @@ StudyRequestController.push({
   handler: async (request) => {
     const user = request.auth.credentials;
     const studyRequest = await StudyRequestDAO.create(request.payload, user);
-    try {
-      const email = new EmailStudyRequestConfirmation(user, studyRequest);
-      const emailOptions = await email.getOptions();
-      const emailResponse = await Mailer.send(emailOptions);
-      request.log(LogTag.DEBUG, emailResponse);
-    } catch (err) {
-      request.log(LogTag.ERROR, err);
-    }
+    const emailRequestedAdmin = new EmailStudyRequestRequestedAdmin(studyRequest);
+    const emailRequested = new EmailStudyRequestRequested(studyRequest);
+    await Promise.all([
+      sendEmailSafe(emailRequestedAdmin),
+      sendEmailSafe(emailRequested),
+    ]);
     return studyRequest;
   },
 });
@@ -333,6 +332,13 @@ StudyRequestController.push({
       StudyRequestDAO.update(studyRequest, user),
       StudyRequestCommentDAO.create(request.payload, studyRequest, user),
     ]);
+
+    const emailNewComment = new EmailStudyRequestNewComment(
+      studyRequestUpdated,
+      studyRequestComment,
+    );
+    await sendEmailSafe(emailNewComment);
+
     return {
       studyRequest: studyRequestUpdated,
       studyRequestComment,

--- a/lib/email/EmailBase.js
+++ b/lib/email/EmailBase.js
@@ -7,7 +7,6 @@ import { NotImplementedError } from '@/lib/error/MoveErrors';
 const PORT_HTTPS_DEFAULT = 443;
 const {
   emailSender,
-  ENV,
   PUBLIC_PATH,
   session: { domain = 'localhost' },
   webPort = PORT_HTTPS_DEFAULT,
@@ -92,7 +91,7 @@ class EmailBase {
    * spamming the Data Collection team with test requests!
    */
   static getRecipientStudyRequestAdmin() {
-    if (ENV === 'production') {
+    if (domain === 'move.intra.prod-toronto.ca') {
       /*
        * This goes to the Data Collection team, which manages study requests and coordinates
        * their completion with vendors.

--- a/lib/email/EmailBase.js
+++ b/lib/email/EmailBase.js
@@ -132,7 +132,7 @@ class EmailBase {
   async getOptions() {
     await this.init();
     const from = EmailBase.getSender();
-    const to = this.getRecipients();
+    const to = Array.from(new Set(this.getRecipients()));
     const subject = this.getSubject();
     const html = this.render();
     return {
@@ -157,6 +157,6 @@ EmailBase.REPLY_TO = 'move-team@toronto.ca';
  * @memberof EmailBase
  * @type {string}
  */
-EmailBase.TO_TSU = 'trafficdata@toronto.ca';
+EmailBase.TO_DATA_COLLECTION = 'trafficdata@toronto.ca';
 
 export default EmailBase;

--- a/lib/email/EmailBase.js
+++ b/lib/email/EmailBase.js
@@ -3,15 +3,15 @@ import Mustache from 'mustache';
 
 import config from '@/lib/config/MoveConfig';
 import { NotImplementedError } from '@/lib/error/MoveErrors';
-import vueConfig from '@/vue.config';
 
 const PORT_HTTPS_DEFAULT = 443;
 const {
   emailSender,
+  ENV,
+  PUBLIC_PATH,
   session: { domain = 'localhost' },
   webPort = PORT_HTTPS_DEFAULT,
 } = config;
-const { publicPath } = vueConfig;
 
 /**
  * Email message options, to be passed to `Mailer.send()`.
@@ -58,7 +58,7 @@ class EmailBase {
    */
   static getUrl(path) {
     const port = webPort === PORT_HTTPS_DEFAULT ? '' : `:${webPort}`;
-    let fullPath = `${publicPath}${path}`;
+    let fullPath = `${PUBLIC_PATH}${path}`;
     fullPath = fullPath.replace('//', '/');
     return `https://${domain}${port}${fullPath}`;
   }
@@ -84,6 +84,27 @@ class EmailBase {
    */
   static getSender() {
     return emailSender;
+  }
+
+  /**
+   * Returns the study request admin email address for this environment.  We
+   * redirect this to an internal MOVE list in non-production environments, to avoid
+   * spamming the Data Collection team with test requests!
+   */
+  static getRecipientStudyRequestAdmin() {
+    if (ENV === 'production') {
+      /*
+       * This goes to the Data Collection team, which manages study requests and coordinates
+       * their completion with vendors.
+       */
+      return 'TrafficData@toronto.ca';
+    }
+    /*
+     * This is the MOVE operational channel.  Although these emails aren't ops-related per se,
+     * they are automated, so we send them here instead of bombarding our `move-team@toronto.ca`
+     * address.
+     */
+    return 'move-ops@toronto.ca';
   }
 
   /**
@@ -172,13 +193,5 @@ class EmailBase {
  * incoming email address.
  */
 EmailBase.REPLY_TO = 'move-team@toronto.ca';
-
-/**
- * Alias for Data Collection Supervisors at the City of Toronto.
- *
- * @memberof EmailBase
- * @type {string}
- */
-EmailBase.TO_DATA_COLLECTION = 'trafficdata@toronto.ca';
 
 export default EmailBase;

--- a/lib/email/EmailBase.js
+++ b/lib/email/EmailBase.js
@@ -1,5 +1,8 @@
 /* eslint-disable class-methods-use-this */
+import Mustache from 'mustache';
+
 import config from '@/lib/config/MoveConfig';
+import { NotImplementedError } from '@/lib/error/MoveErrors';
 import vueConfig from '@/vue.config';
 
 const PORT_HTTPS_DEFAULT = 443;
@@ -92,7 +95,7 @@ class EmailBase {
    * @returns {Array<string>} list of recipients
    */
   getRecipients() {
-    throw new Error('getRecipients() not implemented!');
+    throw new NotImplementedError();
   }
 
   /**
@@ -103,7 +106,24 @@ class EmailBase {
    * @returns {string} email subject line
    */
   getSubject() {
-    throw new Error('getSubject() not implemented!');
+    throw new NotImplementedError();
+  }
+
+  /**
+   * Returns the template to be used to render the HTML body of this
+   * email.
+   */
+  getBodyTemplate() {
+    throw new NotImplementedError();
+  }
+
+  /**
+   * Returns the template parameters to be used with the result of
+   * {@link EmailBase#getBodyTemplate} to render the HTML body of this
+   * email.
+   */
+  getBodyParams() {
+    throw new NotImplementedError();
   }
 
   /**
@@ -118,7 +138,9 @@ class EmailBase {
    * @returns {string} HTML body of email
    */
   render() {
-    throw new Error('render() not implemented!');
+    const template = this.getBodyTemplate();
+    const options = this.getBodyParams();
+    return Mustache.render(template, options);
   }
 
   /**

--- a/lib/email/EmailBaseStudyRequest.js
+++ b/lib/email/EmailBaseStudyRequest.js
@@ -1,0 +1,19 @@
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import EmailBase from '@/lib/email/EmailBase';
+
+class EmailBaseStudyRequest extends EmailBase {
+  constructor(user, studyRequest) {
+    super();
+    this.user = user;
+    this.studyRequest = studyRequest;
+    this.location = null;
+  }
+
+  async init() {
+    const { centrelineId, centrelineType } = this.studyRequest;
+    const feature = { centrelineId, centrelineType };
+    this.location = await CentrelineDAO.byFeature(feature);
+  }
+}
+
+export default EmailBaseStudyRequest;

--- a/lib/email/EmailBaseStudyRequest.js
+++ b/lib/email/EmailBaseStudyRequest.js
@@ -1,6 +1,9 @@
+import { LocationSelectionType } from '@/lib/Constants';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import UserDAO from '@/lib/db/UserDAO';
 import EmailBase from '@/lib/email/EmailBase';
+import EmailStudyRequestUtils from '@/lib/email/EmailStudyRequestUtils';
+import CompositeId from '@/lib/io/CompositeId';
 
 class EmailBaseStudyRequest extends EmailBase {
   constructor(studyRequest) {
@@ -19,6 +22,42 @@ class EmailBaseStudyRequest extends EmailBase {
     ]);
     this.location = location;
     this.requester = requester;
+  }
+
+  getBodyParams() {
+    const { id } = this.studyRequest;
+    const hrefStudyRequest = EmailBase.getUrl(`requests/study/${id}`);
+
+    /*
+     * If this study somehow refers to a centreline feature that no longer exists, we can
+     * still send out the email without crashing.
+     *
+     * In this particular case, this is *extremely* unlikely.  The centreline would have to
+     * be updated by our pipelines sometime between when the user starts the new study request
+     * flow and when the email is sent out, and that update would have to remove the centreline
+     * feature that the user has selected.
+     */
+    let location = null;
+    let hrefLocation = null;
+    if (this.location !== null) {
+      location = this.location.description;
+      const s1 = CompositeId.encode([this.location]);
+      const selectionType = LocationSelectionType.POINTS;
+      hrefLocation = EmailBase.getUrl(`/view/location/${s1}/${selectionType.name}`);
+    }
+
+    const days = EmailStudyRequestUtils.renderDays(this.studyRequest);
+    const hours = EmailStudyRequestUtils.renderHours(this.studyRequest);
+    const { studyType: { label: studyType } } = this.studyRequest;
+
+    return {
+      days,
+      hrefLocation,
+      hrefStudyRequest,
+      hours,
+      location,
+      studyType,
+    };
   }
 }
 

--- a/lib/email/EmailBaseStudyRequest.js
+++ b/lib/email/EmailBaseStudyRequest.js
@@ -1,18 +1,24 @@
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import UserDAO from '@/lib/db/UserDAO';
 import EmailBase from '@/lib/email/EmailBase';
 
 class EmailBaseStudyRequest extends EmailBase {
-  constructor(user, studyRequest) {
+  constructor(studyRequest) {
     super();
-    this.user = user;
     this.studyRequest = studyRequest;
     this.location = null;
+    this.requester = null;
   }
 
   async init() {
     const { centrelineId, centrelineType } = this.studyRequest;
     const feature = { centrelineId, centrelineType };
-    this.location = await CentrelineDAO.byFeature(feature);
+    const [location, requester] = await Promise.all([
+      CentrelineDAO.byFeature(feature),
+      UserDAO.byId(this.studyRequest.userId),
+    ]);
+    this.location = location;
+    this.requester = requester;
   }
 }
 

--- a/lib/email/EmailBaseStudyRequestBulk.js
+++ b/lib/email/EmailBaseStudyRequestBulk.js
@@ -1,8 +1,10 @@
-import { centrelineKey } from '@/lib/Constants';
+import { centrelineKey, LocationSelectionType } from '@/lib/Constants';
 import { mapBy } from '@/lib/MapUtils';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import UserDAO from '@/lib/db/UserDAO';
 import EmailBase from '@/lib/email/EmailBase';
+import EmailStudyRequestUtils from '@/lib/email/EmailStudyRequestUtils';
+import { getLocationsSelectionDescription } from '@/lib/geo/CentrelineUtils';
 import CompositeId from '@/lib/io/CompositeId';
 
 class EmailBaseStudyRequestBulk extends EmailBase {
@@ -34,6 +36,66 @@ class EmailBaseStudyRequestBulk extends EmailBase {
     let studyRequestLocations = await CentrelineDAO.byFeatures(studyRequestFeatures);
     studyRequestLocations = studyRequestLocations.filter(location => location !== null);
     this.locationsMap = mapBy(studyRequestLocations, centrelineKey);
+  }
+
+  getStudyRequestParams(studyRequest) {
+    const days = EmailStudyRequestUtils.renderDays(studyRequest);
+    const hours = EmailStudyRequestUtils.renderHours(studyRequest);
+    const { studyType: { label: studyType } } = studyRequest;
+
+    const key = centrelineKey(studyRequest);
+    let location = null;
+    let hrefLocation = null;
+    if (this.studyRequestLocationsMap.has(key)) {
+      const studyRequestLocation = this.studyRequestLocationsMap.get(key);
+      location = studyRequestLocation.description;
+      const s1 = CompositeId.encode([studyRequestLocation]);
+      const selectionType = LocationSelectionType.POINTS;
+      hrefLocation = EmailBase.getUrl(`/view/location/${s1}/${selectionType.name}`);
+    }
+
+    return {
+      days,
+      hours,
+      hrefLocation,
+      location,
+      studyType,
+    };
+  }
+
+  getBodyParams() {
+    const { id, name } = this.studyRequestBulk;
+    const hrefStudyRequestBulk = EmailBase.getUrl(`requests/study/bulk/${id}`);
+
+    /*
+     * If this study somehow refers entirely to centreline features that no longer exist, we can
+     * still send out the email without crashing.
+     *
+     * In this particular case, this is *extremely* unlikely.  The centreline would have to
+     * be updated by our pipelines sometime between when the user starts the new study request
+     * flow and when the email is sent out, and that update would have to remove all centreline
+     * features that the user has selected.
+     */
+    let location = null;
+    let hrefLocation = null;
+    if (this.locationsSelection !== null) {
+      location = getLocationsSelectionDescription(this.locationsSelection);
+      const { locations, selectionType } = this.locationsSelection;
+      const s1 = CompositeId.encode(locations);
+      hrefLocation = EmailBase.getUrl(`/view/location/${s1}/${selectionType.name}`);
+    }
+
+    const studyRequests = this.studyRequestBulk.studyRequests.map(
+      this.getStudyRequestParams.bind(this),
+    );
+
+    return {
+      hrefLocation,
+      hrefStudyRequestBulk,
+      location,
+      name,
+      studyRequests,
+    };
   }
 }
 

--- a/lib/email/EmailBaseStudyRequestBulk.js
+++ b/lib/email/EmailBaseStudyRequestBulk.js
@@ -1,0 +1,35 @@
+import { centrelineKey } from '@/lib/Constants';
+import { mapBy } from '@/lib/MapUtils';
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import EmailBase from '@/lib/email/EmailBase';
+import CompositeId from '@/lib/io/CompositeId';
+
+class EmailBaseStudyRequestBulk extends EmailBase {
+  constructor(user, studyRequestBulk) {
+    super();
+    this.user = user;
+    this.studyRequestBulk = studyRequestBulk;
+    this.studyRequestLocationsMap = new Map();
+    this.locationsSelection = null;
+  }
+
+  async init() {
+    const { s1, selectionType, studyRequests } = this.studyRequestBulk;
+
+    const features = CompositeId.decode(s1);
+    let locations = await CentrelineDAO.byFeatures(features);
+    locations = locations.filter(location => location !== null);
+    if (locations.length > 0) {
+      this.locationsSelection = { locations, selectionType };
+    }
+
+    const studyRequestFeatures = studyRequests.map(
+      ({ centrelineId, centrelineType }) => ({ centrelineId, centrelineType }),
+    );
+    let studyRequestLocations = await CentrelineDAO.byFeatures(studyRequestFeatures);
+    studyRequestLocations = studyRequestLocations.filter(location => location !== null);
+    this.locationsMap = mapBy(studyRequestLocations, centrelineKey);
+  }
+}
+
+export default EmailBaseStudyRequestBulk;

--- a/lib/email/EmailBaseStudyRequestBulk.js
+++ b/lib/email/EmailBaseStudyRequestBulk.js
@@ -1,27 +1,32 @@
 import { centrelineKey } from '@/lib/Constants';
 import { mapBy } from '@/lib/MapUtils';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import UserDAO from '@/lib/db/UserDAO';
 import EmailBase from '@/lib/email/EmailBase';
 import CompositeId from '@/lib/io/CompositeId';
 
 class EmailBaseStudyRequestBulk extends EmailBase {
-  constructor(user, studyRequestBulk) {
+  constructor(studyRequestBulk) {
     super();
-    this.user = user;
     this.studyRequestBulk = studyRequestBulk;
-    this.studyRequestLocationsMap = new Map();
     this.locationsSelection = null;
+    this.requester = null;
+    this.studyRequestLocationsMap = new Map();
   }
 
   async init() {
     const { s1, selectionType, studyRequests } = this.studyRequestBulk;
 
     const features = CompositeId.decode(s1);
-    let locations = await CentrelineDAO.byFeatures(features);
-    locations = locations.filter(location => location !== null);
-    if (locations.length > 0) {
-      this.locationsSelection = { locations, selectionType };
+    const [locations, requester] = await Promise.all([
+      CentrelineDAO.byFeatures(features),
+      UserDAO.byId(this.studyRequestBulk.userId),
+    ]);
+    const locationsFiltered = locations.filter(location => location !== null);
+    if (locationsFiltered.length > 0) {
+      this.locationsSelection = { locations: locationsFiltered, selectionType };
     }
+    this.requester = requester;
 
     const studyRequestFeatures = studyRequests.map(
       ({ centrelineId, centrelineType }) => ({ centrelineId, centrelineType }),

--- a/lib/email/EmailStudyRequestBulkCancelled.js
+++ b/lib/email/EmailStudyRequestBulkCancelled.js
@@ -6,8 +6,12 @@ import EmailBaseStudyRequestBulk from '@/lib/email/EmailBaseStudyRequestBulk';
  */
 class EmailStudyRequestBulkCancelled extends EmailBaseStudyRequestBulk {
   getRecipients() {
+    const recipients = [];
+    if (this.requester !== null) {
+      recipients.push(this.requester.email);
+    }
     return [
-      this.requester.email,
+      ...recipients,
       ...this.studyRequestBulk.ccEmails,
     ];
   }

--- a/lib/email/EmailStudyRequestBulkCancelled.js
+++ b/lib/email/EmailStudyRequestBulkCancelled.js
@@ -1,0 +1,56 @@
+import EmailBaseStudyRequestBulk from '@/lib/email/EmailBaseStudyRequestBulk';
+
+/**
+ * Notifies the requester that a bulk study request has been cancelled.  This is sent immediately
+ * when the request is marked as cancelled, either by Data Collection or by the requester.
+ */
+class EmailStudyRequestBulkCancelled extends EmailBaseStudyRequestBulk {
+  getRecipients() {
+    return [
+      this.requester.email,
+      ...this.studyRequestBulk.ccEmails,
+    ];
+  }
+
+  getSubject() {
+    const { name } = this.studyRequestBulk;
+    return `[MOVE] Requests cancelled: ${name}`;
+  }
+
+  /* eslint-disable-next-line class-methods-use-this */
+  getBodyTemplate() {
+    return `
+    <div>
+      <p>
+        Your bulk request for the following studies
+        {{#location}}
+          at
+          <a href="{{hrefLocation}}>{{location}}</a>
+        {{/location}}
+        has been cancelled:
+      </p>
+      <p>
+        {{name}}
+      </p>
+      <ul>
+        {{#studyRequests}}
+        <li>
+          {{#location}}
+            <a href="{{hrefLocation}}>{{location}}</a> &mdash;
+          {{/location}}
+          <strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}
+        </li>
+        {{/studyRequests}}
+      </ul>
+      <p>
+        If you believe this is a mistake, please reach out to the data collection team at
+        <a href="mailto:trafficdata@toronto.ca">trafficdata@toronto.ca</a>.
+      </p>
+      <p>
+        <a href="{{hrefStudyRequestBulk}}">View your cancelled bulk request</a>
+      </p>
+    </div>`;
+  }
+}
+
+export default EmailStudyRequestBulkCancelled;

--- a/lib/email/EmailStudyRequestBulkCompleted.js
+++ b/lib/email/EmailStudyRequestBulkCompleted.js
@@ -6,8 +6,12 @@ import EmailBaseStudyRequestBulk from '@/lib/email/EmailBaseStudyRequestBulk';
  */
 class EmailStudyRequestBulkCompleted extends EmailBaseStudyRequestBulk {
   getRecipients() {
+    const recipients = [];
+    if (this.requester !== null) {
+      recipients.push(this.requester.email);
+    }
     return [
-      this.requester.email,
+      ...recipients,
       ...this.studyRequestBulk.ccEmails,
     ];
   }

--- a/lib/email/EmailStudyRequestBulkCompleted.js
+++ b/lib/email/EmailStudyRequestBulkCompleted.js
@@ -1,21 +1,20 @@
-import EmailBase from '@/lib/email/EmailBase';
 import EmailBaseStudyRequestBulk from '@/lib/email/EmailBaseStudyRequestBulk';
 
 /**
- * Notifies the Data Collection team that a new bulk study request has been requested.  This is sent
- * immediately upon completion of the multi-location Request Study user flow in the frontend.
+ * Notifies the requester that a bulk study request has been completed.  This is sent immediately
+ * when Data Collection marks the request as completed.
  */
-class EmailStudyRequestBulkRequestedAdmin extends EmailBaseStudyRequestBulk {
-  /* eslint-disable-next-line class-methods-use-this */
+class EmailStudyRequestBulkCompleted extends EmailBaseStudyRequestBulk {
   getRecipients() {
     return [
-      EmailBase.TO_DATA_COLLECTION,
+      this.requester.email,
+      ...this.studyRequestBulk.ccEmails,
     ];
   }
 
   getSubject() {
     const { name } = this.studyRequestBulk;
-    return `[MOVE] New requests for ${name}`;
+    return `[MOVE] Your requests are complete! (${name})`;
   }
 
   /* eslint-disable-next-line class-methods-use-this */
@@ -23,11 +22,13 @@ class EmailStudyRequestBulkRequestedAdmin extends EmailBaseStudyRequestBulk {
     return `
     <div>
       <p>
-        A bulk request has been submitted for the following studies
+        Your requests for the following studies
         {{#location}}
-          to be conducted at
+          at
           <a href="{{hrefLocation}}>{{location}}</a>
-        {{/location}}:
+        {{/location}}
+        are now complete!
+        Your data will be available in MOVE within 1 business day.
       </p>
       <p>
         {{name}}
@@ -43,10 +44,10 @@ class EmailStudyRequestBulkRequestedAdmin extends EmailBaseStudyRequestBulk {
         {{/studyRequests}}
       </ul>
       <p>
-        <a href="{{hrefStudyRequestBulk}}">View bulk request</a>
+        <a href="{{hrefStudyRequestBulk}}">View your completed bulk request</a>
       </p>
     </div>`;
   }
 }
 
-export default EmailStudyRequestBulkRequestedAdmin;
+export default EmailStudyRequestBulkCompleted;

--- a/lib/email/EmailStudyRequestBulkConfirmation.js
+++ b/lib/email/EmailStudyRequestBulkConfirmation.js
@@ -1,39 +1,9 @@
-import Mustache from 'mustache';
-
 import { centrelineKey, LocationSelectionType } from '@/lib/Constants';
 import EmailBase from '@/lib/email/EmailBase';
 import EmailBaseStudyRequestBulk from '@/lib/email/EmailBaseStudyRequestBulk';
 import EmailStudyRequestUtils from '@/lib/email/EmailStudyRequestUtils';
 import { getLocationsSelectionDescription } from '@/lib/geo/CentrelineUtils';
 import CompositeId from '@/lib/io/CompositeId';
-
-const TEMPLATE = `
-<div>
-  <p>
-    We received your bulk request for the following studies
-    {{#location}}
-      to be conducted at
-      <a href="{{hrefLocation}}>{{location}}</a>
-    {{/location}}:
-  </p>
-  <p>
-    {{name}}
-  </p>
-  <ul>
-    {{#studyRequests}}
-    <li>
-      {{#location}}
-        <a href="{{hrefLocation}}>{{location}}</a> &mdash;
-      {{/location}}
-      <strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}
-    </li>
-    {{/studyRequests}}
-  </ul>
-  <p>
-    <a href="{{hrefStudyRequestBulk}}">View your bulk request</a>
-  </p>
-</div>`;
-Mustache.parse(TEMPLATE);
 
 class EmailStudyRequestBulkConfirmation extends EmailBaseStudyRequestBulk {
   getRecipients() {
@@ -72,7 +42,37 @@ class EmailStudyRequestBulkConfirmation extends EmailBaseStudyRequestBulk {
     };
   }
 
-  render() {
+  /* eslint-disable-next-line class-methods-use-this */
+  getBodyTemplate() {
+    return `
+    <div>
+      <p>
+        We received your bulk request for the following studies
+        {{#location}}
+          to be conducted at
+          <a href="{{hrefLocation}}>{{location}}</a>
+        {{/location}}:
+      </p>
+      <p>
+        {{name}}
+      </p>
+      <ul>
+        {{#studyRequests}}
+        <li>
+          {{#location}}
+            <a href="{{hrefLocation}}>{{location}}</a> &mdash;
+          {{/location}}
+          <strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}
+        </li>
+        {{/studyRequests}}
+      </ul>
+      <p>
+        <a href="{{hrefStudyRequestBulk}}">View your bulk request</a>
+      </p>
+    </div>`;
+  }
+
+  getBodyParams() {
     const { id, name } = this.studyRequestBulk;
     const hrefStudyRequestBulk = EmailBase.getUrl(`requests/study/bulk/${id}`);
 
@@ -98,14 +98,13 @@ class EmailStudyRequestBulkConfirmation extends EmailBaseStudyRequestBulk {
       this.getStudyRequestParams.bind(this),
     );
 
-    const params = {
+    return {
       hrefLocation,
       hrefStudyRequestBulk,
       location,
       name,
       studyRequests,
     };
-    return Mustache.render(TEMPLATE, params);
   }
 }
 

--- a/lib/email/EmailStudyRequestBulkConfirmation.js
+++ b/lib/email/EmailStudyRequestBulkConfirmation.js
@@ -1,48 +1,41 @@
 import Mustache from 'mustache';
 
-import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import { centrelineKey, LocationSelectionType } from '@/lib/Constants';
 import EmailBase from '@/lib/email/EmailBase';
-import TimeFormatters from '@/lib/time/TimeFormatters';
+import EmailBaseStudyRequestBulk from '@/lib/email/EmailBaseStudyRequestBulk';
+import EmailStudyRequestUtils from '@/lib/email/EmailStudyRequestUtils';
+import { getLocationsSelectionDescription } from '@/lib/geo/CentrelineUtils';
+import CompositeId from '@/lib/io/CompositeId';
 
 const TEMPLATE = `
 <div>
   <p>
-    We received your request for the following studies to be conducted as
-    part of {{name}}:
+    We received your bulk request for the following studies
+    {{#location}}
+      to be conducted at
+      <a href="{{hrefLocation}}>{{location}}</a>
+    {{/location}}:
+  </p>
+  <p>
+    {{name}}
   </p>
   <ul>
-    {{#studies}}
+    {{#studyRequests}}
     <li>
-      <strong>{{studyType}}</strong>
       {{#location}}
-        <span>at {{location}}</span>
+        <a href="{{hrefLocation}}>{{location}}</a> &mdash;
       {{/location}}
-      <span>: {{hours}}</span>
+      <strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}
     </li>
-    {{/studies}}
+    {{/studyRequests}}
   </ul>
   <p>
-    <a href="{{href}}">Track Request</a>
+    <a href="{{hrefStudyRequestBulk}}">View your bulk request</a>
   </p>
 </div>`;
 Mustache.parse(TEMPLATE);
 
-class EmailStudyRequestBulkConfirmation extends EmailBase {
-  constructor(user, studyRequestBulk) {
-    super();
-    this.user = user;
-    this.studyRequestBulk = studyRequestBulk;
-    this.locations = null;
-  }
-
-  async init() {
-    const features = this.studyRequestBulk.studyRequests.map(
-      ({ centrelineId, centrelineType }) => ({ centrelineId, centrelineType }),
-    );
-    const locations = await CentrelineDAO.byFeatures(features);
-    this.locations = locations.filter(location => location !== null);
-  }
-
+class EmailStudyRequestBulkConfirmation extends EmailBaseStudyRequestBulk {
   getRecipients() {
     const { email } = this.user;
     const { ccEmails } = this.studyRequestBulk;
@@ -51,48 +44,66 @@ class EmailStudyRequestBulkConfirmation extends EmailBase {
 
   getSubject() {
     const { name } = this.studyRequestBulk;
-    return `Bulk request received for ${name} - validation in progress`;
+    return `[MOVE] Requests received for ${name}`;
   }
 
-  static renderHours(studyRequest) {
-    const {
-      daysOfWeek,
-      studyType: { automatic },
-    } = studyRequest;
-    const daysOfWeekHuman = TimeFormatters.formatDaysOfWeek(daysOfWeek);
-    if (automatic) {
-      const { duration } = studyRequest;
-      return `${duration} hour count, on ${daysOfWeekHuman}`;
+  getStudyRequestParams(studyRequest) {
+    const days = EmailStudyRequestUtils.renderDays(studyRequest);
+    const hours = EmailStudyRequestUtils.renderHours(studyRequest);
+    const { studyType: { label: studyType } } = studyRequest;
+
+    const key = centrelineKey(studyRequest);
+    let location = null;
+    let hrefLocation = null;
+    if (this.studyRequestLocationsMap.has(key)) {
+      const studyRequestLocation = this.studyRequestLocationsMap.get(key);
+      location = studyRequestLocation.description;
+      const s1 = CompositeId.encode([studyRequestLocation]);
+      const selectionType = LocationSelectionType.POINTS;
+      hrefLocation = EmailBase.getUrl(`/view/location/${s1}/${selectionType.name}`);
     }
-    let { hours } = studyRequest;
-    hours = hours.description.toLowerCase();
-    return `${hours} hours, on ${daysOfWeekHuman}`;
+
+    return {
+      days,
+      hours,
+      hrefLocation,
+      location,
+      studyType,
+    };
   }
 
   render() {
-    const { id } = this.studyRequestBulk;
-    const href = EmailBase.getUrl(`requests/study/bulk/${id}`);
+    const { id, name } = this.studyRequestBulk;
+    const hrefStudyRequestBulk = EmailBase.getUrl(`requests/study/bulk/${id}`);
 
-    const { name, studyRequests } = this.studyRequestBulk;
-    const studies = studyRequests.map((studyRequest) => {
-      const hours = EmailStudyRequestBulkConfirmation.renderHours(studyRequest);
-      const {
-        centrelineId,
-        centrelineType,
-        studyType: { label: studyType },
-      } = studyRequest;
-      const studyRequestLocation = this.locations.find(
-        location => location.centrelineType === centrelineType
-          && location.centrelineId === centrelineId,
-      );
-      const location = studyRequestLocation === undefined ? '' : studyRequestLocation.description;
-      return { hours, location, studyType };
-    });
+    /*
+     * If this study somehow refers entirely to centreline features that no longer exist, we can
+     * still send out the email without crashing.
+     *
+     * In this particular case, this is *extremely* unlikely.  The centreline would have to
+     * be updated by our pipelines sometime between when the user starts the new study request
+     * flow and when the email is sent out, and that update would have to remove all centreline
+     * features that the user has selected.
+     */
+    let location = null;
+    let hrefLocation = null;
+    if (this.locationsSelection !== null) {
+      location = getLocationsSelectionDescription(this.locationsSelection);
+      const { locations, selectionType } = this.locationsSelection;
+      const s1 = CompositeId.encode(locations);
+      hrefLocation = EmailBase.getUrl(`/view/location/${s1}/${selectionType.name}`);
+    }
+
+    const studyRequests = this.studyRequestBulk.studyRequests.map(
+      this.getStudyRequestParams.bind(this),
+    );
 
     const params = {
-      href,
+      hrefLocation,
+      hrefStudyRequestBulk,
+      location,
       name,
-      studies,
+      studyRequests,
     };
     return Mustache.render(TEMPLATE, params);
   }

--- a/lib/email/EmailStudyRequestBulkRequested.js
+++ b/lib/email/EmailStudyRequestBulkRequested.js
@@ -6,8 +6,12 @@ import EmailBaseStudyRequestBulk from '@/lib/email/EmailBaseStudyRequestBulk';
  */
 class EmailStudyRequestBulkRequested extends EmailBaseStudyRequestBulk {
   getRecipients() {
+    const recipients = [];
+    if (this.requester !== null) {
+      recipients.push(this.requester.email);
+    }
     return [
-      this.requester.email,
+      ...recipients,
       ...this.studyRequestBulk.ccEmails,
     ];
   }

--- a/lib/email/EmailStudyRequestBulkRequested.js
+++ b/lib/email/EmailStudyRequestBulkRequested.js
@@ -1,9 +1,4 @@
-import { centrelineKey, LocationSelectionType } from '@/lib/Constants';
-import EmailBase from '@/lib/email/EmailBase';
 import EmailBaseStudyRequestBulk from '@/lib/email/EmailBaseStudyRequestBulk';
-import EmailStudyRequestUtils from '@/lib/email/EmailStudyRequestUtils';
-import { getLocationsSelectionDescription } from '@/lib/geo/CentrelineUtils';
-import CompositeId from '@/lib/io/CompositeId';
 
 /**
  * Confirms to the requester that a bulk study request has been requested.  This is sent
@@ -20,31 +15,6 @@ class EmailStudyRequestBulkRequested extends EmailBaseStudyRequestBulk {
   getSubject() {
     const { name } = this.studyRequestBulk;
     return `[MOVE] Requests received for ${name}`;
-  }
-
-  getStudyRequestParams(studyRequest) {
-    const days = EmailStudyRequestUtils.renderDays(studyRequest);
-    const hours = EmailStudyRequestUtils.renderHours(studyRequest);
-    const { studyType: { label: studyType } } = studyRequest;
-
-    const key = centrelineKey(studyRequest);
-    let location = null;
-    let hrefLocation = null;
-    if (this.studyRequestLocationsMap.has(key)) {
-      const studyRequestLocation = this.studyRequestLocationsMap.get(key);
-      location = studyRequestLocation.description;
-      const s1 = CompositeId.encode([studyRequestLocation]);
-      const selectionType = LocationSelectionType.POINTS;
-      hrefLocation = EmailBase.getUrl(`/view/location/${s1}/${selectionType.name}`);
-    }
-
-    return {
-      days,
-      hours,
-      hrefLocation,
-      location,
-      studyType,
-    };
   }
 
   /* eslint-disable-next-line class-methods-use-this */
@@ -75,41 +45,6 @@ class EmailStudyRequestBulkRequested extends EmailBaseStudyRequestBulk {
         <a href="{{hrefStudyRequestBulk}}">View your bulk request</a>
       </p>
     </div>`;
-  }
-
-  getBodyParams() {
-    const { id, name } = this.studyRequestBulk;
-    const hrefStudyRequestBulk = EmailBase.getUrl(`requests/study/bulk/${id}`);
-
-    /*
-     * If this study somehow refers entirely to centreline features that no longer exist, we can
-     * still send out the email without crashing.
-     *
-     * In this particular case, this is *extremely* unlikely.  The centreline would have to
-     * be updated by our pipelines sometime between when the user starts the new study request
-     * flow and when the email is sent out, and that update would have to remove all centreline
-     * features that the user has selected.
-     */
-    let location = null;
-    let hrefLocation = null;
-    if (this.locationsSelection !== null) {
-      location = getLocationsSelectionDescription(this.locationsSelection);
-      const { locations, selectionType } = this.locationsSelection;
-      const s1 = CompositeId.encode(locations);
-      hrefLocation = EmailBase.getUrl(`/view/location/${s1}/${selectionType.name}`);
-    }
-
-    const studyRequests = this.studyRequestBulk.studyRequests.map(
-      this.getStudyRequestParams.bind(this),
-    );
-
-    return {
-      hrefLocation,
-      hrefStudyRequestBulk,
-      location,
-      name,
-      studyRequests,
-    };
   }
 }
 

--- a/lib/email/EmailStudyRequestBulkRequested.js
+++ b/lib/email/EmailStudyRequestBulkRequested.js
@@ -5,11 +5,16 @@ import EmailStudyRequestUtils from '@/lib/email/EmailStudyRequestUtils';
 import { getLocationsSelectionDescription } from '@/lib/geo/CentrelineUtils';
 import CompositeId from '@/lib/io/CompositeId';
 
+/**
+ * Confirms to the requester that a bulk study request has been requested.  This is sent
+ * immediately upon completion of the multi-location Request Study user flow in the frontend.
+ */
 class EmailStudyRequestBulkRequested extends EmailBaseStudyRequestBulk {
   getRecipients() {
-    const { email } = this.user;
-    const { ccEmails } = this.studyRequestBulk;
-    return [email].concat(ccEmails);
+    return [
+      this.requester.email,
+      ...this.studyRequestBulk.ccEmails,
+    ];
   }
 
   getSubject() {

--- a/lib/email/EmailStudyRequestBulkRequested.js
+++ b/lib/email/EmailStudyRequestBulkRequested.js
@@ -5,7 +5,7 @@ import EmailStudyRequestUtils from '@/lib/email/EmailStudyRequestUtils';
 import { getLocationsSelectionDescription } from '@/lib/geo/CentrelineUtils';
 import CompositeId from '@/lib/io/CompositeId';
 
-class EmailStudyRequestBulkConfirmation extends EmailBaseStudyRequestBulk {
+class EmailStudyRequestBulkRequested extends EmailBaseStudyRequestBulk {
   getRecipients() {
     const { email } = this.user;
     const { ccEmails } = this.studyRequestBulk;
@@ -108,4 +108,4 @@ class EmailStudyRequestBulkConfirmation extends EmailBaseStudyRequestBulk {
   }
 }
 
-export default EmailStudyRequestBulkConfirmation;
+export default EmailStudyRequestBulkRequested;

--- a/lib/email/EmailStudyRequestBulkRequestedAdmin.js
+++ b/lib/email/EmailStudyRequestBulkRequestedAdmin.js
@@ -1,0 +1,116 @@
+import { centrelineKey, LocationSelectionType } from '@/lib/Constants';
+import EmailBase from '@/lib/email/EmailBase';
+import EmailBaseStudyRequestBulk from '@/lib/email/EmailBaseStudyRequestBulk';
+import EmailStudyRequestUtils from '@/lib/email/EmailStudyRequestUtils';
+import { getLocationsSelectionDescription } from '@/lib/geo/CentrelineUtils';
+import CompositeId from '@/lib/io/CompositeId';
+
+/**
+ * Notifies the Data Collection team that a new bulk study request has been requested.  This is sent
+ * immediately upon completion of the multi-location Request Study user flow in the frontend.
+ */
+class EmailStudyRequestBulkRequestedAdmin extends EmailBaseStudyRequestBulk {
+  /* eslint-disable-next-line class-methods-use-this */
+  getRecipients() {
+    return [
+      EmailBase.TO_DATA_COLLECTION,
+    ];
+  }
+
+  getSubject() {
+    const { name } = this.studyRequestBulk;
+    return `[MOVE] New bulk request for ${name}`;
+  }
+
+  getStudyRequestParams(studyRequest) {
+    const days = EmailStudyRequestUtils.renderDays(studyRequest);
+    const hours = EmailStudyRequestUtils.renderHours(studyRequest);
+    const { studyType: { label: studyType } } = studyRequest;
+
+    const key = centrelineKey(studyRequest);
+    let location = null;
+    let hrefLocation = null;
+    if (this.studyRequestLocationsMap.has(key)) {
+      const studyRequestLocation = this.studyRequestLocationsMap.get(key);
+      location = studyRequestLocation.description;
+      const s1 = CompositeId.encode([studyRequestLocation]);
+      const selectionType = LocationSelectionType.POINTS;
+      hrefLocation = EmailBase.getUrl(`/view/location/${s1}/${selectionType.name}`);
+    }
+
+    return {
+      days,
+      hours,
+      hrefLocation,
+      location,
+      studyType,
+    };
+  }
+
+  /* eslint-disable-next-line class-methods-use-this */
+  getBodyTemplate() {
+    return `
+    <div>
+      <p>
+        A request has been submitted for the following studies
+        {{#location}}
+          to be conducted at
+          <a href="{{hrefLocation}}>{{location}}</a>
+        {{/location}}:
+      </p>
+      <p>
+        {{name}}
+      </p>
+      <ul>
+        {{#studyRequests}}
+        <li>
+          {{#location}}
+            <a href="{{hrefLocation}}>{{location}}</a> &mdash;
+          {{/location}}
+          <strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}
+        </li>
+        {{/studyRequests}}
+      </ul>
+      <p>
+        <a href="{{hrefStudyRequestBulk}}">View bulk request</a>
+      </p>
+    </div>`;
+  }
+
+  getBodyParams() {
+    const { id, name } = this.studyRequestBulk;
+    const hrefStudyRequestBulk = EmailBase.getUrl(`requests/study/bulk/${id}`);
+
+    /*
+     * If this study somehow refers entirely to centreline features that no longer exist, we can
+     * still send out the email without crashing.
+     *
+     * In this particular case, this is *extremely* unlikely.  The centreline would have to
+     * be updated by our pipelines sometime between when the user starts the new study request
+     * flow and when the email is sent out, and that update would have to remove all centreline
+     * features that the user has selected.
+     */
+    let location = null;
+    let hrefLocation = null;
+    if (this.locationsSelection !== null) {
+      location = getLocationsSelectionDescription(this.locationsSelection);
+      const { locations, selectionType } = this.locationsSelection;
+      const s1 = CompositeId.encode(locations);
+      hrefLocation = EmailBase.getUrl(`/view/location/${s1}/${selectionType.name}`);
+    }
+
+    const studyRequests = this.studyRequestBulk.studyRequests.map(
+      this.getStudyRequestParams.bind(this),
+    );
+
+    return {
+      hrefLocation,
+      hrefStudyRequestBulk,
+      location,
+      name,
+      studyRequests,
+    };
+  }
+}
+
+export default EmailStudyRequestBulkRequestedAdmin;

--- a/lib/email/EmailStudyRequestBulkRequestedAdmin.js
+++ b/lib/email/EmailStudyRequestBulkRequestedAdmin.js
@@ -9,7 +9,7 @@ class EmailStudyRequestBulkRequestedAdmin extends EmailBaseStudyRequestBulk {
   /* eslint-disable-next-line class-methods-use-this */
   getRecipients() {
     return [
-      EmailBase.TO_DATA_COLLECTION,
+      EmailBase.getRecipientStudyRequestAdmin(),
     ];
   }
 

--- a/lib/email/EmailStudyRequestBulkRequestedAdmin.js
+++ b/lib/email/EmailStudyRequestBulkRequestedAdmin.js
@@ -1,9 +1,5 @@
-import { centrelineKey, LocationSelectionType } from '@/lib/Constants';
 import EmailBase from '@/lib/email/EmailBase';
 import EmailBaseStudyRequestBulk from '@/lib/email/EmailBaseStudyRequestBulk';
-import EmailStudyRequestUtils from '@/lib/email/EmailStudyRequestUtils';
-import { getLocationsSelectionDescription } from '@/lib/geo/CentrelineUtils';
-import CompositeId from '@/lib/io/CompositeId';
 
 /**
  * Notifies the Data Collection team that a new bulk study request has been requested.  This is sent
@@ -19,32 +15,7 @@ class EmailStudyRequestBulkRequestedAdmin extends EmailBaseStudyRequestBulk {
 
   getSubject() {
     const { name } = this.studyRequestBulk;
-    return `[MOVE] New bulk request for ${name}`;
-  }
-
-  getStudyRequestParams(studyRequest) {
-    const days = EmailStudyRequestUtils.renderDays(studyRequest);
-    const hours = EmailStudyRequestUtils.renderHours(studyRequest);
-    const { studyType: { label: studyType } } = studyRequest;
-
-    const key = centrelineKey(studyRequest);
-    let location = null;
-    let hrefLocation = null;
-    if (this.studyRequestLocationsMap.has(key)) {
-      const studyRequestLocation = this.studyRequestLocationsMap.get(key);
-      location = studyRequestLocation.description;
-      const s1 = CompositeId.encode([studyRequestLocation]);
-      const selectionType = LocationSelectionType.POINTS;
-      hrefLocation = EmailBase.getUrl(`/view/location/${s1}/${selectionType.name}`);
-    }
-
-    return {
-      days,
-      hours,
-      hrefLocation,
-      location,
-      studyType,
-    };
+    return `[MOVE] New requests for ${name}`;
   }
 
   /* eslint-disable-next-line class-methods-use-this */
@@ -75,41 +46,6 @@ class EmailStudyRequestBulkRequestedAdmin extends EmailBaseStudyRequestBulk {
         <a href="{{hrefStudyRequestBulk}}">View bulk request</a>
       </p>
     </div>`;
-  }
-
-  getBodyParams() {
-    const { id, name } = this.studyRequestBulk;
-    const hrefStudyRequestBulk = EmailBase.getUrl(`requests/study/bulk/${id}`);
-
-    /*
-     * If this study somehow refers entirely to centreline features that no longer exist, we can
-     * still send out the email without crashing.
-     *
-     * In this particular case, this is *extremely* unlikely.  The centreline would have to
-     * be updated by our pipelines sometime between when the user starts the new study request
-     * flow and when the email is sent out, and that update would have to remove all centreline
-     * features that the user has selected.
-     */
-    let location = null;
-    let hrefLocation = null;
-    if (this.locationsSelection !== null) {
-      location = getLocationsSelectionDescription(this.locationsSelection);
-      const { locations, selectionType } = this.locationsSelection;
-      const s1 = CompositeId.encode(locations);
-      hrefLocation = EmailBase.getUrl(`/view/location/${s1}/${selectionType.name}`);
-    }
-
-    const studyRequests = this.studyRequestBulk.studyRequests.map(
-      this.getStudyRequestParams.bind(this),
-    );
-
-    return {
-      hrefLocation,
-      hrefStudyRequestBulk,
-      location,
-      name,
-      studyRequests,
-    };
   }
 }
 

--- a/lib/email/EmailStudyRequestCancelled.js
+++ b/lib/email/EmailStudyRequestCancelled.js
@@ -1,0 +1,51 @@
+import EmailBaseStudyRequest from '@/lib/email/EmailBaseStudyRequest';
+
+/**
+ * Notifies the requester that a study request has been completed.  This is sent immediately when
+ * Data Collection marks the request as completed.
+ */
+class EmailStudyRequestCancelled extends EmailBaseStudyRequest {
+  getRecipients() {
+    return [
+      this.requester.email,
+      ...this.studyRequest.ccEmails,
+    ];
+  }
+
+  getSubject() {
+    const { id } = this.studyRequest;
+    if (this.location === null) {
+      return `[MOVE] Request cancelled: #${id}`;
+    }
+    const { description } = this.location;
+    return `[MOVE] Request cancelled: #${id} - ${description}`;
+  }
+
+  /* eslint-disable-next-line class-methods-use-this */
+  getBodyTemplate() {
+    return `
+    <div>
+      <p>
+        Your request for the following study
+        {{#location}}
+          at
+          <a href="{{hrefLocation}}>{{location}}</a>
+        {{/location}}
+        has been cancelled:
+      </p>
+      <p>
+        <strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}
+      </p>
+      <p>
+        If you believe this is a mistake, please comment on the request in MOVE, or reach out
+        to the data collection team at
+        <a href="mailto:trafficdata@toronto.ca">trafficdata@toronto.ca</a>.
+      </p>
+      <p>
+        <a href="{{hrefStudyRequest}}">View your cancelled request</a>
+      </p>
+    </div>`;
+  }
+}
+
+export default EmailStudyRequestCancelled;

--- a/lib/email/EmailStudyRequestCancelled.js
+++ b/lib/email/EmailStudyRequestCancelled.js
@@ -6,8 +6,12 @@ import EmailBaseStudyRequest from '@/lib/email/EmailBaseStudyRequest';
  */
 class EmailStudyRequestCancelled extends EmailBaseStudyRequest {
   getRecipients() {
+    const recipients = [];
+    if (this.requester !== null) {
+      recipients.push(this.requester.email);
+    }
     return [
-      this.requester.email,
+      ...recipients,
       ...this.studyRequest.ccEmails,
     ];
   }

--- a/lib/email/EmailStudyRequestCompleted.js
+++ b/lib/email/EmailStudyRequestCompleted.js
@@ -1,0 +1,46 @@
+import EmailBaseStudyRequest from '@/lib/email/EmailBaseStudyRequest';
+
+/**
+ * Notifies the requester that a study request has been completed.  This is sent immediately when
+ * Data Collection marks the request as completed.
+ */
+class EmailStudyRequestCompleted extends EmailBaseStudyRequest {
+  getRecipients() {
+    return [
+      this.requester.email,
+      ...this.studyRequest.ccEmails,
+    ];
+  }
+
+  getSubject() {
+    if (this.location === null) {
+      return '[MOVE] Your request is complete!';
+    }
+    const { description } = this.location;
+    return `[MOVE] Your request is complete! (${description})`;
+  }
+
+  /* eslint-disable-next-line class-methods-use-this */
+  getBodyTemplate() {
+    return `
+    <div>
+      <p>
+        Your request for the following study
+        {{#location}}
+          at
+          <a href="{{hrefLocation}}>{{location}}</a>
+        {{/location}}
+        is now complete!
+        Your data will be available in MOVE within 1 business day.
+      </p>
+      <p>
+        <strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}
+      </p>
+      <p>
+        <a href="{{hrefStudyRequest}}">View your completed request</a>
+      </p>
+    </div>`;
+  }
+}
+
+export default EmailStudyRequestCompleted;

--- a/lib/email/EmailStudyRequestCompleted.js
+++ b/lib/email/EmailStudyRequestCompleted.js
@@ -6,8 +6,12 @@ import EmailBaseStudyRequest from '@/lib/email/EmailBaseStudyRequest';
  */
 class EmailStudyRequestCompleted extends EmailBaseStudyRequest {
   getRecipients() {
+    const recipients = [];
+    if (this.requester !== null) {
+      recipients.push(this.requester.email);
+    }
     return [
-      this.requester.email,
+      ...recipients,
       ...this.studyRequest.ccEmails,
     ];
   }

--- a/lib/email/EmailStudyRequestConfirmation.js
+++ b/lib/email/EmailStudyRequestConfirmation.js
@@ -1,23 +1,25 @@
 import Mustache from 'mustache';
 
-import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import { LocationSelectionType } from '@/lib/Constants';
 import EmailBase from '@/lib/email/EmailBase';
-import TimeFormatters from '@/lib/time/TimeFormatters';
+import EmailBaseStudyRequest from '@/lib/email/EmailBaseStudyRequest';
+import EmailStudyRequestUtils from '@/lib/email/EmailStudyRequestUtils';
+import CompositeId from '@/lib/io/CompositeId';
 
 const TEMPLATE = `
 <div>
   <p>
     We received your request for the following study
     {{#location}}
-      to be conducted at {{location}}
-    {{/location}}
-    :
+      to be conducted at
+      <a href="{{hrefLocation}}>{{location}}</a>
+    {{/location}}:
   </p>
-  <ul>
-    <li><strong>{{studyType}}</strong>: {{hours}}</li>
-  </ul>
   <p>
-    <a href="{{href}}">Track Request</a>
+    <strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}
+  </p>
+  <p>
+    <a href="{{hrefStudyRequest}}">View your request</a>
   </p>
 </div>`;
 Mustache.parse(TEMPLATE);
@@ -27,52 +29,25 @@ Mustache.parse(TEMPLATE);
  * This is sent immediately upon completion of the "Request Study" user flow
  * in the frontend.
  */
-class EmailStudyRequestConfirmation extends EmailBase {
-  constructor(user, studyRequest) {
-    super();
-    this.user = user;
-    this.studyRequest = studyRequest;
-    this.location = null;
-  }
-
-  async init() {
-    const { centrelineId, centrelineType } = this.studyRequest;
-    const feature = { centrelineId, centrelineType };
-    this.location = await CentrelineDAO.byFeature(feature);
-  }
-
+class EmailStudyRequestConfirmation extends EmailBaseStudyRequest {
   getRecipients() {
-    const { email } = this.user;
-    const { ccEmails } = this.studyRequest;
-    return [email].concat(ccEmails);
+    return [
+      this.user.email,
+      ...this.studyRequest.ccEmails,
+    ];
   }
 
   getSubject() {
     if (this.location === null) {
-      return 'Request received - validation in progress';
+      return '[MOVE] Request received';
     }
     const { description } = this.location;
-    return `Request received for ${description} - validation in progress`;
-  }
-
-  static renderHours(studyRequest) {
-    const {
-      daysOfWeek,
-      studyType: { automatic },
-    } = studyRequest;
-    const daysOfWeekHuman = TimeFormatters.formatDaysOfWeek(daysOfWeek);
-    if (automatic) {
-      const { duration } = studyRequest;
-      return `${duration} hour count, on ${daysOfWeekHuman}`;
-    }
-    let { hours } = studyRequest;
-    hours = hours.description.toLowerCase();
-    return `${hours} hours, on ${daysOfWeekHuman}`;
+    return `[MOVE] Request received for ${description}`;
   }
 
   render() {
     const { id } = this.studyRequest;
-    const href = EmailBase.getUrl(`requests/study/${id}`);
+    const hrefStudyRequest = EmailBase.getUrl(`requests/study/${id}`);
 
     /*
      * If this study somehow refers to a centreline feature that no longer exists, we can
@@ -84,15 +59,22 @@ class EmailStudyRequestConfirmation extends EmailBase {
      * feature that the user has selected.
      */
     let location = null;
+    let hrefLocation = null;
     if (this.location !== null) {
       location = this.location.description;
+      const s1 = CompositeId.encode([this.location]);
+      const selectionType = LocationSelectionType.POINTS;
+      hrefLocation = EmailBase.getUrl(`/view/location/${s1}/${selectionType.name}`);
     }
 
-    const hours = EmailStudyRequestConfirmation.renderHours(this.studyRequest);
+    const days = EmailStudyRequestUtils.renderDays(this.studyRequest);
+    const hours = EmailStudyRequestUtils.renderHours(this.studyRequest);
     const { studyType: { label: studyType } } = this.studyRequest;
 
     const params = {
-      href,
+      days,
+      hrefLocation,
+      hrefStudyRequest,
       hours,
       location,
       studyType,

--- a/lib/email/EmailStudyRequestConfirmation.js
+++ b/lib/email/EmailStudyRequestConfirmation.js
@@ -1,28 +1,8 @@
-import Mustache from 'mustache';
-
 import { LocationSelectionType } from '@/lib/Constants';
 import EmailBase from '@/lib/email/EmailBase';
 import EmailBaseStudyRequest from '@/lib/email/EmailBaseStudyRequest';
 import EmailStudyRequestUtils from '@/lib/email/EmailStudyRequestUtils';
 import CompositeId from '@/lib/io/CompositeId';
-
-const TEMPLATE = `
-<div>
-  <p>
-    We received your request for the following study
-    {{#location}}
-      to be conducted at
-      <a href="{{hrefLocation}}>{{location}}</a>
-    {{/location}}:
-  </p>
-  <p>
-    <strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}
-  </p>
-  <p>
-    <a href="{{hrefStudyRequest}}">View your request</a>
-  </p>
-</div>`;
-Mustache.parse(TEMPLATE);
 
 /**
  * `EmailBase` subclass for confirming that a study request has been received.
@@ -45,7 +25,27 @@ class EmailStudyRequestConfirmation extends EmailBaseStudyRequest {
     return `[MOVE] Request received for ${description}`;
   }
 
-  render() {
+  /* eslint-disable-next-line class-methods-use-this */
+  getBodyTemplate() {
+    return `
+    <div>
+      <p>
+        We received your request for the following study
+        {{#location}}
+          to be conducted at
+          <a href="{{hrefLocation}}>{{location}}</a>
+        {{/location}}:
+      </p>
+      <p>
+        <strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}
+      </p>
+      <p>
+        <a href="{{hrefStudyRequest}}">View your request</a>
+      </p>
+    </div>`;
+  }
+
+  getBodyParams() {
     const { id } = this.studyRequest;
     const hrefStudyRequest = EmailBase.getUrl(`requests/study/${id}`);
 
@@ -71,7 +71,7 @@ class EmailStudyRequestConfirmation extends EmailBaseStudyRequest {
     const hours = EmailStudyRequestUtils.renderHours(this.studyRequest);
     const { studyType: { label: studyType } } = this.studyRequest;
 
-    const params = {
+    return {
       days,
       hrefLocation,
       hrefStudyRequest,
@@ -79,7 +79,6 @@ class EmailStudyRequestConfirmation extends EmailBaseStudyRequest {
       location,
       studyType,
     };
-    return Mustache.render(TEMPLATE, params);
   }
 }
 

--- a/lib/email/EmailStudyRequestNewComment.js
+++ b/lib/email/EmailStudyRequestNewComment.js
@@ -1,0 +1,71 @@
+import UserDAO from '@/lib/db/UserDAO';
+import EmailBase from '@/lib/email/EmailBase';
+import EmailBaseStudyRequest from '@/lib/email/EmailBaseStudyRequest';
+
+class EmailStudyRequestNewComment extends EmailBaseStudyRequest {
+  constructor(studyRequest, studyRequestComment) {
+    super(studyRequest);
+    this.studyRequestComment = studyRequestComment;
+    this.commenter = null;
+  }
+
+  async init() {
+    await super.init();
+    const commenter = await UserDAO.byId(this.studyRequestComment.userId);
+    this.commenter = commenter;
+  }
+
+  getRecipients() {
+    let recipients = [
+      EmailBase.getRecipientStudyRequestAdmin(),
+    ];
+    if (this.requester !== null) {
+      recipients.push(this.requester.email);
+    }
+    recipients = [
+      ...recipients,
+      ...this.studyRequest.ccEmails,
+    ];
+    if (this.commenter !== null) {
+      recipients = recipients.filter(email => email !== this.commenter.email);
+    }
+    return recipients;
+  }
+
+  getSubject() {
+    const { id } = this.studyRequest;
+    if (this.location === null) {
+      return `[MOVE] New comment on request #${id}`;
+    }
+    const { description } = this.location;
+    return `[MOVE] New comment on request #${id} for ${description}`;
+  }
+
+  /* eslint-disable-next-line class-methods-use-this */
+  getBodyTemplate() {
+    return `
+    <div>
+      <p>
+        A comment has been added to the {{studyType}} request
+        {{#location}}
+          for
+          <a href="{{hrefLocation}}>{{location}}</a>
+        {{/location}}:
+      </p>
+      <p>
+        <i>{{comment}}</i>
+      </p>
+      <p>
+        <a href="{{hrefStudyRequest}}">View or respond to this comment</a>
+      </p>
+    </div>`;
+  }
+
+  getBodyParams() {
+    const params = super.getBodyParams();
+    const { comment } = this.studyRequestComment;
+    return { comment, ...params };
+  }
+}
+
+export default EmailStudyRequestNewComment;

--- a/lib/email/EmailStudyRequestRequested.js
+++ b/lib/email/EmailStudyRequestRequested.js
@@ -5,14 +5,13 @@ import EmailStudyRequestUtils from '@/lib/email/EmailStudyRequestUtils';
 import CompositeId from '@/lib/io/CompositeId';
 
 /**
- * `EmailBase` subclass for confirming that a study request has been received.
- * This is sent immediately upon completion of the "Request Study" user flow
- * in the frontend.
+ * Confirms to the requester that a study request has been requested.  This is sent immediately upon
+ * completion of the single-location Request Study user flow in the frontend.
  */
 class EmailStudyRequestRequested extends EmailBaseStudyRequest {
   getRecipients() {
     return [
-      this.user.email,
+      this.requester.email,
       ...this.studyRequest.ccEmails,
     ];
   }

--- a/lib/email/EmailStudyRequestRequested.js
+++ b/lib/email/EmailStudyRequestRequested.js
@@ -1,8 +1,4 @@
-import { LocationSelectionType } from '@/lib/Constants';
-import EmailBase from '@/lib/email/EmailBase';
 import EmailBaseStudyRequest from '@/lib/email/EmailBaseStudyRequest';
-import EmailStudyRequestUtils from '@/lib/email/EmailStudyRequestUtils';
-import CompositeId from '@/lib/io/CompositeId';
 
 /**
  * Confirms to the requester that a study request has been requested.  This is sent immediately upon
@@ -42,42 +38,6 @@ class EmailStudyRequestRequested extends EmailBaseStudyRequest {
         <a href="{{hrefStudyRequest}}">View your request</a>
       </p>
     </div>`;
-  }
-
-  getBodyParams() {
-    const { id } = this.studyRequest;
-    const hrefStudyRequest = EmailBase.getUrl(`requests/study/${id}`);
-
-    /*
-     * If this study somehow refers to a centreline feature that no longer exists, we can
-     * still send out the email without crashing.
-     *
-     * In this particular case, this is *extremely* unlikely.  The centreline would have to
-     * be updated by our pipelines sometime between when the user starts the new study request
-     * flow and when the email is sent out, and that update would have to remove the centreline
-     * feature that the user has selected.
-     */
-    let location = null;
-    let hrefLocation = null;
-    if (this.location !== null) {
-      location = this.location.description;
-      const s1 = CompositeId.encode([this.location]);
-      const selectionType = LocationSelectionType.POINTS;
-      hrefLocation = EmailBase.getUrl(`/view/location/${s1}/${selectionType.name}`);
-    }
-
-    const days = EmailStudyRequestUtils.renderDays(this.studyRequest);
-    const hours = EmailStudyRequestUtils.renderHours(this.studyRequest);
-    const { studyType: { label: studyType } } = this.studyRequest;
-
-    return {
-      days,
-      hrefLocation,
-      hrefStudyRequest,
-      hours,
-      location,
-      studyType,
-    };
   }
 }
 

--- a/lib/email/EmailStudyRequestRequested.js
+++ b/lib/email/EmailStudyRequestRequested.js
@@ -6,8 +6,12 @@ import EmailBaseStudyRequest from '@/lib/email/EmailBaseStudyRequest';
  */
 class EmailStudyRequestRequested extends EmailBaseStudyRequest {
   getRecipients() {
+    const recipients = [];
+    if (this.requester !== null) {
+      recipients.push(this.requester.email);
+    }
     return [
-      this.requester.email,
+      ...recipients,
       ...this.studyRequest.ccEmails,
     ];
   }

--- a/lib/email/EmailStudyRequestRequested.js
+++ b/lib/email/EmailStudyRequestRequested.js
@@ -9,7 +9,7 @@ import CompositeId from '@/lib/io/CompositeId';
  * This is sent immediately upon completion of the "Request Study" user flow
  * in the frontend.
  */
-class EmailStudyRequestConfirmation extends EmailBaseStudyRequest {
+class EmailStudyRequestRequested extends EmailBaseStudyRequest {
   getRecipients() {
     return [
       this.user.email,
@@ -82,4 +82,4 @@ class EmailStudyRequestConfirmation extends EmailBaseStudyRequest {
   }
 }
 
-export default EmailStudyRequestConfirmation;
+export default EmailStudyRequestRequested;

--- a/lib/email/EmailStudyRequestRequestedAdmin.js
+++ b/lib/email/EmailStudyRequestRequestedAdmin.js
@@ -1,8 +1,5 @@
-import { LocationSelectionType } from '@/lib/Constants';
 import EmailBase from '@/lib/email/EmailBase';
 import EmailBaseStudyRequest from '@/lib/email/EmailBaseStudyRequest';
-import EmailStudyRequestUtils from '@/lib/email/EmailStudyRequestUtils';
-import CompositeId from '@/lib/io/CompositeId';
 
 /**
  * Notifies the Data Collection team that a new study request has been requested.  This is sent
@@ -42,42 +39,6 @@ class EmailStudyRequestRequestedAdmin extends EmailBaseStudyRequest {
         <a href="{{hrefStudyRequest}}">View request</a>
       </p>
     </div>`;
-  }
-
-  getBodyParams() {
-    const { id } = this.studyRequest;
-    const hrefStudyRequest = EmailBase.getUrl(`requests/study/${id}`);
-
-    /*
-     * If this study somehow refers to a centreline feature that no longer exists, we can
-     * still send out the email without crashing.
-     *
-     * In this particular case, this is *extremely* unlikely.  The centreline would have to
-     * be updated by our pipelines sometime between when the user starts the new study request
-     * flow and when the email is sent out, and that update would have to remove the centreline
-     * feature that the user has selected.
-     */
-    let location = null;
-    let hrefLocation = null;
-    if (this.location !== null) {
-      location = this.location.description;
-      const s1 = CompositeId.encode([this.location]);
-      const selectionType = LocationSelectionType.POINTS;
-      hrefLocation = EmailBase.getUrl(`/view/location/${s1}/${selectionType.name}`);
-    }
-
-    const days = EmailStudyRequestUtils.renderDays(this.studyRequest);
-    const hours = EmailStudyRequestUtils.renderHours(this.studyRequest);
-    const { studyType: { label: studyType } } = this.studyRequest;
-
-    return {
-      days,
-      hrefLocation,
-      hrefStudyRequest,
-      hours,
-      location,
-      studyType,
-    };
   }
 }
 

--- a/lib/email/EmailStudyRequestRequestedAdmin.js
+++ b/lib/email/EmailStudyRequestRequestedAdmin.js
@@ -9,7 +9,7 @@ class EmailStudyRequestRequestedAdmin extends EmailBaseStudyRequest {
   /* eslint-disable-next-line class-methods-use-this */
   getRecipients() {
     return [
-      EmailBase.TO_DATA_COLLECTION,
+      EmailBase.getRecipientStudyRequestAdmin(),
     ];
   }
 

--- a/lib/email/EmailStudyRequestRequestedAdmin.js
+++ b/lib/email/EmailStudyRequestRequestedAdmin.js
@@ -1,0 +1,84 @@
+import { LocationSelectionType } from '@/lib/Constants';
+import EmailBase from '@/lib/email/EmailBase';
+import EmailBaseStudyRequest from '@/lib/email/EmailBaseStudyRequest';
+import EmailStudyRequestUtils from '@/lib/email/EmailStudyRequestUtils';
+import CompositeId from '@/lib/io/CompositeId';
+
+/**
+ * Notifies the Data Collection team that a new study request has been requested.  This is sent
+ * immediately upon completion of the single-location Request Study user flow in the frontend.
+ */
+class EmailStudyRequestRequestedAdmin extends EmailBaseStudyRequest {
+  /* eslint-disable-next-line class-methods-use-this */
+  getRecipients() {
+    return [
+      EmailBase.TO_DATA_COLLECTION,
+    ];
+  }
+
+  getSubject() {
+    if (this.location === null) {
+      return '[MOVE] New request';
+    }
+    const { description } = this.location;
+    return `[MOVE] New request for ${description}`;
+  }
+
+  /* eslint-disable-next-line class-methods-use-this */
+  getBodyTemplate() {
+    return `
+    <div>
+      <p>
+        A request has been submitted for the following study
+        {{#location}}
+          to be conducted at
+          <a href="{{hrefLocation}}>{{location}}</a>
+        {{/location}}:
+      </p>
+      <p>
+        <strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}
+      </p>
+      <p>
+        <a href="{{hrefStudyRequest}}">View request</a>
+      </p>
+    </div>`;
+  }
+
+  getBodyParams() {
+    const { id } = this.studyRequest;
+    const hrefStudyRequest = EmailBase.getUrl(`requests/study/${id}`);
+
+    /*
+     * If this study somehow refers to a centreline feature that no longer exists, we can
+     * still send out the email without crashing.
+     *
+     * In this particular case, this is *extremely* unlikely.  The centreline would have to
+     * be updated by our pipelines sometime between when the user starts the new study request
+     * flow and when the email is sent out, and that update would have to remove the centreline
+     * feature that the user has selected.
+     */
+    let location = null;
+    let hrefLocation = null;
+    if (this.location !== null) {
+      location = this.location.description;
+      const s1 = CompositeId.encode([this.location]);
+      const selectionType = LocationSelectionType.POINTS;
+      hrefLocation = EmailBase.getUrl(`/view/location/${s1}/${selectionType.name}`);
+    }
+
+    const days = EmailStudyRequestUtils.renderDays(this.studyRequest);
+    const hours = EmailStudyRequestUtils.renderHours(this.studyRequest);
+    const { studyType: { label: studyType } } = this.studyRequest;
+
+    return {
+      days,
+      hrefLocation,
+      hrefStudyRequest,
+      hours,
+      location,
+      studyType,
+    };
+  }
+}
+
+export default EmailStudyRequestRequestedAdmin;

--- a/lib/email/EmailStudyRequestUtils.js
+++ b/lib/email/EmailStudyRequestUtils.js
@@ -1,0 +1,23 @@
+import TimeFormatters from '@/lib/time/TimeFormatters';
+
+class EmailStudyRequestUtils {
+  static renderDays(studyRequest) {
+    const { daysOfWeek } = studyRequest;
+    return TimeFormatters.formatDaysOfWeek(daysOfWeek);
+  }
+
+  static renderHours(studyRequest) {
+    const {
+      studyType: { automatic },
+    } = studyRequest;
+    if (automatic) {
+      const { duration } = studyRequest;
+      return `${duration} hours`;
+    }
+    let { hours } = studyRequest;
+    hours = hours.description.toLowerCase();
+    return `${hours} hours`;
+  }
+}
+
+export default EmailStudyRequestUtils;

--- a/lib/email/MailUtils.js
+++ b/lib/email/MailUtils.js
@@ -27,8 +27,8 @@ function getStudyRequestUpdateEmails(studyRequestNew, studyRequestOld) {
 function getStudyRequestBulkUpdateEmails(studyRequestBulkNew, studyRequestBulkOld) {
   const emails = [];
 
-  const bulkStatusOld = bulkStatus(studyRequestBulkOld);
-  const bulkStatusNew = bulkStatus(studyRequestBulkNew);
+  const bulkStatusNew = bulkStatus(studyRequestBulkNew.studyRequests);
+  const bulkStatusOld = bulkStatus(studyRequestBulkOld.studyRequests);
   if (bulkStatusNew !== bulkStatusOld) {
     if (bulkStatusNew === StudyRequestStatus.CANCELLED) {
       const emailCancelled = new EmailStudyRequestBulkCancelled(studyRequestBulkNew);

--- a/lib/email/MailUtils.js
+++ b/lib/email/MailUtils.js
@@ -1,0 +1,23 @@
+import Mailer from '@/lib/email/Mailer';
+import LogTag from '@/lib/log/LogTag';
+
+async function sendEmailSafe(request, email) {
+  try {
+    const emailOptions = await email.getOptions();
+    const emailResponse = await Mailer.send(emailOptions);
+    request.log(LogTag.DEBUG, emailResponse);
+    return true;
+  } catch (err) {
+    request.log(LogTag.ERROR, err);
+    return false;
+  }
+}
+
+const MailUtils = {
+  sendEmailSafe,
+};
+
+export {
+  MailUtils as default,
+  sendEmailSafe,
+};

--- a/lib/email/MailUtils.js
+++ b/lib/email/MailUtils.js
@@ -1,5 +1,46 @@
+import { StudyRequestStatus } from '@/lib/Constants';
+import StudyRequestBulkDAO from '@/lib/db/StudyRequestBulkDAO';
+import EmailStudyRequestBulkCancelled from '@/lib/email/EmailStudyRequestBulkCancelled';
+import EmailStudyRequestBulkCompleted from '@/lib/email/EmailStudyRequestBulkCompleted';
+import EmailStudyRequestCancelled from '@/lib/email/EmailStudyRequestCancelled';
+import EmailStudyRequestCompleted from '@/lib/email/EmailStudyRequestCompleted';
 import Mailer from '@/lib/email/Mailer';
 import LogTag from '@/lib/log/LogTag';
+import { bulkStatus } from '@/lib/requests/RequestStudyBulkUtils';
+
+function getStudyRequestUpdateEmails(studyRequestNew, studyRequestOld) {
+  const emails = [];
+
+  if (studyRequestNew.status !== studyRequestOld.status) {
+    if (studyRequestNew.status === StudyRequestStatus.CANCELLED) {
+      const emailCancelled = new EmailStudyRequestCancelled(studyRequestNew);
+      emails.push(emailCancelled);
+    } else if (studyRequestNew.status === StudyRequestStatus.COMPLETED) {
+      const emailCompleted = new EmailStudyRequestCompleted(studyRequestNew);
+      emails.push(emailCompleted);
+    }
+  }
+
+  return emails;
+}
+
+function getStudyRequestBulkUpdateEmails(studyRequestBulkNew, studyRequestBulkOld) {
+  const emails = [];
+
+  const bulkStatusOld = bulkStatus(studyRequestBulkOld);
+  const bulkStatusNew = bulkStatus(studyRequestBulkNew);
+  if (bulkStatusNew !== bulkStatusOld) {
+    if (bulkStatusNew === StudyRequestStatus.CANCELLED) {
+      const emailCancelled = new EmailStudyRequestBulkCancelled(studyRequestBulkNew);
+      emails.push(emailCancelled);
+    } else if (bulkStatusNew === StudyRequestStatus.COMPLETED) {
+      const emailCompleted = new EmailStudyRequestBulkCompleted(studyRequestBulkNew);
+      emails.push(emailCompleted);
+    }
+  }
+
+  return emails;
+}
 
 async function sendEmailSafe(request, email) {
   try {
@@ -13,11 +54,92 @@ async function sendEmailSafe(request, email) {
   }
 }
 
+async function sendStudyRequestBulkUpdateEmailsSafe(
+  request,
+  studyRequestBulkNew,
+  studyRequestBulkOld,
+) {
+  const emails = getStudyRequestBulkUpdateEmails(studyRequestBulkNew, studyRequestBulkOld);
+
+  const n = studyRequestBulkNew.studyRequests.length;
+  for (let i = 0; i < n; i++) {
+    const studyRequestNew = studyRequestBulkNew.studyRequests[i];
+    const studyRequestOld = studyRequestBulkOld.studyRequests[i];
+
+    const emailsStudyRequest = getStudyRequestUpdateEmails(studyRequestNew, studyRequestOld);
+    emails.push(...emailsStudyRequest);
+  }
+
+  if (emails.length === 0) {
+    return true;
+  }
+  const tasks = emails.map(email => sendEmailSafe(request, email));
+  const results = await Promise.all(tasks);
+  return results.every(result => result);
+}
+
+async function sendStudyRequestUpdateEmailsSafe(
+  request,
+  studyRequestNew,
+  studyRequestOld,
+) {
+  const emails = getStudyRequestUpdateEmails(studyRequestNew, studyRequestOld);
+
+  if (studyRequestNew.studyRequestBulkId !== null) {
+    const studyRequestBulk = await StudyRequestBulkDAO.byId(studyRequestNew.studyRequestBulkId);
+    const i = studyRequestBulk.studyRequests.findIndex(
+      ({ id }) => id === studyRequestNew.id,
+    );
+    if (i !== -1) {
+      /*
+       * We use `studyRequestNew`, `studyRequestOld` to reconstruct both the new and old versions
+       * of the associated bulk request.  This allows us to not have to depend on the order in
+       * which this function is called in the REST API endpoint handler.  (For example: if we only
+       * used `studyRequestNew` to reconstruct the new version, we'd be relying on
+       * `studyRequestBulk` being the old version, which would imply that this function must be
+       * called before the study request update.)
+       */
+      const studyRequestBulkNew = {
+        ...studyRequestBulk,
+        studyRequests: [...studyRequestBulk.studyRequests],
+      };
+      studyRequestBulkNew.studyRequests[i] = studyRequestNew;
+
+      const studyRequestBulkOld = {
+        ...studyRequestBulk,
+        studyRequests: [...studyRequestBulk.studyRequests],
+      };
+      studyRequestBulkOld.studyRequests[i] = studyRequestOld;
+
+      const emailsStudyRequestBulk = getStudyRequestBulkUpdateEmails(
+        studyRequestBulkNew,
+        studyRequestBulkOld,
+      );
+      emails.push(...emailsStudyRequestBulk);
+    }
+  }
+
+  if (emails.length === 0) {
+    return true;
+  }
+  const tasks = emails.map(email => sendEmailSafe(request, email));
+  const results = await Promise.all(tasks);
+  return results.every(result => result);
+}
+
 const MailUtils = {
+  getStudyRequestBulkUpdateEmails,
+  getStudyRequestUpdateEmails,
   sendEmailSafe,
+  sendStudyRequestBulkUpdateEmailsSafe,
+  sendStudyRequestUpdateEmailsSafe,
 };
 
 export {
   MailUtils as default,
+  getStudyRequestBulkUpdateEmails,
+  getStudyRequestUpdateEmails,
   sendEmailSafe,
+  sendStudyRequestBulkUpdateEmailsSafe,
+  sendStudyRequestUpdateEmailsSafe,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7673,14 +7673,6 @@
         "num2fraction": "^1.2.2",
         "postcss": "^7.0.32",
         "postcss-value-parser": "^4.1.0"
-      },
-      "dependencies": {
-        "caniuse-lite": {
-          "version": "1.0.30001161",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001161.tgz",
-          "integrity": "sha512-JharrCDxOqPLBULF9/SPa6yMcBRTjZARJ6sc3cuKrPfyIk64JN6kuMINWqA99Xc8uElMFcROliwtz0n9pYej+g==",
-          "dev": true
-        }
       }
     },
     "await-to-js": {
@@ -9348,9 +9340,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001083",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001083.tgz",
-      "integrity": "sha512-CnYJ27awX4h7yj5glfK7r1TOI13LBytpLzEgfj0s4mY75/F8pnQcYjL+oVpmS38FB59+vU0gscQ9D8tc+lIXvA==",
+      "version": "1.0.30001179",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001179.tgz",
+      "integrity": "sha512-blMmO0QQujuUWZKyVrD1msR4WNDAqb/UPO1Sw2WWsQ7deoM5bJiicKnWJ1Y0NS/aGINSnKPIWBMw5luX+NDUCA==",
       "dev": true
     },
     "capital-case": {

--- a/tests/jest/api/StudyRequestBulkController.spec.js
+++ b/tests/jest/api/StudyRequestBulkController.spec.js
@@ -74,6 +74,7 @@ function mockDAOsForStudyRequestBulk(studyRequestBulk) {
 test('StudyRequestBulkController.postStudyRequestBulk', async () => {
   const transientStudyRequestBulk = generateStudyRequestBulk();
   mockDAOsForStudyRequestBulk(transientStudyRequestBulk);
+  Mailer.send.mockClear();
 
   client.setUser(requester);
   let response = await client.fetch('/requests/study/bulk', {
@@ -81,7 +82,7 @@ test('StudyRequestBulkController.postStudyRequestBulk', async () => {
     data: transientStudyRequestBulk,
   });
   expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
-  expect(Mailer.send).toHaveBeenCalled();
+  expect(Mailer.send).toHaveBeenCalledTimes(2);
   const persistedStudyRequestBulk = response.result;
   expect(persistedStudyRequestBulk.id).not.toBeNull();
   expect(persistedStudyRequestBulk.userId).toBe(requester.id);

--- a/tests/jest/unit/email/EmailStudyRequestBulkCancelled.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestBulkCancelled.spec.js
@@ -1,0 +1,43 @@
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import UserDAO from '@/lib/db/UserDAO';
+import EmailStudyRequestBulkCancelled from '@/lib/email/EmailStudyRequestBulkCancelled';
+import CompositeId from '@/lib/io/CompositeId';
+import { generateStudyRequestBulk } from '@/lib/test/random/StudyRequestGenerator';
+import { generateUser } from '@/lib/test/random/UserGenerator';
+
+jest.mock('@/lib/db/CentrelineDAO');
+jest.mock('@/lib/db/UserDAO');
+
+test('EmailStudyRequestBulkCancelled', async () => {
+  const requester = generateUser();
+  const studyRequestBulk = generateStudyRequestBulk();
+  studyRequestBulk.id = 17;
+  const email = new EmailStudyRequestBulkCancelled(studyRequestBulk);
+
+  const locations = studyRequestBulk.studyRequests.map(({ centrelineId, centrelineType }, i) => ({
+    centrelineId,
+    centrelineType,
+    description: `Test location #${i + 1}`,
+  }));
+  CentrelineDAO.byFeatures.mockResolvedValue(locations);
+  UserDAO.byId.mockResolvedValue(requester);
+
+  await email.init();
+
+  const recipients = email.getRecipients();
+  expect(recipients).toEqual([requester.email, ...studyRequestBulk.ccEmails]);
+
+  const subject = email.getSubject();
+  expect(subject).toEqual(`[MOVE] Requests cancelled: ${studyRequestBulk.name}`);
+
+  const params = email.getBodyParams();
+  const s1 = CompositeId.encode(locations);
+  expect(params.hrefLocation).toEqual(`https://localhost:8080/view/location/${s1}/POINTS`);
+  expect(params.hrefStudyRequestBulk).toEqual('https://localhost:8080/requests/study/bulk/17');
+  expect(params.location).toMatch(/^Test location #1/);
+  expect(params.studyRequests).toHaveLength(studyRequestBulk.studyRequests.length);
+
+  expect(() => {
+    email.render();
+  }).not.toThrow();
+});

--- a/tests/jest/unit/email/EmailStudyRequestBulkCompleted.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestBulkCompleted.spec.js
@@ -1,0 +1,43 @@
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import UserDAO from '@/lib/db/UserDAO';
+import EmailStudyRequestBulkCompleted from '@/lib/email/EmailStudyRequestBulkCompleted';
+import CompositeId from '@/lib/io/CompositeId';
+import { generateStudyRequestBulk } from '@/lib/test/random/StudyRequestGenerator';
+import { generateUser } from '@/lib/test/random/UserGenerator';
+
+jest.mock('@/lib/db/CentrelineDAO');
+jest.mock('@/lib/db/UserDAO');
+
+test('EmailStudyRequestBulkCompleted', async () => {
+  const requester = generateUser();
+  const studyRequestBulk = generateStudyRequestBulk();
+  studyRequestBulk.id = 17;
+  const email = new EmailStudyRequestBulkCompleted(studyRequestBulk);
+
+  const locations = studyRequestBulk.studyRequests.map(({ centrelineId, centrelineType }, i) => ({
+    centrelineId,
+    centrelineType,
+    description: `Test location #${i + 1}`,
+  }));
+  CentrelineDAO.byFeatures.mockResolvedValue(locations);
+  UserDAO.byId.mockResolvedValue(requester);
+
+  await email.init();
+
+  const recipients = email.getRecipients();
+  expect(recipients).toEqual([requester.email, ...studyRequestBulk.ccEmails]);
+
+  const subject = email.getSubject();
+  expect(subject).toEqual(`[MOVE] Your requests are complete! (${studyRequestBulk.name})`);
+
+  const params = email.getBodyParams();
+  const s1 = CompositeId.encode(locations);
+  expect(params.hrefLocation).toEqual(`https://localhost:8080/view/location/${s1}/POINTS`);
+  expect(params.hrefStudyRequestBulk).toEqual('https://localhost:8080/requests/study/bulk/17');
+  expect(params.location).toMatch(/^Test location #1/);
+  expect(params.studyRequests).toHaveLength(studyRequestBulk.studyRequests.length);
+
+  expect(() => {
+    email.render();
+  }).not.toThrow();
+});

--- a/tests/jest/unit/email/EmailStudyRequestBulkConfirmation.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestBulkConfirmation.spec.js
@@ -1,0 +1,40 @@
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import EmailStudyRequestBulkConfirmation from '@/lib/email/EmailStudyRequestBulkConfirmation';
+import CompositeId from '@/lib/io/CompositeId';
+import { generateStudyRequestBulk } from '@/lib/test/random/StudyRequestGenerator';
+import { generateUser } from '@/lib/test/random/UserGenerator';
+
+jest.mock('@/lib/db/CentrelineDAO');
+
+test('EmailStudyRequestConfirmation', async () => {
+  const user = generateUser();
+  const studyRequestBulk = generateStudyRequestBulk();
+  studyRequestBulk.id = 17;
+  const email = new EmailStudyRequestBulkConfirmation(user, studyRequestBulk);
+
+  const locations = studyRequestBulk.studyRequests.map(({ centrelineId, centrelineType }, i) => ({
+    centrelineId,
+    centrelineType,
+    description: `Test location #${i + 1}`,
+  }));
+  CentrelineDAO.byFeatures.mockResolvedValue(locations);
+
+  await email.init();
+
+  const recipients = email.getRecipients();
+  expect(recipients).toEqual([user.email, ...studyRequestBulk.ccEmails]);
+
+  const subject = email.getSubject();
+  expect(subject).toEqual(`[MOVE] Requests received for ${studyRequestBulk.name}`);
+
+  const params = email.getBodyParams();
+  const s1 = CompositeId.encode(locations);
+  expect(params.hrefLocation).toEqual(`https://localhost:8080/view/location/${s1}/POINTS`);
+  expect(params.hrefStudyRequestBulk).toEqual('https://localhost:8080/requests/study/bulk/17');
+  expect(params.location).toMatch(/^Test location #1/);
+  expect(params.studyRequests).toHaveLength(studyRequestBulk.studyRequests.length);
+
+  expect(() => {
+    email.render();
+  }).not.toThrow();
+});

--- a/tests/jest/unit/email/EmailStudyRequestBulkRequested.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestBulkRequested.spec.js
@@ -1,16 +1,16 @@
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
-import EmailStudyRequestBulkConfirmation from '@/lib/email/EmailStudyRequestBulkConfirmation';
+import EmailStudyRequestBulkRequested from '@/lib/email/EmailStudyRequestBulkRequested';
 import CompositeId from '@/lib/io/CompositeId';
 import { generateStudyRequestBulk } from '@/lib/test/random/StudyRequestGenerator';
 import { generateUser } from '@/lib/test/random/UserGenerator';
 
 jest.mock('@/lib/db/CentrelineDAO');
 
-test('EmailStudyRequestConfirmation', async () => {
+test('EmailStudyRequestBulkRequested', async () => {
   const user = generateUser();
   const studyRequestBulk = generateStudyRequestBulk();
   studyRequestBulk.id = 17;
-  const email = new EmailStudyRequestBulkConfirmation(user, studyRequestBulk);
+  const email = new EmailStudyRequestBulkRequested(user, studyRequestBulk);
 
   const locations = studyRequestBulk.studyRequests.map(({ centrelineId, centrelineType }, i) => ({
     centrelineId,

--- a/tests/jest/unit/email/EmailStudyRequestBulkRequestedAdmin.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestBulkRequestedAdmin.spec.js
@@ -26,7 +26,7 @@ test('EmailStudyRequestBulkRequestedAdmin', async () => {
   await email.init();
 
   const recipients = email.getRecipients();
-  expect(recipients).toEqual([EmailBase.TO_DATA_COLLECTION]);
+  expect(recipients).toEqual([EmailBase.getRecipientStudyRequestAdmin()]);
 
   const subject = email.getSubject();
   expect(subject).toEqual(`[MOVE] New requests for ${studyRequestBulk.name}`);

--- a/tests/jest/unit/email/EmailStudyRequestBulkRequestedAdmin.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestBulkRequestedAdmin.spec.js
@@ -1,0 +1,44 @@
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import UserDAO from '@/lib/db/UserDAO';
+import EmailBase from '@/lib/email/EmailBase';
+import EmailStudyRequestBulkRequestedAdmin from '@/lib/email/EmailStudyRequestBulkRequestedAdmin';
+import CompositeId from '@/lib/io/CompositeId';
+import { generateStudyRequestBulk } from '@/lib/test/random/StudyRequestGenerator';
+import { generateUser } from '@/lib/test/random/UserGenerator';
+
+jest.mock('@/lib/db/CentrelineDAO');
+jest.mock('@/lib/db/UserDAO');
+
+test('EmailStudyRequestBulkRequestedAdmin', async () => {
+  const requester = generateUser();
+  const studyRequestBulk = generateStudyRequestBulk();
+  studyRequestBulk.id = 17;
+  const email = new EmailStudyRequestBulkRequestedAdmin(studyRequestBulk);
+
+  const locations = studyRequestBulk.studyRequests.map(({ centrelineId, centrelineType }, i) => ({
+    centrelineId,
+    centrelineType,
+    description: `Test location #${i + 1}`,
+  }));
+  CentrelineDAO.byFeatures.mockResolvedValue(locations);
+  UserDAO.byId.mockResolvedValue(requester);
+
+  await email.init();
+
+  const recipients = email.getRecipients();
+  expect(recipients).toEqual([EmailBase.TO_DATA_COLLECTION]);
+
+  const subject = email.getSubject();
+  expect(subject).toEqual(`[MOVE] New bulk request for ${studyRequestBulk.name}`);
+
+  const params = email.getBodyParams();
+  const s1 = CompositeId.encode(locations);
+  expect(params.hrefLocation).toEqual(`https://localhost:8080/view/location/${s1}/POINTS`);
+  expect(params.hrefStudyRequestBulk).toEqual('https://localhost:8080/requests/study/bulk/17');
+  expect(params.location).toMatch(/^Test location #1/);
+  expect(params.studyRequests).toHaveLength(studyRequestBulk.studyRequests.length);
+
+  expect(() => {
+    email.render();
+  }).not.toThrow();
+});

--- a/tests/jest/unit/email/EmailStudyRequestBulkRequestedAdmin.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestBulkRequestedAdmin.spec.js
@@ -29,7 +29,7 @@ test('EmailStudyRequestBulkRequestedAdmin', async () => {
   expect(recipients).toEqual([EmailBase.TO_DATA_COLLECTION]);
 
   const subject = email.getSubject();
-  expect(subject).toEqual(`[MOVE] New bulk request for ${studyRequestBulk.name}`);
+  expect(subject).toEqual(`[MOVE] New requests for ${studyRequestBulk.name}`);
 
   const params = email.getBodyParams();
   const s1 = CompositeId.encode(locations);

--- a/tests/jest/unit/email/EmailStudyRequestCancelled.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestCancelled.spec.js
@@ -1,0 +1,42 @@
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import UserDAO from '@/lib/db/UserDAO';
+import EmailStudyRequestCancelled from '@/lib/email/EmailStudyRequestCancelled';
+import CompositeId from '@/lib/io/CompositeId';
+import { generateStudyRequest } from '@/lib/test/random/StudyRequestGenerator';
+import { generateUser } from '@/lib/test/random/UserGenerator';
+
+jest.mock('@/lib/db/CentrelineDAO');
+jest.mock('@/lib/db/UserDAO');
+
+test('EmailStudyRequestCancelled', async () => {
+  const requester = generateUser();
+  const studyRequest = generateStudyRequest();
+  studyRequest.id = 42;
+  const email = new EmailStudyRequestCancelled(studyRequest);
+
+  const { centrelineId, centrelineType } = studyRequest;
+  CentrelineDAO.byFeature.mockResolvedValue({
+    centrelineId,
+    centrelineType,
+    description: 'Test location',
+  });
+  UserDAO.byId.mockResolvedValue(requester);
+
+  await email.init();
+
+  const recipients = email.getRecipients();
+  expect(recipients).toEqual([requester.email, ...studyRequest.ccEmails]);
+
+  const subject = email.getSubject();
+  expect(subject).toEqual('[MOVE] Request cancelled: #42 - Test location');
+
+  const params = email.getBodyParams();
+  const s1 = CompositeId.encode([studyRequest]);
+  expect(params.hrefLocation).toEqual(`https://localhost:8080/view/location/${s1}/POINTS`);
+  expect(params.hrefStudyRequest).toEqual('https://localhost:8080/requests/study/42');
+  expect(params.location).toEqual('Test location');
+
+  expect(() => {
+    email.render();
+  }).not.toThrow();
+});

--- a/tests/jest/unit/email/EmailStudyRequestCompleted.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestCompleted.spec.js
@@ -1,0 +1,42 @@
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import UserDAO from '@/lib/db/UserDAO';
+import EmailStudyRequestCompleted from '@/lib/email/EmailStudyRequestCompleted';
+import CompositeId from '@/lib/io/CompositeId';
+import { generateStudyRequest } from '@/lib/test/random/StudyRequestGenerator';
+import { generateUser } from '@/lib/test/random/UserGenerator';
+
+jest.mock('@/lib/db/CentrelineDAO');
+jest.mock('@/lib/db/UserDAO');
+
+test('EmailStudyRequestCompleted', async () => {
+  const requester = generateUser();
+  const studyRequest = generateStudyRequest();
+  studyRequest.id = 42;
+  const email = new EmailStudyRequestCompleted(studyRequest);
+
+  const { centrelineId, centrelineType } = studyRequest;
+  CentrelineDAO.byFeature.mockResolvedValue({
+    centrelineId,
+    centrelineType,
+    description: 'Test location',
+  });
+  UserDAO.byId.mockResolvedValue(requester);
+
+  await email.init();
+
+  const recipients = email.getRecipients();
+  expect(recipients).toEqual([requester.email, ...studyRequest.ccEmails]);
+
+  const subject = email.getSubject();
+  expect(subject).toEqual('[MOVE] Your request is complete! (Test location)');
+
+  const params = email.getBodyParams();
+  const s1 = CompositeId.encode([studyRequest]);
+  expect(params.hrefLocation).toEqual(`https://localhost:8080/view/location/${s1}/POINTS`);
+  expect(params.hrefStudyRequest).toEqual('https://localhost:8080/requests/study/42');
+  expect(params.location).toEqual('Test location');
+
+  expect(() => {
+    email.render();
+  }).not.toThrow();
+});

--- a/tests/jest/unit/email/EmailStudyRequestConfirmation.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestConfirmation.spec.js
@@ -1,0 +1,39 @@
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import EmailStudyRequestConfirmation from '@/lib/email/EmailStudyRequestConfirmation';
+import CompositeId from '@/lib/io/CompositeId';
+import { generateStudyRequest } from '@/lib/test/random/StudyRequestGenerator';
+import { generateUser } from '@/lib/test/random/UserGenerator';
+
+jest.mock('@/lib/db/CentrelineDAO');
+
+test('EmailStudyRequestConfirmation', async () => {
+  const user = generateUser();
+  const studyRequest = generateStudyRequest();
+  studyRequest.id = 42;
+  const email = new EmailStudyRequestConfirmation(user, studyRequest);
+
+  const { centrelineId, centrelineType } = studyRequest;
+  CentrelineDAO.byFeature.mockResolvedValue({
+    centrelineId,
+    centrelineType,
+    description: 'Test location',
+  });
+
+  await email.init();
+
+  const recipients = email.getRecipients();
+  expect(recipients).toEqual([user.email, ...studyRequest.ccEmails]);
+
+  const subject = email.getSubject();
+  expect(subject).toEqual('[MOVE] Request received for Test location');
+
+  const params = email.getBodyParams();
+  const s1 = CompositeId.encode([studyRequest]);
+  expect(params.hrefLocation).toEqual(`https://localhost:8080/view/location/${s1}/POINTS`);
+  expect(params.hrefStudyRequest).toEqual('https://localhost:8080/requests/study/42');
+  expect(params.location).toEqual('Test location');
+
+  expect(() => {
+    email.render();
+  }).not.toThrow();
+});

--- a/tests/jest/unit/email/EmailStudyRequestNewComment.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestNewComment.spec.js
@@ -1,0 +1,47 @@
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import UserDAO from '@/lib/db/UserDAO';
+import EmailBase from '@/lib/email/EmailBase';
+import EmailStudyRequestNewComment from '@/lib/email/EmailStudyRequestNewComment';
+import CompositeId from '@/lib/io/CompositeId';
+import { generateStudyRequest } from '@/lib/test/random/StudyRequestGenerator';
+import { generateUser } from '@/lib/test/random/UserGenerator';
+
+jest.mock('@/lib/db/CentrelineDAO');
+jest.mock('@/lib/db/UserDAO');
+
+test('EmailStudyRequestNewComment', async () => {
+  const requester = generateUser();
+  const studyRequest = generateStudyRequest();
+  studyRequest.id = 42;
+  const studyRequestComment = {
+    comment: 'Test comment',
+  };
+  const email = new EmailStudyRequestNewComment(studyRequest, studyRequestComment);
+
+  const { centrelineId, centrelineType } = studyRequest;
+  CentrelineDAO.byFeature.mockResolvedValue({
+    centrelineId,
+    centrelineType,
+    description: 'Test location',
+  });
+  UserDAO.byId.mockResolvedValue(requester);
+
+  await email.init();
+
+  const recipients = email.getRecipients();
+  expect(recipients).toEqual([EmailBase.getRecipientStudyRequestAdmin(), ...studyRequest.ccEmails]);
+
+  const subject = email.getSubject();
+  expect(subject).toEqual('[MOVE] New comment on request #42 for Test location');
+
+  const params = email.getBodyParams();
+  const s1 = CompositeId.encode([studyRequest]);
+  expect(params.comment).toEqual('Test comment');
+  expect(params.hrefLocation).toEqual(`https://localhost:8080/view/location/${s1}/POINTS`);
+  expect(params.hrefStudyRequest).toEqual('https://localhost:8080/requests/study/42');
+  expect(params.location).toEqual('Test location');
+
+  expect(() => {
+    email.render();
+  }).not.toThrow();
+});

--- a/tests/jest/unit/email/EmailStudyRequestRequested.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestRequested.spec.js
@@ -1,16 +1,18 @@
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import UserDAO from '@/lib/db/UserDAO';
 import EmailStudyRequestRequested from '@/lib/email/EmailStudyRequestRequested';
 import CompositeId from '@/lib/io/CompositeId';
 import { generateStudyRequest } from '@/lib/test/random/StudyRequestGenerator';
 import { generateUser } from '@/lib/test/random/UserGenerator';
 
 jest.mock('@/lib/db/CentrelineDAO');
+jest.mock('@/lib/db/UserDAO');
 
 test('EmailStudyRequestRequested', async () => {
-  const user = generateUser();
+  const requester = generateUser();
   const studyRequest = generateStudyRequest();
   studyRequest.id = 42;
-  const email = new EmailStudyRequestRequested(user, studyRequest);
+  const email = new EmailStudyRequestRequested(studyRequest);
 
   const { centrelineId, centrelineType } = studyRequest;
   CentrelineDAO.byFeature.mockResolvedValue({
@@ -18,11 +20,12 @@ test('EmailStudyRequestRequested', async () => {
     centrelineType,
     description: 'Test location',
   });
+  UserDAO.byId.mockResolvedValue(requester);
 
   await email.init();
 
   const recipients = email.getRecipients();
-  expect(recipients).toEqual([user.email, ...studyRequest.ccEmails]);
+  expect(recipients).toEqual([requester.email, ...studyRequest.ccEmails]);
 
   const subject = email.getSubject();
   expect(subject).toEqual('[MOVE] Request received for Test location');

--- a/tests/jest/unit/email/EmailStudyRequestRequested.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestRequested.spec.js
@@ -1,16 +1,16 @@
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
-import EmailStudyRequestConfirmation from '@/lib/email/EmailStudyRequestConfirmation';
+import EmailStudyRequestRequested from '@/lib/email/EmailStudyRequestRequested';
 import CompositeId from '@/lib/io/CompositeId';
 import { generateStudyRequest } from '@/lib/test/random/StudyRequestGenerator';
 import { generateUser } from '@/lib/test/random/UserGenerator';
 
 jest.mock('@/lib/db/CentrelineDAO');
 
-test('EmailStudyRequestConfirmation', async () => {
+test('EmailStudyRequestRequested', async () => {
   const user = generateUser();
   const studyRequest = generateStudyRequest();
   studyRequest.id = 42;
-  const email = new EmailStudyRequestConfirmation(user, studyRequest);
+  const email = new EmailStudyRequestRequested(user, studyRequest);
 
   const { centrelineId, centrelineType } = studyRequest;
   CentrelineDAO.byFeature.mockResolvedValue({

--- a/tests/jest/unit/email/EmailStudyRequestRequestedAdmin.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestRequestedAdmin.spec.js
@@ -1,0 +1,43 @@
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import UserDAO from '@/lib/db/UserDAO';
+import EmailBase from '@/lib/email/EmailBase';
+import EmailStudyRequestRequestedAdmin from '@/lib/email/EmailStudyRequestRequestedAdmin';
+import CompositeId from '@/lib/io/CompositeId';
+import { generateStudyRequest } from '@/lib/test/random/StudyRequestGenerator';
+import { generateUser } from '@/lib/test/random/UserGenerator';
+
+jest.mock('@/lib/db/CentrelineDAO');
+jest.mock('@/lib/db/UserDAO');
+
+test('EmailStudyRequestRequestedAdmin', async () => {
+  const requester = generateUser();
+  const studyRequest = generateStudyRequest();
+  studyRequest.id = 42;
+  const email = new EmailStudyRequestRequestedAdmin(studyRequest);
+
+  const { centrelineId, centrelineType } = studyRequest;
+  CentrelineDAO.byFeature.mockResolvedValue({
+    centrelineId,
+    centrelineType,
+    description: 'Test location',
+  });
+  UserDAO.byId.mockResolvedValue(requester);
+
+  await email.init();
+
+  const recipients = email.getRecipients();
+  expect(recipients).toEqual([EmailBase.TO_DATA_COLLECTION]);
+
+  const subject = email.getSubject();
+  expect(subject).toEqual('[MOVE] New request for Test location');
+
+  const params = email.getBodyParams();
+  const s1 = CompositeId.encode([studyRequest]);
+  expect(params.hrefLocation).toEqual(`https://localhost:8080/view/location/${s1}/POINTS`);
+  expect(params.hrefStudyRequest).toEqual('https://localhost:8080/requests/study/42');
+  expect(params.location).toEqual('Test location');
+
+  expect(() => {
+    email.render();
+  }).not.toThrow();
+});

--- a/tests/jest/unit/email/EmailStudyRequestRequestedAdmin.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestRequestedAdmin.spec.js
@@ -26,7 +26,7 @@ test('EmailStudyRequestRequestedAdmin', async () => {
   await email.init();
 
   const recipients = email.getRecipients();
-  expect(recipients).toEqual([EmailBase.TO_DATA_COLLECTION]);
+  expect(recipients).toEqual([EmailBase.getRecipientStudyRequestAdmin()]);
 
   const subject = email.getSubject();
   expect(subject).toEqual('[MOVE] New request for Test location');


### PR DESCRIPTION
# Issue Addressed
This PR closes #748 .

# Description
We refactor the `EmailBase` hierarchy, introducing `EmailStudyRequestBase` and `EmailStudyRequestBulkBase`, and a slew of specific email subclasses under each.  We add testing for all these subclasses, and expand checks for `Mailer.send` calls in our REST API tests.  We then update our study request creation, commenting, and update REST API endpoints to send emails as appropriate.

# Tests
New unit and REST API tests.  Will test end-to-end directly in AWS dev, as we do not currently have a way to test delivery itself in local development (only that subjects, recipients, parameters, etc. are as expected).