### PR TITLE
Small tweaks to email notifications

### DIFF
--- a/lib/controller/StudyRequestBulkController.js
+++ b/lib/controller/StudyRequestBulkController.js
@@ -6,7 +6,10 @@ import StudyRequestBulkDAO from '@/lib/db/StudyRequestBulkDAO';
 import StudyRequestChangeDAO from '@/lib/db/StudyRequestChangeDAO';
 import EmailStudyRequestBulkRequested from '@/lib/email/EmailStudyRequestBulkRequested';
 import EmailStudyRequestBulkRequestedAdmin from '@/lib/email/EmailStudyRequestBulkRequestedAdmin';
-import { sendEmailSafe, sendStudyRequestBulkUpdateEmailsSafe } from '@/lib/email/MailUtils';
+import {
+  getStudyRequestBulkUpdateEmails,
+  sendEmailsSafe,
+} from '@/lib/email/MailUtils';
 import Joi from '@/lib/model/Joi';
 import StudyRequestBulk from '@/lib/model/StudyRequestBulk';
 import StudyRequestChange from '@/lib/model/StudyRequestChange';
@@ -56,12 +59,11 @@ StudyRequestBulkController.push({
   handler: async (request) => {
     const user = request.auth.credentials;
     const studyRequestBulk = await StudyRequestBulkDAO.create(request.payload, user);
+
     const emailRequestedAdmin = new EmailStudyRequestBulkRequestedAdmin(studyRequestBulk);
     const emailRequested = new EmailStudyRequestBulkRequested(studyRequestBulk);
-    await Promise.all([
-      sendEmailSafe(request, emailRequestedAdmin),
-      sendEmailSafe(request, emailRequested),
-    ]);
+    await sendEmailsSafe(request, [emailRequestedAdmin, emailRequested]);
+
     return studyRequestBulk;
   },
 });
@@ -241,7 +243,11 @@ StudyRequestBulkController.push({
     }
     const [studyRequestBulk] = await Promise.all(tasks);
 
-    await sendStudyRequestBulkUpdateEmailsSafe(request, studyRequestBulkNew, studyRequestBulkOld);
+    const emails = await getStudyRequestBulkUpdateEmails(
+      studyRequestBulkNew,
+      studyRequestBulkOld,
+    );
+    await sendEmailsSafe(request, emails);
 
     return studyRequestBulk;
   },

--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -9,7 +9,11 @@ import StudyRequestCommentDAO from '@/lib/db/StudyRequestCommentDAO';
 import EmailStudyRequestNewComment from '@/lib/email/EmailStudyRequestNewComment';
 import EmailStudyRequestRequested from '@/lib/email/EmailStudyRequestRequested';
 import EmailStudyRequestRequestedAdmin from '@/lib/email/EmailStudyRequestRequestedAdmin';
-import { sendEmailSafe, sendStudyRequestUpdateEmailsSafe } from '@/lib/email/MailUtils';
+import {
+  getStudyRequestUpdateEmailsDeep,
+  sendEmailSafe,
+  sendEmailsSafe,
+} from '@/lib/email/MailUtils';
 import CompositeId from '@/lib/io/CompositeId';
 import Joi from '@/lib/model/Joi';
 import StudyRequest from '@/lib/model/StudyRequest';
@@ -63,12 +67,11 @@ StudyRequestController.push({
   handler: async (request) => {
     const user = request.auth.credentials;
     const studyRequest = await StudyRequestDAO.create(request.payload, user);
+
     const emailRequestedAdmin = new EmailStudyRequestRequestedAdmin(studyRequest);
     const emailRequested = new EmailStudyRequestRequested(studyRequest);
-    await Promise.all([
-      sendEmailSafe(request, emailRequestedAdmin),
-      sendEmailSafe(request, emailRequested),
-    ]);
+    await sendEmailsSafe(request, [emailRequestedAdmin, emailRequested]);
+
     return studyRequest;
   },
 });
@@ -240,7 +243,8 @@ StudyRequestController.push({
     }
     const [studyRequest] = await Promise.all(tasks);
 
-    await sendStudyRequestUpdateEmailsSafe(request, studyRequestNew, studyRequestOld);
+    const emails = await getStudyRequestUpdateEmailsDeep(studyRequestNew, studyRequestOld);
+    await sendEmailsSafe(request, emails);
 
     return studyRequest;
   },

--- a/lib/email/EmailBaseStudyRequest.js
+++ b/lib/email/EmailBaseStudyRequest.js
@@ -1,9 +1,7 @@
-import { LocationSelectionType } from '@/lib/Constants';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import UserDAO from '@/lib/db/UserDAO';
 import EmailBase from '@/lib/email/EmailBase';
 import EmailStudyRequestUtils from '@/lib/email/EmailStudyRequestUtils';
