### PR TITLE
Close attribute quotes for emails

### DIFF
--- a/lib/email/EmailStudyRequestBulkCancelled.js
+++ b/lib/email/EmailStudyRequestBulkCancelled.js
@@ -29,7 +29,7 @@ class EmailStudyRequestBulkCancelled extends EmailBaseStudyRequestBulk {
         Your bulk request for the following studies
         {{#location}}
           at
-          <a href="{{hrefLocation}}>{{location}}</a>
+          <a href="{{hrefLocation}}">{{location}}</a>
         {{/location}}
         has been cancelled:
       </p>
@@ -40,7 +40,7 @@ class EmailStudyRequestBulkCancelled extends EmailBaseStudyRequestBulk {
         {{#studyRequests}}
         <li>
           {{#location}}
-            <a href="{{hrefLocation}}>{{location}}</a> &mdash;
+            <a href="{{hrefLocation}}">{{location}}</a> &mdash;
           {{/location}}
           <strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}
         </li>

--- a/lib/email/EmailStudyRequestBulkCompleted.js
+++ b/lib/email/EmailStudyRequestBulkCompleted.js
@@ -29,7 +29,7 @@ class EmailStudyRequestBulkCompleted extends EmailBaseStudyRequestBulk {
         Your requests for the following studies
         {{#location}}
           at
-          <a href="{{hrefLocation}}>{{location}}</a>
+          <a href="{{hrefLocation}}">{{location}}</a>
         {{/location}}
         are now complete!
         Your data will be available in MOVE within 1 business day.
@@ -41,7 +41,7 @@ class EmailStudyRequestBulkCompleted extends EmailBaseStudyRequestBulk {
         {{#studyRequests}}
         <li>
           {{#location}}
-            <a href="{{hrefLocation}}>{{location}}</a> &mdash;
+            <a href="{{hrefLocation}}">{{location}}</a> &mdash;
           {{/location}}
           <strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}
         </li>

--- a/lib/email/EmailStudyRequestBulkRequested.js
+++ b/lib/email/EmailStudyRequestBulkRequested.js
@@ -29,7 +29,7 @@ class EmailStudyRequestBulkRequested extends EmailBaseStudyRequestBulk {
         We received your bulk request for the following studies
         {{#location}}
           to be conducted at
-          <a href="{{hrefLocation}}>{{location}}</a>
+          <a href="{{hrefLocation}}">{{location}}</a>
         {{/location}}:
       </p>
       <p>
@@ -39,7 +39,7 @@ class EmailStudyRequestBulkRequested extends EmailBaseStudyRequestBulk {
         {{#studyRequests}}
         <li>
           {{#location}}
-            <a href="{{hrefLocation}}>{{location}}</a> &mdash;
+            <a href="{{hrefLocation}}">{{location}}</a> &mdash;
           {{/location}}
           <strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}
         </li>

--- a/lib/email/EmailStudyRequestBulkRequestedAdmin.js
+++ b/lib/email/EmailStudyRequestBulkRequestedAdmin.js
@@ -26,7 +26,7 @@ class EmailStudyRequestBulkRequestedAdmin extends EmailBaseStudyRequestBulk {
         A bulk request has been submitted for the following studies
         {{#location}}
           to be conducted at
-          <a href="{{hrefLocation}}>{{location}}</a>
+          <a href="{{hrefLocation}}">{{location}}</a>
         {{/location}}:
       </p>
       <p>
@@ -36,7 +36,7 @@ class EmailStudyRequestBulkRequestedAdmin extends EmailBaseStudyRequestBulk {
         {{#studyRequests}}
         <li>
           {{#location}}
-            <a href="{{hrefLocation}}>{{location}}</a> &mdash;
+            <a href="{{hrefLocation}}">{{location}}</a> &mdash;
           {{/location}}
           <strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}
         </li>

--- a/lib/email/EmailStudyRequestCancelled.js
+++ b/lib/email/EmailStudyRequestCancelled.js
@@ -33,7 +33,7 @@ class EmailStudyRequestCancelled extends EmailBaseStudyRequest {
         Your request for the following study
         {{#location}}
           at
-          <a href="{{hrefLocation}}>{{location}}</a>
+          <a href="{{hrefLocation}}">{{location}}</a>
         {{/location}}
         has been cancelled:
       </p>

--- a/lib/email/EmailStudyRequestCompleted.js
+++ b/lib/email/EmailStudyRequestCompleted.js
@@ -32,7 +32,7 @@ class EmailStudyRequestCompleted extends EmailBaseStudyRequest {
         Your request for the following study
         {{#location}}
           at
-          <a href="{{hrefLocation}}>{{location}}</a>
+          <a href="{{hrefLocation}}">{{location}}</a>
         {{/location}}
         is now complete!
         Your data will be available in MOVE within 1 business day.

--- a/lib/email/EmailStudyRequestNewComment.js
+++ b/lib/email/EmailStudyRequestNewComment.js
@@ -49,7 +49,7 @@ class EmailStudyRequestNewComment extends EmailBaseStudyRequest {
         A comment has been added to the {{studyType}} request
         {{#location}}
           for
-          <a href="{{hrefLocation}}>{{location}}</a>
+          <a href="{{hrefLocation}}">{{location}}</a>
         {{/location}}:
       </p>
       <p>

--- a/lib/email/EmailStudyRequestRequested.js
+++ b/lib/email/EmailStudyRequestRequested.js
@@ -32,7 +32,7 @@ class EmailStudyRequestRequested extends EmailBaseStudyRequest {
         We received your request for the following study
         {{#location}}
           to be conducted at
-          <a href="{{hrefLocation}}>{{location}}</a>
+          <a href="{{hrefLocation}}">{{location}}</a>
         {{/location}}:
       </p>
       <p>

--- a/lib/email/EmailStudyRequestRequestedAdmin.js
+++ b/lib/email/EmailStudyRequestRequestedAdmin.js
@@ -29,7 +29,7 @@ class EmailStudyRequestRequestedAdmin extends EmailBaseStudyRequest {
         A request has been submitted for the following study
         {{#location}}
           to be conducted at
-          <a href="{{hrefLocation}}>{{location}}</a>
+          <a href="{{hrefLocation}}">{{location}}</a>
         {{/location}}:
       </p>
       <p>


### PR DESCRIPTION
# Issue Addressed
This PR makes progress on #763 .

# Description
Found the issue: we had `<a href="{{hrefLocation}}>` (without a closing quote on the `href` attribute) in all of our email templates, probably due to copy-pasting.

Leaving issue open until fix is confirmed.

# Tests
Unit tests still pass.  CI / CD.  Will check in AWS dev.
