### PR TITLE
One-time userOnly initialization for Track Requests

### DIFF
--- a/lib/requests/RequestActions.js
+++ b/lib/requests/RequestActions.js
@@ -44,7 +44,11 @@ class RequestActions {
   }
 
   static canCancel(user, studyRequest) {
-    return RequestActions.canEdit(user, studyRequest);
+    if (!RequestActions.canEdit(user, studyRequest)) {
+      return false;
+    }
+    const { status } = studyRequest;
+    return status !== StudyRequestStatus.CANCELLED;
   }
 
   static canEdit(user, studyRequest) {
@@ -58,11 +62,19 @@ class RequestActions {
   }
 
   static canMarkCompleted(user, studyRequest) {
-    return RequestActions.canEdit(user, studyRequest);
+    if (!RequestActions.canEdit(user, studyRequest)) {
+      return false;
+    }
+    const { status } = studyRequest;
+    return status !== StudyRequestStatus.COMPLETED;
   }
 
   static canRejectData(user, studyRequest) {
-    return RequestActions.canEdit(user, studyRequest);
+    if (!RequestActions.canEdit(user, studyRequest)) {
+      return false;
+    }
+    const { status } = studyRequest;
+    return status !== StudyRequestStatus.REJECTED;
   }
 
   static canReopen(user, studyRequest) {
@@ -72,8 +84,12 @@ class RequestActions {
     return studyRequest.status === StudyRequestStatus.CANCELLED;
   }
 
-  static canRequestChanges(user) {
-    return hasAuthScope(user, AuthScope.STUDY_REQUESTS_ADMIN);
+  static canRequestChanges(user, studyRequest) {
+    if (!hasAuthScope(user, AuthScope.STUDY_REQUESTS_ADMIN)) {
+      return false;
+    }
+    const { status } = studyRequest;
+    return status !== StudyRequestStatus.CHANGES_NEEDED;
   }
 }
 

--- a/web/store/modules/trackRequests.js
+++ b/web/store/modules/trackRequests.js
@@ -18,6 +18,7 @@ export default {
       studyTypes: [],
       userOnly: false,
     },
+    filtersRequestUserOnlyInited: false,
     searchRequest: {
       column: null,
       query: null,
@@ -96,7 +97,10 @@ export default {
       state.filtersRequest = filtersRequest;
     },
     setFiltersRequestUserOnly(state, userOnly) {
-      state.filtersRequest.userOnly = userOnly;
+      if (!state.filtersRequestUserOnlyInited) {
+        state.filtersRequest.userOnly = userOnly;
+        state.filtersRequestUserOnlyInited = true;
+      }
     },
     setSearchRequestColumn(state, column) {
       state.searchRequest.column = column;


### PR DESCRIPTION
# Issue Addressed
This PR closes #783 .

# Description
We initialize `userOnly` once in `FcRequestsTrack`.  We also make one small tweak to `RequestActions`: to avoid confusion, we disable the current status in the status menu (except for `ASSIGNED`, so that staff can still reassign things).

# Tests
Tested quickly in frontend, plus CI checks to ensure `RequestActions` changes don't break REST API.