-import CompositeId from '@/lib/io/CompositeId';
 
 class EmailBaseStudyRequest extends EmailBase {
   constructor(studyRequest) {
@@ -38,12 +36,8 @@ class EmailBaseStudyRequest extends EmailBase {
      * feature that the user has selected.
      */
     let location = null;
-    let hrefLocation = null;
     if (this.location !== null) {
       location = this.location.description;
-      const s1 = CompositeId.encode([this.location]);
-      const selectionType = LocationSelectionType.POINTS;
-      hrefLocation = EmailBase.getUrl(`/view/location/${s1}/${selectionType.name}`);
     }
 
     const days = EmailStudyRequestUtils.renderDays(this.studyRequest);
@@ -52,7 +46,6 @@ class EmailBaseStudyRequest extends EmailBase {
 
     return {
       days,
-      hrefLocation,
       hrefStudyRequest,
       hours,
       location,

--- a/lib/email/EmailBaseStudyRequestBulk.js
+++ b/lib/email/EmailBaseStudyRequestBulk.js
@@ -1,4 +1,4 @@
-import { centrelineKey, LocationSelectionType } from '@/lib/Constants';
+import { centrelineKey } from '@/lib/Constants';
 import { mapBy } from '@/lib/MapUtils';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import UserDAO from '@/lib/db/UserDAO';
@@ -7,6 +7,9 @@ import EmailStudyRequestUtils from '@/lib/email/EmailStudyRequestUtils';
 import { getLocationsSelectionDescription } from '@/lib/geo/CentrelineUtils';
 import CompositeId from '@/lib/io/CompositeId';
 
+/**
+ * Common superclass for email notifications related to bulk study requests.
+ */
 class EmailBaseStudyRequestBulk extends EmailBase {
   constructor(studyRequestBulk) {
     super();
@@ -35,29 +38,26 @@ class EmailBaseStudyRequestBulk extends EmailBase {
     );
     let studyRequestLocations = await CentrelineDAO.byFeatures(studyRequestFeatures);
     studyRequestLocations = studyRequestLocations.filter(location => location !== null);
-    this.locationsMap = mapBy(studyRequestLocations, centrelineKey);
+    this.studyRequestLocationsMap = mapBy(studyRequestLocations, centrelineKey);
   }
 
   getStudyRequestParams(studyRequest) {
     const days = EmailStudyRequestUtils.renderDays(studyRequest);
     const hours = EmailStudyRequestUtils.renderHours(studyRequest);
-    const { studyType: { label: studyType } } = studyRequest;
+    const { id, studyType: { label: studyType } } = studyRequest;
+    const hrefStudyRequest = EmailBase.getUrl(`requests/study/${id}`);
 
     const key = centrelineKey(studyRequest);
     let location = null;
-    let hrefLocation = null;
     if (this.studyRequestLocationsMap.has(key)) {
       const studyRequestLocation = this.studyRequestLocationsMap.get(key);
       location = studyRequestLocation.description;
-      const s1 = CompositeId.encode([studyRequestLocation]);
-      const selectionType = LocationSelectionType.POINTS;
-      hrefLocation = EmailBase.getUrl(`/view/location/${s1}/${selectionType.name}`);
     }
 
     return {
       days,
       hours,
-      hrefLocation,
+      hrefStudyRequest,
       location,
       studyType,
     };
@@ -77,12 +77,8 @@ class EmailBaseStudyRequestBulk extends EmailBase {
      * features that the user has selected.
      */
     let location = null;
-    let hrefLocation = null;
     if (this.locationsSelection !== null) {
       location = getLocationsSelectionDescription(this.locationsSelection);
-      const { locations, selectionType } = this.locationsSelection;
-      const s1 = CompositeId.encode(locations);
-      hrefLocation = EmailBase.getUrl(`/view/location/${s1}/${selectionType.name}`);
     }
 
     const studyRequests = this.studyRequestBulk.studyRequests.map(
@@ -90,7 +86,6 @@ class EmailBaseStudyRequestBulk extends EmailBase {
     );
 
     return {
-      hrefLocation,
       hrefStudyRequestBulk,
       location,
       name,
@@ -98,5 +93,25 @@ class EmailBaseStudyRequestBulk extends EmailBase {
     };
   }
 }
+
+/**
+ * List of individual study requests in a bulk request.  Each bulk request email should
+ * contain this list.
+ */
+EmailBaseStudyRequestBulk.TEMPLATE_LIST_STUDY_REQUESTS = `
+<p>
+{{name}}
+</p>
+<div>
+{{#studyRequests}}
+  <div>
+    {{#location}}
+      {{location}} &mdash;
+    {{/location}}
+    <strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}
+    (<a href="{{{hrefStudyRequest}}}">View request</a>)
+  </div>
+{{/studyRequests}}
+</div>`;
 
 export default EmailBaseStudyRequestBulk;

--- a/lib/email/EmailStudyRequestBulkCancelled.js
+++ b/lib/email/EmailStudyRequestBulkCancelled.js
@@ -28,30 +28,17 @@ class EmailStudyRequestBulkCancelled extends EmailBaseStudyRequestBulk {
       <p>
         Your bulk request for the following studies
         {{#location}}
-          at
-          <a href="{{hrefLocation}}">{{location}}</a>
+          at {{location}}
         {{/location}}
         has been cancelled:
       </p>
-      <p>
-        {{name}}
-      </p>
-      <ul>
-        {{#studyRequests}}
-        <li>
-          {{#location}}
-            <a href="{{hrefLocation}}">{{location}}</a> &mdash;
-          {{/location}}
-          <strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}
-        </li>
-        {{/studyRequests}}
-      </ul>
+      ${EmailBaseStudyRequestBulk.TEMPLATE_LIST_STUDY_REQUESTS}
       <p>
         If you believe this is a mistake, please reach out to the data collection team at
         <a href="mailto:trafficdata@toronto.ca">trafficdata@toronto.ca</a>.
       </p>
       <p>
-        <a href="{{hrefStudyRequestBulk}}">View your cancelled bulk request</a>
+        <a href="{{{hrefStudyRequestBulk}}}">View your cancelled bulk request</a>
       </p>
     </div>`;
   }

--- a/lib/email/EmailStudyRequestBulkCompleted.js
+++ b/lib/email/EmailStudyRequestBulkCompleted.js
@@ -28,27 +28,14 @@ class EmailStudyRequestBulkCompleted extends EmailBaseStudyRequestBulk {
       <p>
         Your requests for the following studies
         {{#location}}
-          at
-          <a href="{{hrefLocation}}">{{location}}</a>
+          at {{location}}
         {{/location}}
         are now complete!
         Your data will be available in MOVE within 1 business day.
       </p>
+      ${EmailBaseStudyRequestBulk.TEMPLATE_LIST_STUDY_REQUESTS}
       <p>
-        {{name}}
-      </p>
-      <ul>
-        {{#studyRequests}}
-        <li>
-          {{#location}}
-            <a href="{{hrefLocation}}">{{location}}</a> &mdash;
-          {{/location}}
-          <strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}
-        </li>
-        {{/studyRequests}}
-      </ul>
-      <p>
-        <a href="{{hrefStudyRequestBulk}}">View your completed bulk request</a>
+        <a href="{{{hrefStudyRequestBulk}}}">View your completed bulk request</a>
       </p>
     </div>`;
   }

--- a/lib/email/EmailStudyRequestBulkRequested.js
+++ b/lib/email/EmailStudyRequestBulkRequested.js
@@ -28,25 +28,12 @@ class EmailStudyRequestBulkRequested extends EmailBaseStudyRequestBulk {
       <p>
         We received your bulk request for the following studies
         {{#location}}
-          to be conducted at
-          <a href="{{hrefLocation}}">{{location}}</a>
+          to be conducted at {{location}}
         {{/location}}:
       </p>
+      ${EmailBaseStudyRequestBulk.TEMPLATE_LIST_STUDY_REQUESTS}
       <p>
-        {{name}}
-      </p>
-      <ul>
-        {{#studyRequests}}
-        <li>
-          {{#location}}
-            <a href="{{hrefLocation}}">{{location}}</a> &mdash;
-          {{/location}}
-          <strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}
-        </li>
-        {{/studyRequests}}
-      </ul>
-      <p>
-        <a href="{{hrefStudyRequestBulk}}">View your bulk request</a>
+        <a href="{{{hrefStudyRequestBulk}}}">View your bulk request</a>
       </p>
     </div>`;
   }

--- a/lib/email/EmailStudyRequestBulkRequestedAdmin.js
+++ b/lib/email/EmailStudyRequestBulkRequestedAdmin.js
@@ -25,25 +25,12 @@ class EmailStudyRequestBulkRequestedAdmin extends EmailBaseStudyRequestBulk {
       <p>
         A bulk request has been submitted for the following studies
         {{#location}}
-          to be conducted at
-          <a href="{{hrefLocation}}">{{location}}</a>
+          to be conducted at {{location}}
         {{/location}}:
       </p>
+      ${EmailBaseStudyRequestBulk.TEMPLATE_LIST_STUDY_REQUESTS}
       <p>
-        {{name}}
-      </p>
-      <ul>
-        {{#studyRequests}}
-        <li>
-          {{#location}}
-            <a href="{{hrefLocation}}">{{location}}</a> &mdash;
-          {{/location}}
-          <strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}
-        </li>
-        {{/studyRequests}}
-      </ul>
-      <p>
-        <a href="{{hrefStudyRequestBulk}}">View bulk request</a>
+        <a href="{{{hrefStudyRequestBulk}}}">View bulk request</a>
       </p>
     </div>`;
   }

--- a/lib/email/EmailStudyRequestCancelled.js
+++ b/lib/email/EmailStudyRequestCancelled.js
@@ -32,8 +32,7 @@ class EmailStudyRequestCancelled extends EmailBaseStudyRequest {
       <p>
         Your request for the following study
         {{#location}}
-          at
-          <a href="{{hrefLocation}}">{{location}}</a>
+          at {{location}}
         {{/location}}
         has been cancelled:
       </p>
@@ -46,7 +45,7 @@ class EmailStudyRequestCancelled extends EmailBaseStudyRequest {
         <a href="mailto:trafficdata@toronto.ca">trafficdata@toronto.ca</a>.
       </p>
       <p>
-        <a href="{{hrefStudyRequest}}">View your cancelled request</a>
+        <a href="{{{hrefStudyRequest}}}">View your cancelled request</a>
       </p>
     </div>`;
   }

--- a/lib/email/EmailStudyRequestCompleted.js
+++ b/lib/email/EmailStudyRequestCompleted.js
@@ -31,8 +31,7 @@ class EmailStudyRequestCompleted extends EmailBaseStudyRequest {
       <p>
         Your request for the following study
         {{#location}}
-          at
-          <a href="{{hrefLocation}}">{{location}}</a>
+          at {{location}}
         {{/location}}
         is now complete!
         Your data will be available in MOVE within 1 business day.
@@ -41,7 +40,7 @@ class EmailStudyRequestCompleted extends EmailBaseStudyRequest {
         <strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}
       </p>
       <p>
-        <a href="{{hrefStudyRequest}}">View your completed request</a>
+        <a href="{{{hrefStudyRequest}}}">View your completed request</a>
       </p>
     </div>`;
   }

--- a/lib/email/EmailStudyRequestNewComment.js
+++ b/lib/email/EmailStudyRequestNewComment.js
@@ -1,3 +1,4 @@
+import { formatUsername } from '@/lib/StringFormatters';
 import UserDAO from '@/lib/db/UserDAO';
 import EmailBase from '@/lib/email/EmailBase';
 import EmailBaseStudyRequest from '@/lib/email/EmailBaseStudyRequest';
@@ -48,15 +49,17 @@ class EmailStudyRequestNewComment extends EmailBaseStudyRequest {
       <p>
         A comment has been added to the {{studyType}} request
         {{#location}}
-          for
-          <a href="{{hrefLocation}}">{{location}}</a>
-        {{/location}}:
+          for {{location}}
+        {{/location}}
+        {{#usernameCommenter}}
+          by {{usernameCommenter}}
+        {{/usernameCommenter}}:
       </p>
       <p>
         <i>{{comment}}</i>
       </p>
       <p>
-        <a href="{{hrefStudyRequest}}">View or respond to this comment</a>
+        <a href="{{{hrefStudyRequest}}}">View or respond to this comment</a>
       </p>
     </div>`;
   }
@@ -64,7 +67,12 @@ class EmailStudyRequestNewComment extends EmailBaseStudyRequest {
   getBodyParams() {
     const params = super.getBodyParams();
     const { comment } = this.studyRequestComment;
-    return { comment, ...params };
+    const usernameCommenter = this.commenter === null ? null : formatUsername(this.commenter);
+    return {
+      ...params,
+      comment,
+      usernameCommenter,
+    };
   }
 }
 

--- a/lib/email/EmailStudyRequestRequested.js
+++ b/lib/email/EmailStudyRequestRequested.js
@@ -31,15 +31,14 @@ class EmailStudyRequestRequested extends EmailBaseStudyRequest {
       <p>
         We received your request for the following study
         {{#location}}
-          to be conducted at
-          <a href="{{hrefLocation}}">{{location}}</a>
+          to be conducted at {{location}}
         {{/location}}:
       </p>
       <p>
         <strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}
       </p>
       <p>
-        <a href="{{hrefStudyRequest}}">View your request</a>
+        <a href="{{{hrefStudyRequest}}}">View your request</a>
       </p>
     </div>`;
   }

--- a/lib/email/EmailStudyRequestRequestedAdmin.js
+++ b/lib/email/EmailStudyRequestRequestedAdmin.js
@@ -28,15 +28,14 @@ class EmailStudyRequestRequestedAdmin extends EmailBaseStudyRequest {
       <p>
         A request has been submitted for the following study
         {{#location}}
-          to be conducted at
-          <a href="{{hrefLocation}}">{{location}}</a>
+          to be conducted at {{location}}
         {{/location}}:
       </p>
       <p>
         <strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}
       </p>
       <p>
-        <a href="{{hrefStudyRequest}}">View request</a>
+        <a href="{{{hrefStudyRequest}}}">View request</a>
       </p>
     </div>`;
   }

--- a/lib/email/MailUtils.js
+++ b/lib/email/MailUtils.js
@@ -42,6 +42,57 @@ function getStudyRequestBulkUpdateEmails(studyRequestBulkNew, studyRequestBulkOl
   return emails;
 }
 
+async function getStudyRequestUpdateEmailsDeep(studyRequestNew, studyRequestOld) {
+  if (studyRequestNew.studyRequestBulkId === null) {
+    return getStudyRequestUpdateEmails(studyRequestNew, studyRequestOld);
+  }
+
+  const emails = [];
+
+  if (studyRequestNew.status === StudyRequestStatus.CANCELLED) {
+    /*
+     * When an individual study request is cancelled, we always send an email notification,
+     * regardless of whether it's part of a larger bulk request or not.
+     */
+    const emailsCancelled = getStudyRequestUpdateEmails(studyRequestNew, studyRequestOld);
+    emails.push(...emailsCancelled);
+  }
+
+  const studyRequestBulk = await StudyRequestBulkDAO.byId(studyRequestNew.studyRequestBulkId);
+  const i = studyRequestBulk.studyRequests.findIndex(
+    ({ id }) => id === studyRequestNew.id,
+  );
+  if (i === -1) {
+    return emails;
+  }
+
+  /*
+    * We use `studyRequestNew`, `studyRequestOld` to reconstruct both the new and old versions
+    * of the associated bulk request.  This allows us to not have to depend on the order in
+    * which this function is called in the REST API endpoint handler.  (For example: if we only
+    * used `studyRequestNew` to reconstruct the new version, we'd be relying on
+    * `studyRequestBulk` being the old version, which would imply that this function must be
+    * called before the study request update.)
+    */
+  const studyRequestBulkNew = {
+    ...studyRequestBulk,
+    studyRequests: [...studyRequestBulk.studyRequests],
+  };
+  studyRequestBulkNew.studyRequests[i] = studyRequestNew;
+  const studyRequestBulkOld = {
+    ...studyRequestBulk,
+    studyRequests: [...studyRequestBulk.studyRequests],
+  };
+  studyRequestBulkOld.studyRequests[i] = studyRequestOld;
+  const emailsStudyRequestBulk = getStudyRequestBulkUpdateEmails(
+    studyRequestBulkNew,
+    studyRequestBulkOld,
+  );
+  emails.push(...emailsStudyRequestBulk);
+
+  return emails;
+}
+
 async function sendEmailSafe(request, email) {
   try {
     const emailOptions = await email.getOptions();
@@ -54,71 +105,7 @@ async function sendEmailSafe(request, email) {
   }
 }
 
-async function sendStudyRequestBulkUpdateEmailsSafe(
-  request,
-  studyRequestBulkNew,
-  studyRequestBulkOld,
-) {
-  const emails = getStudyRequestBulkUpdateEmails(studyRequestBulkNew, studyRequestBulkOld);
-
-  const n = studyRequestBulkNew.studyRequests.length;
-  for (let i = 0; i < n; i++) {
-    const studyRequestNew = studyRequestBulkNew.studyRequests[i];
-    const studyRequestOld = studyRequestBulkOld.studyRequests[i];
-
-    const emailsStudyRequest = getStudyRequestUpdateEmails(studyRequestNew, studyRequestOld);
-    emails.push(...emailsStudyRequest);
-  }
-
-  if (emails.length === 0) {
-    return true;
-  }
-  const tasks = emails.map(email => sendEmailSafe(request, email));
-  const results = await Promise.all(tasks);
-  return results.every(result => result);
-}
-
-async function sendStudyRequestUpdateEmailsSafe(
-  request,
-  studyRequestNew,
-  studyRequestOld,
-) {
-  const emails = getStudyRequestUpdateEmails(studyRequestNew, studyRequestOld);
-
-  if (studyRequestNew.studyRequestBulkId !== null) {
-    const studyRequestBulk = await StudyRequestBulkDAO.byId(studyRequestNew.studyRequestBulkId);
-    const i = studyRequestBulk.studyRequests.findIndex(
-      ({ id }) => id === studyRequestNew.id,
-    );
-    if (i !== -1) {
-      /*
-       * We use `studyRequestNew`, `studyRequestOld` to reconstruct both the new and old versions
-       * of the associated bulk request.  This allows us to not have to depend on the order in
-       * which this function is called in the REST API endpoint handler.  (For example: if we only
-       * used `studyRequestNew` to reconstruct the new version, we'd be relying on
-       * `studyRequestBulk` being the old version, which would imply that this function must be
-       * called before the study request update.)
-       */
-      const studyRequestBulkNew = {
-        ...studyRequestBulk,
-        studyRequests: [...studyRequestBulk.studyRequests],
-      };
-      studyRequestBulkNew.studyRequests[i] = studyRequestNew;
-
-      const studyRequestBulkOld = {
-        ...studyRequestBulk,
-        studyRequests: [...studyRequestBulk.studyRequests],
-      };
-      studyRequestBulkOld.studyRequests[i] = studyRequestOld;
-
-      const emailsStudyRequestBulk = getStudyRequestBulkUpdateEmails(
-        studyRequestBulkNew,
-        studyRequestBulkOld,
-      );
-      emails.push(...emailsStudyRequestBulk);
-    }
-  }
-
+async function sendEmailsSafe(request, emails) {
   if (emails.length === 0) {
     return true;
   }
@@ -129,17 +116,15 @@ async function sendStudyRequestUpdateEmailsSafe(
 
 const MailUtils = {
   getStudyRequestBulkUpdateEmails,
-  getStudyRequestUpdateEmails,
+  getStudyRequestUpdateEmailsDeep,
   sendEmailSafe,
-  sendStudyRequestBulkUpdateEmailsSafe,
-  sendStudyRequestUpdateEmailsSafe,
+  sendEmailsSafe,
 };
 
 export {
   MailUtils as default,
   getStudyRequestBulkUpdateEmails,
-  getStudyRequestUpdateEmails,
+  getStudyRequestUpdateEmailsDeep,
   sendEmailSafe,
-  sendStudyRequestBulkUpdateEmailsSafe,
-  sendStudyRequestUpdateEmailsSafe,
+  sendEmailsSafe,
 };

--- a/lib/email/MailUtils.js
+++ b/lib/email/MailUtils.js
@@ -116,6 +116,7 @@ async function sendEmailsSafe(request, emails) {
 
 const MailUtils = {
   getStudyRequestBulkUpdateEmails,
+  getStudyRequestUpdateEmails,
   getStudyRequestUpdateEmailsDeep,
   sendEmailSafe,
   sendEmailsSafe,
@@ -124,6 +125,7 @@ const MailUtils = {
 export {
   MailUtils as default,
   getStudyRequestBulkUpdateEmails,
+  getStudyRequestUpdateEmails,
   getStudyRequestUpdateEmailsDeep,
   sendEmailSafe,
   sendEmailsSafe,

--- a/lib/requests/RequestStudyBulkUtils.js
+++ b/lib/requests/RequestStudyBulkUtils.js
@@ -36,11 +36,11 @@ function bulkStatus(studyRequests) {
   if (statuses.has(StudyRequestStatus.ASSIGNED)) {
     return StudyRequestStatus.ASSIGNED;
   }
-  if (statuses.has(StudyRequestStatus.COMPLETED)) {
-    return StudyRequestStatus.COMPLETED;
-  }
   if (statuses.has(StudyRequestStatus.REJECTED)) {
     return StudyRequestStatus.REJECTED;
+  }
+  if (statuses.has(StudyRequestStatus.COMPLETED)) {
+    return StudyRequestStatus.COMPLETED;
   }
   return StudyRequestStatus.CANCELLED;
 }

--- a/tests/jest/unit/email/EmailStudyRequestBulkCompleted.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestBulkCompleted.spec.js
@@ -1,7 +1,6 @@
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import UserDAO from '@/lib/db/UserDAO';
 import EmailStudyRequestBulkCompleted from '@/lib/email/EmailStudyRequestBulkCompleted';
-import CompositeId from '@/lib/io/CompositeId';
 import { generateStudyRequestBulk } from '@/lib/test/random/StudyRequestGenerator';
 import { generateUser } from '@/lib/test/random/UserGenerator';
 
@@ -31,11 +30,12 @@ test('EmailStudyRequestBulkCompleted', async () => {
   expect(subject).toEqual(`[MOVE] Your requests are complete! (${studyRequestBulk.name})`);
 
   const params = email.getBodyParams();
-  const s1 = CompositeId.encode(locations);
-  expect(params.hrefLocation).toEqual(`https://localhost:8080/view/location/${s1}/POINTS`);
   expect(params.hrefStudyRequestBulk).toEqual('https://localhost:8080/requests/study/bulk/17');
   expect(params.location).toMatch(/^Test location #1/);
   expect(params.studyRequests).toHaveLength(studyRequestBulk.studyRequests.length);
+  params.studyRequests.forEach((studyRequest, i) => {
+    expect(studyRequest.location).toEqual(`Test location #${i + 1}`);
+  });
 
   expect(() => {
     email.render();

--- a/tests/jest/unit/email/EmailStudyRequestBulkRequested.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestBulkRequested.spec.js
@@ -1,7 +1,6 @@
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import UserDAO from '@/lib/db/UserDAO';
 import EmailStudyRequestBulkRequested from '@/lib/email/EmailStudyRequestBulkRequested';
-import CompositeId from '@/lib/io/CompositeId';
 import { generateStudyRequestBulk } from '@/lib/test/random/StudyRequestGenerator';
 import { generateUser } from '@/lib/test/random/UserGenerator';
 
@@ -31,11 +30,12 @@ test('EmailStudyRequestBulkRequested', async () => {
   expect(subject).toEqual(`[MOVE] Requests received for ${studyRequestBulk.name}`);
 
   const params = email.getBodyParams();
-  const s1 = CompositeId.encode(locations);
-  expect(params.hrefLocation).toEqual(`https://localhost:8080/view/location/${s1}/POINTS`);
   expect(params.hrefStudyRequestBulk).toEqual('https://localhost:8080/requests/study/bulk/17');
   expect(params.location).toMatch(/^Test location #1/);
   expect(params.studyRequests).toHaveLength(studyRequestBulk.studyRequests.length);
+  params.studyRequests.forEach((studyRequest, i) => {
+    expect(studyRequest.location).toEqual(`Test location #${i + 1}`);
+  });
 
   expect(() => {
     email.render();

--- a/tests/jest/unit/email/EmailStudyRequestBulkRequestedAdmin.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestBulkRequestedAdmin.spec.js
@@ -2,7 +2,6 @@ import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import UserDAO from '@/lib/db/UserDAO';
 import EmailBase from '@/lib/email/EmailBase';
 import EmailStudyRequestBulkRequestedAdmin from '@/lib/email/EmailStudyRequestBulkRequestedAdmin';
-import CompositeId from '@/lib/io/CompositeId';
 import { generateStudyRequestBulk } from '@/lib/test/random/StudyRequestGenerator';
 import { generateUser } from '@/lib/test/random/UserGenerator';
 
@@ -32,11 +31,12 @@ test('EmailStudyRequestBulkRequestedAdmin', async () => {
   expect(subject).toEqual(`[MOVE] New requests for ${studyRequestBulk.name}`);
 
   const params = email.getBodyParams();
-  const s1 = CompositeId.encode(locations);
-  expect(params.hrefLocation).toEqual(`https://localhost:8080/view/location/${s1}/POINTS`);
   expect(params.hrefStudyRequestBulk).toEqual('https://localhost:8080/requests/study/bulk/17');
   expect(params.location).toMatch(/^Test location #1/);
   expect(params.studyRequests).toHaveLength(studyRequestBulk.studyRequests.length);
+  params.studyRequests.forEach((studyRequest, i) => {
+    expect(studyRequest.location).toEqual(`Test location #${i + 1}`);
+  });
 
   expect(() => {
     email.render();

--- a/tests/jest/unit/email/EmailStudyRequestCancelled.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestCancelled.spec.js
@@ -1,7 +1,6 @@
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import UserDAO from '@/lib/db/UserDAO';
 import EmailStudyRequestCancelled from '@/lib/email/EmailStudyRequestCancelled';
-import CompositeId from '@/lib/io/CompositeId';
 import { generateStudyRequest } from '@/lib/test/random/StudyRequestGenerator';
 import { generateUser } from '@/lib/test/random/UserGenerator';
 
@@ -31,8 +30,6 @@ test('EmailStudyRequestCancelled', async () => {
   expect(subject).toEqual('[MOVE] Request cancelled: #42 - Test location');
 
   const params = email.getBodyParams();
-  const s1 = CompositeId.encode([studyRequest]);
-  expect(params.hrefLocation).toEqual(`https://localhost:8080/view/location/${s1}/POINTS`);
   expect(params.hrefStudyRequest).toEqual('https://localhost:8080/requests/study/42');
   expect(params.location).toEqual('Test location');
 

--- a/tests/jest/unit/email/EmailStudyRequestCompleted.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestCompleted.spec.js
@@ -1,7 +1,6 @@
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import UserDAO from '@/lib/db/UserDAO';
 import EmailStudyRequestCompleted from '@/lib/email/EmailStudyRequestCompleted';
-import CompositeId from '@/lib/io/CompositeId';
 import { generateStudyRequest } from '@/lib/test/random/StudyRequestGenerator';
 import { generateUser } from '@/lib/test/random/UserGenerator';
 
@@ -31,8 +30,6 @@ test('EmailStudyRequestCompleted', async () => {
   expect(subject).toEqual('[MOVE] Your request is complete! (Test location)');
 
   const params = email.getBodyParams();
-  const s1 = CompositeId.encode([studyRequest]);
-  expect(params.hrefLocation).toEqual(`https://localhost:8080/view/location/${s1}/POINTS`);
   expect(params.hrefStudyRequest).toEqual('https://localhost:8080/requests/study/42');
   expect(params.location).toEqual('Test location');
 

--- a/tests/jest/unit/email/EmailStudyRequestNewComment.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestNewComment.spec.js
@@ -2,7 +2,6 @@ import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import UserDAO from '@/lib/db/UserDAO';
 import EmailBase from '@/lib/email/EmailBase';
 import EmailStudyRequestNewComment from '@/lib/email/EmailStudyRequestNewComment';
-import CompositeId from '@/lib/io/CompositeId';
 import { generateStudyRequest } from '@/lib/test/random/StudyRequestGenerator';
 import { generateUser } from '@/lib/test/random/UserGenerator';
 
@@ -35,9 +34,7 @@ test('EmailStudyRequestNewComment', async () => {
   expect(subject).toEqual('[MOVE] New comment on request #42 for Test location');
 
   const params = email.getBodyParams();
-  const s1 = CompositeId.encode([studyRequest]);
   expect(params.comment).toEqual('Test comment');
-  expect(params.hrefLocation).toEqual(`https://localhost:8080/view/location/${s1}/POINTS`);
   expect(params.hrefStudyRequest).toEqual('https://localhost:8080/requests/study/42');
   expect(params.location).toEqual('Test location');
 

--- a/tests/jest/unit/email/EmailStudyRequestRequested.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestRequested.spec.js
@@ -1,7 +1,6 @@
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import UserDAO from '@/lib/db/UserDAO';
 import EmailStudyRequestRequested from '@/lib/email/EmailStudyRequestRequested';
-import CompositeId from '@/lib/io/CompositeId';
 import { generateStudyRequest } from '@/lib/test/random/StudyRequestGenerator';
 import { generateUser } from '@/lib/test/random/UserGenerator';
 
@@ -31,8 +30,6 @@ test('EmailStudyRequestRequested', async () => {
   expect(subject).toEqual('[MOVE] Request received for Test location');
 
   const params = email.getBodyParams();
-  const s1 = CompositeId.encode([studyRequest]);
-  expect(params.hrefLocation).toEqual(`https://localhost:8080/view/location/${s1}/POINTS`);
   expect(params.hrefStudyRequest).toEqual('https://localhost:8080/requests/study/42');
   expect(params.location).toEqual('Test location');
 

--- a/tests/jest/unit/email/EmailStudyRequestRequestedAdmin.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestRequestedAdmin.spec.js
@@ -2,7 +2,6 @@ import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import UserDAO from '@/lib/db/UserDAO';
 import EmailBase from '@/lib/email/EmailBase';
 import EmailStudyRequestRequestedAdmin from '@/lib/email/EmailStudyRequestRequestedAdmin';
-import CompositeId from '@/lib/io/CompositeId';
 import { generateStudyRequest } from '@/lib/test/random/StudyRequestGenerator';
 import { generateUser } from '@/lib/test/random/UserGenerator';
 
@@ -32,8 +31,6 @@ test('EmailStudyRequestRequestedAdmin', async () => {
   expect(subject).toEqual('[MOVE] New request for Test location');
 
   const params = email.getBodyParams();
-  const s1 = CompositeId.encode([studyRequest]);
-  expect(params.hrefLocation).toEqual(`https://localhost:8080/view/location/${s1}/POINTS`);
   expect(params.hrefStudyRequest).toEqual('https://localhost:8080/requests/study/42');
   expect(params.location).toEqual('Test location');
 

--- a/tests/jest/unit/email/MailUtils.spec.js
+++ b/tests/jest/unit/email/MailUtils.spec.js
@@ -1,0 +1,179 @@
+import { StudyRequestStatus } from '@/lib/Constants';
+import StudyRequestBulkDAO from '@/lib/db/StudyRequestBulkDAO';
+import EmailStudyRequestBulkCancelled from '@/lib/email/EmailStudyRequestBulkCancelled';
+import EmailStudyRequestBulkCompleted from '@/lib/email/EmailStudyRequestBulkCompleted';
+import EmailStudyRequestCancelled from '@/lib/email/EmailStudyRequestCancelled';
+import EmailStudyRequestCompleted from '@/lib/email/EmailStudyRequestCompleted';
+import {
+  getStudyRequestBulkUpdateEmails,
+  getStudyRequestUpdateEmails,
+  getStudyRequestUpdateEmailsDeep,
+} from '@/lib/email/MailUtils';
+import {
+  generateStudyRequest,
+  generateStudyRequestBulk,
+} from '@/lib/test/random/StudyRequestGenerator';
+
+jest.mock('@/lib/db/StudyRequestBulkDAO');
+
+function studyRequestBulkWithStatus(studyRequestBulk, status) {
+  return {
+    ...studyRequestBulk,
+    studyRequests: studyRequestBulk.studyRequests.map(studyRequest => ({
+      ...studyRequest,
+      status,
+    })),
+  };
+}
+
+test('MailUtils.getStudyRequestBulkUpdateEmails', () => {
+  const studyRequestBulk = generateStudyRequestBulk();
+  studyRequestBulk.id = 42;
+
+  let studyRequestBulkNew = studyRequestBulkWithStatus(
+    studyRequestBulk,
+    StudyRequestStatus.CHANGES_NEEDED,
+  );
+  let studyRequestBulkOld = studyRequestBulk;
+  let emails = getStudyRequestBulkUpdateEmails(studyRequestBulkNew, studyRequestBulkOld);
+  expect(emails).toHaveLength(0);
+
+  studyRequestBulkOld = studyRequestBulkNew;
+  studyRequestBulkNew = studyRequestBulkWithStatus(
+    studyRequestBulk,
+    StudyRequestStatus.CANCELLED,
+  );
+  emails = getStudyRequestBulkUpdateEmails(studyRequestBulkNew, studyRequestBulkOld);
+  expect(emails).toHaveLength(1);
+  expect(emails[0]).toBeInstanceOf(EmailStudyRequestBulkCancelled);
+
+  studyRequestBulkOld = studyRequestBulkWithStatus(
+    studyRequestBulk,
+    StudyRequestStatus.ASSIGNED,
+  );
+  studyRequestBulkNew = studyRequestBulkWithStatus(
+    studyRequestBulk,
+    StudyRequestStatus.COMPLETED,
+  );
+  emails = getStudyRequestBulkUpdateEmails(studyRequestBulkNew, studyRequestBulkOld);
+  expect(emails).toHaveLength(1);
+  expect(emails[0]).toBeInstanceOf(EmailStudyRequestBulkCompleted);
+});
+
+test('MailUtils.getStudyRequestUpdateEmails', () => {
+  const studyRequest = generateStudyRequest();
+  studyRequest.id = 42;
+
+  let studyRequestNew = {
+    ...studyRequest,
+    status: StudyRequestStatus.CHANGES_NEEDED,
+  };
+  let studyRequestOld = studyRequest;
+  let emails = getStudyRequestUpdateEmails(studyRequestNew, studyRequestOld);
+  expect(emails).toHaveLength(0);
+
+  studyRequestOld = studyRequestNew;
+  studyRequestNew = {
+    ...studyRequest,
+    status: StudyRequestStatus.CANCELLED,
+  };
+  emails = getStudyRequestUpdateEmails(studyRequestNew, studyRequestOld);
+  expect(emails).toHaveLength(1);
+  expect(emails[0]).toBeInstanceOf(EmailStudyRequestCancelled);
+
+  studyRequestOld = {
+    ...studyRequest,
+    status: StudyRequestStatus.ASSIGNED,
+  };
+  studyRequestNew = {
+    ...studyRequest,
+    status: StudyRequestStatus.COMPLETED,
+  };
+  emails = getStudyRequestUpdateEmails(studyRequestNew, studyRequestOld);
+  expect(emails).toHaveLength(1);
+  expect(emails[0]).toBeInstanceOf(EmailStudyRequestCompleted);
+});
+
+test('MailUtils.getStudyRequestUpdateEmailsDeep [cancelling single request]', async () => {
+  const studyRequestBulk = generateStudyRequestBulk();
+  studyRequestBulk.id = 42;
+  studyRequestBulk.studyRequests = studyRequestBulk.studyRequests.map((studyRequest, i) => ({
+    ...studyRequest,
+    status: StudyRequestStatus.REQUESTED,
+    id: i + 1,
+    studyRequestBulkId: studyRequestBulk.id,
+  }));
+  StudyRequestBulkDAO.byId.mockResolvedValue(studyRequestBulk);
+
+  const studyRequestNew = {
+    ...studyRequestBulk.studyRequests[0],
+    status: StudyRequestStatus.CANCELLED,
+  };
+  const studyRequestOld = studyRequestBulk.studyRequests[0];
+  const emails = await getStudyRequestUpdateEmailsDeep(studyRequestNew, studyRequestOld);
+  expect(emails).toHaveLength(1);
+  expect(emails[0]).toBeInstanceOf(EmailStudyRequestCancelled);
+});
+
+test('MailUtils.getStudyRequestUpdateEmailsDeep [completing single request]', async () => {
+  const studyRequestBulk = generateStudyRequestBulk();
+  studyRequestBulk.id = 42;
+  studyRequestBulk.studyRequests = studyRequestBulk.studyRequests.map((studyRequest, i) => ({
+    ...studyRequest,
+    status: StudyRequestStatus.REQUESTED,
+    id: i + 1,
+    studyRequestBulkId: studyRequestBulk.id,
+  }));
+  StudyRequestBulkDAO.byId.mockResolvedValue(studyRequestBulk);
+
+  const studyRequestNew = {
+    ...studyRequestBulk.studyRequests[0],
+    status: StudyRequestStatus.COMPLETED,
+  };
+  const studyRequestOld = studyRequestBulk.studyRequests[0];
+  const emails = await getStudyRequestUpdateEmailsDeep(studyRequestNew, studyRequestOld);
+  expect(emails).toHaveLength(0);
+});
+
+test('MailUtils.getStudyRequestUpdateEmailsDeep [completing last request]', async () => {
+  const studyRequestBulk = generateStudyRequestBulk();
+  studyRequestBulk.id = 42;
+  studyRequestBulk.studyRequests = studyRequestBulk.studyRequests.map((studyRequest, i) => ({
+    ...studyRequest,
+    status: i === 0 ? StudyRequestStatus.REQUESTED : StudyRequestStatus.COMPLETED,
+    id: i + 1,
+    studyRequestBulkId: studyRequestBulk.id,
+  }));
+  StudyRequestBulkDAO.byId.mockResolvedValue(studyRequestBulk);
+
+  const studyRequestNew = {
+    ...studyRequestBulk.studyRequests[0],
+    status: StudyRequestStatus.COMPLETED,
+  };
+  const studyRequestOld = studyRequestBulk.studyRequests[0];
+  const emails = await getStudyRequestUpdateEmailsDeep(studyRequestNew, studyRequestOld);
+  expect(emails).toHaveLength(1);
+  expect(emails[0]).toBeInstanceOf(EmailStudyRequestBulkCompleted);
+});
+
+test('MailUtils.getStudyRequestUpdateEmailsDeep [cancelling last request]', async () => {
+  const studyRequestBulk = generateStudyRequestBulk();
+  studyRequestBulk.id = 42;
+  studyRequestBulk.studyRequests = studyRequestBulk.studyRequests.map((studyRequest, i) => ({
+    ...studyRequest,
+    status: i === 0 ? StudyRequestStatus.REQUESTED : StudyRequestStatus.COMPLETED,
+    id: i + 1,
+    studyRequestBulkId: studyRequestBulk.id,
+  }));
+  StudyRequestBulkDAO.byId.mockResolvedValue(studyRequestBulk);
+
+  const studyRequestNew = {
+    ...studyRequestBulk.studyRequests[0],
+    status: StudyRequestStatus.CANCELLED,
+  };
+  const studyRequestOld = studyRequestBulk.studyRequests[0];
+  const emails = await getStudyRequestUpdateEmailsDeep(studyRequestNew, studyRequestOld);
+  expect(emails).toHaveLength(2);
+  expect(emails[0]).toBeInstanceOf(EmailStudyRequestCancelled);
+  expect(emails[1]).toBeInstanceOf(EmailStudyRequestBulkCompleted);
+});

--- a/tests/jest/unit/requests/RequestStudyBulkUtils.spec.js
+++ b/tests/jest/unit/requests/RequestStudyBulkUtils.spec.js
@@ -40,13 +40,13 @@ test('RequestStudyBulkUtils.bulkStatus', () => {
     StudyRequestStatus.ASSIGNED,
   ], StudyRequestStatus.ASSIGNED);
 
-  // unless all requests are cancelled or rejected, ignore them for bulk status
+  // unless all requests are cancelled, ignore them for bulk status
   expectBulkStatus([
     StudyRequestStatus.COMPLETED,
     StudyRequestStatus.REJECTED,
     StudyRequestStatus.COMPLETED,
     StudyRequestStatus.CANCELLED,
-  ], StudyRequestStatus.COMPLETED);
+  ], StudyRequestStatus.REJECTED);
 
   // if all requests are cancelled, bulk status is cancelled
   expectBulkStatus([


### PR DESCRIPTION
# Issue Addressed
This PR makes significant progress on #803 .

# Description
We update email notification copy to fix a bug where per-request locations weren't showing up for bulk request emails, and add commenter details.  In the process, we refactor the common list of requests in a bulk request out into a reusable template string.

We also update `MailUtils` to reduce the volume of emails sent around bulk requests.

Finally, we add more testing of `MailUtils` and various `EmailBase` subclasses.

# Tests
Ran additional unit tests, plus the usual `ci:jest-coverage` check.  Will have to test end-to-end delivery in AWS dev.
