### PR TITLE
Use description lists for metadata

### DIFF
--- a/web/components/data/FcDetailCollisions.vue
+++ b/web/components/data/FcDetailCollisions.vue
@@ -4,36 +4,44 @@
       v-if="loading"
       indeterminate />
     <template v-else>
-      <div class="flex-grow-1 flex-shrink-1">
-        <div class="body-1">
-          Amount
+      <dl class="d-flex flex-grow-1 flex-shrink-1">
+        <div class="flex-grow-1 flex-shrink-1">
+          <dt class="body-1">
+            Amount
+          </dt>
+          <dd>
+            <FcTextSummaryFraction
+              :a="collisionSummary.amount"
+              :b="collisionSummaryUnfiltered.amount"
+              class="mt-1"
+              :show-b="hasFiltersCollision" />
+          </dd>
         </div>
-        <FcTextSummaryFraction
-          :a="collisionSummary.amount"
-          :b="collisionSummaryUnfiltered.amount"
-          class="mt-2"
-          :show-b="hasFiltersCollision" />
-      </div>
-      <div class="flex-grow-1 flex-shrink-1">
-        <div class="body-1">
-          KSI
+        <div class="flex-grow-1 flex-shrink-1">
+          <dt class="body-1">
+            KSI
+          </dt>
+          <dd>
+            <FcTextSummaryFraction
+              :a="collisionSummary.ksi"
+              :b="collisionSummaryUnfiltered.ksi"
+              class="mt-1"
+              :show-b="hasFiltersCollision" />
+          </dd>
         </div>
-        <FcTextSummaryFraction
-          :a="collisionSummary.ksi"
-          :b="collisionSummaryUnfiltered.ksi"
-          class="mt-2"
-          :show-b="hasFiltersCollision" />
-      </div>
-      <div class="fc-collisions-validated flex-grow-0 flex-shrink-0 mr-8">
-        <div class="body-1">
-          Validated
+        <div class="fc-collisions-validated flex-grow-0 flex-shrink-0 mr-8">
+          <dt class="body-1">
+            Validated
+          </dt>
+          <dd>
+            <FcTextSummaryFraction
+              :a="collisionSummary.validated"
+              :b="collisionSummaryUnfiltered.validated"
+              class="mt-1"
+              :show-b="hasFiltersCollision" />
+          </dd>
         </div>
-        <FcTextSummaryFraction
-          :a="collisionSummary.validated"
-          :b="collisionSummaryUnfiltered.validated"
-          class="mt-2"
-          :show-b="hasFiltersCollision" />
-      </div>
+      </dl>
       <FcButton
         class="flex-grow-0 flex-shrink-0"
         type="tertiary"

--- a/web/components/location/FcSummaryPoi.vue
+++ b/web/components/location/FcSummaryPoi.vue
@@ -6,24 +6,22 @@
       indeterminate
       :size="20"
       :width="2" />
-    <template v-else>
-      <dl>
-        <FcSummaryPoiChip
-          v-if="poiSummary.hospital !== null"
-          class="mr-2"
-          color="pink"
-          icon="mdi-hospital-box"
-          :poi="poiSummary.hospital"
-          text="Hospital" />
-        <FcSummaryPoiChip
-          v-if="poiSummary.school !== null"
-          class="mr-2"
-          color="teal"
-          icon="mdi-school"
-          :poi="poiSummary.school"
-          text="School Zone" />
-      </dl>
-    </template>
+    <dl v-else-if="poiSummary.hospital !== null || poiSummary.school !== null">
+      <FcSummaryPoiChip
+        v-if="poiSummary.hospital !== null"
+        class="mr-2"
+        color="pink"
+        icon="mdi-hospital-box"
+        :poi="poiSummary.hospital"
+        text="Hospital" />
+      <FcSummaryPoiChip
+        v-if="poiSummary.school !== null"
+        class="mr-2"
+        color="teal"
+        icon="mdi-school"
+        :poi="poiSummary.school"
+        text="School Zone" />
+    </dl>
   </div>
 </template>
 

