### PR TITLE
Address axe issues for dialogs

### DIFF
--- a/lib/validation/ValidationsCollisionFilters.js
+++ b/lib/validation/ValidationsCollisionFilters.js
@@ -1,12 +1,18 @@
 import { requiredIf } from 'vuelidate/lib/validators';
 
-const ValidationsFilters = {
+const ValidationsCollisionFilters = {
   dateRangeStart: {
     requiredIfApplyDateRange: requiredIf(({ applyDateRange }) => applyDateRange),
   },
   dateRangeEnd: {
     requiredIfApplyDateRange: requiredIf(({ applyDateRange }) => applyDateRange),
   },
+  hoursOfDay: {
+    fromBeforeTo(hoursOfDay) {
+      const [fromHour, toHour] = hoursOfDay;
+      return fromHour < toHour;
+    },
+  },
 };
 
-export default ValidationsFilters;
+export default ValidationsCollisionFilters;

--- a/lib/validation/ValidationsStudyFilters.js
+++ b/lib/validation/ValidationsStudyFilters.js
@@ -1,0 +1,12 @@
+import { requiredIf } from 'vuelidate/lib/validators';
+
+const ValidationsStudyFilters = {
+  dateRangeStart: {
+    requiredIfApplyDateRange: requiredIf(({ applyDateRange }) => applyDateRange),
+  },
+  dateRangeEnd: {
+    requiredIfApplyDateRange: requiredIf(({ applyDateRange }) => applyDateRange),
+  },
+};
+
+export default ValidationsStudyFilters;

--- a/web/components/dialogs/FcDialogAlert.vue
+++ b/web/components/dialogs/FcDialogAlert.vue
@@ -2,9 +2,11 @@
   <v-dialog
     v-model="internalValue"
     max-width="560">
-    <v-card role="dialog">
+    <v-card
+      aria-labelledby="heading_dialog_alert"
+      role="dialog">
       <v-card-title class="shading">
-        <h2 class="display-1">{{title}}</h2>
+        <h2 class="display-1" id="heading_dialog_alert">{{title}}</h2>
       </v-card-title>
 
       <v-divider></v-divider>

--- a/web/components/dialogs/FcDialogCollisionFilters.vue
+++ b/web/components/dialogs/FcDialogCollisionFilters.vue
@@ -64,17 +64,10 @@
             :value="i"></v-checkbox>
         </fieldset>
 
-        <fieldset class="mt-6">
-          <legend class="headline">Time of Day</legend>
-
-          <v-range-slider
-            v-model="internalFilters.hoursOfDay"
-            class="mt-11"
-            hide-details
-            :max="24"
-            :min="0"
-            thumb-label="always"></v-range-slider>
-        </fieldset>
+        <FcFilterHoursOfDay
+          v-model="internalFilters.hoursOfDay"
+          class="mt-6"
+          :error-messages="errorMessagesHoursOfDay" />
 
         <fieldset class="mt-6">
           <legend class="headline">Weather</legend>
@@ -118,7 +111,8 @@ import {
   CollisionRoadSurfaceCondition,
 } from '@/lib/Constants';
 import TimeFormatters from '@/lib/time/TimeFormatters';
-import ValidationsFilters from '@/lib/validation/ValidationsFilters';
+import ValidationsCollisionFilters from '@/lib/validation/ValidationsCollisionFilters';
+import FcFilterHoursOfDay from '@/web/components/filters/FcFilterHoursOfDay.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcDatePicker from '@/web/components/inputs/FcDatePicker.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
@@ -129,6 +123,7 @@ export default {
   components: {
     FcButton,
     FcDatePicker,
+    FcFilterHoursOfDay,
   },
   props: {
     filters: Object,
@@ -138,7 +133,10 @@ export default {
       CollisionEmphasisArea,
       CollisionRoadSurfaceCondition,
       DAYS_OF_WEEK: TimeFormatters.DAYS_OF_WEEK,
-      internalFilters: { ...this.filters },
+      internalFilters: {
+        ...this.filters,
+        hoursOfDay: [...this.filters.hoursOfDay],
+      },
     };
   },
   computed: {
@@ -160,10 +158,17 @@ export default {
       }
       return errors;
     },
+    errorMessagesHoursOfDay() {
+      const errors = [];
+      if (!this.$v.internalFilters.hoursOfDay.fromBeforeTo) {
+        errors.push('From hour must be before to hour');
+      }
+      return errors;
+    },
     ...mapState(['now']),
   },
   validations: {
-    internalFilters: ValidationsFilters,
+    internalFilters: ValidationsCollisionFilters,
   },
   watch: {
     applyDateRange() {

--- a/web/components/dialogs/FcDialogCollisionFilters.vue
+++ b/web/components/dialogs/FcDialogCollisionFilters.vue
@@ -3,9 +3,13 @@
     v-model="internalValue"
     max-width="336"
     scrollable>
-    <v-card role="dialog">
+    <v-card
+      aria-labelledby="heading_dialog_collision_filters"
+      role="dialog">
       <v-card-title class="shading">
-        <h2 class="display-1">Filter Collisions</h2>
+        <h2 class="display-1" id="heading_dialog_collision_filters">
+          Filter Collisions
+        </h2>
         <v-spacer></v-spacer>
         <FcButton
           type="secondary"

--- a/web/components/dialogs/FcDialogConfirm.vue
+++ b/web/components/dialogs/FcDialogConfirm.vue
@@ -3,9 +3,11 @@
     v-model="internalValue"
     class="shading"
     max-width="560">
-    <v-card role="dialog">
+    <v-card
+      aria-labelledby="heading_dialog_confirm"
+      role="dialog">
       <v-card-title>
-        <h2 class="display-1">{{title}}</h2>
+        <h2 class="display-1" id="heading_dialog_confirm">{{title}}</h2>
       </v-card-title>
 
       <v-divider></v-divider>

--- a/web/components/dialogs/FcDialogRequestFilters.vue
+++ b/web/components/dialogs/FcDialogRequestFilters.vue
@@ -3,9 +3,13 @@
     v-model="internalValue"
     max-width="336"
     scrollable>
-    <v-card role="dialog">
+    <v-card
+      aria-labelledby="heading_dialog_request_filters"
+      role="dialog">
       <v-card-title class="shading">
-        <h2 class="display-1">Filter Requests</h2>
+        <h2 class="display-1" id="heading_dialog_request_filters">
+          Filter Requests
+        </h2>
         <v-spacer></v-spacer>
         <FcButton
           type="secondary"

--- a/web/components/dialogs/FcDialogStudyFilters.vue
+++ b/web/components/dialogs/FcDialogStudyFilters.vue
@@ -3,9 +3,13 @@
     v-model="internalValue"
     max-width="336"
     scrollable>
-    <v-card role="dialog">
+    <v-card
+      aria-labelledby="heading_dialog_collision_filters"
+      role="dialog">
       <v-card-title class="shading">
-        <h2 class="display-1">Filter Studies</h2>
+        <h2 class="display-1" id="heading_dialog_study_filters">
+          Filter Studies
+        </h2>
         <v-spacer></v-spacer>
         <FcButton
           type="secondary"

--- a/web/components/dialogs/FcDialogStudyFilters.vue
+++ b/web/components/dialogs/FcDialogStudyFilters.vue
@@ -4,7 +4,7 @@
     max-width="336"
     scrollable>
     <v-card
-      aria-labelledby="heading_dialog_collision_filters"
+      aria-labelledby="heading_dialog_study_filters"
       role="dialog">
       <v-card-title class="shading">
         <h2 class="display-1" id="heading_dialog_study_filters">

--- a/web/components/dialogs/FcDialogStudyFilters.vue
+++ b/web/components/dialogs/FcDialogStudyFilters.vue
@@ -106,7 +106,7 @@ import {
   StudyType,
 } from '@/lib/Constants';
 import TimeFormatters from '@/lib/time/TimeFormatters';
-import ValidationsFilters from '@/lib/validation/ValidationsFilters';
+import ValidationsStudyFilters from '@/lib/validation/ValidationsStudyFilters';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcDatePicker from '@/web/components/inputs/FcDatePicker.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
@@ -151,7 +151,7 @@ export default {
     ...mapState(['now']),
   },
   validations: {
-    internalFilters: ValidationsFilters,
+    internalFilters: ValidationsStudyFilters,
   },
   watch: {
     applyDateRange() {

--- a/web/components/filters/FcFilterHoursOfDay.vue
+++ b/web/components/filters/FcFilterHoursOfDay.vue
@@ -1,0 +1,39 @@
+<template>
+  <fieldset>
+    <legend class="headline">Time of Day</legend>
+
+    <v-slider
+      v-model="internalValue[0]"
+      class="mt-11"
+      :error-messages="errorMessages"
+      label="From Hour"
+      :max="24"
+      :min="0"
+      thumb-label="always" />
+
+    <v-slider
+      v-model="internalValue[1]"
+      class="mt-11"
+      :error-messages="errorMessages"
+      hide-details="auto"
+      label="To Hour"
+      :max="24"
+      :min="0"
+      thumb-label="always" />
+  </fieldset>
+</template>
+
+<script>
+import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+
+export default {
+  name: 'FcFilterHoursOfDay',
+  mixins: [FcMixinVModelProxy(Array)],
+  props: {
+    errorMessages: {
+      type: Array,
+      default() { return []; },
+    },
+  },
+};
+</script>


### PR DESCRIPTION
# Issue Addressed
This PR makes further progress on #798 .

# Description
We add `aria-labelledby` attributes pointing at the `h2` for dialogs, and introduce `FcFilterHoursOfDay` with a double-slider control to address a11y issues in the previous `v-range-slider`-based control.

# Tests
Tested quickly in frontend, including running it under the axe Chrome extension.
