### PR TITLE
aria-live div on DOM load

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,7 @@
     <noscript>
       <strong>MOVE requires JavaScript support.  Please enable JavaScript in your browser settings to continue.</strong>
     </noscript>
+    <div aria-live="polite" class="sr-only" id="aria_notification" role="status"></div>
     <div id="app"></div>
     <!-- built files will be auto injected -->
   </body>

--- a/web/App.vue
+++ b/web/App.vue
@@ -83,6 +83,7 @@ export default {
       },
     },
     ...mapState([
+      'ariaNotification',
       'auth',
       'dialog',
       'dialogData',
@@ -94,6 +95,10 @@ export default {
     ...mapGetters(['pageTitle']),
   },
   watch: {
+    ariaNotification() {
+      const $ariaNotification = document.querySelector('#aria_notification');
+      $ariaNotification.innerText = this.ariaNotification;
+    },
     pageTitle: {
       handler() {
         const $title = document.querySelector('title');

--- a/web/components/dialogs/FcToast.vue
+++ b/web/components/dialogs/FcToast.vue
@@ -1,7 +1,7 @@
 <template>
   <v-snackbar
     v-model="internalValue"
-    top
+    bottom
     class="fc-toast pb-5 pl-7"
     :color="color + ' darker-1'"
     :timeout="timeout">
@@ -57,12 +57,20 @@ export default {
       return this.action === null ? TIMEOUT_AUTO_CLOSE : TIMEOUT_NEVER;
     },
   },
+  watch: {
+    text: {
+      handler() {
+        this.setAriaNotification(this.text);
+      },
+      immediate: true,
+    },
+  },
   methods: {
     actionCallback() {
       this.$emit('toast-action');
       this.clearToast();
     },
-    ...mapMutations(['clearToast']),
+    ...mapMutations(['clearToast', 'setAriaNotification']),
   },
 };
 </script>

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -47,6 +47,7 @@ export default new Vuex.Store({
     now: DateTime.local(),
     title: '',
     // TOP-LEVEL UI
+    ariaNotification: '',
     dialog: null,
     dialogData: {},
     drawerOpen: false,
@@ -200,6 +201,9 @@ export default new Vuex.Store({
       Vue.set(state, 'title', title);
     },
     // TOP-LEVEL UI
+    setAriaNotification(state, ariaNotification) {
+      Vue.set(state, 'ariaNotification', ariaNotification);
+    },
     clearDialog(state) {
       Vue.set(state, 'dialog', null);
       Vue.set(state, 'dialogData', {});


### PR DESCRIPTION
# Issue Addressed
This PR closes #791 .

# Description
We add a new `<div aria-live="polite" role="status">` to our `index.html` page, and update it whenever `FcToast` text is shown / updated.

# Tests
Quickly tested in frontend.