--- a/web/components/location/FcSummaryPoi.vue
+++ b/web/components/location/FcSummaryPoi.vue
@@ -7,18 +7,22 @@
       :size="20"
       :width="2" />
     <template v-else>
-      <FcSummaryPoiChip
-        v-if="poiSummary.hospital !== null"
-        color="pink"
-        icon="mdi-hospital-box"
-        :poi="poiSummary.hospital"
-        text="Hospital" />
-      <FcSummaryPoiChip
-        v-if="poiSummary.school !== null"
-        color="teal"
-        icon="mdi-school"
-        :poi="poiSummary.school"
-        text="School Zone" />
+      <dl>
+        <FcSummaryPoiChip
+          v-if="poiSummary.hospital !== null"
+          class="mr-2"
+          color="pink"
+          icon="mdi-hospital-box"
+          :poi="poiSummary.hospital"
+          text="Hospital" />
+        <FcSummaryPoiChip
+          v-if="poiSummary.school !== null"
+          class="mr-2"
+          color="teal"
+          icon="mdi-school"
+          :poi="poiSummary.school"
+          text="School Zone" />
+      </dl>
     </template>
   </div>
 </template>

--- a/web/components/location/FcSummaryPoiChip.vue
+++ b/web/components/location/FcSummaryPoiChip.vue
@@ -1,19 +1,22 @@
 <template>
-  <v-tooltip bottom>
-    <template v-slot:activator="{ on }">
-      <v-chip
-        v-on="on"
-        class="mr-2"
-        :color="color + ' lighten-4'"
-        :text-color="color + ' darken-4'">
-        <v-avatar left>
-          <v-icon>{{icon}}</v-icon>
-        </v-avatar>
-        {{text}}
-      </v-chip>
-    </template>
-    <span>{{poiDistance}} m</span>
-  </v-tooltip>
+  <div>
+    <v-tooltip bottom>
+      <template v-slot:activator="{ on }">
+        <v-chip
+          v-on="on"
+          :color="color + ' lighten-4'"
+          tag="dt"
+          :text-color="color + ' darken-4'">
+          <v-avatar left>
+            <v-icon>{{icon}}</v-icon>
+          </v-avatar>
+          {{text}}
+        </v-chip>
+      </template>
+      <span>{{poiDistance}} m</span>
+    </v-tooltip>
+    <dd class="sr-only">{{poiDistance}} m</dd>
+  </div>
 </template>
 
 <script>

--- a/web/components/reports/FcReportMetadata.vue
+++ b/web/components/reports/FcReportMetadata.vue
@@ -1,17 +1,17 @@
 <template>
-  <v-row class="mb-6">
+  <v-row class="mb-6" tag="dl">
     <v-col
       v-for="({ cols, name, value }, i) in entries"
       :key="i"
       :cols="cols">
-      <div class="subtitle-1">{{name}}</div>
-      <div class="mt-1 display-1">
+      <dt class="subtitle-1">{{name}}</dt>
+      <dd class="mt-1 display-1 font-weight-medium">
         <v-icon v-if="value === true">mdi-check</v-icon>
         <v-icon v-else-if="value === false">mdi-close</v-icon>
         <span v-else-if="value === null">None</span>
         <span v-else-if="Number.isFinite(value)">{{value | number}}</span>
         <span v-else>{{value}}</span>
-      </div>
+      </dd>
     </v-col>
   </v-row>
 </template>

--- a/web/components/requests/FcCardStudyRequestConfirm.vue
+++ b/web/components/requests/FcCardStudyRequestConfirm.vue
@@ -6,62 +6,65 @@
       <FcIconLocationMulti
         class="mr-5"
         v-bind="iconProps" />
-      <div class="fc-card-study-request-title">
+      <h3 class="headline">
         {{location.description}}
-      </div>
+      </h3>
     </v-card-title>
-    <v-card-text class="pb-0">
+    <v-card-text class="default--text">
       <div class="mx-9">
-        <v-row>
+        <v-row tag="dl">
           <v-col class="py-2" cols="6">
