### PR TITLE
Hide volume data and layer

### DIFF
--- a/web/components/FcPaneMapPopup.vue
+++ b/web/components/FcPaneMapPopup.vue
@@ -147,15 +147,7 @@ function getCentrelineDescription(feature, { location }) {
   const locationStr = getLocationDescription(location);
   description.push(locationStr);
 
-  const { centrelineType } = feature.properties;
-  if (centrelineType === CentrelineType.SEGMENT) {
-    let { aadt = null } = feature.properties;
-    if (aadt !== null) {
-      aadt = 100 * Math.round(aadt / 100);
-      aadt = `AADT (est. 2018): ${aadt}`;
-      description.push(aadt);
-    }
-  }
+  // TODO: add AADT back here once model accuracy improves
 
   return description;
 }

--- a/web/components/inputs/FcPaneMapLegend.vue
+++ b/web/components/inputs/FcPaneMapLegend.vue
@@ -64,7 +64,6 @@ export default {
     const layers = [
       { text: 'Studies', value: 'studies' },
       { text: 'Collisions', value: 'collisions' },
-      { text: 'Volume', value: 'volume' },
     ];
     return {
       itemsDatesFrom,

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -63,7 +63,7 @@ export default new Vuex.Store({
       layers: {
         collisions: true,
         studies: true,
-        volume: true,
+        volume: false,
       },
     },
     legendOptionsFocusLocations: {
@@ -71,7 +71,7 @@ export default new Vuex.Store({
       layers: {
         collisions: false,
         studies: true,
-        volume: true,
+        volume: false,
       },
     },
     locations: [],


### PR DESCRIPTION
# Issue Addressed
This PR closes #793 .

# Description
We remove the Volume layer from the legend, hide it on the map (by setting `volume: false` in layer settings), and remove AADT estimates from midblock popups.  However, we also leave the backend pieces in place, so that we can quickly roll this back out once AADT estimates are more accurate.

# Tests
Tested quickly in frontend.