### PR TITLE
a11y: fieldset and legend usage

### DIFF
--- a/tests/jest/unit/ui/DomIdGenerator.spec.js
+++ b/tests/jest/unit/ui/DomIdGenerator.spec.js
@@ -1,0 +1,13 @@
+import Random from '@/lib/Random';
+import DomIdGenerator from '@/web/ui/DomIdGenerator';
+
+test('DomIdGenerator.generate', () => {
+  const generatedIds = new Set();
+  for (let i = 0; i < 100; i++) {
+    const prefix = Random.choice(['a', 'b', 'c']);
+    const id = DomIdGenerator.generateId(prefix);
+    expect(generatedIds.has(id)).toBe(false);
+    generatedIds.add(id);
+  }
+  expect(generatedIds.size).toBe(100);
+});

--- a/web/components/dialogs/FcDialogAlert.vue
+++ b/web/components/dialogs/FcDialogAlert.vue
@@ -6,9 +6,15 @@
       <v-card-title class="shading">
         <h2 class="display-1">{{title}}</h2>
       </v-card-title>
-      <v-card-text>
+
+      <v-divider></v-divider>
+
+      <v-card-text class="pt-4">
         <slot></slot>
       </v-card-text>
+
+      <v-divider></v-divider>
+
       <v-card-actions class="shading">
         <v-spacer></v-spacer>
         <FcButton

--- a/web/components/dialogs/FcDialogCollisionFilters.vue
+++ b/web/components/dialogs/FcDialogCollisionFilters.vue
@@ -31,17 +31,11 @@
         </fieldset>
 
         <fieldset class="mt-6">
-          <legend class="headline">Dates</legend>
+          <legend class="headline">Date Range</legend>
 
-          <v-checkbox
-            v-model="internalFilters.applyDateRange"
-            class="mt-2"
-            hide-details
-            label="Filter by date?"></v-checkbox>
           <FcDatePicker
             v-model="$v.internalFilters.dateRangeStart.$model"
             class="mt-2"
-            :disabled="!internalFilters.applyDateRange"
             :error-messages="errorMessagesDateRangeStart"
             hide-details="auto"
             label="From (YYYY-MM-DD)"
@@ -50,7 +44,6 @@
           <FcDatePicker
             v-model="$v.internalFilters.dateRangeEnd.$model"
             class="mt-2"
-            :disabled="!internalFilters.applyDateRange"
             :error-messages="errorMessagesDateRangeEnd"
             hide-details="auto"
             label="To (YYYY-MM-DD)"