-            <div class="subtitle-1">
+            <dt class="subtitle-1">
               Study Type
-            </div>
-            <div class="mt-1 display-1">
+            </dt>
+            <dd class="mt-1 display-1">
               {{studyRequest.studyType.label}}
-            </div>
+            </dd>
           </v-col>
           <v-col class="py-2" cols="6">
-            <div class="subtitle-1">
-              Days
-            </div>
-            <div class="mt-1 display-1">
+            <dt class="subtitle-1">
+              Study Days
+            </dt>
+            <dd class="mt-1 display-1">
               {{studyRequest.daysOfWeek | daysOfWeek}}
-            </div>
+            </dd>
           </v-col>
-        </v-row>
-        <v-row>
           <v-col class="py-2" cols="6">
             <template v-if="studyRequest.studyType.automatic">
-              <div class="subtitle-1">
-                Duration
-              </div>
-              <div class="mt-1 display-1">
+              <dt class="subtitle-1">
+                Study Duration
+              </dt>
+              <dd class="mt-1 display-1">
                 {{studyRequest.duration | durationHuman}}
-              </div>
-              <v-messages
-                class="mt-1"
-                :value="[studyRequest.duration + ' hours']"></v-messages>
+              </dd>
+              <dd>
+                <v-messages
+                  class="mt-1"
+                  :value="[studyRequest.duration + ' hours']" />
+              </dd>
             </template>
             <template v-else>
-              <div class="subtitle-1">
-                Hours
-              </div>
-              <div class="mt-1 display-1">
+              <dt class="subtitle-1">
+                Study Hours
+              </dt>
+              <dd class="mt-1 display-1">
                 {{studyRequest.hours.description}}
-              </div>
+              </dd>
+              <dd>
+                <v-messages
+                  class="mt-1"
+                  :value="[studyRequest.hours.hint]" />
+              </dd>
             </template>
           </v-col>
-        </v-row>
-        <v-row>
           <v-col class="py-2" cols="12">
-            <div class="subtitle-1">
+            <dt class="subtitle-1">
               Additional Information
-            </div>
-            <div class="mt-1 display-1">
+            </dt>
+            <dd class="mt-1 display-1">
               <span v-if="studyRequest.notes">{{studyRequest.notes}}</span>
               <span v-else>None</span>
-            </div>
+            </dd>
           </v-col>
         </v-row>
       </div>

--- a/web/components/requests/summary/FcSummaryStudy.vue
+++ b/web/components/requests/summary/FcSummaryStudy.vue
@@ -1,42 +1,48 @@
 <template>
   <section>
-    <h2 class="headline mt-5">{{study.studyType.label}}</h2>
-    <v-row class="mt-2 mb-6">
+    <h4 class="headline mt-5">{{study.studyType.label}}</h4>
+    <v-row class="mt-2 mb-6" tag="dl">
       <v-col cols="6">
-        <div class="subtitle-1">Study Days</div>
-        <div class="mt-1 display-1">
+        <dt class="subtitle-1">Study Days</dt>
+        <dd class="mt-1 display-1">
           {{study.daysOfWeek | daysOfWeek}}
-        </div>
-        <v-messages
-          class="mt-1"
-          :value="messagesDaysOfWeek"></v-messages>
+        </dd>
+        <dd v-if="messagesDaysOfWeek.length > 0">
+          <v-messages
+            class="mt-1"
+            :value="messagesDaysOfWeek" />
+        </dd>
       </v-col>
       <v-col cols="6">
         <template v-if="study.studyType.automatic">
-          <div class="subtitle-1">Study Duration</div>
-          <div class="mt-1 display-1">
+          <dt class="subtitle-1">Study Duration</dt>
+          <dd class="mt-1 display-1">
             {{study.duration | durationHuman}}
-          </div>
-          <v-messages
-            class="mt-1"
-            :value="[study.duration + ' hours']"></v-messages>
+          </dd>
+          <dd>
+            <v-messages
+              class="mt-1"
+              :value="[study.duration + ' hours']" />
+          </dd>
         </template>
         <template v-else>
