### PR TITLE
Address remaining axe issues, define progress / tooltip wrappers

### DIFF
--- a/lib/geo/GeoStyle.js
+++ b/lib/geo/GeoStyle.js
@@ -258,7 +258,7 @@ injectSources(STYLE_BASE_AERIAL);
 
 // MOVE FEATURE LAYERS
 
-const COLOR_CENTRELINE_GREY = '#acacac';
+const COLOR_CENTRELINE_GREY = '#9b9b9b';
 const COLOR_COLLISION_HEATMAP_ZERO = 'rgba(244, 227, 219, 0)';
 const COLOR_COLLISION_HEATMAP_HALF = '#f39268';
 const COLOR_COLLISION_FILL = '#ef4848';
@@ -406,7 +406,7 @@ class GeoStyle {
             'interpolate',
             ['linear'],
             ['zoom'],
-            MapZoom.LEVEL_3.minzoom, 0.5,
+            MapZoom.LEVEL_3.minzoom, 0.6,
             MapZoom.LEVEL_2.minzoom, 1,
           ],
           'line-width': [
@@ -483,9 +483,9 @@ class GeoStyle {
         minzoom: MapZoom.LEVEL_2.minzoom,
         maxzoom: MapZoom.LEVEL_1.maxzoomSource + 1,
         paint: {
-          'line-color': '#404040',
+          'line-color': '#272727',
           'line-gap-width': lineWidth,
-          'line-width': 1,
+          'line-width': 2,
         },
       },
       getLayer(baseStyle, 'intersections', 'circle', {
@@ -528,7 +528,7 @@ class GeoStyle {
           'circle-color': '#54a1e5',
           'circle-opacity': 0,
           'circle-stroke-color': '#404040',
-          'circle-stroke-width': 1,
+          'circle-stroke-width': 2,
           'circle-radius': 6,
         },
       },

--- a/web/App.vue
+++ b/web/App.vue
@@ -17,7 +17,6 @@
     <FcNavbar />
     <v-main>
       <router-view></router-view>
-      <aside id="fc_tooltips"></aside>
     </v-main>
   </v-app>
 </template>

--- a/web/App.vue
+++ b/web/App.vue
@@ -17,6 +17,7 @@
     <FcNavbar />
     <v-main>
       <router-view></router-view>
+      <aside id="fc_tooltips"></aside>
     </v-main>
   </v-app>
 </template>

--- a/web/components/FcDataTable.vue
+++ b/web/components/FcDataTable.vue
@@ -139,7 +139,12 @@ export default {
     // keyboard navigation of sortable header toggles
     const $thSortable = this.$el.querySelectorAll('th.sortable');
     $thSortable.forEach(($th) => {
+      const ariaLabel = $th.getAttribute('aria-label');
+      $th.removeAttribute('aria-label');
+
       const $sortIcon = $th.querySelector('.v-data-table-header__icon');
+      $sortIcon.removeAttribute('aria-hidden');
+      $sortIcon.setAttribute('aria-label', ariaLabel);
       $sortIcon.setAttribute('tabindex', 0);
       $sortIcon.addEventListener('keypress', (evt) => {
         if (evt.keyCode === KeyCode.SPACE) {

--- a/web/components/FcDataTableRequests.vue
+++ b/web/components/FcDataTableRequests.vue
@@ -33,7 +33,7 @@
       <span class="sr-only">Select</span>
     </template>
     <template v-slot:item.SELECT="{ item }">
-      <v-tooltip right>
+      <FcTooltip right>
         <template v-slot:activator="{ on }">
           <div v-on="on">
             <v-checkbox
@@ -54,7 +54,7 @@
           </div>
         </template>
         <span>Select {{item.ariaLabel}}</span>
-      </v-tooltip>
+      </FcTooltip>
 
     </template>
     <template v-slot:item.ID="{ item }">
@@ -205,6 +205,7 @@ import RequestActions from '@/lib/requests/RequestActions';
 import { ItemType } from '@/lib/requests/RequestStudyBulkUtils';
 import FcDataTable from '@/web/components/FcDataTable.vue';
 import FcTextNumberTotal from '@/web/components/data/FcTextNumberTotal.vue';
+import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
 import FcButtonAria from '@/web/components/inputs/FcButtonAria.vue';
 import FcMenuStudyRequestsAssignTo
   from '@/web/components/requests/status/FcMenuStudyRequestsAssignTo.vue';
@@ -238,6 +239,7 @@ export default {
     FcDataTable,
     FcMenuStudyRequestsAssignTo,
     FcTextNumberTotal,
+    FcTooltip,
   },
   props: {
     ariaLabelledby: {

--- a/web/components/FcDrawerRequestStudyBulkEdit.vue
+++ b/web/components/FcDrawerRequestStudyBulkEdit.vue
@@ -14,6 +14,7 @@
 
     <v-progress-linear
       v-if="loading"
+      aria-label="Loading bulk study request for editing"
       indeterminate />
     <div
       v-else

--- a/web/components/FcDrawerRequestStudyBulkEdit.vue
+++ b/web/components/FcDrawerRequestStudyBulkEdit.vue
@@ -12,10 +12,9 @@
 
     <v-divider></v-divider>
 
-    <v-progress-linear
+    <FcProgressLinear
       v-if="loading"
-      aria-label="Loading bulk study request for editing"
-      indeterminate />
+      aria-label="Loading bulk study request for editing" />
     <div
       v-else
       class="flex-grow-1 flex-shrink-1 min-height-0">
@@ -33,6 +32,7 @@ import { mapActions, mapMutations, mapState } from 'vuex';
 import { getStudyRequestBulk } from '@/lib/api/WebApi';
 import CompositeId from '@/lib/io/CompositeId';
 import { bulkIndicesDeselected } from '@/lib/requests/RequestStudyBulkUtils';
+import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcEditStudyRequestBulk from '@/web/components/requests/FcEditStudyRequestBulk.vue';
 import FcNavStudyRequest from '@/web/components/requests/nav/FcNavStudyRequest.vue';
 import FcMixinRequestStudyLeaveGuard from '@/web/mixins/FcMixinRequestStudyLeaveGuard';
@@ -47,6 +47,7 @@ export default {
   components: {
     FcEditStudyRequestBulk,
     FcNavStudyRequest,
+    FcProgressLinear,
   },
   data() {
     return {

--- a/web/components/FcDrawerRequestStudyEdit.vue
+++ b/web/components/FcDrawerRequestStudyEdit.vue
@@ -14,6 +14,7 @@
 
     <v-progress-linear
       v-if="loading"
+      aria-label="Loading study request for editing"
       indeterminate />
     <div
       v-else

--- a/web/components/FcDrawerRequestStudyEdit.vue
+++ b/web/components/FcDrawerRequestStudyEdit.vue
@@ -12,10 +12,9 @@
 
     <v-divider></v-divider>
 
-    <v-progress-linear
+    <FcProgressLinear
       v-if="loading"
-      aria-label="Loading study request for editing"
-      indeterminate />
+      aria-label="Loading study request for editing" />
     <div
       v-else
       class="flex-grow-1 flex-shrink-1 min-height-0">
@@ -33,6 +32,7 @@ import { mapActions, mapGetters } from 'vuex';
 
 import { LocationSelectionType } from '@/lib/Constants';
 import { getStudyRequest, getStudyRequestBulkName } from '@/lib/api/WebApi';
+import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcDetailsStudyRequest from '@/web/components/requests/FcDetailsStudyRequest.vue';
 import FcNavStudyRequest from '@/web/components/requests/nav/FcNavStudyRequest.vue';
 import FcMixinRequestStudyLeaveGuard from '@/web/mixins/FcMixinRequestStudyLeaveGuard';
@@ -47,6 +47,7 @@ export default {
   components: {
     FcDetailsStudyRequest,
     FcNavStudyRequest,
+    FcProgressLinear,
   },
   data() {
     return {

--- a/web/components/FcDrawerRequestStudyNew.vue
+++ b/web/components/FcDrawerRequestStudyNew.vue
@@ -12,10 +12,9 @@
 
     <v-divider v-if="!isBulk"></v-divider>
 
-    <v-progress-linear
+    <FcProgressLinear
       v-if="loading"
-      aria-label="Loading Request New Study form"
-      indeterminate />
+      aria-label="Loading Request New Study form" />
     <div
       v-else
       class="flex-grow-1 flex-shrink-1 min-height-0">
@@ -49,6 +48,7 @@ import {
 } from '@/lib/Constants';
 import { getStudiesByCentrelineSummaryPerLocation } from '@/lib/api/WebApi';
 import CompositeId from '@/lib/io/CompositeId';
+import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcCreateStudyRequestBulk from '@/web/components/requests/FcCreateStudyRequestBulk.vue';
 import FcDetailsStudyRequest from '@/web/components/requests/FcDetailsStudyRequest.vue';
 import FcNavStudyRequest from '@/web/components/requests/nav/FcNavStudyRequest.vue';
@@ -126,6 +126,7 @@ export default {
     FcCreateStudyRequestBulk,
     FcDetailsStudyRequest,
     FcNavStudyRequest,
+    FcProgressLinear,
   },
   data() {
     return {

--- a/web/components/FcDrawerRequestStudyNew.vue
+++ b/web/components/FcDrawerRequestStudyNew.vue
@@ -14,6 +14,7 @@
 
     <v-progress-linear
       v-if="loading"
+      aria-label="Loading Request New Study form"
       indeterminate />
     <div
       v-else

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -98,13 +98,9 @@
         <div
           v-if="loadingReportLayout"
           class="ma-3 text-center">
-          <v-progress-circular
-            v-if="loadingReportLayout"
+          <FcProgressCircular
             aria-label="Loading selected report"
-            class="ma-3"
-            color="primary"
-            indeterminate
-            size="80" />
+            class="ma-3" />
           <div class="font-weight-regular headline secondary--text">
             This page is loading, please wait.
           </div>
@@ -141,6 +137,7 @@ import {
 import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
 import CompositeId from '@/lib/io/CompositeId';
 import FcDialogConfirm from '@/web/components/dialogs/FcDialogConfirm.vue';
+import FcProgressCircular from '@/web/components/dialogs/FcProgressCircular.vue';
 import FcListFilterChips from '@/web/components/filters/FcListFilterChips.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcMenuDownloadReportFormat from '@/web/components/inputs/FcMenuDownloadReportFormat.vue';
@@ -159,6 +156,7 @@ export default {
     FcListFilterChips,
     FcListLocationMulti,
     FcMenuDownloadReportFormat,
+    FcProgressCircular,
     FcReport,
   },
   data() {

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -13,6 +13,7 @@
     </FcDialogConfirm>
     <v-progress-linear
       v-if="loading"
+      aria-label="Loading collision reports viewer"
       indeterminate />
     <template v-else>
       <div>
@@ -99,6 +100,7 @@
           class="ma-3 text-center">
           <v-progress-circular
             v-if="loadingReportLayout"
+            aria-label="Loading selected report"
             class="ma-3"
             color="primary"
             indeterminate

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -11,10 +11,9 @@
         Are you sure you want to leave?
       </span>
     </FcDialogConfirm>
-    <v-progress-linear
+    <FcProgressLinear
       v-if="loading"
-      aria-label="Loading collision reports viewer"
-      indeterminate />
+      aria-label="Loading collision reports viewer" />
     <template v-else>
       <div>
         <div class="align-center d-flex flex-grow-0 flex-shrink-0 px-3 pt-2">
@@ -138,6 +137,7 @@ import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
 import CompositeId from '@/lib/io/CompositeId';
 import FcDialogConfirm from '@/web/components/dialogs/FcDialogConfirm.vue';
 import FcProgressCircular from '@/web/components/dialogs/FcProgressCircular.vue';
+import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcListFilterChips from '@/web/components/filters/FcListFilterChips.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcMenuDownloadReportFormat from '@/web/components/inputs/FcMenuDownloadReportFormat.vue';
@@ -157,6 +157,7 @@ export default {
     FcListLocationMulti,
     FcMenuDownloadReportFormat,
     FcProgressCircular,
+    FcProgressLinear,
     FcReport,
   },
   data() {

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -32,10 +32,9 @@
     </header>
     <section class="flex-grow-1 flex-shrink-1 overflow-y-auto">
       <v-divider></v-divider>
-      <v-progress-linear
+      <FcProgressLinear
         v-if="loading"
-        aria-label="Loading View Data drawer"
-        indeterminate />
+        aria-label="Loading View Data drawer" />
       <template v-else>
         <FcViewDataMultiEdit
           v-if="locationMode === LocationMode.MULTI_EDIT"
@@ -69,6 +68,7 @@ import CompositeId from '@/lib/io/CompositeId';
 import FcViewDataAggregate from '@/web/components/data/FcViewDataAggregate.vue';
 import FcViewDataDetail from '@/web/components/data/FcViewDataDetail.vue';
 import FcViewDataMultiEdit from '@/web/components/data/FcViewDataMultiEdit.vue';
+import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcSelectorSingleLocation from '@/web/components/inputs/FcSelectorSingleLocation.vue';
 import FcSelectorMultiLocation from '@/web/components/inputs/FcSelectorMultiLocation.vue';
@@ -84,6 +84,7 @@ export default {
   components: {
     FcButton,
     FcHeaderSingleLocation,
+    FcProgressLinear,
     FcSelectorMultiLocation,
     FcSelectorSingleLocation,
     FcSummaryPoi,

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -34,6 +34,7 @@
       <v-divider></v-divider>
       <v-progress-linear
         v-if="loading"
+        aria-label="Loading View Data drawer"
         indeterminate />
       <template v-else>
         <FcViewDataMultiEdit

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -13,6 +13,7 @@
     </FcDialogConfirm>
     <v-progress-linear
       v-if="loading"
+      aria-label="Loading study reports viewer"
       indeterminate />
     <template v-else>
       <div>
@@ -130,6 +131,7 @@
           class="ma-3 text-center">
           <v-progress-circular
             v-if="loadingReportLayout"
+            aria-label="Loading selected report"
             class="ma-3"
             color="primary"
             indeterminate

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -129,13 +129,9 @@
         <div
           v-else-if="loadingReportLayout"
           class="ma-3 text-center">
-          <v-progress-circular
-            v-if="loadingReportLayout"
+          <FcProgressCircular
             aria-label="Loading selected report"
-            class="ma-3"
-            color="primary"
-            indeterminate
-            size="80" />
+            class="ma-3" />
           <div class="font-weight-regular headline secondary--text">
             This page is loading, please wait.
           </div>
@@ -182,6 +178,7 @@ import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
 import CompositeId from '@/lib/io/CompositeId';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 import FcDialogConfirm from '@/web/components/dialogs/FcDialogConfirm.vue';
+import FcProgressCircular from '@/web/components/dialogs/FcProgressCircular.vue';
 import FcListFilterChips from '@/web/components/filters/FcListFilterChips.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcMenuDownloadReportFormat from '@/web/components/inputs/FcMenuDownloadReportFormat.vue';
@@ -201,6 +198,7 @@ export default {
     FcListFilterChips,
     FcListLocationMulti,
     FcMenuDownloadReportFormat,
+    FcProgressCircular,
     FcReport,
     FcReportParameters,
   },

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -11,10 +11,9 @@
         Are you sure you want to leave?
       </span>
     </FcDialogConfirm>
-    <v-progress-linear
+    <FcProgressLinear
       v-if="loading"
-      aria-label="Loading study reports viewer"
-      indeterminate />
+      aria-label="Loading study reports viewer" />
     <template v-else>
       <div>
         <div class="align-center d-flex flex-grow-0 flex-shrink-0 px-3 pt-2">
@@ -179,6 +178,7 @@ import CompositeId from '@/lib/io/CompositeId';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 import FcDialogConfirm from '@/web/components/dialogs/FcDialogConfirm.vue';
 import FcProgressCircular from '@/web/components/dialogs/FcProgressCircular.vue';
+import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcListFilterChips from '@/web/components/filters/FcListFilterChips.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcMenuDownloadReportFormat from '@/web/components/inputs/FcMenuDownloadReportFormat.vue';
@@ -199,6 +199,7 @@ export default {
     FcListLocationMulti,
     FcMenuDownloadReportFormat,
     FcProgressCircular,
+    FcProgressLinear,
     FcReport,
     FcReportParameters,
   },

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -7,10 +7,10 @@
 
     <template v-if="!background">
       <div class="pane-map-progress">
-        <v-progress-linear
-          :active="loading"
+        <FcProgressLinear
+          v-if="loading"
           aria-label="Loading map layers and data"
-          indeterminate />
+          silent />
       </div>
       <div
         class="pane-map-location-search"
@@ -121,6 +121,7 @@ import CompositeId from '@/lib/io/CompositeId';
 import FcPaneMapPopup from '@/web/components/FcPaneMapPopup.vue';
 import FcDialogConfirmMultiLocationLeave
   from '@/web/components/dialogs/FcDialogConfirmMultiLocationLeave.vue';
+import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcButtonAria from '@/web/components/inputs/FcButtonAria.vue';
 import FcPaneMapLegend from '@/web/components/inputs/FcPaneMapLegend.vue';
@@ -195,6 +196,7 @@ export default {
     FcDialogConfirmMultiLocationLeave,
     FcPaneMapLegend,
     FcPaneMapPopup,
+    FcProgressLinear,
     FcSelectorCollapsedLocation,
     FcSelectorMultiLocation,
     FcSelectorSingleLocation,

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -9,6 +9,7 @@
       <div class="pane-map-progress">
         <v-progress-linear
           :active="loading"
+          aria-label="Loading map layers and data"
           indeterminate />
       </div>
       <div
@@ -490,8 +491,8 @@ export default {
       this.map.addControl(
         new mapboxgl.AttributionControl({
           customAttribution: [
-            '<a href="https://docs.mapbox.com/mapbox-gl-js/overview/">Mapbox GL</a>',
-            'Powered by <a href="https://www.esri.com/">Esri</a>',
+            '<span role="listitem"><a href="https://docs.mapbox.com/mapbox-gl-js/overview/">Mapbox GL</a></span>',
+            '<span role="listitem">Powered by <a href="https://www.esri.com/">Esri</a></span>',
           ],
         }),
         'bottom-left',

--- a/web/components/FcPaneMapPopup.vue
+++ b/web/components/FcPaneMapPopup.vue
@@ -12,6 +12,7 @@
       <v-card-text>
         <v-progress-linear
           v-if="loading"
+          aria-label="Loading feature details"
           indeterminate />
         <template v-else>
           <p

--- a/web/components/FcPaneMapPopup.vue
+++ b/web/components/FcPaneMapPopup.vue
@@ -10,10 +10,9 @@
       <v-divider></v-divider>
 
       <v-card-text>
-        <v-progress-linear
+        <FcProgressLinear
           v-if="loading"
-          aria-label="Loading feature details"
-          indeterminate />
+          aria-label="Loading feature details" />
         <template v-else>
           <p
             v-for="(line, i) in description"
@@ -59,6 +58,7 @@ import { getLocationFeatureType } from '@/lib/geo/CentrelineUtils';
 import { getGeometryMidpoint } from '@/lib/geo/GeometryUtils';
 import CompositeId from '@/lib/io/CompositeId';
 import TimeFormatters from '@/lib/time/TimeFormatters';
+import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 
 const MSG_LOCATION_REMOVED = 'Location removed from centreline';
@@ -271,6 +271,7 @@ export default {
   name: 'PaneMapPopup',
   components: {
     FcButton,
+    FcProgressLinear,
   },
   props: {
     feature: Object,

--- a/web/components/admin/FcAdminPermissions.vue
+++ b/web/components/admin/FcAdminPermissions.vue
@@ -18,7 +18,7 @@
         <div
           :key="'u:' + item.id + ':' + authScope.name"
           class="d-flex">
-          <v-tooltip right>
+          <FcTooltip right>
             <template v-slot:activator="{ on }">
               <v-checkbox
                 v-model="item.scope"
@@ -37,7 +37,7 @@
                 Grant {{authScope.name}}
               </span>
             </span>
-          </v-tooltip>
+          </FcTooltip>
         </div>
       </template>
     </FcDataTable>
@@ -51,6 +51,7 @@ import { AuthScope } from '@/lib/Constants';
 import { formatUsername } from '@/lib/StringFormatters';
 import { getUsers, putUser } from '@/lib/api/WebApi';
 import FcDataTable from '@/web/components/FcDataTable.vue';
+import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
 import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
 
 export default {
@@ -60,6 +61,7 @@ export default {
   ],
   components: {
     FcDataTable,
+    FcTooltip,
   },
   data() {
     const authScopeSlots = AuthScope.enumValues.map((authScope) => {

--- a/web/components/data/FcAggregateCollisions.vue
+++ b/web/components/data/FcAggregateCollisions.vue
@@ -12,6 +12,7 @@
         <v-expansion-panel
           v-for="field in fields"
           :key="field.name"
+          :aria-disabled="collisionSummary[field.name] === 0"
           class="fc-collisions-summary-per-location"
           :disabled="collisionSummary[field.name] === 0">
           <v-expansion-panel-header class="pr-8">

--- a/web/components/data/FcAggregateCollisions.vue
+++ b/web/components/data/FcAggregateCollisions.vue
@@ -2,6 +2,7 @@
   <div class="fc-aggregate-collisions mb-5 ml-5">
     <v-progress-linear
       v-if="loading"
+      aria-label="Loading Aggregate View collisions data"
       indeterminate />
     <template v-else>
       <v-expansion-panels

--- a/web/components/data/FcAggregateCollisions.vue
+++ b/web/components/data/FcAggregateCollisions.vue
@@ -1,9 +1,8 @@
 <template>
   <div class="fc-aggregate-collisions mb-5 ml-5">
-    <v-progress-linear
+    <FcProgressLinear
       v-if="loading"
-      aria-label="Loading Aggregate View collisions data"
-      indeterminate />
+      aria-label="Loading Aggregate View collisions data" />
     <template v-else>
       <v-expansion-panels
         v-model="indexOpen"
@@ -53,12 +52,14 @@ import { mapGetters } from 'vuex';
 
 import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
 import FcTextSummaryFraction from '@/web/components/data/FcTextSummaryFraction.vue';
+import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcListLocationMulti from '@/web/components/location/FcListLocationMulti.vue';
 
 export default {
   name: 'FcAggregateCollisions',
   components: {
     FcListLocationMulti,
+    FcProgressLinear,
     FcTextSummaryFraction,
   },
   props: {

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -2,6 +2,7 @@
   <div class="fc-aggregate-studies mb-5 ml-5">
     <v-progress-linear
       v-if="loading"
+      aria-label="Loading Aggregate View studies data"
       indeterminate />
     <p
       v-else-if="studySummaryUnfiltered.length === 0"

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -18,6 +18,7 @@
         <v-expansion-panel
           v-for="(item, i) in items"
           :key="i"
+          :aria-disabled="item.n === 0"
           class="fc-studies-summary-per-location"
           :disabled="item.n === 0">
           <v-expansion-panel-header class="pr-8">

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -1,9 +1,8 @@
 <template>
   <div class="fc-aggregate-studies mb-5 ml-5">
-    <v-progress-linear
+    <FcProgressLinear
       v-if="loading"
-      aria-label="Loading Aggregate View studies data"
-      indeterminate />
+      aria-label="Loading Aggregate View studies data" />
     <p
       v-else-if="studySummaryUnfiltered.length === 0"
       class="my-8 py-12 secondary--text text-center">
@@ -84,6 +83,7 @@ import { mapGetters } from 'vuex';
 import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
 import FcTextMostRecent from '@/web/components/data/FcTextMostRecent.vue';
 import FcTextSummaryFraction from '@/web/components/data/FcTextSummaryFraction.vue';
+import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcListLocationMulti from '@/web/components/location/FcListLocationMulti.vue';
 
@@ -92,6 +92,7 @@ export default {
   components: {
     FcButton,
     FcListLocationMulti,
+    FcProgressLinear,
     FcTextMostRecent,
     FcTextSummaryFraction,
   },

--- a/web/components/data/FcDetailCollisions.vue
+++ b/web/components/data/FcDetailCollisions.vue
@@ -2,6 +2,7 @@
   <div class="fc-detail-collisions align-end d-flex mb-5 mx-5">
     <v-progress-linear
       v-if="loading"
+      aria-label="Loading Detail View collisions data"
       indeterminate />
     <template v-else>
       <dl class="d-flex flex-grow-1 flex-shrink-1">

--- a/web/components/data/FcDetailCollisions.vue
+++ b/web/components/data/FcDetailCollisions.vue
@@ -1,9 +1,8 @@
 <template>
   <div class="fc-detail-collisions align-end d-flex mb-5 mx-5">
-    <v-progress-linear
+    <FcProgressLinear
       v-if="loading"
-      aria-label="Loading Detail View collisions data"
-      indeterminate />
+      aria-label="Loading Detail View collisions data" />
     <template v-else>
       <dl class="d-flex flex-grow-1 flex-shrink-1">
         <div class="flex-grow-1 flex-shrink-1">
@@ -58,12 +57,14 @@
 import { mapGetters } from 'vuex';
 
 import FcTextSummaryFraction from '@/web/components/data/FcTextSummaryFraction.vue';
+import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 
 export default {
   name: 'FcDetailCollisions',
   components: {
     FcButton,
+    FcProgressLinear,
     FcTextSummaryFraction,
   },
   props: {

--- a/web/components/data/FcDetailStudies.vue
+++ b/web/components/data/FcDetailStudies.vue
@@ -1,9 +1,8 @@
 <template>
   <div class="fc-detail-studies">
-    <v-progress-linear
+    <FcProgressLinear
       v-if="loading"
-      aria-label="Loading Detail View studies data"
-      indeterminate />
+      aria-label="Loading Detail View studies data" />
     <p
       v-else-if="studySummaryUnfiltered.length === 0"
       class="my-8 py-12 secondary--text text-center">
@@ -56,12 +55,14 @@ import { mapGetters } from 'vuex';
 
 import FcTextMostRecent from '@/web/components/data/FcTextMostRecent.vue';
 import FcTextSummaryFraction from '@/web/components/data/FcTextSummaryFraction.vue';
+import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 
 export default {
   name: 'FcDetailStudies',
   components: {
     FcButton,
+    FcProgressLinear,
     FcTextMostRecent,
     FcTextSummaryFraction,
   },

--- a/web/components/data/FcDetailStudies.vue
+++ b/web/components/data/FcDetailStudies.vue
@@ -2,6 +2,7 @@
   <div class="fc-detail-studies">
     <v-progress-linear
       v-if="loading"
+      aria-label="Loading Detail View studies data"
       indeterminate />
     <p
       v-else-if="studySummaryUnfiltered.length === 0"

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -1,9 +1,8 @@
 <template>
   <div class="fc-view-data-aggregate">
-    <v-progress-linear
+    <FcProgressLinear
       v-if="loading || locations.length === 0"
-      aria-label="Loading Aggregate View for View Data"
-      indeterminate />
+      aria-label="Loading Aggregate View for View Data" />
     <template v-else>
       <section>
         <FcHeaderCollisions
@@ -137,6 +136,7 @@ import FcHeaderCollisions from '@/web/components/data/FcHeaderCollisions.vue';
 import FcHeaderStudies from '@/web/components/data/FcHeaderStudies.vue';
 import FcSectionStudyRequestsBulkPending
   from '@/web/components/data/FcSectionStudyRequestsBulkPending.vue';
+import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcMenuDownloadReportFormat from '@/web/components/inputs/FcMenuDownloadReportFormat.vue';
 import FcMixinAuthScope from '@/web/mixins/FcMixinAuthScope';
@@ -153,6 +153,7 @@ export default {
     FcHeaderCollisions,
     FcHeaderStudies,
     FcMenuDownloadReportFormat,
+    FcProgressLinear,
     FcSectionStudyRequestsBulkPending,
   },
   props: {

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -2,6 +2,7 @@
   <div class="fc-view-data-aggregate">
     <v-progress-linear
       v-if="loading || locations.length === 0"
+      aria-label="Loading Aggregate View for View Data"
       indeterminate />
     <template v-else>
       <section>

--- a/web/components/data/FcViewDataDetail.vue
+++ b/web/components/data/FcViewDataDetail.vue
@@ -1,9 +1,8 @@
 <template>
   <div class="fc-view-data-detail">
-    <v-progress-linear
+    <FcProgressLinear
       v-if="loading || location === null"
-      aria-label="Loading Detail View for View Data"
-      indeterminate />
+      aria-label="Loading Detail View for View Data" />
     <template v-else>
       <section>
         <FcHeaderCollisions :collision-total="collisionTotal" />
@@ -63,6 +62,7 @@ import FcHeaderCollisions from '@/web/components/data/FcHeaderCollisions.vue';
 import FcHeaderStudies from '@/web/components/data/FcHeaderStudies.vue';
 import FcSectionStudyRequestsPending
   from '@/web/components/data/FcSectionStudyRequestsPending.vue';
+import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcMixinAuthScope from '@/web/mixins/FcMixinAuthScope';
 
@@ -77,6 +77,7 @@ export default {
     FcDetailStudies,
     FcHeaderCollisions,
     FcHeaderStudies,
+    FcProgressLinear,
     FcSectionStudyRequestsPending,
   },
   props: {

--- a/web/components/data/FcViewDataDetail.vue
+++ b/web/components/data/FcViewDataDetail.vue
@@ -2,6 +2,7 @@
   <div class="fc-view-data-detail">
     <v-progress-linear
       v-if="loading || location === null"
+      aria-label="Loading Detail View for View Data"
       indeterminate />
     <template v-else>
       <section>

--- a/web/components/data/FcViewDataMultiEdit.vue
+++ b/web/components/data/FcViewDataMultiEdit.vue
@@ -1,9 +1,8 @@
 <template>
   <div class="fc-view-data-multi-edit">
-    <v-progress-linear
+    <FcProgressLinear
       v-if="loading || locations.length === 0"
-      aria-label="Loading multi-location edit mode for View Data"
-      indeterminate />
+      aria-label="Loading multi-location edit mode for View Data" />
     <template v-else>
       <section
         aria-labelledby="heading_multi_edit_totals"
@@ -67,12 +66,14 @@ import {
 import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
 import FcTextMostRecent from '@/web/components/data/FcTextMostRecent.vue';
 import FcTextNumberTotal from '@/web/components/data/FcTextNumberTotal.vue';
+import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcListLocationMulti from '@/web/components/location/FcListLocationMulti.vue';
 
 export default {
   name: 'FcViewDataMultiEdit',
   components: {
     FcListLocationMulti,
+    FcProgressLinear,
     FcTextMostRecent,
     FcTextNumberTotal,
   },

--- a/web/components/data/FcViewDataMultiEdit.vue
+++ b/web/components/data/FcViewDataMultiEdit.vue
@@ -2,6 +2,7 @@
   <div class="fc-view-data-multi-edit">
     <v-progress-linear
       v-if="loading || locations.length === 0"
+      aria-label="Loading multi-location edit mode for View Data"
       indeterminate />
     <template v-else>
       <section

--- a/web/components/dialogs/FcProgressCircular.vue
+++ b/web/components/dialogs/FcProgressCircular.vue
@@ -1,0 +1,43 @@
+<template>
+  <v-progress-circular
+    :aria-label="ariaLabel"
+    color="primary"
+    indeterminate
+    :size="size"
+    :width="width" />
+</template>
+
+<script>
+import { mapMutations } from 'vuex';
+
+export default {
+  name: 'FcProgressCircular',
+  props: {
+    ariaLabel: String,
+    silent: {
+      type: Boolean,
+      default: false,
+    },
+    small: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  computed: {
+    size() {
+      return this.small ? 20 : 80;
+    },
+    width() {
+      return this.small ? 2 : 4;
+    },
+  },
+  mounted() {
+    if (!this.silent) {
+      this.setAriaNotification(this.ariaLabel);
+    }
+  },
+  methods: {
+    ...mapMutations(['setAriaNotification']),
+  },
+};
+</script>

--- a/web/components/dialogs/FcProgressLinear.vue
+++ b/web/components/dialogs/FcProgressLinear.vue
@@ -1,0 +1,29 @@
+<template>
+  <v-progress-linear
+    :aria-label="ariaLabel"
+    color="primary"
+    indeterminate />
+</template>
+
+<script>
+import { mapMutations } from 'vuex';
+
+export default {
+  name: 'FcProgressLinear',
+  props: {
+    ariaLabel: String,
+    silent: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  mounted() {
+    if (!this.silent) {
+      this.setAriaNotification(this.ariaLabel);
+    }
+  },
+  methods: {
+    ...mapMutations(['setAriaNotification']),
+  },
+};
+</script>

--- a/web/components/dialogs/FcTooltip.vue
+++ b/web/components/dialogs/FcTooltip.vue
@@ -1,0 +1,41 @@
+<template>
+  <v-tooltip
+    :bottom="bottom"
+    :left="left"
+    :right="right"
+    :top="top"
+    :z-index="zIndex">
+    <template v-slot:activator="scope">
+      <slot name="activator" v-bind="scope" />
+    </template>
+    <slot />
+  </v-tooltip>
+</template>
+
+<script>
+export default {
+  name: 'FcTooltip',
+  props: {
+    bottom: {
+      type: Boolean,
+      default: false,
+    },
+    left: {
+      type: Boolean,
+      default: false,
+    },
+    right: {
+      type: Boolean,
+      default: false,
+    },
+    top: {
+      type: Boolean,
+      default: false,
+    },
+    zIndex: {
+      type: Number,
+      default: 100,
+    },
+  },
+};
+</script>

--- a/web/components/dialogs/FcTooltip.vue
+++ b/web/components/dialogs/FcTooltip.vue
@@ -32,10 +32,25 @@ export default {
       type: Boolean,
       default: false,
     },
-    zIndex: {
-      type: Number,
-      default: 100,
-    },
+  },
+  data() {
+    return {
+      /*
+       * This is carefully chosen to be higher than `var(--z-index-controls)`, so that tooltips
+       * will display on top of map controls.
+       */
+      zIndex: 100,
+    };
+  },
+  mounted() {
+    const inDialog = this.$el.closest('.v-dialog') !== null;
+    if (inDialog) {
+      /*
+       * Bring this above the z-plane of the dialog, so that it displays properly.  (When we last
+       * checked, `.v-dialog` had `z-index: 202`.)
+       */
+      this.zIndex = 300;
+    }
   },
 };
 </script>

--- a/web/components/inputs/FcButtonAria.vue
+++ b/web/components/inputs/FcButtonAria.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-tooltip
+  <FcTooltip
     :bottom="bottom"
     :left="left"
     :right="right"
@@ -18,16 +18,18 @@
       </FcButton>
     </template>
     <span>{{ariaLabel}}</span>
-  </v-tooltip>
+  </FcTooltip>
 </template>
 
 <script>
+import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 
 export default {
   name: 'FcButtonAria',
   components: {
     FcButton,
+    FcTooltip,
   },
   props: {
     ariaLabel: String,

--- a/web/components/inputs/FcDatePicker.vue
+++ b/web/components/inputs/FcDatePicker.vue
@@ -8,8 +8,8 @@
       min-width="290px"
       offset-y
       transition="scale-transition">
-      <template v-slot:activator="{ attrs, on: onMenu }">
-        <div v-bind="attrs">
+      <template v-slot:activator="{ attrs: attrsMenu, on: onMenu }">
+        <div v-bind="attrsMenu">
           <v-text-field
             v-model="valueFormatted"
             append-icon="mdi-calendar"

--- a/web/components/inputs/FcDatePicker.vue
+++ b/web/components/inputs/FcDatePicker.vue
@@ -9,33 +9,35 @@
       offset-y
       transition="scale-transition">
       <template v-slot:activator="{ attrs, on: onMenu }">
-        <v-text-field
-          v-model="valueFormatted"
-          append-icon="mdi-calendar"
-          offset-y
-          v-bind="{ ...attrs, ...$attrs }"
-          @blur="resetValueFormatted"
-          @input="updateValueFormatted"
-          @click:append="showMenu = !showMenu"
-          v-on="onMenu">
-          <template v-slot:append>
-            <v-tooltip right>
-              <template v-slot:activator="{ on: onTooltip }">
-                <v-icon
-                  aria-label="Select date using calendar"
-                  :color="color"
-                  right
-                  v-on="{
-                    ...onMenu,
-                    ...onTooltip,
-                  }">
-                  mdi-calendar
-                </v-icon>
-              </template>
-              <span>Select date using calendar</span>
-            </v-tooltip>
-          </template>
-        </v-text-field>
+        <div v-bind="attrs">
+          <v-text-field
+            v-model="valueFormatted"
+            append-icon="mdi-calendar"
+            offset-y
+            v-bind="$attrs"
+            @blur="resetValueFormatted"
+            @input="updateValueFormatted"
+            @click:append="showMenu = !showMenu"
+            v-on="onMenu">
+            <template v-slot:append>
+              <FcTooltip right>
+                <template v-slot:activator="{ on: onTooltip }">
+                  <v-icon
+                    aria-label="Select date using calendar"
+                    :color="color"
+                    right
+                    v-on="{
+                      ...onMenu,
+                      ...onTooltip,
+                    }">
+                    mdi-calendar
+                  </v-icon>
+                </template>
+                <span>Select date using calendar</span>
+              </FcTooltip>
+            </template>
+          </v-text-field>
+        </div>
       </template>
       <v-date-picker
         v-model="internalValue"
@@ -51,6 +53,7 @@
 <script>
 import DateTime from '@/lib/time/DateTime';
 import TimeFormatters from '@/lib/time/TimeFormatters';
+import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
 
 const REGEX_VALUE_FORMATTED = /[0-9]{4}-[0-9]{2}-[0-9]{2}/;
 
@@ -85,6 +88,9 @@ function toInternalValue(value) {
 
 export default {
   name: 'FcDatePicker',
+  components: {
+    FcTooltip,
+  },
   props: {
     max: {
       type: DateTime,

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -8,8 +8,8 @@
       :close-on-content-click="false"
       :offset-y="true"
       :open-on-click="false">
-      <template v-slot:activator="{ attrs, on: onMenu }">
-        <div v-bind="attrs">
+      <template v-slot:activator="{ attrs: attrsMenu, on: onMenu }">
+        <div v-bind="attrsMenu">
           <v-text-field
             v-model="query"
             :aria-label="query"

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -9,57 +9,56 @@
       :offset-y="true"
       :open-on-click="false">
       <template v-slot:activator="{ attrs, on: onMenu }">
-        <v-text-field
-          v-model="query"
-          :aria-label="query"
-          autocomplete="off"
-          dense
-          :flat="hasLocationIndex"
-          hide-details
-          label="Choose location or click on the map"
-          :loading="loading"
-          solo
-          v-bind="{
-            ...attrs,
-            ...$attrs,
-          }"
-          @blur="actionBlur"
-          @focus="actionFocus"
-          @input="actionInput"
-          v-on="onMenu">
-          <template v-slot:append>
-            <template v-if="hasLocationIndex">
-              <FcIconLocationMulti
-                v-if="!hasLocationToAddIndex"
-                :location-index="locationIndex"
-                :selected="selected" />
-              <span v-else>&nbsp;</span>
+        <div v-bind="attrs">
+          <v-text-field
+            v-model="query"
+            :aria-label="query"
+            autocomplete="off"
+            dense
+            :flat="hasLocationIndex"
+            hide-details
+            label="Choose location or click on the map"
+            :loading="loading"
+            solo
+            v-bind="$attrs"
+            @blur="actionBlur"
+            @focus="actionFocus"
+            @input="actionInput"
+            v-on="onMenu">
+            <template v-slot:append>
+              <template v-if="hasLocationIndex">
+                <FcIconLocationMulti
+                  v-if="!hasLocationToAddIndex"
+                  :location-index="locationIndex"
+                  :selected="selected" />
+                <span v-else>&nbsp;</span>
+              </template>
+              <template v-else>
+                <FcTooltip
+                  v-if="internalValue !== null || query !== null"
+                  right>
+                  <template v-slot:activator="{ on: onTooltip }">
+                    <FcButton
+                      aria-label="Clear Location"
+                      class="mr-1"
+                      type="icon"
+                      @click="actionClear"
+                      v-on="onTooltip">
+                      <v-icon>mdi-close-circle</v-icon>
+                    </FcButton>
+                  </template>
+                  <span>Clear Location</span>
+                </FcTooltip>
+                <v-divider vertical />
+                <v-icon
+                  :color="hasFocus ? 'primary' : null"
+                  right>
+                  mdi-magnify
+                </v-icon>
+              </template>
             </template>
-            <template v-else>
-              <v-tooltip
-                v-if="internalValue !== null || query !== null"
-                right>
-                <template v-slot:activator="{ on: onTooltip }">
-                  <FcButton
-                    aria-label="Clear Location"
-                    class="mr-1"
-                    type="icon"
-                    @click="actionClear"
-                    v-on="onTooltip">
-                    <v-icon>mdi-close-circle</v-icon>
-                  </FcButton>
-                </template>
-                <span>Clear Location</span>
-              </v-tooltip>
-              <v-divider vertical />
-              <v-icon
-                :color="hasFocus ? 'primary' : null"
-                right>
-                mdi-magnify
-              </v-icon>
-            </template>
-          </template>
-        </v-text-field>
+          </v-text-field>
+        </div>
       </template>
       <v-list
         ref="listLocationSuggestions"
@@ -83,6 +82,7 @@
 import { Enum } from '@/lib/ClassUtils';
 import { debounce } from '@/lib/FunctionUtils';
 import { getLocationSuggestions } from '@/lib/api/WebApi';
+import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcIconLocationMulti from '@/web/components/location/FcIconLocationMulti.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
@@ -102,6 +102,7 @@ export default {
   components: {
     FcButton,
     FcIconLocationMulti,
+    FcTooltip,
   },
   props: {
     locationIndex: {

--- a/web/components/inputs/FcMenu.vue
+++ b/web/components/inputs/FcMenu.vue
@@ -1,15 +1,15 @@
 <template>
   <v-menu :min-width="minWidth">
-    <template v-slot:activator="{ on, attrs }">
+    <template v-slot:activator="{ attrs: attrsMenu, on: onMenu }">
       <FcButton
         :class="buttonClass"
         :disabled="disabled"
         type="secondary"
         v-bind="{
-          ...attrs,
+          ...attrsMenu,
           ...$attrs,
         }"
-        v-on="on">
+        v-on="onMenu">
         <slot></slot>
         <v-icon right>mdi-menu-down</v-icon>
       </FcButton>

--- a/web/components/inputs/FcPaneMapLegend.vue
+++ b/web/components/inputs/FcPaneMapLegend.vue
@@ -22,7 +22,7 @@
               :class="'icon-layer-' + layer.value"
               class="mr-5"></div>
             <div class="body-1 flex-grow-1 mt-1">{{layer.text}}</div>
-            <v-tooltip left>
+            <FcTooltip left>
               <template v-slot:activator="{ on }">
                 <div v-on="on">
                   <v-checkbox
@@ -37,7 +37,7 @@
                 </div>
               </template>
               <span>{{layerLabels[layer.value]}}</span>
-            </v-tooltip>
+            </FcTooltip>
           </div>
         </fieldset>
       </section>
@@ -49,11 +49,15 @@
 import { mapState } from 'vuex';
 
 import TimeFormatters from '@/lib/time/TimeFormatters';
+import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
 export default {
   name: 'FcPaneMapLegend',
   mixins: [FcMixinVModelProxy(Object)],
+  components: {
+    FcTooltip,
+  },
   data() {
     const itemsDatesFrom = [
       { text: 'Last year', value: 1 },

--- a/web/components/inputs/FcSelectorCollapsedLocation.vue
+++ b/web/components/inputs/FcSelectorCollapsedLocation.vue
@@ -1,8 +1,6 @@
 <template>
   <div class="fc-selector-collapsed-location">
-    <v-tooltip
-      right
-      :z-index="100">
+    <FcTooltip right>
       <template v-slot:activator="{ on }">
         <FcButton
           aria-label="Search for new location"
@@ -14,17 +12,19 @@
         </FcButton>
       </template>
       <span>Search for new location</span>
-    </v-tooltip>
+    </FcTooltip>
   </div>
 </template>
 
 <script>
+import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 
 export default {
   name: 'FcSelectorCollapsedLocation',
   components: {
     FcButton,
+    FcTooltip,
   },
 };
 </script>

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -67,9 +67,7 @@
             class="mt-4"
             :location="locationActive" />
           <v-spacer></v-spacer>
-          <v-tooltip
-            left
-            :z-index="100">
+          <FcTooltip left>
             <template v-slot:activator="{ on }">
               <FcButton
                 aria-label="Previous location"
@@ -81,10 +79,8 @@
               </FcButton>
             </template>
             <span>Previous location</span>
-          </v-tooltip>
-          <v-tooltip
-            right
-            :z-index="100">
+          </FcTooltip>
+          <FcTooltip right>
             <template v-slot:activator="{ on }">
               <FcButton
                 aria-label="Next location"
@@ -97,7 +93,7 @@
               </FcButton>
             </template>
             <span>Next location</span>
-          </v-tooltip>
+          </FcTooltip>
         </template>
         <template v-else>
           <h2 class="display-3 mb-4">{{locationsDescription}}</h2>
@@ -184,6 +180,7 @@ import DateTime from '@/lib/time/DateTime';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 import FcDialogConfirmMultiLocationLeave
   from '@/web/components/dialogs/FcDialogConfirmMultiLocationLeave.vue';
+import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcButtonAria from '@/web/components/inputs/FcButtonAria.vue';
 import FcInputLocationSearch from '@/web/components/inputs/FcInputLocationSearch.vue';
@@ -203,6 +200,7 @@ export default {
     FcHeaderSingleLocation,
     FcInputLocationSearch,
     FcSummaryPoi,
+    FcTooltip,
   },
   props: {
     detailView: {

--- a/web/components/location/FcHeaderSingleLocation.vue
+++ b/web/components/location/FcHeaderSingleLocation.vue
@@ -2,6 +2,7 @@
   <div class="fc-header-single-location">
     <v-progress-circular
       v-if="loading || location === null"
+      aria-label="Loading location details"
       color="primary"
       indeterminate
       :size="20"

--- a/web/components/location/FcHeaderSingleLocation.vue
+++ b/web/components/location/FcHeaderSingleLocation.vue
@@ -1,12 +1,9 @@
 <template>
   <div class="fc-header-single-location">
-    <v-progress-circular
+    <FcProgressCircular
       v-if="loading || location === null"
       aria-label="Loading location details"
-      color="primary"
-      indeterminate
-      :size="20"
-      :width="2" />
+      small />
     <template v-else>
       <h2 class="display-3">{{location.description}}</h2>
       <div class="label mt-2">
@@ -21,9 +18,13 @@ import { getStudiesByCentrelineSummary } from '@/lib/api/WebApi';
 import { getLocationFeatureType } from '@/lib/geo/CentrelineUtils';
 import DateTime from '@/lib/time/DateTime';
 import TimeFormatters from '@/lib/time/TimeFormatters';
+import FcProgressCircular from '@/web/components/dialogs/FcProgressCircular.vue';
 
 export default {
   name: 'FcHeaderSingleLocation',
+  components: {
+    FcProgressCircular,
+  },
   props: {
     location: Object,
   },

--- a/web/components/location/FcSummaryPoi.vue
+++ b/web/components/location/FcSummaryPoi.vue
@@ -1,12 +1,10 @@
 <template>
   <div class="fc-summary-poi">
-    <v-progress-circular
+    <FcProgressCircular
       v-if="loading || location === null"
       aria-label="Loading points of interest near this location"
-      color="primary"
-      indeterminate
-      :size="20"
-      :width="2" />
+      silent
+      small />
     <dl v-else-if="poiSummary.hospital !== null || poiSummary.school !== null">
       <FcSummaryPoiChip
         v-if="poiSummary.hospital !== null"
@@ -28,11 +26,13 @@
 
 <script>
 import { getPoiByCentrelineSummary } from '@/lib/api/WebApi';
+import FcProgressCircular from '@/web/components/dialogs/FcProgressCircular.vue';
 import FcSummaryPoiChip from '@/web/components/location/FcSummaryPoiChip.vue';
 
 export default {
   name: 'FcSummaryPoi',
   components: {
+    FcProgressCircular,
     FcSummaryPoiChip,
   },
   props: {

--- a/web/components/location/FcSummaryPoi.vue
+++ b/web/components/location/FcSummaryPoi.vue
@@ -2,6 +2,7 @@
   <div class="fc-summary-poi">
     <v-progress-circular
       v-if="loading || location === null"
+      aria-label="Loading points of interest near this location"
       color="primary"
       indeterminate
       :size="20"

--- a/web/components/location/FcSummaryPoiChip.vue
+++ b/web/components/location/FcSummaryPoiChip.vue
@@ -1,6 +1,6 @@
 <template>
-  <span>
-    <v-tooltip bottom>
+  <div class="fc-summary-poi-chip">
+    <FcTooltip bottom>
       <template v-slot:activator="{ on }">
         <v-chip
           v-on="on"
@@ -14,14 +14,19 @@
         </v-chip>
       </template>
       <span>{{poiDistance}} m</span>
-    </v-tooltip>
+    </FcTooltip>
     <dd class="sr-only">{{poiDistance}} m</dd>
-  </span>
+  </div>
 </template>
 
 <script>
+import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
+
 export default {
   name: 'FcSummaryPoiChip',
+  components: {
+    FcTooltip,
+  },
   props: {
     color: String,
     icon: String,
@@ -35,3 +40,9 @@ export default {
   },
 };
 </script>
+
+<style lang="scss">
+.fc-summary-poi-chip {
+  display: inline-block;
+}
+</style>

--- a/web/components/nav/FcAppbar.vue
+++ b/web/components/nav/FcAppbar.vue
@@ -10,7 +10,7 @@
     <v-chip
       v-if="frontendEnv !== FrontendEnv.PROD"
       class="ml-2"
-      :color="frontendEnv.colorClass + ' darken-3'"
+      :color="frontendEnv.colorClass + ' darken-4'"
       dark
       small>
       {{frontendEnv.name.toLowerCase()}}

--- a/web/components/nav/FcDashboardNavBrand.vue
+++ b/web/components/nav/FcDashboardNavBrand.vue
@@ -1,7 +1,5 @@
 <template>
-  <v-tooltip
-    bottom
-    :z-index="100">
+  <FcTooltip bottom>
     <template v-slot:activator="{ on }">
       <v-app-bar-nav-icon
         @click="actionClick"
@@ -15,14 +13,18 @@
       </v-app-bar-nav-icon>
     </template>
     <span>{{textIcon}}</span>
-  </v-tooltip>
+  </FcTooltip>
 </template>
 
 <script>
 import FrontendEnv from '@/web/config/FrontendEnv';
+import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
 
 export default {
   name: 'FcDashboardNavBrand',
+  components: {
+    FcTooltip,
+  },
   data() {
     const textIcon = `${FrontendEnv.PROD.appTitle}: Home`;
     return { textIcon };

--- a/web/components/nav/FcDashboardNavItem.vue
+++ b/web/components/nav/FcDashboardNavItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-tooltip right>
+  <FcTooltip right>
     <template v-slot:activator="{ on }">
       <v-list-item
         v-on="on"
@@ -31,11 +31,13 @@
       </v-list-item>
     </template>
     <span>{{label}}</span>
-  </v-tooltip>
+  </FcTooltip>
 </template>
 
 <script>
 import { mapState } from 'vuex';
+
+import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
 
 const ROUTES_BACK_REQUEST_VIEW = [
   'requestStudyBulkView',
@@ -44,6 +46,9 @@ const ROUTES_BACK_REQUEST_VIEW = [
 
 export default {
   name: 'FcDashboardNavItem',
+  components: {
+    FcTooltip,
+  },
   props: {
     activeRouteNames: {
       type: Array,

--- a/web/components/nav/FcDashboardNavUser.vue
+++ b/web/components/nav/FcDashboardNavUser.vue
@@ -23,7 +23,7 @@
       top
       :z-index="100">
       <template v-slot:activator="{ attrs, on: onMenu }">
-        <v-tooltip right>
+        <FcTooltip right>
           <template v-slot:activator="{ on: onTooltip }">
             <FcButton
               ref="btn"
@@ -35,7 +35,7 @@
             </FcButton>
           </template>
           <span>{{username}}</span>
-        </v-tooltip>
+        </FcTooltip>
       </template>
       <v-list class="text-left" id="fc_menu_user">
         <v-list-item
@@ -49,7 +49,7 @@
         </v-list-item>
       </v-list>
     </v-menu>
-    <v-tooltip
+    <FcTooltip
       v-else
       right>
       <template v-slot:activator="{ on }">
@@ -62,7 +62,7 @@
         </FcButton>
       </template>
       <span>Sign In</span>
-    </v-tooltip>
+    </FcTooltip>
   </div>
 </template>
 
@@ -70,6 +70,7 @@
 import Vue from 'vue';
 import { mapGetters, mapState } from 'vuex';
 
+import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcMixinAuthScope from '@/web/mixins/FcMixinAuthScope';
 import { saveLoginState } from '@/web/store/LoginState';
@@ -81,6 +82,7 @@ export default {
   ],
   components: {
     FcButton,
+    FcTooltip,
   },
   computed: {
     ...mapState(['auth']),

--- a/web/components/nav/FcDashboardNavUser.vue
+++ b/web/components/nav/FcDashboardNavUser.vue
@@ -22,14 +22,14 @@
       :min-width="140"
       top
       :z-index="100">
-      <template v-slot:activator="{ attrs, on: onMenu }">
+      <template v-slot:activator="{ attrs: attrsMenu, on: onMenu }">
         <FcTooltip right>
           <template v-slot:activator="{ on: onTooltip }">
             <FcButton
               ref="btn"
               :aria-label="username"
               type="fab-icon"
-              v-bind="attrs"
+              v-bind="attrsMenu"
               v-on="{ ...onMenu, ...onTooltip }">
               <v-icon>mdi-account-circle</v-icon>
             </FcButton>
@@ -49,9 +49,7 @@
         </v-list-item>
       </v-list>
     </v-menu>
-    <FcTooltip
-      v-else
-      right>
+    <FcTooltip v-else right>
       <template v-slot:activator="{ on }">
         <FcButton
           aria-label="Sign In"

--- a/web/components/requests/FcCommentsStudyRequest.vue
+++ b/web/components/requests/FcCommentsStudyRequest.vue
@@ -1,39 +1,46 @@
 <template>
-  <aside class="fc-comments-study-request">
-    <section aria-labelledby="heading_request_comments">
-      <v-row no-gutters>
-        <v-col class="px-5" cols="6">
-          <h3 class="display-2" id="heading_request_comments">
-            <span>Comments</span>
-            <FcTextNumberTotal class="ml-2" :n="studyRequestComments.length" />
-          </h3>
-          <div class="fc-comment-new">
-            <FcTextarea
-              v-model="commentText"
-              class="mt-4"
-              label="Compose new comment"
-              :loading="loadingAddComment" />
-            <div class="text-right mb-4">
-              <FcButton
-                :disabled="commentText.length === 0"
-                :loading="loadingAddComment"
-                type="primary"
-                @click="actionAddComment">
-                Submit
-              </FcButton>
-            </div>
+  <section
+    aria-labelledby="heading_request_comments"
+    class="fc-comments-study-request">
+    <v-row no-gutters>
+      <v-col class="px-5" cols="6">
+        <h3 class="display-2" id="heading_request_comments">
+          <span>Comments</span>
+          <FcTextNumberTotal class="ml-2" :n="studyRequestComments.length" />
+        </h3>
+        <div class="fc-comment-new">
+          <FcTextarea
+            v-model="commentText"
+            class="mt-4"
+            label="Compose new comment"
+            :loading="loadingAddComment" />
+          <div class="text-right mb-4">
+            <FcButton
+              :disabled="commentText.length === 0"
+              :loading="loadingAddComment"
+              type="primary"
+              @click="actionAddComment">
+              Submit
+            </FcButton>
           </div>
-        </v-col>
-        <v-col class="px-5" cols="6">
-          <dl
+        </div>
+      </v-col>
+      <v-col class="px-5" cols="6">
+        <dl>
+          <div
             v-for="(comment, i) in studyRequestComments"
-            :key="comment.id">
+            :key="comment.id"
+            class="fc-comment">
             <dt class="align-center d-flex mt-2">
-              <span
-                v-if="studyRequestUsers.has(comment.userId)"
-                class="body-1 default--text font-weight-medium">
+              <span class="body-1 default--text font-weight-medium">
                 <span class="sr-only">Author: </span>
-                {{studyRequestUsers.get(comment.userId) | username}}
+                <span v-if="studyRequestUsers.has(comment.userId)">
+                  {{studyRequestUsers.get(comment.userId) | username}}
+                </span>
+                <span v-else-if="comment.userId === auth.user.id">
+                  {{auth.user | username}}
+                </span>
+                <span v-else class="sr-only">Unknown</span>
               </span>
 
               <v-spacer></v-spacer>
@@ -54,12 +61,11 @@
             <dd class="body-2 mt-3 mb-2">
               {{ comment.comment }}
             </dd>
-            <v-divider></v-divider>
-          </dl>
-        </v-col>
-      </v-row>
-    </section>
-  </aside>
+          </div>
+        </dl>
+      </v-col>
+    </v-row>
+  </section>
 </template>
 
 <script>
@@ -116,3 +122,11 @@ export default {
   },
 };
 </script>
+
+<style lang="scss">
+.fc-comments-study-request {
+  & dl > .fc-comment:not(:first-child) {
+    border-top: 1px solid var(--v-border-base);
+  }
+}
+</style>

--- a/web/components/requests/FcStudyRequestBulkLocations.vue
+++ b/web/components/requests/FcStudyRequestBulkLocations.vue
@@ -4,7 +4,7 @@
       v-for="i in indices"
       :key="i"
       class="align-center d-flex">
-      <v-tooltip right>
+      <FcTooltip right>
         <template v-slot:activator="{ on }">
           <div v-on="on">
             <v-checkbox
@@ -15,7 +15,7 @@
           </div>
         </template>
         <span>Include {{locations[i].description}} in request</span>
-      </v-tooltip>
+      </FcTooltip>
       <FcCardStudyRequest
         class="flex-grow-1 flex-shrink-1 mr-5 my-1"
         :icon-props="locationsIconProps[i]"
@@ -31,6 +31,7 @@
 <script>
 import { StudyType } from '@/lib/Constants';
 import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
+import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
 import FcCardStudyRequest from '@/web/components/requests/FcCardStudyRequest.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
@@ -39,6 +40,7 @@ export default {
   mixins: [FcMixinVModelProxy(Array)],
   components: {
     FcCardStudyRequest,
+    FcTooltip,
   },
   props: {
     indices: Array,

--- a/web/components/requests/nav/FcBreadcrumbsStudyRequest.vue
+++ b/web/components/requests/nav/FcBreadcrumbsStudyRequest.vue
@@ -2,13 +2,10 @@
   <nav
     aria-label="Breadcrumbs: Study Request"
     class="fc-breadcrumbs-study-request">
-    <v-progress-circular
+    <FcProgressCircular
       v-if="this.itemCurrent === null"
       aria-label="Loading breadcrumbs"
-      color="primary"
-      indeterminate
-      :size="20"
-      :width="2" />
+      small />
     <v-breadcrumbs
       v-else
       class="pa-0"
@@ -31,9 +28,13 @@
 import { mapGetters, mapState } from 'vuex';
 
 import { getLocationsSelectionDescription } from '@/lib/geo/CentrelineUtils';
+import FcProgressCircular from '@/web/components/dialogs/FcProgressCircular.vue';
 
 export default {
   name: 'FcBreadcrumbsStudyRequest',
+  components: {
+    FcProgressCircular,
+  },
   props: {
     studyRequest: Object,
     studyRequestBulkName: {

--- a/web/components/requests/nav/FcBreadcrumbsStudyRequest.vue
+++ b/web/components/requests/nav/FcBreadcrumbsStudyRequest.vue
@@ -4,6 +4,7 @@
     class="fc-breadcrumbs-study-request">
     <v-progress-circular
       v-if="this.itemCurrent === null"
+      aria-label="Loading breadcrumbs"
       color="primary"
       indeterminate
       :size="20"

--- a/web/components/requests/nav/FcHeadingStudyRequest.vue
+++ b/web/components/requests/nav/FcHeadingStudyRequest.vue
@@ -5,6 +5,7 @@
     </span>
     <v-progress-circular
       v-if="subtitle === null"
+      aria-label="Loading study request subtitle"
       color="primary"
       indeterminate
       :size="20"

--- a/web/components/requests/nav/FcHeadingStudyRequest.vue
+++ b/web/components/requests/nav/FcHeadingStudyRequest.vue
@@ -3,13 +3,10 @@
     <span>
       {{title}}:
     </span>
-    <v-progress-circular
+    <FcProgressCircular
       v-if="subtitle === null"
       aria-label="Loading study request subtitle"
-      color="primary"
-      indeterminate
-      :size="20"
-      :width="2" />
+      small />
     <span
       v-else
       class="font-weight-regular">
@@ -23,9 +20,13 @@ import { mapState } from 'vuex';
 
 import { LocationMode } from '@/lib/Constants';
 import { getLocationsSelectionDescription } from '@/lib/geo/CentrelineUtils';
+import FcProgressCircular from '@/web/components/dialogs/FcProgressCircular.vue';
 
 export default {
   name: 'FcHeadingStudyRequest',
+  components: {
+    FcProgressCircular,
+  },
   props: {
     studyRequest: Object,
   },

--- a/web/components/requests/status/FcMenuStudyRequestsAssignTo.vue
+++ b/web/components/requests/status/FcMenuStudyRequestsAssignTo.vue
@@ -1,6 +1,6 @@
 <template>
   <v-menu>
-    <template v-slot:activator="{ on, attrs }">
+    <template v-slot:activator="{ attrs: attrsMenu, on: onMenu }">
       <FcButton
         :class="buttonClass"
         :disabled="disabled || !canAssignTo"
@@ -8,10 +8,10 @@
         type="secondary"
         :width="width"
         v-bind="{
-          ...attrs,
+          ...attrsMenu,
           ...$attrs,
         }"
-        v-on="on">
+        v-on="onMenu">
         <span>{{text}}</span>
         <span
           v-if="textScreenReader !== null"

--- a/web/components/requests/status/FcStatusStudyRequests.vue
+++ b/web/components/requests/status/FcStatusStudyRequests.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="fc-status-study-requests">
     <v-progress-linear
+      aria-hidden="true"
       background-color="border"
       class="status-progress"
       color="primary"

--- a/web/views/FcDownloadsManage.vue
+++ b/web/views/FcDownloadsManage.vue
@@ -4,12 +4,9 @@
       <div
         v-if="loading"
         class="ma-3 mt-9 text-center">
-        <v-progress-circular
+        <FcProgressCircular
           aria-label="Loading your download history"
-          class="ma-3"
-          color="primary"
-          indeterminate
-          size="80" />
+          class="ma-3" />
         <div class="font-weight-regular headline secondary--text">
           This page is loading, please wait.
         </div>
@@ -60,6 +57,7 @@
 import { mapGetters } from 'vuex';
 
 import { getJobs } from '@/lib/api/WebApi';
+import FcProgressCircular from '@/web/components/dialogs/FcProgressCircular.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcSectionJobs from '@/web/components/jobs/FcSectionJobs.vue';
 import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
@@ -71,6 +69,7 @@ export default {
   ],
   components: {
     FcButton,
+    FcProgressCircular,
     FcSectionJobs,
   },
   data() {

--- a/web/views/FcDownloadsManage.vue
+++ b/web/views/FcDownloadsManage.vue
@@ -5,6 +5,7 @@
         v-if="loading"
         class="ma-3 mt-9 text-center">
         <v-progress-circular
+          aria-label="Loading your download history"
           class="ma-3"
           color="primary"
           indeterminate

--- a/web/views/FcLayoutDrawerMap.vue
+++ b/web/views/FcLayoutDrawerMap.vue
@@ -17,10 +17,9 @@
           left>{{iconDrawerToggle}}</v-icon>
         {{labelDrawerToggle}}
       </FcButton>
-      <v-tooltip
+      <FcTooltip
         v-else
-        right
-        :z-index="100">
+        right>
         <template v-slot:activator="{ on }">
           <FcButton
             :aria-label="labelDrawerToggle"
@@ -32,7 +31,7 @@
           </FcButton>
         </template>
         <span>{{labelDrawerToggle}}</span>
-      </v-tooltip>
+      </FcTooltip>
     </template>
     <div
       class="fc-pane-wrapper d-flex fill-height"
@@ -64,6 +63,7 @@
 <script>
 import { mapMutations, mapState } from 'vuex';
 
+import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcPaneMap from '@/web/components/FcPaneMap.vue';
 
@@ -77,6 +77,7 @@ export default {
   components: {
     FcButton,
     FcPaneMap,
+    FcTooltip,
   },
   computed: {
     hasDrawer() {

--- a/web/views/FcLayoutDrawerMap.vue
+++ b/web/views/FcLayoutDrawerMap.vue
@@ -17,9 +17,7 @@
           left>{{iconDrawerToggle}}</v-icon>
         {{labelDrawerToggle}}
       </FcButton>
-      <FcTooltip
-        v-else
-        right>
+      <FcTooltip v-else right>
         <template v-slot:activator="{ on }">
           <FcButton
             :aria-label="labelDrawerToggle"

--- a/web/views/FcRequestStudyBulkView.vue
+++ b/web/views/FcRequestStudyBulkView.vue
@@ -8,6 +8,7 @@
     <div class="flex-grow-1 flex-shrink-1 overflow-y-auto">
       <v-progress-linear
         v-if="loading"
+        aria-label="Loading bulk study request"
         indeterminate />
       <section
         v-else

--- a/web/views/FcRequestStudyBulkView.vue
+++ b/web/views/FcRequestStudyBulkView.vue
@@ -6,10 +6,9 @@
     <v-divider></v-divider>
 
     <div class="flex-grow-1 flex-shrink-1 overflow-y-auto">
-      <v-progress-linear
+      <FcProgressLinear
         v-if="loading"
-        aria-label="Loading bulk study request"
-        indeterminate />
+        aria-label="Loading bulk study request" />
       <section
         v-else
         aria-labelledby="heading_bulk_request_details">
@@ -110,6 +109,7 @@ import RequestDataTableColumns from '@/lib/requests/RequestDataTableColumns';
 import { bulkIndicesDeselected, bulkStatus } from '@/lib/requests/RequestStudyBulkUtils';
 import FcDataTableRequests from '@/web/components/FcDataTableRequests.vue';
 import FcTextNumberTotal from '@/web/components/data/FcTextNumberTotal.vue';
+import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcNavStudyRequest from '@/web/components/requests/nav/FcNavStudyRequest.vue';
 import FcMenuStudyRequestsAssignTo
   from '@/web/components/requests/status/FcMenuStudyRequestsAssignTo.vue';
@@ -136,6 +136,7 @@ export default {
     FcMenuStudyRequestsStatus,
     FcNavStudyRequest,
     FcPaneMap,
+    FcProgressLinear,
     FcStatusStudyRequests,
     FcSummaryStudyRequest,
     FcTextNumberTotal,

--- a/web/views/FcRequestStudyView.vue
+++ b/web/views/FcRequestStudyView.vue
@@ -16,6 +16,7 @@
     <div class="flex-grow-1 flex-shrink-1 overflow-y-auto">
       <v-progress-linear
         v-if="loading"
+        aria-label="Loading study request"
         indeterminate />
       <section
         v-else

--- a/web/views/FcRequestStudyView.vue
+++ b/web/views/FcRequestStudyView.vue
@@ -14,10 +14,9 @@
     <v-divider></v-divider>
 
     <div class="flex-grow-1 flex-shrink-1 overflow-y-auto">
-      <v-progress-linear
+      <FcProgressLinear
         v-if="loading"
-        aria-label="Loading study request"
-        indeterminate />
+        aria-label="Loading study request" />
       <section
         v-else
         aria-labelledby="heading_request_details">
@@ -75,6 +74,7 @@ import { mapActions, mapMutations, mapState } from 'vuex';
 import { LocationSelectionType } from '@/lib/Constants';
 import { getStudyRequest, getStudyRequestBulkName } from '@/lib/api/WebApi';
 import FcPaneMap from '@/web/components/FcPaneMap.vue';
+import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcCommentsStudyRequest from '@/web/components/requests/FcCommentsStudyRequest.vue';
 import FcNavStudyRequest from '@/web/components/requests/nav/FcNavStudyRequest.vue';
 import FcMenuStudyRequestsStatus
@@ -96,6 +96,7 @@ export default {
     FcMenuStudyRequestsStatus,
     FcNavStudyRequest,
     FcPaneMap,
+    FcProgressLinear,
     FcStatusStudyRequests,
     FcSummaryStudy,
     FcSummaryStudyRequest,


### PR DESCRIPTION
# Issue Addressed
This PR makes further progress on #798 .

# Description
We run another axe sweep over major parts of MOVE, fixing things along the way.  In the process, we define a few new wrapper components for accessible progress indicators and tooltips.

# Tests
Tested quickly in frontend, including a sweep with the axe Chrome extension.
