### PR TITLE
Study request management: small fixes

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -918,11 +918,7 @@ StudyRequestReason.init({
 /**
  * Possible status codes for study requests.
  */
-class StudyRequestStatus extends Enum {
-  canTransitionTo(status) {
-    return this.transitionsTo.includes(status);
-  }
-}
+class StudyRequestStatus extends Enum {}
 StudyRequestStatus.init({
   REQUESTED: {
     color: 'statusRequested',
@@ -932,13 +928,6 @@ StudyRequestStatus.init({
     text: 'Requested',
     textVerb: 'reopen',
     textVerbPastTense: 'reopened',
-    get transitionsTo() {
-      return [
-        StudyRequestStatus.CHANGES_NEEDED,
-        StudyRequestStatus.CANCELLED,
-        StudyRequestStatus.ASSIGNED,
-      ];
-    },
   },
   CHANGES_NEEDED: {
     color: 'statusChangesNeeded',
@@ -948,13 +937,6 @@ StudyRequestStatus.init({
     text: 'Changes Needed',
     textVerb: 'request changes for',
     textVerbPastTense: 'returned to submitter for changes',
-    get transitionsTo() {
-      return [
-        StudyRequestStatus.REQUESTED,
-        StudyRequestStatus.CANCELLED,
-        StudyRequestStatus.ASSIGNED,
-      ];
-    },
   },
   CANCELLED: {
     color: 'statusCancelled',
@@ -964,11 +946,6 @@ StudyRequestStatus.init({
     text: 'Cancelled',
     textVerb: 'cancel',
     textVerbPastTense: 'cancelled',
-    get transitionsTo() {
-      return [
-        StudyRequestStatus.REQUESTED,
-      ];
-    },
   },
   ASSIGNED: {
     color: 'statusAssigned',
@@ -978,13 +955,6 @@ StudyRequestStatus.init({
     text: 'Assigned',
     textVerb: 'assign',
     textVerbPastTense: 'assigned',
-    get transitionsTo() {
-      return [
-        StudyRequestStatus.REQUESTED,
-        StudyRequestStatus.REJECTED,
-        StudyRequestStatus.COMPLETED,
-      ];
-    },
   },
   REJECTED: {
     color: 'statusRejected',
@@ -994,9 +964,6 @@ StudyRequestStatus.init({
     text: 'Rejected',
     textVerb: 'reject',
     textVerbPastTense: 'rejected',
-    get transitionsTo() {
-      return [];
-    },
   },
   COMPLETED: {
     color: 'statusCompleted',
@@ -1006,9 +973,6 @@ StudyRequestStatus.init({
     text: 'Completed',
     textVerb: 'complete',
     textVerbPastTense: 'completed',
-    get transitionsTo() {
-      return [];
-    },
   },
 });
 

--- a/lib/auth/StudyRequestPermissions.js
+++ b/lib/auth/StudyRequestPermissions.js
@@ -55,12 +55,6 @@ function canUpdateStudyRequest(studyRequestNew, studyRequestOld, user) {
   if (studyRequestNew.studyBulkRequestId !== studyRequestOld.studyBulkRequestId) {
     return Boom.badRequest('cannot change bulk request ID for study request');
   }
-  if (studyRequestNew.status !== studyRequestOld.status
-    && !studyRequestOld.status.canTransitionTo(studyRequestNew.status)) {
-    return Boom.badRequest(
-      `invalid state transition: ${studyRequestOld.status} -> ${studyRequestNew.status}`,
-    );
-  }
 
   if (!hasAuthScope(user, AuthScope.STUDY_REQUESTS_ADMIN)) {
     if (studyRequestOld.userId !== user.id) {

--- a/lib/geo/CentrelineUtils.js
+++ b/lib/geo/CentrelineUtils.js
@@ -27,7 +27,10 @@ function getLocationFeatureType(location) {
 function getLocationStudyTypes(location) {
   const locationFeatureType = getLocationFeatureType(location);
   if (locationFeatureType instanceof RoadIntersectionType) {
-    return [StudyType.TMC];
+    return [
+      StudyType.PED_DELAY,
+      StudyType.TMC,
+    ];
   }
   if (locationFeatureType === RoadSegmentType.EXPRESSWAY) {
     return [StudyType.RESCU];

--- a/lib/requests/RequestActions.js
+++ b/lib/requests/RequestActions.js
@@ -10,6 +10,7 @@ class RequestActions {
     } else {
       studyRequest.status = StudyRequestStatus.ASSIGNED;
     }
+    studyRequest.closed = false;
   }
 
   static actionCancel(studyRequest) {
@@ -24,7 +25,7 @@ class RequestActions {
 
   static actionRejectData(studyRequest) {
     studyRequest.status = StudyRequestStatus.REJECTED;
-    studyRequest.closed = true;
+    studyRequest.closed = false;
   }
 
   static actionReopen(studyRequest) {
@@ -34,24 +35,16 @@ class RequestActions {
 
   static actionRequestChanges(studyRequest) {
     studyRequest.status = StudyRequestStatus.CHANGES_NEEDED;
+    studyRequest.closed = false;
   }
   /* eslint-enable no-param-reassign */
 
-  static canAssignTo(user, studyRequest) {
-    if (!hasAuthScope(user, AuthScope.STUDY_REQUESTS_ADMIN)) {
-      return false;
-    }
-    const { status } = studyRequest;
-    return status.canTransitionTo(StudyRequestStatus.ASSIGNED)
-      || status === StudyRequestStatus.ASSIGNED;
+  static canAssignTo(user) {
+    return hasAuthScope(user, AuthScope.STUDY_REQUESTS_ADMIN);
   }
 
   static canCancel(user, studyRequest) {
-    if (!RequestActions.canEdit(user, studyRequest)) {
-      return false;
-    }
-    const { status } = studyRequest;
-    return status.canTransitionTo(StudyRequestStatus.CANCELLED);
+    return RequestActions.canEdit(user, studyRequest);
   }
 
   static canEdit(user, studyRequest) {
@@ -65,35 +58,22 @@ class RequestActions {
   }
 
   static canMarkCompleted(user, studyRequest) {
-    if (!RequestActions.canEdit(user, studyRequest)) {
-      return false;
-    }
-    const { status } = studyRequest;
-    return status.canTransitionTo(StudyRequestStatus.COMPLETED);
+    return RequestActions.canEdit(user, studyRequest);
   }
 
   static canRejectData(user, studyRequest) {
-    if (!RequestActions.canEdit(user, studyRequest)) {
-      return false;
-    }
-    const { status } = studyRequest;
-    return status.canTransitionTo(StudyRequestStatus.REJECTED);
+    return RequestActions.canEdit(user, studyRequest);
   }
 
   static canReopen(user, studyRequest) {
     if (!RequestActions.canEdit(user, studyRequest)) {
       return false;
     }
-    const { closed, status } = studyRequest;
-    return closed && status.canTransitionTo(StudyRequestStatus.REQUESTED);
+    return studyRequest.status === StudyRequestStatus.CANCELLED;
   }
 
-  static canRequestChanges(user, studyRequest) {
-    if (!hasAuthScope(user, AuthScope.STUDY_REQUESTS_ADMIN)) {
-      return false;
-    }
-    const { status } = studyRequest;
-    return status.canTransitionTo(StudyRequestStatus.CHANGES_NEEDED);
+  static canRequestChanges(user) {
+    return hasAuthScope(user, AuthScope.STUDY_REQUESTS_ADMIN);
   }
 }
 

--- a/tests/jest/api/StudyRequestController.spec.js
+++ b/tests/jest/api/StudyRequestController.spec.js
@@ -450,17 +450,6 @@ test('StudyRequestController.putStudyRequest [status changes]', async () => {
   persistedStudyRequest = response.result;
   expect(Mailer.send).toHaveBeenCalledTimes(0);
 
-  // supervisor cannot make invalid transition
-  client.setUser(supervisor);
-  response = await client.fetch(`/requests/study/${persistedStudyRequest.id}`, {
-    method: 'PUT',
-    data: {
-      ...persistedStudyRequest,
-      status: StudyRequestStatus.CHANGES_NEEDED,
-    },
-  });
-  expect(response.statusCode).toBe(HttpStatus.BAD_REQUEST.statusCode);
-
   // requester cannot complete
   client.setUser(requester);
   response = await client.fetch(`/requests/study/${persistedStudyRequest.id}`, {

--- a/tests/jest/unit/Constants.spec.js
+++ b/tests/jest/unit/Constants.spec.js
@@ -2,7 +2,6 @@ import {
   HttpStatus,
   ReportParameter,
   StudyHours,
-  StudyRequestStatus,
 } from '@/lib/Constants';
 import { STUDY_HOURS_HINT_OTHER } from '@/lib/i18n/Strings';
 import DateTime from '@/lib/time/DateTime';
@@ -28,35 +27,4 @@ test('StudyHours#hint', () => {
   expect(StudyHours.OTHER.hint).toEqual(STUDY_HOURS_HINT_OTHER);
   expect(StudyHours.ROUTINE.hint)
     .toEqual('07:30 -- 09:30, 10:00 -- 12:00, 13:00 -- 15:00, 16:00 -- 18:00');
-});
-
-test('StudyRequestStatus#canTransitionTo', () => {
-  function expectCanTransitionTo(statusFrom, statusTo, expected = true) {
-    const actual = statusFrom.canTransitionTo(statusTo);
-    expect(actual).toBe(expected);
-  }
-
-  expectCanTransitionTo(StudyRequestStatus.REQUESTED, StudyRequestStatus.CHANGES_NEEDED);
-  expectCanTransitionTo(StudyRequestStatus.REQUESTED, StudyRequestStatus.CANCELLED);
-  expectCanTransitionTo(StudyRequestStatus.REQUESTED, StudyRequestStatus.ASSIGNED);
-  expectCanTransitionTo(StudyRequestStatus.REQUESTED, StudyRequestStatus.REJECTED, false);
-  expectCanTransitionTo(StudyRequestStatus.REQUESTED, StudyRequestStatus.COMPLETED, false);
-
-  expectCanTransitionTo(StudyRequestStatus.CHANGES_NEEDED, StudyRequestStatus.REQUESTED);
-  expectCanTransitionTo(StudyRequestStatus.CHANGES_NEEDED, StudyRequestStatus.CANCELLED);
-  expectCanTransitionTo(StudyRequestStatus.CHANGES_NEEDED, StudyRequestStatus.ASSIGNED);
-
-  expectCanTransitionTo(StudyRequestStatus.CANCELLED, StudyRequestStatus.REQUESTED);
-
-  expectCanTransitionTo(StudyRequestStatus.ASSIGNED, StudyRequestStatus.REQUESTED);
-  expectCanTransitionTo(StudyRequestStatus.ASSIGNED, StudyRequestStatus.REJECTED);
-  expectCanTransitionTo(StudyRequestStatus.ASSIGNED, StudyRequestStatus.COMPLETED);
-
-  expectCanTransitionTo(StudyRequestStatus.COMPLETED, StudyRequestStatus.ASSIGNED, false);
-});
-
-test('StudyRequestStatus#transitionsTo', () => {
-  StudyRequestStatus.enumValues.forEach((status) => {
-    expect(status.transitionsTo).toBeInstanceOf(Array);
-  });
 });

--- a/tests/jest/unit/geo/CentrelineUtils.spec.js
+++ b/tests/jest/unit/geo/CentrelineUtils.spec.js
@@ -51,7 +51,10 @@ test('CentrelineUtils.getLocationStudyTypes', () => {
       centrelineType: CentrelineType.INTERSECTION,
       featureCode,
     };
-    expect(getLocationStudyTypes(location)).toEqual([StudyType.TMC]);
+    expect(getLocationStudyTypes(location)).toEqual([
+      StudyType.PED_DELAY,
+      StudyType.TMC,
+    ]);
   });
   RoadSegmentType.enumValues.forEach(({ featureCode }) => {
     const location = {

--- a/web/components/location/FcSummaryPoiChip.vue
+++ b/web/components/location/FcSummaryPoiChip.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <span>
     <v-tooltip bottom>
       <template v-slot:activator="{ on }">
         <v-chip
@@ -16,7 +16,7 @@
       <span>{{poiDistance}} m</span>
     </v-tooltip>
     <dd class="sr-only">{{poiDistance}} m</dd>
-  </div>
+  </span>
 </template>
 
 <script>

--- a/web/components/requests/FcCardStudyRequest.vue
+++ b/web/components/requests/FcCardStudyRequest.vue
@@ -2,7 +2,7 @@
   <v-card
     class="fc-card-study-request"
     :class="{ selected }"
-    flat>
+    outlined>
     <v-card-title class="align-start pb-2">
       <FcIconLocationMulti
         class="mr-5"
@@ -15,6 +15,7 @@
           :study="mostRecentByStudyType.get(studyRequest.studyType)" />
       </div>
     </v-card-title>
+
     <v-card-text class="pb-0">
       <fieldset class="mx-9">
         <legend class="sr-only">Study Type for Request</legend>

--- a/web/components/requests/FcCardStudyRequestConfirm.vue
+++ b/web/components/requests/FcCardStudyRequestConfirm.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card
     class="fc-card-study-request-confirm"
-    flat>
+    outlined>
     <v-card-title class="align-start pb-2">
       <FcIconLocationMulti
         class="mr-5"
@@ -10,9 +10,10 @@
         {{location.description}}
       </h3>
     </v-card-title>
+
     <v-card-text class="default--text">
       <div class="mx-9">
-        <v-row tag="dl">
+        <v-row class="mt-1" tag="dl">
           <v-col class="py-2" cols="6">
             <dt class="subtitle-1">
               Study Type

--- a/web/components/requests/summary/FcSummaryStudy.vue
+++ b/web/components/requests/summary/FcSummaryStudy.vue
@@ -1,62 +1,85 @@
 <template>
-  <section>
-    <h4 class="headline mt-5">{{study.studyType.label}}</h4>
-    <v-row class="mt-2 mb-6" tag="dl">
-      <v-col cols="6">
-        <dt class="subtitle-1">Study Days</dt>
-        <dd class="mt-1 display-1">
-          {{study.daysOfWeek | daysOfWeek}}
-        </dd>
-        <dd v-if="messagesDaysOfWeek.length > 0">
-          <v-messages
-            class="mt-1"
-            :value="messagesDaysOfWeek" />
-        </dd>
-      </v-col>
-      <v-col cols="6">
-        <template v-if="study.studyType.automatic">
-          <dt class="subtitle-1">Study Duration</dt>
-          <dd class="mt-1 display-1">
-            {{study.duration | durationHuman}}
-          </dd>
-          <dd>
-            <v-messages
-              class="mt-1"
-              :value="[study.duration + ' hours']" />
-          </dd>
-        </template>
-        <template v-else>
-          <dt class="subtitle-1">Study Hours</dt>
-          <dd class="mt-1 display-1">
-            {{study.hours.description}}
-          </dd>
-          <dd>
-            <v-messages
-              class="mt-1"
-              :value="[study.hours.hint]"></v-messages>
-          </dd>
-        </template>
-      </v-col>
-      <v-col cols="12">
-        <dt class="subtitle-1">Additional Information</dt>
-        <dd class="mt-1 display-1">
-          <span v-if="study.notes">{{study.notes}}</span>
-          <span v-else>None</span>
-        </dd>
-      </v-col>
-    </v-row>
-  </section>
+  <v-card
+    outlined
+    tag="section">
+    <v-card-title class="d-flex">
+      <img
+        :alt="alt"
+        class="mr-5"
+        height="20"
+        src="/icons/map/location-single.svg"
+        width="16" />
+      <h4 class="headline font-weight-bold">{{study.studyType.label}}</h4>
+    </v-card-title>
+
+    <v-card-text class="default--text">
+      <div class="mx-9">
+        <v-row tag="dl">
+          <v-col cols="6">
+            <dt class="subtitle-1">Study Days</dt>
+            <dd class="mt-1 display-1">
+              {{study.daysOfWeek | daysOfWeek}}
+            </dd>
+            <dd v-if="messagesDaysOfWeek.length > 0">
+              <v-messages
+                class="mt-1"
+                :value="messagesDaysOfWeek" />
+            </dd>
+          </v-col>
+          <v-col cols="6">
+            <template v-if="study.studyType.automatic">
+              <dt class="subtitle-1">Study Duration</dt>
+              <dd class="mt-1 display-1">
+                {{study.duration | durationHuman}}
+              </dd>
+              <dd>
+                <v-messages
+                  class="mt-1"
+                  :value="[study.duration + ' hours']" />
+              </dd>
+            </template>
+            <template v-else>
+              <dt class="subtitle-1">Study Hours</dt>
+              <dd class="mt-1 display-1">
+                {{study.hours.description}}
+              </dd>
+              <dd>
+                <v-messages
+                  class="mt-1"
+                  :value="[study.hours.hint]"></v-messages>
+              </dd>
+            </template>
+          </v-col>
+          <v-col cols="12">
+            <dt class="subtitle-1">Additional Information</dt>
+            <dd class="mt-1 display-1">
+              <span v-if="study.notes">{{study.notes}}</span>
+              <span v-else>None</span>
+            </dd>
+          </v-col>
+        </v-row>
+      </div>
+    </v-card-text>
+  </v-card>
 </template>
 
 <script>
+import { mapState } from 'vuex';
+
+import { getLocationsSelectionDescription } from '@/lib/geo/CentrelineUtils';
 import { numConsecutiveDaysOfWeek } from '@/lib/time/TimeUtils';
 
 export default {
   name: 'FcSummaryStudy',
   props: {
+    location: Object,
     study: Object,
   },
   computed: {
+    alt() {
+      const description = getLocationsSelectionDescription(this.locationsSelection);
+      return `Study Location: ${description}`;
+    },
     messagesDaysOfWeek() {
       const { daysOfWeek, duration, studyType } = this.study;
       if (studyType.automatic) {
@@ -75,6 +98,7 @@ export default {
       }
       return ['The study will be performed on one of these days.'];
     },
+    ...mapState(['locationsSelection']),
   },
 };
 </script>

--- a/web/components/requests/summary/FcSummaryStudyRequest.vue
+++ b/web/components/requests/summary/FcSummaryStudyRequest.vue
@@ -17,10 +17,14 @@
           </dd>
         </template>
       </v-col>
+
       <v-col cols="6">
         <dt class="subtitle-1">Reason</dt>
         <dd class="mt-1 display-1">
-          {{studyRequest.reason.text}}
+          <span>{{studyRequest.reason.text}}</span>
+          <span v-if="studyRequest.reason === StudyRequestReason.OTHER">
+            ({{studyRequest.reasonOther}})
+          </span>
         </dd>
       </v-col>
       <v-col cols="6">
@@ -40,6 +44,32 @@
             :value="['Standard times to request counts are 2-3 months.']" />
         </dd>
       </v-col>
+
+      <v-col cols="6">
+        <template v-if="!isCreate">
+          <dt class="subtitle-1">Assigned To</dt>
+          <dd class="mt-1 display-1">
+            {{assignedToStr}}
+          </dd>
+        </template>
+      </v-col>
+      <v-col cols="6">
+        <template v-if="!isCreate">
+          <dt class="subtitle-1">Staff Informed</dt>
+          <dd class="mt-1 display-1">
+            <v-chip
+              v-for="(ccEmail, i) in studyRequest.ccEmails"
+              :key="i"
+              class="mr-2"
+              color="secondary"
+              label
+              small>
+              <span>{{ccEmail}}</span>
+            </v-chip>
+          </dd>
+        </template>
+      </v-col>
+
       <v-col cols="12">
         <dt class="subtitle-1">Additional Information</dt>
         <dd class="mt-1 display-1">
@@ -56,6 +86,9 @@
 <script>
 import { mapState } from 'vuex';
 
+import { StudyRequestReason } from '@/lib/Constants';
+import { bulkAssignedToStr } from '@/lib/requests/RequestStudyBulkUtils';
+
 export default {
   name: 'FcSummaryStudyRequest',
   props: {
@@ -69,7 +102,20 @@ export default {
       default() { return new Map(); },
     },
   },
+  data() {
+    return {
+      StudyRequestReason,
+    };
+  },
   computed: {
+    assignedToStr() {
+      if (Object.prototype.hasOwnProperty.call(this.studyRequest, 'assignedTo')) {
+        const { assignedTo } = this.studyRequest;
+        return assignedTo === null ? 'Unassigned' : assignedTo.text;
+      }
+      const { studyRequests } = this.studyRequest;
+      return bulkAssignedToStr(studyRequests);
+    },
     requestedBy() {
       if (this.isCreate) {
         return this.auth.user;

--- a/web/views/FcRequestStudyView.vue
+++ b/web/views/FcRequestStudyView.vue
@@ -30,20 +30,19 @@
 
             <div class="subtitle-1 pb-2">Status</div>
             <FcStatusStudyRequests
-              class="my-2"
+              class="mt-2 mb-4"
               :created-at="studyRequest.createdAt"
               :study-requests="[studyRequest]"
               :study-request-changes="studyRequestChanges" />
           </v-col>
           <v-col class="px-5" cols="6">
-            <FcSummaryStudyRequest
-              :study-request="studyRequest"
-              :study-request-users="studyRequestUsers" />
-
-            <v-divider></v-divider>
-
             <FcSummaryStudy
               :study="studyRequest" />
+
+            <FcSummaryStudyRequest
+              class="mt-2"
+              :study-request="studyRequest"
+              :study-request-users="studyRequestUsers" />
           </v-col>
           <v-col cols="6">
             <FcPaneMap


### PR DESCRIPTION
# Issue Addressed
This PR closes #794 .

# Description
We remove most transition restrictions on study request statuses - the only such restrictions now are a) that certain statuses require `STUDY_REQUEST_ADMIN` permissions and b) that "Reopen" can only be done from `CANCELLED` state.

# Tests
Tested quickly in frontend, updated and ran relevant unit tests.