-          <div class="subtitle-1">Study Hours</div>
-          <div class="mt-1 display-1">
+          <dt class="subtitle-1">Study Hours</dt>
+          <dd class="mt-1 display-1">
             {{study.hours.description}}
-          </div>
-          <v-messages
-            class="mt-1"
-            :value="[study.hours.hint]"></v-messages>
+          </dd>
+          <dd>
+            <v-messages
+              class="mt-1"
+              :value="[study.hours.hint]"></v-messages>
+          </dd>
         </template>
       </v-col>
       <v-col cols="12">
-        <div class="subtitle-1">Additional Information</div>
-        <div class="mt-1 display-1">
+        <dt class="subtitle-1">Additional Information</dt>
+        <dd class="mt-1 display-1">
           <span v-if="study.notes">{{study.notes}}</span>
           <span v-else>None</span>
-        </div>
+        </dd>
       </v-col>
     </v-row>
   </section>

--- a/web/components/requests/summary/FcSummaryStudyRequest.vue
+++ b/web/components/requests/summary/FcSummaryStudyRequest.vue
@@ -1,52 +1,53 @@
 <template>
   <section>
-    <v-row class="mt-1 mb-2">
+    <v-row class="mt-1 mb-2" tag="dl">
       <v-col cols="6">
-        <div class="subtitle-1">Requester</div>
-        <div class="mt-1 display-1">
+        <dt class="subtitle-1">Requester</dt>
+        <dd class="mt-1 display-1">
           <span v-if="requestedBy !== null">
             {{requestedBy | username}}
           </span>
-        </div>
+        </dd>
       </v-col>
       <v-col cols="6">
         <template v-if="!isCreate">
-          <div class="subtitle-1">Submitted</div>
-          <div class="mt-1 display-1">
+          <dt class="subtitle-1">Submitted</dt>
+          <dd class="mt-1 display-1">
             {{studyRequest.createdAt | date}}
-          </div>
+          </dd>
         </template>
       </v-col>
       <v-col cols="6">
-        <div class="subtitle-1">Reason</div>
-        <div class="mt-1 display-1">
+        <dt class="subtitle-1">Reason</dt>
+        <dd class="mt-1 display-1">
           {{studyRequest.reason.text}}
-        </div>
+        </dd>
       </v-col>
       <v-col cols="6">
-        <div class="subtitle-1">Due Date</div>
-        <div class="mt-1 display-1">
+        <dt class="subtitle-1">Due Date</dt>
+        <dd class="mt-1 display-1">
           {{studyRequest.dueDate | date}}
-        </div>
-        <div
+        </dd>
+        <dd
           v-if="studyRequest.urgent"
           class="align-center d-flex">
           <v-icon color="warning" left>mdi-clipboard-alert</v-icon>
-          <v-messages :value="['This request has been marked as urgent.']"></v-messages>
-        </div>
-        <v-messages
-          v-else
-          class="mt-1"
-          :value="['Standard times to request counts are 2-3 months.']"></v-messages>
+          <v-messages :value="['This request has been marked as urgent.']" />
+        </dd>
+        <dd v-else>
+          <v-messages
+            class="mt-1"
+            :value="['Standard times to request counts are 2-3 months.']" />
+        </dd>
       </v-col>
       <v-col cols="12">
-        <div class="subtitle-1">Additional Information</div>
-        <div class="mt-1 display-1">
+        <dt class="subtitle-1">Additional Information</dt>
+        <dd class="mt-1 display-1">
           <span v-if="studyRequest.urgentReason">
             {{studyRequest.urgentReason}}
           </span>
           <span v-else>None</span>
-        </div>
+        </dd>
       </v-col>
     </v-row>
   </section>


### PR DESCRIPTION
# Issue Addressed
This PR closes #786 .

# Description
We update several parts of the application to use `<dl>`, `<dt>`, and `<dd>` to mark up key-value metadata.

# Tests
Tested quickly in frontend.
