### PR TITLE
Only send email to @toronto.ca addresses

### DIFF
--- a/lib/email/EmailBase.js
+++ b/lib/email/EmailBase.js
@@ -174,7 +174,8 @@ class EmailBase {
   async getOptions() {
     await this.init();
     const from = EmailBase.getSender();
-    const to = Array.from(new Set(this.getRecipients()));
+    const to = Array.from(new Set(this.getRecipients()))
+      .filter(email => email.endsWith('@toronto.ca'));
     const subject = this.getSubject();
     const html = this.render();
     return {

--- a/lib/email/EmailBase.js
+++ b/lib/email/EmailBase.js
@@ -176,6 +176,9 @@ class EmailBase {
     const from = EmailBase.getSender();
     const to = Array.from(new Set(this.getRecipients()))
       .filter(email => email.endsWith('@toronto.ca'));
+    if (to.length === 0) {
+      throw new Error('no valid @toronto.ca recipients found!');
+    }
     const subject = this.getSubject();
     const html = this.render();
     return {


### PR DESCRIPTION
# Issue Addressed
This PR closes #760 .

# Description
In `EmailBase`, we filter recipients to only those with `@toronto.ca` email addresses.  This should allow emails to be sent in dev / QA successfully, and should not (based on a quick scan of the `users` table there) affect prod.

# Tests
Ran relevant user tests.  CI / CD checks.  Will be testing email deliverability in dev / QA.