@@ -149,6 +142,10 @@ export default {
     };
   },
   computed: {
+    applyDateRange() {
+      const { dateRangeStart, dateRangeEnd } = this.internalFilters;
+      return dateRangeStart !== null || dateRangeEnd !== null;
+    },
     errorMessagesDateRangeStart() {
       const errors = [];
       if (!this.$v.internalFilters.dateRangeStart.requiredIfApplyDateRange) {
@@ -167,6 +164,11 @@ export default {
   },
   validations: {
     internalFilters: ValidationsFilters,
+  },
+  watch: {
+    applyDateRange() {
+      this.internalFilters.applyDateRange = this.applyDateRange;
+    },
   },
   methods: {
     actionClearAll() {

--- a/web/components/dialogs/FcDialogConfirm.vue
+++ b/web/components/dialogs/FcDialogConfirm.vue
@@ -7,9 +7,15 @@
       <v-card-title>
         <h2 class="display-1">{{title}}</h2>
       </v-card-title>
-      <v-card-text>
+
+      <v-divider></v-divider>
+
+      <v-card-text class="pt-4">
         <slot></slot>
       </v-card-text>
+
+      <v-divider></v-divider>
+
       <v-card-actions class="shading">
         <v-spacer></v-spacer>
         <FcButton

--- a/web/components/dialogs/FcDialogStudyFilters.vue
+++ b/web/components/dialogs/FcDialogStudyFilters.vue
@@ -44,17 +44,11 @@
         </fieldset>
 
         <fieldset class="mt-6">
-          <legend class="headline">Dates</legend>
+          <legend class="headline">Date Range</legend>
 
-          <v-checkbox
-            v-model="internalFilters.applyDateRange"
-            class="mt-2"
-            hide-details
-            label="Filter by date?"></v-checkbox>
           <FcDatePicker
             v-model="$v.internalFilters.dateRangeStart.$model"
             class="mt-2"
-            :disabled="!internalFilters.applyDateRange"
             :error-messages="errorMessagesDateRangeStart"
             hide-details="auto"
             label="From (YYYY-MM-DD)"
@@ -63,7 +57,6 @@
           <FcDatePicker
             v-model="$v.internalFilters.dateRangeEnd.$model"
             class="mt-2"
-            :disabled="!internalFilters.applyDateRange"
             :error-messages="errorMessagesDateRangeEnd"
             hide-details="auto"
             label="To (YYYY-MM-DD)"
@@ -137,6 +130,10 @@ export default {
     };
   },
   computed: {
+    applyDateRange() {
+      const { dateRangeStart, dateRangeEnd } = this.internalFilters;
+      return dateRangeStart !== null || dateRangeEnd !== null;
+    },
     errorMessagesDateRangeStart() {
       const errors = [];
       if (!this.$v.internalFilters.dateRangeStart.requiredIfApplyDateRange) {
@@ -155,6 +152,11 @@ export default {
   },
   validations: {
     internalFilters: ValidationsFilters,
+  },
+  watch: {
+    applyDateRange() {
+      this.internalFilters.applyDateRange = this.applyDateRange;
+    },
   },
   methods: {
     actionClearAll() {

--- a/web/components/inputs/FcPaneMapLegend.vue
+++ b/web/components/inputs/FcPaneMapLegend.vue
@@ -1,38 +1,46 @@
 <template>
   <v-card class="fc-pane-map-legend" width="200">
-    <v-card-text>
-      <h2 class="headline">View on map</h2>
-      <v-select
-        v-model="internalValue.datesFrom"
-        :aria-label="ariaLabelDatesFrom"
-        :items="itemsDatesFrom"
-        :messages="messagesDatesFrom" />
-      <h2 class="headline mt-6">Legend</h2>
-      <div
-        v-for="layer in layers"
-        :key="layer.value"
-        class="align-center d-flex my-3">
-        <div
-          :class="'icon-layer-' + layer.value"
-          class="mr-5"></div>
-        <div class="body-1 flex-grow-1 mt-1">{{layer.text}}</div>
-        <v-tooltip left>
-          <template v-slot:activator="{ on }">
-            <div v-on="on">
-              <v-checkbox
-                v-model="internalValue.layers[layer.value]"
-                :aria-label="layerLabels[layer.value]"
-                class="mt-0"
-                color="secondary"
-                hide-details
-                off-icon="mdi-eye-off"
-                on-icon="mdi-eye"
-                v-on="on"></v-checkbox>
-            </div>
-          </template>
-          <span>{{layerLabels[layer.value]}}</span>
-        </v-tooltip>
-      </div>
+    <v-card-text class="default--text">
+      <section aria-labelledby="heading_map_settings">
+        <h2 class="display-1" id="heading_map_settings">Map settings</h2>
+
+        <v-select
+          v-model="internalValue.datesFrom"
+          class="mt-4"
+          :items="itemsDatesFrom"
+          label="Show data from"
+          :messages="messagesDatesFrom" />
+
+        <fieldset class="mt-4">
+          <legend class="headline">Layers</legend>
+
+          <div
+            v-for="layer in layers"
+            :key="layer.value"
+            class="align-center d-flex my-2">
+            <div
+              :class="'icon-layer-' + layer.value"
+              class="mr-5"></div>
+            <div class="body-1 flex-grow-1 mt-1">{{layer.text}}</div>
+            <v-tooltip left>
+              <template v-slot:activator="{ on }">
+                <div v-on="on">
+                  <v-checkbox
+                    v-model="internalValue.layers[layer.value]"
+                    :aria-label="layerLabels[layer.value]"
+                    class="mt-0"
+                    color="secondary"
+                    hide-details
+                    off-icon="mdi-eye-off"
+                    on-icon="mdi-eye"
+                    v-on="on"></v-checkbox>
+                </div>
+              </template>
+              <span>{{layerLabels[layer.value]}}</span>
+            </v-tooltip>
+          </div>
+        </fieldset>
+      </section>
     </v-card-text>
   </v-card>
 </template>
@@ -64,14 +72,6 @@ export default {
     };
   },
   computed: {
-    ariaLabelDatesFrom() {
-      const { datesFrom } = this.internalValue;
-      const item = this.itemsDatesFrom.find(({ value }) => value === datesFrom);
-      if (item === undefined) {
-        return null;
-      }
-      return item.text;
-    },
     layerLabels() {
       const layerLabels = {};
       this.layers.forEach(({ text, value }) => {

--- a/web/components/inputs/FcTextarea.vue
+++ b/web/components/inputs/FcTextarea.vue
@@ -2,7 +2,7 @@
   <v-textarea
     v-model="internalValue"
     class="fc-textarea"
-    counter
+    :counter="1000"
     :label="label"
     no-resize
     outlined
@@ -12,12 +12,24 @@
 
 <script>
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+import DomIdGenerator from '@/web/ui/DomIdGenerator';
+
+const PREFIX_DOM_ID = 'textarea';
 
 export default {
   name: 'FcTextarea',
   mixins: [FcMixinVModelProxy(String)],
   props: {
     label: String,
+  },
+  mounted() {
+    const idCounter = DomIdGenerator.generateId(PREFIX_DOM_ID);
+
+    const $counter = this.$el.querySelector('.v-counter');
+    $counter.id = idCounter;
+
+    const $textarea = this.$el.querySelector('textarea');
+    $textarea.setAttribute('aria-describedby', idCounter);
   },
 };
 </script>

--- a/web/components/inputs/FcTextarea.vue
+++ b/web/components/inputs/FcTextarea.vue
@@ -2,7 +2,7 @@
   <v-textarea
     v-model="internalValue"
     class="fc-textarea"
-    :counter="1000"
+    counter
     :label="label"
     no-resize
     outlined

--- a/web/components/inputs/FcTextarea.vue
+++ b/web/components/inputs/FcTextarea.vue
@@ -1,0 +1,23 @@
+<template>
+  <v-textarea
+    v-model="internalValue"
+    class="fc-textarea"
+    counter
+    :label="label"
+    no-resize
+    outlined
+    rows="4"
+    v-bind="$attrs" />
+</template>
+
+<script>
+import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+
+export default {
+  name: 'FcTextarea',
+  mixins: [FcMixinVModelProxy(String)],
+  props: {
+    label: String,
+  },
+};
+</script>

--- a/web/components/requests/FcCardStudyRequest.vue
+++ b/web/components/requests/FcCardStudyRequest.vue
@@ -16,7 +16,9 @@
       </div>
     </v-card-title>
     <v-card-text class="pb-0">
-      <div class="mx-9">
+      <fieldset class="mx-9">
+        <legend class="sr-only">Study Type for Request</legend>
+
         <v-row class="mt-1">
           <v-col class="my-0 py-2" cols="8">
             <FcStudyRequestStudyType
@@ -51,7 +53,7 @@
               :v="v" />
           </v-col>
         </v-row>
-      </div>
+      </fieldset>
     </v-card-text>
   </v-card>
 </template>

--- a/web/components/requests/FcCommentsStudyRequest.vue
+++ b/web/components/requests/FcCommentsStudyRequest.vue
@@ -8,14 +8,11 @@
             <FcTextNumberTotal class="ml-2" :n="studyRequestComments.length" />
           </h3>
           <div class="fc-comment-new">
-            <v-textarea
+            <FcTextarea
               v-model="commentText"
               class="mt-4"
               label="Compose new comment"
-              :loading="loadingAddComment"
-              no-resize
-              outlined
-              rows="4"></v-textarea>
+              :loading="loadingAddComment" />
             <div class="text-right mb-4">
               <FcButton
                 :disabled="commentText.length === 0"
@@ -74,12 +71,14 @@ import {
 import FcTextNumberTotal from '@/web/components/data/FcTextNumberTotal.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcButtonAria from '@/web/components/inputs/FcButtonAria.vue';
+import FcTextarea from '@/web/components/inputs/FcTextarea.vue';
 
 export default {
   name: 'FcCommentsStudyRequest',
   components: {
     FcButton,
     FcButtonAria,
+    FcTextarea,
     FcTextNumberTotal,
   },
   props: {

--- a/web/components/requests/fields/FcStudyRequestNotes.vue
+++ b/web/components/requests/fields/FcStudyRequestNotes.vue
@@ -1,22 +1,23 @@
 <template>
-  <v-textarea
+  <FcTextarea
     v-model="internalNotes"
     :error-messages="errorMessagesNotes"
     label="Additional Information"
     :messages="messagesNotes"
-    no-resize
-    outlined
-    rows="4"
     v-bind="$attrs"
-    @blur="v.notes.$touch()"></v-textarea>
+    @blur="v.notes.$touch()" />
 </template>
 
 <script>
 import { StudyHours } from '@/lib/Constants';
 import { OPTIONAL, REQUEST_STUDY_OTHER_HOURS_REQUIRES_NOTES } from '@/lib/i18n/Strings';
+import FcTextarea from '@/web/components/inputs/FcTextarea.vue';
 
 export default {
   name: 'FcStudyRequestNotes',
+  components: {
+    FcTextarea,
+  },
   props: {
     v: Object,
   },

--- a/web/components/requests/fields/FcStudyRequestUrgent.vue
+++ b/web/components/requests/fields/FcStudyRequestUrgent.vue
@@ -45,17 +45,14 @@
     </div>
 
     <div class="mt-4">
-      <v-textarea
+      <FcTextarea
         v-model="v.urgentReason.$model"
         class="mt-3"
         :error-messages="errorMessagesUrgentReason"
         label="Additional Information"
         :messages="messagesUrgentReason"
-        no-resize
-        outlined
-        rows="4"
         :success="v.urgent.$model && !v.urgentReason.$invalid"
-        @blur="v.urgentReason.$touch()"></v-textarea>
+        @blur="v.urgentReason.$touch()" />
     </div>
   </fieldset>
 </template>
@@ -71,6 +68,7 @@ import {
 import DateTime from '@/lib/time/DateTime';
 import FcDatePicker from '@/web/components/inputs/FcDatePicker.vue';
 import FcInputTextArray from '@/web/components/inputs/FcInputTextArray.vue';
+import FcTextarea from '@/web/components/inputs/FcTextarea.vue';
 import FcStudyRequestReason from '@/web/components/requests/fields/FcStudyRequestReason.vue';
 
 export default {
@@ -79,6 +77,7 @@ export default {
     FcDatePicker,
     FcInputTextArray,
     FcStudyRequestReason,
+    FcTextarea,
   },
   props: {
     isCreate: Boolean,

--- a/web/ui/DomIdGenerator.js
+++ b/web/ui/DomIdGenerator.js
@@ -1,0 +1,12 @@
+const PREFIX = '__fc';
+let NEXT_ID = 1;
+
+class DomIdGenerator {
+  static generateId(name) {
+    const id = NEXT_ID;
+    NEXT_ID += 1;
+    return `${PREFIX}_${name}_${id}`;
+  }
+}
+
+export default DomIdGenerator;


### PR DESCRIPTION
# Issue Addressed
This PR closes #781 .

# Description
We make a first-pass sweep over JIRA tasks relating to the use of `<fieldset>` and `<legend>` in MOVE, adding these where needed.  We also fix a couple of adjacent issues (e.g. removing "filter by date?" checkboxes from filter dialogs) where possible.

# Tests
Added unit tests for `DomIdGenerator`, which can be used to help add `aria-labelledby` / `aria-describedby` relationships in our components.  Tested quickly in frontend; more complete testing pass will happen later.