### PR TITLE
Toasts and screen-reader-only text

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -183,6 +183,11 @@ HttpStatus.init({
   },
 });
 
+const KeyCode = {
+  ENTER: 0x0a,
+  SPACE: 0x20,
+};
+
 class LegendMode extends Enum {}
 LegendMode.init(['FOCUS_LOCATIONS', 'NORMAL']);
 
@@ -1031,6 +1036,7 @@ const Constants = {
   FEATURE_CODES_INTERSECTION,
   FEATURE_CODES_SEGMENT,
   HttpStatus,
+  KeyCode,
   LegendMode,
   LocationMode,
   LocationSearchType,
@@ -1073,6 +1079,7 @@ export {
   FEATURE_CODES_INTERSECTION,
   FEATURE_CODES_SEGMENT,
   HttpStatus,
+  KeyCode,
   LegendMode,
   LocationMode,
   LocationSearchType,

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -867,6 +867,8 @@ StudyRequestStatus.init({
     detailsIndex: 0,
     editable: true,
     text: 'Requested',
+    textVerb: 'reopen',
+    textVerbPastTense: 'reopened',
     get transitionsTo() {
       return [
         StudyRequestStatus.CHANGES_NEEDED,
@@ -881,6 +883,8 @@ StudyRequestStatus.init({
     detailsIndex: 1,
     editable: true,
     text: 'Changes Needed',
+    textVerb: 'request changes for',
+    textVerbPastTense: 'returned to submitter for changes',
     get transitionsTo() {
       return [
         StudyRequestStatus.REQUESTED,
@@ -895,6 +899,8 @@ StudyRequestStatus.init({
     detailsIndex: 1,
     editable: false,
     text: 'Cancelled',
+    textVerb: 'cancel',
+    textVerbPastTense: 'cancelled',
     get transitionsTo() {
       return [
         StudyRequestStatus.REQUESTED,
@@ -907,6 +913,8 @@ StudyRequestStatus.init({
     detailsIndex: 2,
     editable: false,
     text: 'Assigned',
+    textVerb: 'assign',
+    textVerbPastTense: 'assigned',
     get transitionsTo() {
       return [
         StudyRequestStatus.REQUESTED,
@@ -921,6 +929,8 @@ StudyRequestStatus.init({
     detailsIndex: 3,
     editable: false,
     text: 'Rejected',
+    textVerb: 'reject',
+    textVerbPastTense: 'rejected',
     get transitionsTo() {
       return [];
     },
@@ -931,6 +941,8 @@ StudyRequestStatus.init({
     detailsIndex: 4,
     editable: false,
     text: 'Completed',
+    textVerb: 'complete',
+    textVerbPastTense: 'completed',
     get transitionsTo() {
       return [];
     },

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -67,11 +67,24 @@ CardinalDirection.init({
   },
 });
 
+/**
+ * @param {Object} feature - centreline feature
+ * @returns {string} a string key representing the given feature, suitable for use in
+ * ES6 `Map` or `Set` instances
+ */
 function centrelineKey(feature) {
   const { centrelineId, centrelineType } = feature;
   return `${centrelineType}/${centrelineId}`;
 }
 
+/**
+ * Types of features in the centreline.  These codes are used extensively throughout MOVE's
+ * frontend, backend, and data pipelines to distinguish segments (midblocks) from intersections.
+ *
+ * For new code, we prefer the term "midblocks" to "segments", as the former makes it clearer
+ * that this is specific to road networks.  When this was first written, though, we used
+ * "segment".  (We might eventually change this here, but it's not a high priority.)
+ */
 const CentrelineType = {
   SEGMENT: 1,
   INTERSECTION: 2,
@@ -81,6 +94,9 @@ const CentrelineType = {
  * Vision Zero emphasis areas for collisions.
  *
  * @see https://www.toronto.ca/services-payments/streets-parking-transportation/road-safety/vision-zero/emphasis-areas/
+ * @param {string} field - which database column identifies collisions related to
+ * this emphasis area
+ * @param {string} text - human-readable description of the emphasis area
  */
 class CollisionEmphasisArea extends Enum {}
 // TODO: add filtering functions
@@ -115,6 +131,12 @@ CollisionEmphasisArea.init({
   },
 });
 
+/**
+ * Road surface conditions for collisions.
+ *
+ * @param {number} code - MVCR code for this condition
+ * @param {string} text - human-readable description of this code
+ */
 class CollisionRoadSurfaceCondition extends Enum {}
 CollisionRoadSurfaceCondition.init({
   CLEAR: {
@@ -147,13 +169,6 @@ CollisionRoadSurfaceCondition.init({
   },
 });
 
-const FeatureCode = {
-  EXPRESSWAY: 201100,
-  EXPRESSWAY_RAMP: 201101,
-  MAJOR_ARTERIAL: 201200,
-  MINOR_ARTERIAL: 201300,
-};
-
 /**
  * Common HTTP status codes.  Used when you need to compare a status code, or to call
  * `Boom.boomify` on an `Error`.
@@ -183,14 +198,32 @@ HttpStatus.init({
   },
 });
 
+/**
+ * Common keycodes for keyboard interactions.  These are primarily useful for addressing
+ * a11y keyboard navigation issues.
+ */
 const KeyCode = {
   ENTER: 0x0a,
   SPACE: 0x20,
 };
 
+/**
+ * Modes for the map legend.  `FOCUS_LOCATIONS` mode is used to hide extra detail when
+ * selecting locations or submitting study requests, while `NORMAL` is used during normal
+ * map navigation.
+ */
 class LegendMode extends Enum {}
 LegendMode.init(['FOCUS_LOCATIONS', 'NORMAL']);
 
+/**
+ * Modes for the location selector.  In `SINGLE` mode, only a single location may be selected.
+ * `MULTI_EDIT` is an edit mode for multi-location selection; in this mode, locations can be
+ * added and removed from the selection, but these changes must be saved to take effect.  In
+ * `MULTI` mode, multiple locations may be selected, but this multi-location selection cannot
+ * be edited.
+ *
+ * @param {boolean} multi - whether this mode allows for multi-location selection
+ */
 class LocationMode extends Enum {}
 LocationMode.init({
   SINGLE: {
@@ -232,6 +265,12 @@ LocationSelectionType.init([
  * - Level 3: city-wide;
  * - Level 2: ward level;
  * - Level 1: neighbourhood / block level.
+ *
+ * Layers in {@link GeoStyle} may use these constants to describe what data is shown at
+ * each level, and how that data is shown.
+ *
+ * @param {number} minzoom - minimum Mapbox GL zoom level in this MOVE level (inclusive)
+ * @param {number} maxzoomLayer - maximum Mapbox GL zoom level in this MOVE level (exclusive)
  */
 class MapZoom extends Enum {
   get maxzoomSource() {
@@ -255,8 +294,19 @@ MapZoom.init({
 MapZoom.MIN = MapZoom.LEVEL_3.minzoom;
 MapZoom.MAX = MapZoom.LEVEL_1.maxzoomSource;
 
+/**
+ * Maximum number of locations that may be selected at once.
+ *
+ * This is a limit on _waypoints_.  If the user routes a corridor, for instance, they can select
+ * up to `MAX_LOCATIONS` waypoints, but the corridor itself may contain more locations.  See
+ * {@link CompositeId} for the maximum number of locations in a routed corridor.
+ */
 const MAX_LOCATIONS = 5;
 
+/**
+ * Official name of the organization / division that is responsible for data products and services
+ * provided through MOVE.  This is primarily used in the "letterhead" for various reports.
+ */
 const ORG_NAME = 'Transportation Services';
 
 /**
@@ -712,11 +762,11 @@ const FEATURE_CODES_INTERSECTION = RoadIntersectionType.enumValues
 const FEATURE_CODES_SEGMENT = RoadSegmentType.enumValues
   .map(({ featureCode }) => featureCode);
 
-const SignalType = {
-  NORMAL: 1,
-  PEDCROSS: 2,
-};
-
+/**
+ * Used to define sorting directions.  You can use these constants with
+ * {@link ArrayUtils.sortBy} to describe whether sorting should be ascending
+ * or descending.
+ */
 const SortDirection = {
   ASC: 1,
   DESC: -1,
@@ -823,6 +873,8 @@ StudyRequestAssignee.init({
 
 /**
  * Reasons for submitting a study request.
+ *
+ * @param {string} text - human-readable description of reason
  */
 class StudyRequestReason extends Enum {}
 StudyRequestReason.init({
@@ -1044,7 +1096,6 @@ const Constants = {
   CentrelineType,
   CollisionEmphasisArea,
   CollisionRoadSurfaceCondition,
-  FeatureCode,
   FEATURE_CODES_INTERSECTION,
   FEATURE_CODES_SEGMENT,
   HttpStatus,
@@ -1067,7 +1118,6 @@ const Constants = {
   ReportType,
   RoadIntersectionType,
   RoadSegmentType,
-  SignalType,
   SortDirection,
   SPEED_CLASSES,
   StudyHours,
@@ -1087,7 +1137,6 @@ export {
   CentrelineType,
   CollisionEmphasisArea,
   CollisionRoadSurfaceCondition,
-  FeatureCode,
   FEATURE_CODES_INTERSECTION,
   FEATURE_CODES_SEGMENT,
   HttpStatus,
@@ -1110,7 +1159,6 @@ export {
   ReportType,
   RoadIntersectionType,
   RoadSegmentType,
-  SignalType,
   SortDirection,
   SPEED_CLASSES,
   StudyHours,

--- a/lib/controller/AuthController.js
+++ b/lib/controller/AuthController.js
@@ -79,6 +79,8 @@ AuthController.push({
  *
  * @memberof AuthController
  * @name getAdfsCallback
+ * @see {@link saveLoginState}
+ * @see {@link restoreLoginState}
  */
 AuthController.push({
   method: 'GET',
@@ -96,9 +98,21 @@ AuthController.push({
     try {
       const user = await client.callback(request);
       await login(request, user);
+      /*
+       * Before the user logs in, their navigation target page is saved using
+       * `saveLoginState`.
+       *
+       * After login, `restoreLoginState` first checks for the existence of a `login` URL
+       * query parameter.  This parameter is set here to indicate that login has successfully
+       * completed.
+       */
       return h.redirect(`${config.PUBLIC_PATH}?login=1`);
     } catch (err) {
       request.log(LogTag.ERROR, err);
+      /*
+       * Here an error has occurred in processing the user's login, so we do _not_ set the
+       * `login` URL query parameter.
+       */
       return h.redirect(config.PUBLIC_PATH);
     }
   },

--- a/lib/controller/AuthController.js
+++ b/lib/controller/AuthController.js
@@ -96,10 +96,10 @@ AuthController.push({
     try {
       const user = await client.callback(request);
       await login(request, user);
-      return h.redirect(config.PUBLIC_PATH);
+      return h.redirect(`${config.PUBLIC_PATH}?login=1`);
     } catch (err) {
       request.log(LogTag.ERROR, err);
-      return h.redirect('/');
+      return h.redirect(config.PUBLIC_PATH);
     }
   },
 });

--- a/lib/requests/RequestDataTableColumns.js
+++ b/lib/requests/RequestDataTableColumns.js
@@ -4,7 +4,8 @@
 const RequestDataTableColumns = [
   { value: 'SELECT', text: '' },
   { value: 'ID', text: 'ID' },
-  { value: 'data-table-expand', text: 'Location' },
+  { value: 'LOCATION', text: 'Location' },
+  { value: 'data-table-expand', text: '' },
   { value: 'STUDY_TYPE', text: 'Type' },
   { value: 'REQUESTER', text: 'Requester' },
   { value: 'CREATED_AT', text: 'Date Created' },

--- a/lib/requests/RequestDataTableColumns.js
+++ b/lib/requests/RequestDataTableColumns.js
@@ -1,10 +1,25 @@
 /**
  * Columns for `<FcDataTableRequests>`.
+ *
+ * For entries here with `text: ''`, the corresponding column in `<FcDataTableRequests>` will
+ * have an empty header.  This is intentional, as it helps limit on-screen text to only what's
+ * necessary for navigation and usability.  However, it's also an a11y issue - screen reader
+ * users rely on column header text to understand the context of table cells.
+ *
+ * To address that, ensure that you define a corresponding `header.${column.name}` slot.  In
+ * this slot, include `<span class="sr-only"></span>` text that provides adequate context to
+ * screen reader users.
  */
 const RequestDataTableColumns = [
   { value: 'SELECT', text: '' },
   { value: 'ID', text: 'ID' },
   { value: 'LOCATION', text: 'Location' },
+  /*
+   * `data-table-expand` is a special column name, used to include expansion controls in
+   * tables with information nested accordion-style in rows.
+   *
+   * In this case, we use this slot for bulk study requests.
+   */
   { value: 'data-table-expand', text: '' },
   { value: 'STUDY_TYPE', text: 'Type' },
   { value: 'REQUESTER', text: 'Requester' },

--- a/lib/requests/RequestFilters.js
+++ b/lib/requests/RequestFilters.js
@@ -2,78 +2,6 @@ import RequestSearchKeys from '@/lib/requests/RequestSearchKeys';
 import { ItemType } from '@/lib/requests/RequestStudyBulkUtils';
 import DateTime from '@/lib/time/DateTime';
 
-function timeAgoFilterText(prefix, value) {
-  const monthPlural = Math.abs(value) === 1 ? 'month' : 'months';
-  if (value < 0) {
-    return `${prefix} \u003c ${-value} ${monthPlural} ago`;
-  }
-  return `${prefix} \u2265 ${value} ${monthPlural} ago`;
-}
-
-function statusFilterText(items, status) {
-  const { text } = status;
-  let n = 0;
-  items.forEach((item) => {
-    if (item.type === ItemType.STUDY_REQUEST_BULK) {
-      item.studyRequestBulk.studyRequests.forEach((studyRequest) => {
-        if (studyRequest.status === status) {
-          n += 1;
-        }
-      });
-    } else if (item.status === status) {
-      n += 1;
-    }
-  });
-  return `${text} (${n})`;
-}
-
-function getFilterChips(filters, items) {
-  const {
-    assignees,
-    closed,
-    createdAt,
-    lastEditedAt,
-    statuses,
-    studyTypes,
-    userOnly,
-  } = filters;
-  const filterChips = [];
-  studyTypes.forEach((studyType) => {
-    const { label } = studyType;
-    const filterChip = { filter: 'studyTypes', label, value: studyType };
-    filterChips.push(filterChip);
-  });
-  statuses.forEach((status) => {
-    const label = statusFilterText(items, status);
-    const filterChip = { filter: 'statuses', label, value: status };
-    filterChips.push(filterChip);
-  });
-  if (closed) {
-    const filterChip = { filter: 'closed', label: 'Closed', value: true };
-    filterChips.push(filterChip);
-  }
-  assignees.forEach((assignee) => {
-    const label = assignee === null ? 'Unassigned' : assignee.text;
-    const filterChip = { filter: 'assignees', label, value: assignee };
-    filterChips.push(filterChip);
-  });
-  if (createdAt !== 0) {
-    const label = timeAgoFilterText('Created', createdAt);
-    const filterChip = { filter: 'createdAt', label, value: createdAt };
-    filterChips.push(filterChip);
-  }
-  if (lastEditedAt !== 0) {
-    const label = timeAgoFilterText('Updated', lastEditedAt);
-    const filterChip = { filter: 'lastEditedAt', label, value: lastEditedAt };
-    filterChips.push(filterChip);
-  }
-  if (userOnly) {
-    const filterChip = { filter: 'userOnly', label: 'User', value: true };
-    filterChips.push(filterChip);
-  }
-  return filterChips;
-}
-
 function filtersMatchStudyRequest(filters, user, studyRequest) {
   const {
     assignees,
@@ -178,11 +106,9 @@ function filterItem(filters, search, user, item) {
 
 const RequestFilters = {
   filterItem,
-  getFilterChips,
 };
 
 export {
   RequestFilters as default,
   filterItem,
-  getFilterChips,
 };

--- a/lib/requests/RequestItems.js
+++ b/lib/requests/RequestItems.js
@@ -22,8 +22,10 @@ function getStudyRequestItem(
   const feature = { centrelineId, centrelineType };
   const key = centrelineKey(feature);
   let location = null;
+  let ariaLabel = `Request #${id}`;
   if (studyRequestLocations.has(key)) {
     location = studyRequestLocations.get(key);
+    ariaLabel = `${ariaLabel}: ${location.description}`;
   }
 
   let requestedBy = null;
@@ -35,7 +37,7 @@ function getStudyRequestItem(
 
   return {
     type: ItemType.STUDY_REQUEST,
-    ariaLabel: `View Request #${id}`,
+    ariaLabel,
     assignedTo: assignedToStr,
     createdAt,
     dueDate,
@@ -79,7 +81,7 @@ function getStudyRequestBulkItem(
 
   return {
     type: ItemType.STUDY_REQUEST_BULK,
-    ariaLabel: `View Bulk Request: ${studyRequestBulk.name}`,
+    ariaLabel: `Bulk Request: ${studyRequestBulk.name}`,
     assignedTo: bulkAssignedToStr(studyRequests),
     createdAt,
     dueDate,

--- a/lib/requests/RequestSearchKeys.js
+++ b/lib/requests/RequestSearchKeys.js
@@ -10,7 +10,7 @@ const RequestSearchKeys = {
   },
   ASSIGNED_TO: (q, r) => {
     const qLower = q.toLowerCase();
-    let rLower = 'none';
+    let rLower = 'unassigned';
     if (r.studyRequest.assignedTo) {
       rLower = r.studyRequest.assignedTo.text.toLowerCase();
     }

--- a/lib/requests/RequestSearchKeys.js
+++ b/lib/requests/RequestSearchKeys.js
@@ -1,6 +1,13 @@
 import { formatUsername } from '@/lib/StringFormatters';
 
 const RequestSearchKeys = {
+  ID: (q, r) => {
+    const qNum = parseInt(q, 10);
+    if (Number.isNaN(qNum)) {
+      return q === '';
+    }
+    return qNum === r.studyRequest.id;
+  },
   ASSIGNED_TO: (q, r) => {
     const qLower = q.toLowerCase();
     let rLower = 'none';
@@ -9,7 +16,7 @@ const RequestSearchKeys = {
     }
     return rLower.indexOf(qLower) !== -1;
   },
-  'data-table-expand': (q, r) => {
+  LOCATION: (q, r) => {
     if (!r.location || !r.location.description) {
       return q === '';
     }

--- a/web/components/FcDataTable.vue
+++ b/web/components/FcDataTable.vue
@@ -41,6 +41,7 @@
 <script>
 import { Ripple } from 'vuetify/lib/directives';
 
+import { KeyCode } from '@/lib/Constants';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
 function compareKeys(ka, kb, kf) {
@@ -129,10 +130,24 @@ export default {
     },
   },
   mounted() {
+    // using external header to provide ARIA label for entire table
     if (this.ariaLabelledby !== null) {
       const $table = this.$el.querySelector('table');
       $table.setAttribute('aria-labelledby', this.ariaLabelledby);
     }
+
+    // keyboard navigation of sortable header toggles
+    const $thSortable = this.$el.querySelectorAll('th.sortable');
+    $thSortable.forEach(($th) => {
+      const $sortIcon = $th.querySelector('.v-data-table-header__icon');
+      $sortIcon.setAttribute('tabindex', 0);
+      $sortIcon.addEventListener('keypress', (evt) => {
+        if (evt.keyCode === KeyCode.SPACE) {
+          evt.preventDefault();
+          $th.click();
+        }
+      });
+    });
   },
   methods: {
     customSort(items, sortBy, sortDesc) {
@@ -149,6 +164,10 @@ export default {
 
 <style lang="scss">
 .fc-data-table.v-data-table {
+  & .v-data-table-header__icon {
+    opacity: 1;
+  }
+
   &.theme--light tbody tr.v-data-table__selected {
     background: var(--v-accent-lighten2);
     & .v-data-table__checkbox .v-icon.v-icon {

--- a/web/components/FcDataTableRequests.vue
+++ b/web/components/FcDataTableRequests.vue
@@ -159,9 +159,10 @@
       <div class="text-right">
         <v-icon
           v-if="item.urgent"
+          :aria-hidden="false"
+          aria-label="Urgent"
           class="mr-2"
-          color="warning"
-          title="Urgent">mdi-clipboard-alert</v-icon>
+          color="warning">mdi-clipboard-alert</v-icon>
 
         <FcButtonAria
           :aria-label="'View ' + item.ariaLabel"
@@ -276,8 +277,6 @@ export default {
       CREATED_AT: r => r.createdAt.toString(),
       DUE_DATE: r => r.dueDate.toString(),
       ID: (r) => {
-        /* eslint-disable-next-line no-console */
-        console.log(r);
         if (r.type.name === 'STUDY_REQUEST') {
           return r.studyRequest.id;
         }

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -84,6 +84,7 @@
           <div class="mr-3">
             <FcMenuDownloadReportFormat
               :loading="loadingDownload"
+              text-screen-reader="Collision Report"
               type="secondary"
               @download-report-format="actionDownload" />
           </div>

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -157,9 +157,11 @@ export default {
       if (this.detailView) {
         this.setLocationsIndex(-1);
         this.setDetailView(false);
+        this.setToastInfo('The View Data panel is now in Aggregate View.');
       } else {
         this.setLocationsIndex(0);
         this.setDetailView(true);
+        this.setToastInfo('The View Data panel is now in Detail View.');
       }
     },
     async loadAsyncForRoute(to) {
@@ -171,6 +173,7 @@ export default {
     ...mapMutations([
       'setLocationMode',
       'setLocationsIndex',
+      'setToastInfo',
     ]),
     ...mapMutations('viewData', ['setDetailView']),
     ...mapActions(['initLocations']),

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -111,6 +111,7 @@
           <div class="mr-3">
             <FcMenuDownloadReportFormat
               :loading="loadingDownload"
+              text-screen-reader="Study Report"
               type="secondary"
               @download-report-format="actionDownload" />
           </div>

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -51,43 +51,29 @@
         </FcButton>
       </div>
       <div class="pane-map-navigate">
-        <v-tooltip
+        <FcButtonAria
           v-if="showLocationSelection"
+          :aria-label="tooltipLocationMode"
+          class="pa-0"
+          :class="{
+            primary: locationMode.multi,
+            'white--text': locationMode.multi,
+          }"
+          :disabled="locationMode === LocationMode.MULTI_EDIT"
           left
-          :z-index="100">
-          <template v-slot:activator="{ on }">
-            <FcButton
-              :aria-label="tooltipLocationMode"
-              class="pa-0"
-              :class="{
-                primary: locationMode.multi,
-                'white--text': locationMode.multi,
-              }"
-              :disabled="locationMode === LocationMode.MULTI_EDIT"
-              type="fab-text"
-              @click="actionToggleLocationMode"
-              v-on="on">
-              <v-icon class="display-2">mdi-map-marker-multiple</v-icon>
-            </FcButton>
-          </template>
-          <span>{{tooltipLocationMode}}</span>
-        </v-tooltip>
-        <v-tooltip
+          type="fab-text"
+          @click="actionToggleLocationMode">
+          <v-icon class="display-2">mdi-map-marker-multiple</v-icon>
+        </FcButtonAria>
+        <FcButtonAria
           v-if="locationsForMode.length > 0"
+          aria-label="Recenter location"
+          class="pa-0"
           left
-          :z-index="100">
-          <template v-slot:activator="{ on }">
-            <FcButton
-              aria-label="Recenter location"
-              class="pa-0"
-              type="fab-text"
-              @click="recenterLocation()"
-              v-on="on">
-              <v-icon class="display-2">mdi-map-marker-circle</v-icon>
-            </FcButton>
-          </template>
-          <span>Recenter location</span>
-        </v-tooltip>
+          type="fab-text"
+          @click="actionRecenterLocation">
+          <v-icon class="display-2">mdi-map-marker-circle</v-icon>
+        </FcButtonAria>
       </div>
       <FcPaneMapPopup
         v-if="showHoveredPopup"
@@ -128,6 +114,7 @@ import FcPaneMapPopup from '@/web/components/FcPaneMapPopup.vue';
 import FcDialogConfirmMultiLocationLeave
   from '@/web/components/dialogs/FcDialogConfirmMultiLocationLeave.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
+import FcButtonAria from '@/web/components/inputs/FcButtonAria.vue';
 import FcPaneMapLegend from '@/web/components/inputs/FcPaneMapLegend.vue';
 import FcSelectorCollapsedLocation from '@/web/components/inputs/FcSelectorCollapsedLocation.vue';
 import FcSelectorMultiLocation from '@/web/components/inputs/FcSelectorMultiLocation.vue';
@@ -196,6 +183,7 @@ export default {
   name: 'FcPaneMap',
   components: {
     FcButton,
+    FcButtonAria,
     FcDialogConfirmMultiLocationLeave,
     FcPaneMapLegend,
     FcPaneMapPopup,
@@ -628,6 +616,18 @@ export default {
     },
   },
   methods: {
+    actionRecenterLocation() {
+      if (this.locationsForMode.length === 0) {
+        return;
+      }
+      this.easeToLocations(this.locationsForMode, null);
+
+      if (this.locationMode === LocationMode.SINGLE) {
+        this.setToastInfo('Map recentered on selected location.');
+      } else {
+        this.setToastInfo('Map recentered on selected locations.');
+      }
+    },
     actionToggleLocationMode() {
       if (this.locationMode === LocationMode.SINGLE) {
         this.setLocationMode(LocationMode.MULTI_EDIT);
@@ -694,12 +694,6 @@ export default {
           zoom: MapZoom.LEVEL_3.minzoom,
         });
       }
-    },
-    recenterLocation() {
-      if (this.locationsForMode.length === 0) {
-        return;
-      }
-      this.easeToLocations(this.locationsForMode, null);
     },
     getFeatureForLayerAndProperty(layer, key, value) {
       const features = this.map.queryRenderedFeatures({
@@ -810,6 +804,7 @@ export default {
       'setLegendMode',
       'setLegendOptions',
       'setLocationMode',
+      'setToastInfo',
     ]),
   },
 };

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -42,6 +42,13 @@
           class="mr-2"
           type="fab-text"
           @click="openGoogleMaps">
+          <v-icon
+            :aria-hidden="false"
+            aria-label="Opens in a new window"
+            left>
+            mdi-open-in-new
+          </v-icon>
+          <span class="sr-only">Google</span>
           Street View
         </FcButton>
         <FcButton

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -46,7 +46,7 @@
         </FcButton>
         <FcButton
           type="fab-text"
-          @click="aerial = !aerial">
+          @click="actionToggleAerial">
           {{ aerial ? 'Map' : 'Aerial' }}
         </FcButton>
       </div>
@@ -626,6 +626,14 @@ export default {
         this.setToastInfo('Map recentered on selected location.');
       } else {
         this.setToastInfo('Map recentered on selected locations.');
+      }
+    },
+    actionToggleAerial() {
+      this.aerial = !this.aerial;
+      if (this.aerial) {
+        this.setToastInfo('The map is now in Aerial Mode.');
+      } else {
+        this.setToastInfo('The map is no longer in Aerial Mode.');
       }
     },
     actionToggleLocationMode() {

--- a/web/components/FcPaneMapPopup.vue
+++ b/web/components/FcPaneMapPopup.vue
@@ -425,7 +425,13 @@ export default {
   },
   methods: {
     actionRemoveLocationEdit() {
-      this.removeLocationEdit(this.featureLocationsEditIndex);
+      const i = this.featureLocationsEditIndex;
+
+      const { description } = this.locationsEditSelection.locations[i];
+      this.setToastInfo(`Removed ${description} from selected locations.`);
+
+      this.setLocationsEditIndex(-1);
+      this.removeLocationEdit(i);
     },
     actionSelected() {
       if (this.locationMode === LocationMode.MULTI_EDIT) {
@@ -442,6 +448,11 @@ export default {
       const { centrelineId, centrelineType } = this.feature.properties;
       const feature = { centrelineId, centrelineType };
       const location = await getLocationByCentreline(feature);
+
+      if (this.locationsEditIndex === -1) {
+        const { description } = location;
+        this.setToastInfo(`Added ${description} to selected locations.`);
+      }
       this.setLocationEdit(location);
     },
     async actionSetStudyLocation() {
@@ -484,7 +495,9 @@ export default {
       'removeLocationEdit',
       'setDrawerOpen',
       'setLocationEdit',
+      'setLocationsEditIndex',
       'setLocations',
+      'setToastInfo',
     ]),
   },
 };

--- a/web/components/data/FcHeaderCollisions.vue
+++ b/web/components/data/FcHeaderCollisions.vue
@@ -20,6 +20,7 @@
           :color="colorIconFilterCollision"
           left>mdi-filter-variant</v-icon>
         Filter
+        <span class="sr-only">Collisions</span>
       </FcButton>
       <slot name="action" />
     </div>

--- a/web/components/data/FcHeaderCollisions.vue
+++ b/web/components/data/FcHeaderCollisions.vue
@@ -10,7 +10,7 @@
         v-if="showFiltersCollision"
         v-model="showFiltersCollision"
         :filters="filtersCollision"
-        @set-filters="setFiltersCollision">
+        @set-filters="actionSetFiltersCollision">
       </FcDialogCollisionFilters>
       <FcButton
         :disabled="disabled || collisionTotal === 0"
@@ -29,7 +29,7 @@
       v-if="filterChipsCollision.length > 0"
       class="mt-4 mb-2"
       :filter-chips="filterChipsCollision"
-      @click-filter="removeFilterCollision" />
+      @click-filter="actionRemoveFilterCollision" />
   </header>
 </template>
 
@@ -72,6 +72,15 @@ export default {
     ...mapGetters('viewData', ['filterChipsCollision']),
   },
   methods: {
+    actionRemoveFilterCollision(filter) {
+      this.removeFilterCollision(filter);
+      this.setToastInfo(`Removed collision filter: ${filter.label}.`);
+    },
+    actionSetFiltersCollision(filtersCollision) {
+      this.setFiltersCollision(filtersCollision);
+      this.setToastInfo('Updated request filters.');
+    },
+    ...mapMutations(['setToastInfo']),
     ...mapMutations('viewData', [
       'removeFilterCollision',
       'setFiltersCollision',

--- a/web/components/data/FcHeaderStudies.vue
+++ b/web/components/data/FcHeaderStudies.vue
@@ -10,7 +10,7 @@
         v-if="showFiltersStudy"
         v-model="showFiltersStudy"
         :filters="filtersStudy"
-        @set-filters="setFiltersStudy">
+        @set-filters="actionSetFiltersStudy">
       </FcDialogStudyFilters>
       <FcButton
         :disabled="disabled || studyTotal === 0"
@@ -29,7 +29,7 @@
       v-if="filterChipsStudy.length > 0"
       class="mt-4 mb-2"
       :filter-chips="filterChipsStudy"
-      @click-filter="removeFilterStudy" />
+      @click-filter="actionRemoveFilterStudy" />
   </header>
 </template>
 
@@ -72,6 +72,15 @@ export default {
     ...mapGetters('viewData', ['filterChipsStudy']),
   },
   methods: {
+    actionRemoveFilterStudy(filter) {
+      this.removeFilterStudy(filter);
+      this.setToastInfo(`Removed study filter: ${filter.label}.`);
+    },
+    actionSetFiltersStudy(filtersStudy) {
+      this.setFiltersStudy(filtersStudy);
+      this.setToastInfo('Updated study filters.');
+    },
+    ...mapMutations(['setToastInfo']),
     ...mapMutations('viewData', [
       'removeFilterStudy',
       'setFiltersStudy',

--- a/web/components/data/FcHeaderStudies.vue
+++ b/web/components/data/FcHeaderStudies.vue
@@ -20,6 +20,7 @@
           :color="colorIconFilterStudy"
           left>mdi-filter-variant</v-icon>
         Filter
+        <span class="sr-only">Studies</span>
       </FcButton>
       <slot name="action" />
     </div>

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -19,11 +19,11 @@
               @click="actionToggleReportExportMode(ReportExportMode.COLLISIONS)">
               <template v-if="reportExportMode === ReportExportMode.COLLISIONS">
                 <v-icon color="primary" left>mdi-file-cancel-outline</v-icon>
-                <span>Cancel Export</span>
+                <span>Cancel Export <span class="sr-only">of Collision Reports</span></span>
               </template>
               <template v-else>
                 <v-icon color="primary" left>mdi-file-export</v-icon>
-                <span>Export Reports</span>
+                <span>Export <span class="sr-only">Collision</span> Reports</span>
               </template>
             </FcButton>
             <FcButton
@@ -35,11 +35,12 @@
               type="secondary"
               @click="actionShowReportsCollision">
               <v-icon color="primary" left>mdi-file-eye</v-icon>
-              <span>View Report</span>
+              <span>View <span class="sr-only">Collision</span> Report</span>
             </FcButton>
             <FcMenuDownloadReportFormat
               v-else
               :require-auth="true"
+              text-screen-reader="Collision Reports"
               @download-report-format="actionDownloadReportFormatCollisions" />
           </template>
         </FcHeaderCollisions>
@@ -71,11 +72,11 @@
               @click="actionToggleReportExportMode(ReportExportMode.STUDIES)">
               <template v-if="reportExportMode === ReportExportMode.STUDIES">
                 <v-icon color="primary" left>mdi-file-cancel-outline</v-icon>
-                <span>Cancel Export</span>
+                <span>Cancel Export <span class="sr-only">of Study Reports</span></span>
               </template>
               <template v-else>
                 <v-icon color="primary" left>mdi-file-export</v-icon>
-                <span>Export Reports</span>
+                <span>Export <span class="sr-only">Study</span> Reports</span>
               </template>
             </FcButton>
             <FcButton
@@ -85,11 +86,12 @@
               type="secondary"
               @click="actionRequestStudy">
               <v-icon color="primary" left>mdi-plus-box</v-icon>
-              Request New
+              Request New <span class="sr-only">Studies</span>
             </FcButton>
             <FcMenuDownloadReportFormat
               v-else
               :require-auth="true"
+              text-screen-reader="Study Reports"
               @download-report-format="actionDownloadReportFormatStudies" />
           </template>
         </FcHeaderStudies>

--- a/web/components/data/FcViewDataDetail.vue
+++ b/web/components/data/FcViewDataDetail.vue
@@ -25,6 +25,7 @@
               @click="actionRequestStudy">
               <v-icon color="primary" left>mdi-plus-box</v-icon>
               Request New
+              <span class="sr-only">Study</span>
             </FcButton>
           </template>
         </FcHeaderStudies>

--- a/web/components/dialogs/FcDialogAlertStudyRequestsUnactionable.vue
+++ b/web/components/dialogs/FcDialogAlertStudyRequestsUnactionable.vue
@@ -4,7 +4,7 @@
     :title="title">
     <p class="body-1">
       {{studyRequestsUnactionable.length}} of {{studyRequests.length}}
-      requests could not be {{actionVerbPastTense}} due to their status:
+      requests could not be {{status.textVerbPastTense}} due to their status:
     </p>
     <ul class="body-1">
       <li
@@ -19,6 +19,7 @@
 </template>
 
 <script>
+import { StudyRequestStatus } from '@/lib/Constants';
 import FcDialogAlert from '@/web/components/dialogs/FcDialogAlert.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
@@ -29,15 +30,13 @@ export default {
     FcDialogAlert,
   },
   props: {
-    actionVerb: String,
-    actionVerbPastTense: String,
+    status: StudyRequestStatus,
     studyRequests: Array,
     studyRequestsUnactionable: Array,
   },
   computed: {
     title() {
-      const { actionVerb } = this;
-      return `Could not ${actionVerb} all requests`;
+      return `Could not ${this.status.textVerb} all requests`;
     },
   },
 };

--- a/web/components/dialogs/FcDialogRequestFilters.vue
+++ b/web/components/dialogs/FcDialogRequestFilters.vue
@@ -23,7 +23,7 @@
           <v-checkbox
             v-for="studyType in StudyType.enumValues"
             :key="studyType.name"
-            v-model="internalStudyTypes"
+            v-model="internalFilters.studyTypes"
             class="mt-2"
             hide-details
             :label="studyType.label"
@@ -36,13 +36,13 @@
           <v-checkbox
             v-for="status in StudyRequestStatus.enumValues"
             :key="status.name"
-            v-model="internalStatuses"
+            v-model="internalFilters.statuses"
             class="mt-2"
             hide-details
             :label="status.text"
             :value="status"></v-checkbox>
           <v-checkbox
-            v-model="internalClosed"
+            v-model="internalFilters.closed"
             class="mt-2"
             hide-details
             label="Closed"></v-checkbox>
@@ -52,7 +52,7 @@
           <legend class="headline">Assigned To</legend>
 
           <v-checkbox
-            v-model="internalAssignees"
+            v-model="internalFilters.assignees"
             class="mt-2"
             hide-details
             label="None"
@@ -60,7 +60,7 @@
           <v-checkbox
             v-for="assignee in StudyRequestAssignee.enumValues"
             :key="assignee.name"
-            v-model="internalAssignees"
+            v-model="internalFilters.assignees"
             class="mt-2"
             hide-details
             :label="assignee.text"
@@ -68,7 +68,7 @@
         </fieldset>
 
         <FcRadioGroup
-          v-model="internalCreatedAt"
+          v-model="internalFilters.createdAt"
           class="mt-6"
           hide-details
           :items="[
@@ -80,7 +80,7 @@
           label="Date Created" />
 
         <FcRadioGroup
-          v-model="internalLastEditedAt"
+          v-model="internalFilters.lastEditedAt"
           class="mt-6"
           hide-details
           :items="[
@@ -92,7 +92,7 @@
           label="Last Updated" />
 
         <FcRadioGroup
-          v-model="internalUserOnly"
+          v-model="internalFilters.userOnly"
           class="mt-6"
           hide-details
           :items="[
@@ -139,40 +139,15 @@ export default {
     FcRadioGroup,
   },
   props: {
-    assignees: Array,
-    closed: Boolean,
-    createdAt: Number,
-    lastEditedAt: Number,
-    statuses: Array,
-    studyTypes: Array,
-    userOnly: Boolean,
+    filters: Object,
   },
   data() {
     return {
-      internalAssignees: this.assignees,
-      internalClosed: this.closed,
-      internalCreatedAt: this.createdAt,
-      internalLastEditedAt: this.lastEditedAt,
-      internalStatuses: this.statuses,
-      internalStudyTypes: this.studyTypes,
-      internalUserOnly: this.userOnly,
+      internalFilters: { ...this.filters },
       StudyRequestAssignee,
       StudyRequestStatus,
       StudyType,
     };
-  },
-  computed: {
-    internalFilters() {
-      return {
-        assignees: this.internalAssignees,
-        closed: this.internalClosed,
-        createdAt: this.internalCreatedAt,
-        lastEditedAt: this.internalLastEditedAt,
-        statuses: this.internalStatuses,
-        studyTypes: this.internalStudyTypes,
-        userOnly: this.internalUserOnly,
-      };
-    },
   },
   methods: {
     actionClearAll() {

--- a/web/components/dialogs/FcToast.vue
+++ b/web/components/dialogs/FcToast.vue
@@ -1,7 +1,7 @@
 <template>
   <v-snackbar
     v-model="internalValue"
-    bottom
+    top
     class="fc-toast pb-5 pl-7"
     :color="color + ' darker-1'"
     :timeout="timeout">

--- a/web/components/inputs/FcMenuDownloadReportFormat.vue
+++ b/web/components/inputs/FcMenuDownloadReportFormat.vue
@@ -14,6 +14,11 @@
           mdi-cloud-download
         </v-icon>
         <span>Download</span>
+        <span
+          v-if="textScreenReader !== null"
+          class="sr-only">
+          {{textScreenReader}}
+        </span>
         <v-icon right>mdi-menu-down</v-icon>
       </FcButton>
     </template>
@@ -56,6 +61,10 @@ export default {
     requireAuth: {
       type: Boolean,
       default: false,
+    },
+    textScreenReader: {
+      type: String,
+      default: null,
     },
     type: {
       type: String,

--- a/web/components/inputs/FcSearchBarRequests.vue
+++ b/web/components/inputs/FcSearchBarRequests.vue
@@ -3,7 +3,7 @@
     aria-label="Search for requests in table"
     role="search">
     <v-text-field
-      v-model="internalValue.query"
+      v-model="internalQuery"
       append-icon="mdi-magnify"
       class="fc-search-bar-requests flex-grow-0 flex-shrink-0"
       dense
@@ -12,7 +12,7 @@
       outlined>
       <template v-slot:prepend>
         <v-select
-          v-model="internalValue.column"
+          v-model="internalColumn"
           class="fc-search-bar-requests-column font-weight-regular mt-0 pt-0 title"
           dense
           hide-details
@@ -25,6 +25,8 @@
 </template>
 
 <script>
+import { mapState, mapMutations } from 'vuex';
+
 import RequestSearchKeys from '@/lib/requests/RequestSearchKeys';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
@@ -35,6 +37,22 @@ export default {
     columns: Array,
   },
   computed: {
+    internalColumn: {
+      get() {
+        return this.searchRequest.column;
+      },
+      set(column) {
+        this.setSearchRequestColumn(column);
+      },
+    },
+    internalQuery: {
+      get() {
+        return this.searchRequest.query;
+      },
+      set(query) {
+        this.setSearchRequestQuery(query);
+      },
+    },
     itemsColumn() {
       const searchableColumns = this.columns.filter(
         column => Object.prototype.hasOwnProperty.call(RequestSearchKeys, column.value),
@@ -44,6 +62,10 @@ export default {
         ...searchableColumns,
       ];
     },
+    ...mapState('trackRequests', ['searchRequest']),
+  },
+  methods: {
+    ...mapMutations('trackRequests', ['setSearchRequestColumn', 'setSearchRequestQuery']),
   },
 };
 </script>

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -33,14 +33,14 @@
       </div>
       <div class="ml-2">
         <div
-          v-for="(_, i) in locationsEditSelection.locations"
+          v-for="(location, i) in locationsEditSelection.locations"
           :key="'remove_' + i"
           class="fc-input-location-search-remove">
           <FcButtonAria
-            :aria-label="'Remove Location #' + (i + 1)"
+            :aria-label="'Remove Location #' + (i + 1) + ': ' + location.description"
             right
             type="icon"
-            @click="removeLocationEdit(i)">
+            @click="actionRemove(i)">
             <v-icon>mdi-close</v-icon>
           </FcButtonAria>
         </div>
@@ -328,6 +328,9 @@ export default {
   },
   methods: {
     actionAdd(location) {
+      const { description } = location;
+      this.setToastInfo(`Added ${description} to selected locations.`);
+
       this.addLocationEdit(location);
       Vue.nextTick(() => this.autofocus());
     },
@@ -342,6 +345,9 @@ export default {
       }
     },
     actionRemove(i) {
+      const { description } = this.locationsEditSelection.locations[i];
+      this.setToastInfo(`Removed ${description} from selected locations.`);
+
       this.setLocationsEditIndex(-1);
       this.removeLocationEdit(i);
       Vue.nextTick(() => this.autofocus());
@@ -358,6 +364,7 @@ export default {
       'setLocationsIndex',
       'setLocationMode',
       'setToastBackendError',
+      'setToastInfo',
     ]),
   },
 };

--- a/web/components/jobs/FcCardJob.vue
+++ b/web/components/jobs/FcCardJob.vue
@@ -26,6 +26,7 @@
           {{iconAction}}
         </v-icon>
         {{action}}
+        <span class="sr-only">{{job.description}}</span>
       </FcButton>
     </v-card-title>
   </v-card>

--- a/web/components/nav/FcAppbar.vue
+++ b/web/components/nav/FcAppbar.vue
@@ -21,7 +21,12 @@
     <FcButton
       type="secondary"
       @click="actionProd">
-      <v-icon left>mdi-open-in-new</v-icon>
+      <v-icon
+        :aria-hidden="false"
+        aria-label="Opens in a new window"
+        left>
+        mdi-open-in-new
+      </v-icon>
       Open in release version
     </FcButton>
   </v-app-bar>

--- a/web/components/nav/FcDashboardNav.vue
+++ b/web/components/nav/FcDashboardNav.vue
@@ -27,10 +27,10 @@
       :to="{ name: 'downloadsManage' }" />
 
     <FcDashboardNavItem
+      external
       icon="bug"
       label="Report an Issue"
-      :href="urlReportIssue"
-      target="_blank" />
+      :href="urlReportIssue" />
   </v-list>
 </template>
 

--- a/web/components/nav/FcDashboardNavItem.vue
+++ b/web/components/nav/FcDashboardNavItem.vue
@@ -11,7 +11,7 @@
         :disabled="disabled"
         link
         :to="to"
-        v-bind="$attrs"
+        v-bind="attrsListItem"
         @click="actionClick">
         <v-list-item-icon>
           <div class="fc-badge-wrapper">
@@ -23,7 +23,10 @@
           </div>
         </v-list-item-icon>
         <v-list-item-content>
-          <v-list-item-title>{{label}}</v-list-item-title>
+          <v-list-item-title>
+            <span v-if="external" class="sr-only">Opens in a new window</span>
+            {{label}}
+          </v-list-item-title>
         </v-list-item-content>
       </v-list-item>
     </template>
@@ -54,6 +57,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    external: {
+      type: Boolean,
+      default: false,
+    },
     icon: String,
     label: String,
     to: {
@@ -62,6 +69,15 @@ export default {
     },
   },
   computed: {
+    attrsListItem() {
+      if (this.external) {
+        return {
+          target: '_blank',
+          ...this.$attrs,
+        };
+      }
+      return this.$attrs;
+    },
     isActive() {
       const { backViewRequest, to } = this;
       if (to === null) {

--- a/web/components/requests/FcCommentsStudyRequest.vue
+++ b/web/components/requests/FcCommentsStudyRequest.vue
@@ -26,7 +26,7 @@
         </v-col>
         <v-col class="px-5" cols="6">
           <dl
-            v-for="(comment) in studyRequestComments"
+            v-for="(comment, i) in studyRequestComments"
             :key="comment.id">
             <dt class="align-center d-flex mt-2">
               <span

--- a/web/components/requests/FcCreateStudyRequestBulk.vue
+++ b/web/components/requests/FcCreateStudyRequestBulk.vue
@@ -309,14 +309,21 @@ export default {
       }
     },
     actionRemoveStudy(i) {
+      let removed = false;
       let j = this.indicesIntersectionsSelected.indexOf(i);
       if (j !== -1) {
+        removed = true;
         this.indicesIntersectionsSelected.splice(j, 1);
       } else {
         j = this.indicesMidblocksSelected.indexOf(i);
         if (j !== -1) {
+          removed = true;
           this.indicesMidblocksSelected.splice(j, 1);
         }
+      }
+      if (removed) {
+        const { description } = this.locations[i];
+        this.setToastInfo(`Removed ${description} from request.`);
       }
     },
     async actionSubmit() {

--- a/web/components/requests/FcDetailsStudyRequest.vue
+++ b/web/components/requests/FcDetailsStudyRequest.vue
@@ -72,7 +72,7 @@
 </template>
 
 <script>
-import { mapActions } from 'vuex';
+import { mapActions, mapMutations } from 'vuex';
 
 import {
   StudyRequestReason,
@@ -82,7 +82,9 @@ import {
   OPTIONAL,
   REQUEST_STUDY_PROVIDE_URGENT_DUE_DATE,
   REQUEST_STUDY_PROVIDE_URGENT_REASON,
+  REQUEST_STUDY_SUBMITTED,
   REQUEST_STUDY_TIME_TO_FULFILL,
+  REQUEST_STUDY_UPDATED,
 } from '@/lib/i18n/Strings';
 import ValidationsStudyRequest from '@/lib/validation/ValidationsStudyRequest';
 import FcButton from '@/web/components/inputs/FcButton.vue';
@@ -135,9 +137,23 @@ export default {
   },
   methods: {
     actionSubmit() {
+      const { id, urgent } = this.internalValue;
+      const update = id !== undefined;
+      if (update) {
+        this.setToastInfo(REQUEST_STUDY_UPDATED.text);
+      } else if (urgent) {
+        this.setDialog({
+          dialog: 'AlertStudyRequestUrgent',
+          dialogData: { update },
+        });
+      } else {
+        this.setToastInfo(REQUEST_STUDY_SUBMITTED.text);
+      }
+
       this.saveStudyRequest(this.internalValue);
       this.$emit('action-navigate-back', true);
     },
+    ...mapMutations(['setDialog', 'setToastInfo']),
     ...mapActions(['saveStudyRequest']),
   },
 };

--- a/web/components/requests/FcStudyRequestBulkConfirm.vue
+++ b/web/components/requests/FcStudyRequestBulkConfirm.vue
@@ -28,19 +28,14 @@
                 :icon-props="locationsIconProps[i]"
                 :location="locations[i]"
                 :study-request="studyRequests[i]" />
-              <v-tooltip right>
-                <template v-slot:activator="{ on }">
-                  <FcButton
-                    :aria-label="'Remove ' + locations[i].description + ' from Request'"
-                    class="mr-4"
-                    type="icon"
-                    @click="$emit('remove-study', i)"
-                    v-on="on">
-                    <v-icon>mdi-close</v-icon>
-                  </FcButton>
-                </template>
-                <span>Remove {{locations[i].description}} from Request</span>
-              </v-tooltip>
+              <FcButtonAria
+                :aria-label="'Remove ' + locations[i].description + ' from Request'"
+                class="mr-4"
+                right
+                type="icon"
+                @click="$emit('remove-study', i)">
+                <v-icon>mdi-close</v-icon>
+              </FcButtonAria>
             </div>
           </template>
         </v-expansion-panel-content>
@@ -68,19 +63,14 @@
                 :icon-props="locationsIconProps[i]"
                 :location="locations[i]"
                 :study-request="studyRequests[i]" />
-              <v-tooltip right>
-                <template v-slot:activator="{ on }">
-                  <FcButton
-                    aria-label="Remove Study from Request"
-                    class="mr-4"
-                    type="icon"
-                    @click="$emit('remove-study', i)"
-                    v-on="on">
-                    <v-icon>mdi-close</v-icon>
-                  </FcButton>
-                </template>
-                <span>Remove Study from Request</span>
-              </v-tooltip>
+              <FcButtonAria
+                :aria-label="'Remove ' + locations[i].description + ' from Request'"
+                class="mr-4"
+                right
+                type="icon"
+                @click="$emit('remove-study', i)">
+                <v-icon>mdi-close</v-icon>
+              </FcButtonAria>
             </div>
           </template>
         </v-expansion-panel-content>
@@ -97,7 +87,7 @@
 
 <script>
 import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
-import FcButton from '@/web/components/inputs/FcButton.vue';
+import FcButtonAria from '@/web/components/inputs/FcButtonAria.vue';
 import FcCardStudyRequestConfirm from '@/web/components/requests/FcCardStudyRequestConfirm.vue';
 import FcSummaryStudyRequest from '@/web/components/requests/summary/FcSummaryStudyRequest.vue';
 import FcMixinInputAutofocus from '@/web/mixins/FcMixinInputAutofocus';
@@ -106,7 +96,7 @@ export default {
   name: 'FcStudyRequestBulkConfirm',
   mixins: [FcMixinInputAutofocus],
   components: {
-    FcButton,
+    FcButtonAria,
     FcCardStudyRequestConfirm,
     FcSummaryStudyRequest,
   },

--- a/web/components/requests/FcStudyRequestFilterShortcuts.vue
+++ b/web/components/requests/FcStudyRequestFilterShortcuts.vue
@@ -117,16 +117,18 @@ export default {
       },
       set(activeShortcutChip) {
         const { userOnly } = this.filtersRequest;
-        const { filters } = SHORTCUT_CHIPS[activeShortcutChip];
+        const { filters, label } = SHORTCUT_CHIPS[activeShortcutChip];
         this.setFiltersRequest({
           ...filters,
           userOnly,
         });
+        this.setToastInfo(`You're now viewing ${label} requests.`);
       },
     },
     ...mapState('trackRequests', ['filtersRequest']),
   },
   methods: {
+    ...mapMutations(['setToastInfo']),
     ...mapMutations('trackRequests', ['setFiltersRequest']),
   },
 };

--- a/web/components/requests/FcStudyRequestFilterShortcuts.vue
+++ b/web/components/requests/FcStudyRequestFilterShortcuts.vue
@@ -21,6 +21,8 @@
 </template>
 
 <script>
+import { mapMutations, mapState } from 'vuex';
+
 import { StudyRequestStatus } from '@/lib/Constants';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
@@ -107,21 +109,25 @@ export default {
     activeShortcutChip: {
       get() {
         for (let i = 0; i < SHORTCUT_CHIPS.length; i++) {
-          if (filtersMatchShortcutChip(this.internalValue, SHORTCUT_CHIPS[i])) {
+          if (filtersMatchShortcutChip(this.filtersRequest, SHORTCUT_CHIPS[i])) {
             return i;
           }
         }
         return null;
       },
       set(activeShortcutChip) {
-        const { userOnly } = this.internalValue;
+        const { userOnly } = this.filtersRequest;
         const { filters } = SHORTCUT_CHIPS[activeShortcutChip];
-        this.internalValue = {
+        this.setFiltersRequest({
           ...filters,
           userOnly,
-        };
+        });
       },
     },
+    ...mapState('trackRequests', ['filtersRequest']),
+  },
+  methods: {
+    ...mapMutations('trackRequests', ['setFiltersRequest']),
   },
 };
 </script>

--- a/web/components/requests/FcStudyRequestFilters.vue
+++ b/web/components/requests/FcStudyRequestFilters.vue
@@ -4,7 +4,7 @@
       v-if="showFilters"
       v-model="showFilters"
       :filters="filtersRequest"
-      @set-filters="setFiltersRequest" />
+      @set-filters="actionSetFiltersRequest" />
     <FcButton
       v-if="items.length > 0 || filterChipsRequest.length > 0"
       type="secondary"
@@ -19,7 +19,7 @@
       v-if="filterChipsRequest.length > 0"
       class="ml-5"
       :filter-chips="filterChipsRequest"
-      @click-filter="removeFilterRequest" />
+      @click-filter="actionRemoveFilterRequest" />
   </div>
 </template>
 
@@ -58,6 +58,15 @@ export default {
     ...mapState('trackRequests', ['filtersRequest']),
   },
   methods: {
+    actionRemoveFilterRequest(filter) {
+      this.removeFilterRequest(filter);
+      this.setToastInfo(`Removed request filter: ${filter.label}.`);
+    },
+    actionSetFiltersRequest(filtersRequest) {
+      this.setFiltersRequest(filtersRequest);
+      this.setToastInfo('Updated request filters.');
+    },
+    ...mapMutations(['setToastInfo']),
     ...mapMutations('trackRequests', ['removeFilterRequest', 'setFiltersRequest']),
   },
 };

--- a/web/components/requests/FcStudyRequestFilters.vue
+++ b/web/components/requests/FcStudyRequestFilters.vue
@@ -13,6 +13,7 @@
         :color="colorIconFilter"
         left>mdi-filter-variant</v-icon>
       Filter
+      <span class="sr-only">Requests</span>
     </FcButton>
     <FcListFilterChips
       v-if="filterChips.length > 0"

--- a/web/components/requests/FcStudyRequestFilters.vue
+++ b/web/components/requests/FcStudyRequestFilters.vue
@@ -3,10 +3,10 @@
     <FcDialogRequestFilters
       v-if="showFilters"
       v-model="showFilters"
-      v-bind="internalValue"
-      @set-filters="setFilters" />
+      :filters="filtersRequest"
+      @set-filters="setFiltersRequest" />
     <FcButton
-      v-if="items.length > 0 || filterChips.length > 0"
+      v-if="items.length > 0 || filterChipsRequest.length > 0"
       type="secondary"
       @click.stop="showFilters = true">
       <v-icon
@@ -16,22 +16,23 @@
       <span class="sr-only">Requests</span>
     </FcButton>
     <FcListFilterChips
-      v-if="filterChips.length > 0"
+      v-if="filterChipsRequest.length > 0"
       class="ml-5"
-      :filter-chips="filterChips"
-      @click-filter="removeFilter" />
+      :filter-chips="filterChipsRequest"
+      @click-filter="removeFilterRequest" />
   </div>
 </template>
 
 <script>
-import { getFilterChips } from '@/lib/requests/RequestFilters';
+import { mapGetters, mapMutations, mapState } from 'vuex';
+
 import FcDialogRequestFilters from '@/web/components/dialogs/FcDialogRequestFilters.vue';
 import FcListFilterChips from '@/web/components/filters/FcListFilterChips.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
 export default {
-  name: 'FcStudyRequestFilterChips',
+  name: 'FcStudyRequestFilters',
   mixins: [FcMixinVModelProxy(Object)],
   components: {
     FcButton,
@@ -48,36 +49,16 @@ export default {
   },
   computed: {
     colorIconFilter() {
-      if (this.filterChips.length === 0) {
-        return 'unselected';
+      if (this.hasFiltersRequest) {
+        return 'primary';
       }
-      return 'primary';
+      return 'unselected';
     },
-    filterChips() {
-      return getFilterChips(this.internalValue, this.items);
-    },
+    ...mapGetters('trackRequests', ['filterChipsRequest', 'hasFiltersRequest']),
+    ...mapState('trackRequests', ['filtersRequest']),
   },
   methods: {
-    removeFilter({ filter, value }) {
-      if (filter === 'closed') {
-        this.internalValue.closed = false;
-      } else if (filter === 'createdAt') {
-        this.internalValue.createdAt = 0;
-      } else if (filter === 'lastEditedAt') {
-        this.internalValue.lastEditedAt = 0;
-      } else if (filter === 'userOnly') {
-        this.internalValue.userOnly = false;
-      } else {
-        const values = this.internalValue[filter];
-        const i = values.indexOf(value);
-        if (i !== -1) {
-          values.splice(i, 1);
-        }
-      }
-    },
-    setFilters(filters) {
-      this.internalValue = filters;
-    },
+    ...mapMutations('trackRequests', ['removeFilterRequest', 'setFiltersRequest']),
   },
 };
 </script>

--- a/web/components/requests/status/FcMenuStudyRequestsAssignTo.vue
+++ b/web/components/requests/status/FcMenuStudyRequestsAssignTo.vue
@@ -13,6 +13,11 @@
         }"
         v-on="on">
         <span>{{text}}</span>
+        <span
+          v-if="textScreenReader !== null"
+          class="sr-only">
+          : {{textScreenReader}}
+        </span>
         <v-icon right>mdi-menu-down</v-icon>
       </FcButton>
     </template>
@@ -61,6 +66,10 @@ export default {
     text: {
       type: String,
       default: 'Assign To',
+    },
+    textScreenReader: {
+      type: String,
+      default: null,
     },
     width: {
       type: [Number, String],

--- a/web/components/requests/status/FcMenuStudyRequestsAssignTo.vue
+++ b/web/components/requests/status/FcMenuStudyRequestsAssignTo.vue
@@ -37,7 +37,7 @@
 <script>
 import { mapMutations } from 'vuex';
 
-import { StudyRequestAssignee } from '@/lib/Constants';
+import { StudyRequestAssignee, StudyRequestStatus } from '@/lib/Constants';
 import RequestActions from '@/lib/requests/RequestActions';
 import { bulkAssignedToStr } from '@/lib/requests/RequestStudyBulkUtils';
 import FcButton from '@/web/components/inputs/FcButton.vue';
@@ -106,24 +106,29 @@ export default {
           studyRequestsUnactionable.push(studyRequest);
         }
       });
-      if (studyRequestsUnactionable.length > 0) {
-        this.setDialog({
-          dialog: 'AlertStudyRequestsUnactionable',
-          dialogData: {
-            actionVerb: 'assign',
-            actionVerbPastTense: 'assigned',
-            studyRequests: this.studyRequests,
-            studyRequestsUnactionable,
-          },
-        });
-      }
+      this.displayFeedback(studyRequestsUnactionable, item);
     },
     actionMenu(item) {
       this.actionAssignTo(item);
       this.$emit('update');
     },
+    displayFeedback(studyRequestsUnactionable, item) {
+      if (studyRequestsUnactionable.length > 0) {
+        this.setDialog({
+          dialog: 'AlertStudyRequestsUnactionable',
+          dialogData: {
+            status: StudyRequestStatus.ASSIGNED,
+            studyRequests: this.studyRequests,
+            studyRequestsUnactionable,
+          },
+        });
+      } else {
+        const requestsPlural = this.studyRequests.length > 1 ? 'requests have' : 'request has';
+        this.setToastInfo(`Your ${requestsPlural} been assigned to ${item.text}.`);
+      }
+    },
     /* eslint-enable no-param-reassign */
-    ...mapMutations(['setDialog']),
+    ...mapMutations(['setDialog', 'setToastInfo']),
   },
 };
 </script>

--- a/web/components/requests/status/FcMenuStudyRequestsStatus.vue
+++ b/web/components/requests/status/FcMenuStudyRequestsStatus.vue
@@ -188,7 +188,6 @@ export default {
     },
   },
   methods: {
-    /* eslint-disable no-param-reassign */
     actionAssignTo(subitem) {
       const assignedTo = subitem.value;
       const studyRequestsUnactionable = [];
@@ -199,17 +198,7 @@ export default {
           studyRequestsUnactionable.push(studyRequest);
         }
       });
-      if (studyRequestsUnactionable.length > 0) {
-        this.setDialog({
-          dialog: 'AlertStudyRequestsUnactionable',
-          dialogData: {
-            actionVerb: 'assign',
-            actionVerbPastTense: 'assigned',
-            studyRequests: this.studyRequests,
-            studyRequestsUnactionable,
-          },
-        });
-      }
+      this.displayFeedback(studyRequestsUnactionable, StudyRequestStatus.ASSIGNED, subitem);
     },
     actionCancel() {
       const studyRequestsUnactionable = [];
@@ -220,17 +209,7 @@ export default {
           studyRequestsUnactionable.push(studyRequest);
         }
       });
-      if (studyRequestsUnactionable.length > 0) {
-        this.setDialog({
-          dialog: 'AlertStudyRequestsUnactionable',
-          dialogData: {
-            actionVerb: 'cancel',
-            actionVerbPastTense: 'cancelled',
-            studyRequests: this.studyRequests,
-            studyRequestsUnactionable,
-          },
-        });
-      }
+      this.displayFeedback(studyRequestsUnactionable, StudyRequestStatus.CANCELLED);
     },
     actionMarkCompleted() {
       const studyRequestsUnactionable = [];
@@ -241,17 +220,7 @@ export default {
           studyRequestsUnactionable.push(studyRequest);
         }
       });
-      if (studyRequestsUnactionable.length > 0) {
-        this.setDialog({
-          dialog: 'AlertStudyRequestsUnactionable',
-          dialogData: {
-            actionVerb: 'complete',
-            actionVerbPastTense: 'completed',
-            studyRequests: this.studyRequests,
-            studyRequestsUnactionable,
-          },
-        });
-      }
+      this.displayFeedback(studyRequestsUnactionable, StudyRequestStatus.COMPLETED);
     },
     actionMenu(item, subitem) {
       this.showMenu = false;
@@ -281,17 +250,7 @@ export default {
           studyRequestsUnactionable.push(studyRequest);
         }
       });
-      if (studyRequestsUnactionable.length > 0) {
-        this.setDialog({
-          dialog: 'AlertStudyRequestsUnactionable',
-          dialogData: {
-            actionVerb: 'reject',
-            actionVerbPastTense: 'rejected',
-            studyRequests: this.studyRequests,
-            studyRequestsUnactionable,
-          },
-        });
-      }
+      this.displayFeedback(studyRequestsUnactionable, StudyRequestStatus.REJECTED);
     },
     actionReopen() {
       const studyRequestsUnactionable = [];
@@ -302,17 +261,7 @@ export default {
           studyRequestsUnactionable.push(studyRequest);
         }
       });
-      if (studyRequestsUnactionable.length > 0) {
-        this.setDialog({
-          dialog: 'AlertStudyRequestsUnactionable',
-          dialogData: {
-            actionVerb: 'reopen',
-            actionVerbPastTense: 'reopened',
-            studyRequests: this.studyRequests,
-            studyRequestsUnactionable,
-          },
-        });
-      }
+      this.displayFeedback(studyRequestsUnactionable, StudyRequestStatus.REQUESTED);
     },
     actionRequestChanges() {
       const studyRequestsUnactionable = [];
@@ -323,20 +272,31 @@ export default {
           studyRequestsUnactionable.push(studyRequest);
         }
       });
+      this.displayFeedback(studyRequestsUnactionable, StudyRequestStatus.CHANGES_NEEDED);
+    },
+    displayFeedback(studyRequestsUnactionable, status, subitem = null) {
       if (studyRequestsUnactionable.length > 0) {
         this.setDialog({
           dialog: 'AlertStudyRequestsUnactionable',
           dialogData: {
-            actionVerb: 'request changes for',
-            actionVerbPastTense: 'returned to submitter for changes',
+            status,
             studyRequests: this.studyRequests,
             studyRequestsUnactionable,
           },
         });
+      } else {
+        const requestsPlural = this.studyRequests.length > 1 ? 'requests have' : 'request has';
+        if (status === StudyRequestStatus.ASSIGNED) {
+          this.setToastInfo(
+            `Your ${requestsPlural} been ${status.textVerbPastTense} to ${subitem.text}.`,
+          );
+        } else {
+          this.setToastInfo(`Your ${requestsPlural} been ${status.textVerbPastTense}.`);
+        }
       }
     },
     /* eslint-enable no-param-reassign */
-    ...mapMutations(['setDialog']),
+    ...mapMutations(['setDialog', 'setToastInfo']),
   },
 };
 </script>

--- a/web/components/requests/status/FcMenuStudyRequestsStatus.vue
+++ b/web/components/requests/status/FcMenuStudyRequestsStatus.vue
@@ -18,6 +18,11 @@
           mdi-circle-medium
         </v-icon>
         <span>Set Status</span>
+        <span
+          v-if="textScreenReader !== null"
+          class="sr-only">
+          : {{textScreenReader}}
+        </span>
         <v-icon right>mdi-menu-down</v-icon>
       </FcButton>
     </template>
@@ -91,6 +96,10 @@ export default {
       default: null,
     },
     studyRequests: Array,
+    textScreenReader: {
+      type: String,
+      default: null,
+    },
   },
   data() {
     return {

--- a/web/store/LoginState.js
+++ b/web/store/LoginState.js
@@ -1,5 +1,17 @@
 const STORAGE_KEY_LOGIN_STATE = 'ca.toronto.move.loginState';
 
+/**
+ * Restores the navigation target saved by {@link saveLoginState}.  This is intended to
+ * be used after login.  If the user successfully logged in _and_ a valid navigation target
+ * is available in `sessionStorage`, this results in one of two actions:
+ *
+ * 1. when the user used the bottom-right menu to log in, to return them to the page they were on;
+ * 2. when the user clicked a button or link that takes them to a page they must log in to
+ *    access, to complete navigation to that page.
+ *
+ * @param {Function} next - `next` method from `vue-router` navigation guards
+ * @returns {boolean} whether conditions to restore a navigation target were met
+ */
 function restoreLoginState(next) {
   const urlParams = new URLSearchParams(window.location.search);
   const paramLogin = urlParams.get('login');
@@ -35,6 +47,19 @@ function restoreLoginState(next) {
   }
 }
 
+/**
+ * Saves the given navigation target to `sessionStorage`.  This is intended to be called
+ * before login, and is used in one of two ways:
+ *
+ * 1. when the user uses the bottom-right menu to log in, to save their current page;
+ * 2. when the user clicks a button or link that takes them to a page they must log in to
+ *    access, to save that page.
+ *
+ * This navigation target is saved to `sessionStorage`, to be restored by
+ * {@link restoreLoginState} after login.
+ *
+ * @param {Object} to - navigation target
+ */
 function saveLoginState(to) {
   const { name, params = {} } = to;
   const loginState = JSON.stringify({ name, params });

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -359,18 +359,9 @@ export default new Vuex.Store({
       return auth;
     },
     // STUDY REQUESTS
-    async saveStudyRequest({ state, commit }, studyRequest) {
-      const { id, urgent } = studyRequest;
+    async saveStudyRequest({ state }, studyRequest) {
+      const { id } = studyRequest;
       const update = id !== undefined;
-      if (urgent && !update) {
-        commit('setDialog', {
-          dialog: 'AlertStudyRequestUrgent',
-          dialogData: { update },
-        });
-      } else {
-        const toast = update ? REQUEST_STUDY_UPDATED : REQUEST_STUDY_SUBMITTED;
-        commit('setToastInfo', toast.text);
-      }
 
       const { csrf } = state.auth;
       if (update) {
@@ -381,14 +372,15 @@ export default new Vuex.Store({
     async saveStudyRequestBulk({ state, commit }, studyRequestBulk) {
       const { id, urgent } = studyRequestBulk;
       const update = id !== undefined;
-      if (urgent && !update) {
+      if (update) {
+        commit('setToastInfo', REQUEST_STUDY_UPDATED.text);
+      } else if (urgent) {
         commit('setDialog', {
           dialog: 'AlertStudyRequestUrgent',
           dialogData: { update },
         });
       } else {
-        const toast = update ? REQUEST_STUDY_UPDATED : REQUEST_STUDY_SUBMITTED;
-        commit('setToastInfo', toast.text);
+        commit('setToastInfo', REQUEST_STUDY_SUBMITTED.text);
       }
 
       const { csrf } = state.auth;
@@ -397,9 +389,7 @@ export default new Vuex.Store({
       }
       return postStudyRequestBulk(csrf, studyRequestBulk);
     },
-    async updateStudyRequests({ state, commit }, studyRequests) {
-      commit('setToastInfo', `Updated ${studyRequests.length} study request(s).`);
-
+    async updateStudyRequests({ state }, studyRequests) {
       const { csrf } = state.auth;
       const tasks = studyRequests.map(
         studyRequest => putStudyRequest(csrf, studyRequest),

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -25,12 +25,14 @@ import {
 import CompositeId from '@/lib/io/CompositeId';
 import DateTime from '@/lib/time/DateTime';
 import FrontendEnv from '@/web/config/FrontendEnv';
+import trackRequests from '@/web/store/modules/trackRequests';
 import viewData from '@/web/store/modules/viewData';
 
 Vue.use(Vuex);
 
 export default new Vuex.Store({
   modules: {
+    trackRequests,
     viewData,
   },
   // TODO: organize state below

--- a/web/store/modules/trackRequests.js
+++ b/web/store/modules/trackRequests.js
@@ -1,0 +1,108 @@
+function timeAgoFilterText(prefix, value) {
+  const monthPlural = Math.abs(value) === 1 ? 'month' : 'months';
+  if (value < 0) {
+    return `${prefix} \u003c ${-value} ${monthPlural} ago`;
+  }
+  return `${prefix} \u2265 ${value} ${monthPlural} ago`;
+}
+
+export default {
+  namespaced: true,
+  state: {
+    filtersRequest: {
+      assignees: [],
+      closed: false,
+      createdAt: 0,
+      lastEditedAt: 0,
+      statuses: [],
+      studyTypes: [],
+      userOnly: false,
+    },
+    searchRequest: {
+      column: null,
+      query: null,
+    },
+  },
+  getters: {
+    filterChipsRequest(state) {
+      const {
+        assignees,
+        closed,
+        createdAt,
+        lastEditedAt,
+        statuses,
+        studyTypes,
+        userOnly,
+      } = state.filtersRequest;
+      const filterChipsRequest = [];
+      studyTypes.forEach((studyType) => {
+        const { label } = studyType;
+        const filterChip = { filter: 'studyTypes', label, value: studyType };
+        filterChipsRequest.push(filterChip);
+      });
+      statuses.forEach((status) => {
+        const label = status.text;
+        const filterChip = { filter: 'statuses', label, value: status };
+        filterChipsRequest.push(filterChip);
+      });
+      if (closed) {
+        const filterChip = { filter: 'closed', label: 'Closed', value: true };
+        filterChipsRequest.push(filterChip);
+      }
+      assignees.forEach((assignee) => {
+        const label = assignee === null ? 'Unassigned' : assignee.text;
+        const filterChip = { filter: 'assignees', label, value: assignee };
+        filterChipsRequest.push(filterChip);
+      });
+      if (createdAt !== 0) {
+        const label = timeAgoFilterText('Created', createdAt);
+        const filterChip = { filter: 'createdAt', label, value: createdAt };
+        filterChipsRequest.push(filterChip);
+      }
+      if (lastEditedAt !== 0) {
+        const label = timeAgoFilterText('Updated', lastEditedAt);
+        const filterChip = { filter: 'lastEditedAt', label, value: lastEditedAt };
+        filterChipsRequest.push(filterChip);
+      }
+      if (userOnly) {
+        const filterChip = { filter: 'userOnly', label: 'User', value: true };
+        filterChipsRequest.push(filterChip);
+      }
+      return filterChipsRequest;
+    },
+    hasFiltersRequest(state, getters) {
+      return getters.filterChipsRequest.length > 0 || state.searchRequest.query !== null;
+    },
+  },
+  mutations: {
+    removeFilterRequest(state, { filter, value }) {
+      if (filter === 'closed') {
+        state.filtersRequest.closed = false;
+      } else if (filter === 'createdAt') {
+        state.filtersRequest.createdAt = 0;
+      } else if (filter === 'lastEditedAt') {
+        state.filtersRequest.lastEditedAt = 0;
+      } else if (filter === 'userOnly') {
+        state.filtersRequest.userOnly = false;
+      } else {
+        const values = state.filtersRequest[filter];
+        const i = values.indexOf(value);
+        if (i !== -1) {
+          values.splice(i, 1);
+        }
+      }
+    },
+    setFiltersRequest(state, filtersRequest) {
+      state.filtersRequest = filtersRequest;
+    },
+    setFiltersRequestUserOnly(state, userOnly) {
+      state.filtersRequest.userOnly = userOnly;
+    },
+    setSearchRequestColumn(state, column) {
+      state.searchRequest.column = column;
+    },
+    setSearchRequestQuery(state, query) {
+      state.searchRequest.query = query;
+    },
+  },
+};

--- a/web/views/FcRequestStudyBulkView.vue
+++ b/web/views/FcRequestStudyBulkView.vue
@@ -67,12 +67,14 @@
                 :disabled="selectAll === false"
                 :status="bulkStatus"
                 :study-requests="selectedStudyRequests"
+                text-screen-reader="Selected Requests"
                 @update="onUpdateStudyRequests" />
 
               <FcMenuStudyRequestsAssignTo
                 button-class="ml-2"
                 :disabled="selectAll === false"
                 :study-requests="selectedStudyRequests"
+                text-screen-reader="Selected Requests"
                 @update="onUpdateStudyRequests" />
             </template>
           </div>

--- a/web/views/FcRequestStudyView.vue
+++ b/web/views/FcRequestStudyView.vue
@@ -70,7 +70,7 @@
 </template>
 
 <script>
-import { mapActions, mapState } from 'vuex';
+import { mapActions, mapMutations, mapState } from 'vuex';
 
 import { LocationSelectionType } from '@/lib/Constants';
 import { getStudyRequest, getStudyRequestBulkName } from '@/lib/api/WebApi';
@@ -145,10 +145,12 @@ export default {
     onAddComment({ studyRequest, studyRequestComment }) {
       this.studyRequest = studyRequest;
       this.studyRequestComments.unshift(studyRequestComment);
+      this.setToastInfo('Your comment has been submitted.');
     },
     onDeleteComment({ studyRequest, i }) {
       this.studyRequest = studyRequest;
       this.studyRequestComments.splice(i, 1);
+      this.setToastInfo('Your comment has been deleted.');
     },
     async onUpdateStudyRequest() {
       this.loading = true;
@@ -156,6 +158,7 @@ export default {
       await this.loadAsyncForRoute(this.$route);
       this.loading = false;
     },
+    ...mapMutations(['setToastInfo']),
     ...mapActions(['initLocations', 'saveStudyRequest']),
   },
 };

--- a/web/views/FcRequestsTrack.vue
+++ b/web/views/FcRequestsTrack.vue
@@ -48,18 +48,21 @@
               @click="actionDownload(selectedItems)">
               <v-icon color="primary" left>mdi-cloud-download</v-icon>
               Download
+              <span class="sr-only">Requests</span>
             </FcButton>
             <template v-if="hasAuthScope(AuthScope.STUDY_REQUESTS_ADMIN)">
               <FcMenuStudyRequestsStatus
                 button-class="ml-2"
                 :disabled="selectAll === false"
                 :study-requests="selectedStudyRequests"
+                text-screen-reader="Selected Requests"
                 @update="onUpdateStudyRequests" />
 
               <FcMenuStudyRequestsAssignTo
                 button-class="ml-2"
                 :disabled="selectAll === false"
                 :study-requests="selectedStudyRequests"
+                text-screen-reader="Selected Requests"
                 @update="onUpdateStudyRequests" />
             </template>
           </nav>


### PR DESCRIPTION
# Issue Addressed
This PR makes significant progress on #791 and #783 , and closes #769 .

# Description
We use `FcToastInfo` in several new places to add notifications of various state / mode changes throughout the application.  We also add `span.sr-only` elements to provide additional context to screen reader users.

In the process, we make progress on saving Track Requests filters across page transitions, and address an infinite-redirect bug when the ADFS login flow fails or is abandoned.

# Tests
Tested quickly in frontend.
