### PR TITLE
Test updates: TCL v2, validated collision fix 

### DIFF
--- a/lib/db/CollisionDAO.js
+++ b/lib/db/CollisionDAO.js
@@ -251,7 +251,7 @@ ORDER BY i.collision_id`;
 SELECT
   COUNT(*) AS amount,
   COUNT(*) FILTER (WHERE e.ksi) AS ksi,
-  COUNT(*) FILTER (WHERE e.changed IS NOT NULL) AS validated
+  COUNT(*) FILTER (WHERE e.changed = -1) AS validated
 FROM collisions.events e
 JOIN collisions.events_centreline ec ON e.collision_id = ec.collision_id
 WHERE ${collisionFilters}`;
@@ -268,7 +268,7 @@ SELECT
   ec.centreline_id AS "centrelineId",
   COUNT(*) AS amount,
   COUNT(*) FILTER (WHERE e.ksi) AS ksi,
-  COUNT(*) FILTER (WHERE e.changed IS NOT NULL) AS validated
+  COUNT(*) FILTER (WHERE e.changed = -1) AS validated
 FROM collisions.events e
 JOIN collisions.events_centreline ec ON e.collision_id = ec.collision_id
 WHERE ${collisionFilters}

--- a/lib/reports/ReportCollisionDirectory.js
+++ b/lib/reports/ReportCollisionDirectory.js
@@ -22,7 +22,7 @@ class ReportCollisionDirectory extends ReportBaseCrash {
       mvaimg,
       involved,
     } = collision;
-    const verified = changed !== null;
+    const verified = changed === -1;
     const hasMvaImage = mvaimg !== null;
 
     let drivers = involved.filter(

--- a/tests/jest/api/CollisionController.spec.js
+++ b/tests/jest/api/CollisionController.spec.js
@@ -85,7 +85,7 @@ test('CollisionController.getCollisionsByCentrelineSummary', async () => {
   };
   let response = await client.fetch('/collisions/byCentreline/summary', { data });
   expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
-  expect(response.result).toEqual({ amount: 31, ksi: 0, validated: 26 });
+  expect(response.result).toEqual({ amount: 31, ksi: 0, validated: 7 });
 
   features = [
     { centrelineId: 13465434, centrelineType: CentrelineType.INTERSECTION },
@@ -101,7 +101,7 @@ test('CollisionController.getCollisionsByCentrelineSummary', async () => {
   };
   response = await client.fetch('/collisions/byCentreline/summary', { data });
   expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
-  expect(response.result).toEqual({ amount: 26, ksi: 1, validated: 16 });
+  expect(response.result).toEqual({ amount: 26, ksi: 1, validated: 14 });
 
   features = [
     { centrelineId: 1142194, centrelineType: CentrelineType.SEGMENT },
@@ -118,7 +118,7 @@ test('CollisionController.getCollisionsByCentrelineSummary', async () => {
   };
   response = await client.fetch('/collisions/byCentreline/summary', { data });
   expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
-  expect(response.result).toEqual({ amount: 57, ksi: 1, validated: 42 });
+  expect(response.result).toEqual({ amount: 57, ksi: 1, validated: 21 });
 });
 
 test('CollisionController.getCollisionsByCentrelineSummaryPerLocation', async () => {
@@ -139,7 +139,7 @@ test('CollisionController.getCollisionsByCentrelineSummaryPerLocation', async ()
   };
   let response = await client.fetch('/collisions/byCentreline/summaryPerLocation', { data });
   expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
-  expect(response.result).toEqual([{ amount: 31, ksi: 0, validated: 26 }]);
+  expect(response.result).toEqual([{ amount: 31, ksi: 0, validated: 7 }]);
 
   features = [
     { centrelineId: 13465434, centrelineType: CentrelineType.INTERSECTION },
@@ -155,7 +155,7 @@ test('CollisionController.getCollisionsByCentrelineSummaryPerLocation', async ()
   };
   response = await client.fetch('/collisions/byCentreline/summaryPerLocation', { data });
   expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
-  expect(response.result).toEqual([{ amount: 26, ksi: 1, validated: 16 }]);
+  expect(response.result).toEqual([{ amount: 26, ksi: 1, validated: 14 }]);
 
   features = [
     { centrelineId: 1142194, centrelineType: CentrelineType.SEGMENT },
@@ -173,8 +173,8 @@ test('CollisionController.getCollisionsByCentrelineSummaryPerLocation', async ()
   response = await client.fetch('/collisions/byCentreline/summaryPerLocation', { data });
   expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
   expect(response.result).toEqual([
-    { amount: 31, ksi: 0, validated: 26 },
-    { amount: 26, ksi: 1, validated: 16 },
+    { amount: 31, ksi: 0, validated: 7 },
+    { amount: 26, ksi: 1, validated: 14 },
   ]);
 });
 

--- a/tests/jest/api/CollisionController.spec.js
+++ b/tests/jest/api/CollisionController.spec.js
@@ -64,7 +64,7 @@ test('CollisionController.getCollisionsByCentreline', async () => {
   };
   response = await client.fetch('/collisions/byCentreline', { data });
   expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
-  expect(response.result).toHaveLength(27);
+  expect(response.result).toHaveLength(26);
 });
 
 test('CollisionController.getCollisionsByCentrelineSummary', async () => {
@@ -101,7 +101,7 @@ test('CollisionController.getCollisionsByCentrelineSummary', async () => {
   };
   response = await client.fetch('/collisions/byCentreline/summary', { data });
   expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
-  expect(response.result).toEqual({ amount: 27, ksi: 1, validated: 16 });
+  expect(response.result).toEqual({ amount: 26, ksi: 1, validated: 16 });
 
   features = [
     { centrelineId: 1142194, centrelineType: CentrelineType.SEGMENT },
@@ -118,7 +118,7 @@ test('CollisionController.getCollisionsByCentrelineSummary', async () => {
   };
   response = await client.fetch('/collisions/byCentreline/summary', { data });
   expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
-  expect(response.result).toEqual({ amount: 58, ksi: 1, validated: 42 });
+  expect(response.result).toEqual({ amount: 57, ksi: 1, validated: 42 });
 });
 
 test('CollisionController.getCollisionsByCentrelineSummaryPerLocation', async () => {
@@ -155,7 +155,7 @@ test('CollisionController.getCollisionsByCentrelineSummaryPerLocation', async ()
   };
   response = await client.fetch('/collisions/byCentreline/summaryPerLocation', { data });
   expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
-  expect(response.result).toEqual([{ amount: 27, ksi: 1, validated: 16 }]);
+  expect(response.result).toEqual([{ amount: 26, ksi: 1, validated: 16 }]);
 
   features = [
     { centrelineId: 1142194, centrelineType: CentrelineType.SEGMENT },
@@ -174,7 +174,7 @@ test('CollisionController.getCollisionsByCentrelineSummaryPerLocation', async ()
   expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
   expect(response.result).toEqual([
     { amount: 31, ksi: 0, validated: 26 },
-    { amount: 27, ksi: 1, validated: 16 },
+    { amount: 26, ksi: 1, validated: 16 },
   ]);
 });
 
@@ -195,7 +195,7 @@ test('CollisionController.getCollisionsByCentrelineTotal', async () => {
   data = { s1 };
   response = await client.fetch('/collisions/byCentreline/total', { data });
   expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
-  expect(response.result.total).toBeGreaterThanOrEqual(188);
+  expect(response.result.total).toBeGreaterThanOrEqual(184);
 
   features = [
     { centrelineId: 1142194, centrelineType: CentrelineType.SEGMENT },

--- a/tests/jest/db/CollisionDAO.spec.js
+++ b/tests/jest/db/CollisionDAO.spec.js
@@ -65,20 +65,20 @@ test('CollisionDAO.byCentrelineSummary', async () => {
     roadSurfaceConditions: null,
   };
   let result = await CollisionDAO.byCentrelineSummary(features, collisionQuery);
-  expect(result).toEqual({ amount: 31, ksi: 0, validated: 26 });
+  expect(result).toEqual({ amount: 31, ksi: 0, validated: 7 });
 
   features = [
     { centrelineId: 13465434, centrelineType: CentrelineType.INTERSECTION },
   ];
   result = await CollisionDAO.byCentrelineSummary(features, collisionQuery);
-  expect(result).toEqual({ amount: 26, ksi: 1, validated: 16 });
+  expect(result).toEqual({ amount: 26, ksi: 1, validated: 14 });
 
   features = [
     { centrelineId: 1142194, centrelineType: CentrelineType.SEGMENT },
     { centrelineId: 13465434, centrelineType: CentrelineType.INTERSECTION },
   ];
   result = await CollisionDAO.byCentrelineSummary(features, collisionQuery);
-  expect(result).toEqual({ amount: 57, ksi: 1, validated: 42 });
+  expect(result).toEqual({ amount: 57, ksi: 1, validated: 21 });
 });
 
 test('CollisionDAO.byCentrelineSummaryPerLocation', async () => {
@@ -96,13 +96,13 @@ test('CollisionDAO.byCentrelineSummaryPerLocation', async () => {
     roadSurfaceConditions: null,
   };
   let result = await CollisionDAO.byCentrelineSummaryPerLocation(features, collisionQuery);
-  expect(result).toEqual([{ amount: 31, ksi: 0, validated: 26 }]);
+  expect(result).toEqual([{ amount: 31, ksi: 0, validated: 7 }]);
 
   features = [
     { centrelineId: 13465434, centrelineType: CentrelineType.INTERSECTION },
   ];
   result = await CollisionDAO.byCentrelineSummaryPerLocation(features, collisionQuery);
-  expect(result).toEqual([{ amount: 26, ksi: 1, validated: 16 }]);
+  expect(result).toEqual([{ amount: 26, ksi: 1, validated: 14 }]);
 
   features = [
     { centrelineId: 1142194, centrelineType: CentrelineType.SEGMENT },
@@ -110,8 +110,8 @@ test('CollisionDAO.byCentrelineSummaryPerLocation', async () => {
   ];
   result = await CollisionDAO.byCentrelineSummaryPerLocation(features, collisionQuery);
   expect(result).toEqual([
-    { amount: 31, ksi: 0, validated: 26 },
-    { amount: 26, ksi: 1, validated: 16 },
+    { amount: 31, ksi: 0, validated: 7 },
+    { amount: 26, ksi: 1, validated: 14 },
   ]);
 
   features = [
@@ -121,9 +121,9 @@ test('CollisionDAO.byCentrelineSummaryPerLocation', async () => {
   ];
   result = await CollisionDAO.byCentrelineSummaryPerLocation(features, collisionQuery);
   expect(result).toEqual([
-    { amount: 31, ksi: 0, validated: 26 },
-    { amount: 26, ksi: 1, validated: 16 },
-    { amount: 31, ksi: 0, validated: 26 },
+    { amount: 31, ksi: 0, validated: 7 },
+    { amount: 26, ksi: 1, validated: 14 },
+    { amount: 31, ksi: 0, validated: 7 },
   ]);
 });
 

--- a/tests/jest/db/CollisionDAO.spec.js
+++ b/tests/jest/db/CollisionDAO.spec.js
@@ -47,7 +47,7 @@ test('CollisionDAO.byCentreline', async () => {
     roadSurfaceConditions: null,
   };
   result = await CollisionDAO.byCentreline(features, collisionQuery);
-  expect(result).toHaveLength(27);
+  expect(result).toHaveLength(26);
 });
 
 test('CollisionDAO.byCentrelineSummary', async () => {
@@ -71,14 +71,14 @@ test('CollisionDAO.byCentrelineSummary', async () => {
     { centrelineId: 13465434, centrelineType: CentrelineType.INTERSECTION },
   ];
   result = await CollisionDAO.byCentrelineSummary(features, collisionQuery);
-  expect(result).toEqual({ amount: 27, ksi: 1, validated: 16 });
+  expect(result).toEqual({ amount: 26, ksi: 1, validated: 16 });
 
   features = [
     { centrelineId: 1142194, centrelineType: CentrelineType.SEGMENT },
     { centrelineId: 13465434, centrelineType: CentrelineType.INTERSECTION },
   ];
   result = await CollisionDAO.byCentrelineSummary(features, collisionQuery);
-  expect(result).toEqual({ amount: 58, ksi: 1, validated: 42 });
+  expect(result).toEqual({ amount: 57, ksi: 1, validated: 42 });
 });
 
 test('CollisionDAO.byCentrelineSummaryPerLocation', async () => {
@@ -102,7 +102,7 @@ test('CollisionDAO.byCentrelineSummaryPerLocation', async () => {
     { centrelineId: 13465434, centrelineType: CentrelineType.INTERSECTION },
   ];
   result = await CollisionDAO.byCentrelineSummaryPerLocation(features, collisionQuery);
-  expect(result).toEqual([{ amount: 27, ksi: 1, validated: 16 }]);
+  expect(result).toEqual([{ amount: 26, ksi: 1, validated: 16 }]);
 
   features = [
     { centrelineId: 1142194, centrelineType: CentrelineType.SEGMENT },
@@ -111,7 +111,7 @@ test('CollisionDAO.byCentrelineSummaryPerLocation', async () => {
   result = await CollisionDAO.byCentrelineSummaryPerLocation(features, collisionQuery);
   expect(result).toEqual([
     { amount: 31, ksi: 0, validated: 26 },
-    { amount: 27, ksi: 1, validated: 16 },
+    { amount: 26, ksi: 1, validated: 16 },
   ]);
 
   features = [
@@ -122,7 +122,7 @@ test('CollisionDAO.byCentrelineSummaryPerLocation', async () => {
   result = await CollisionDAO.byCentrelineSummaryPerLocation(features, collisionQuery);
   expect(result).toEqual([
     { amount: 31, ksi: 0, validated: 26 },
-    { amount: 27, ksi: 1, validated: 16 },
+    { amount: 26, ksi: 1, validated: 16 },
     { amount: 31, ksi: 0, validated: 26 },
   ]);
 });
@@ -138,7 +138,7 @@ test('CollisionDAO.byCentrelineTotal', async () => {
     { centrelineId: 13465434, centrelineType: CentrelineType.INTERSECTION },
   ];
   result = await CollisionDAO.byCentrelineTotal(features);
-  expect(result).toBeGreaterThanOrEqual(188);
+  expect(result).toBeGreaterThanOrEqual(184);
 
   features = [
     { centrelineId: 1142194, centrelineType: CentrelineType.SEGMENT },

--- a/tests/jest/db/RoutingDAO.spec.js
+++ b/tests/jest/db/RoutingDAO.spec.js
@@ -161,7 +161,7 @@ test('RoutingDAO.routeFeatures', async () => {
   featureTo = { centrelineId: 444912, centrelineType: CentrelineType.SEGMENT };
   result = await RoutingDAO.routeFeatures(featureFrom, featureTo);
   expect(result).toEqual({
-    next: { centrelineId: 13454835, centrelineType: CentrelineType.INTERSECTION },
+    next: { centrelineId: 13455130, centrelineType: CentrelineType.INTERSECTION },
     route: [
       { centrelineId: 445623, centrelineType: CentrelineType.SEGMENT },
       { centrelineId: 13455700, centrelineType: CentrelineType.INTERSECTION },
@@ -180,6 +180,8 @@ test('RoutingDAO.routeFeatures', async () => {
   expect(result).toEqual({
     next: featureTo,
     route: [
+      { centrelineId: 13455130, centrelineType: CentrelineType.INTERSECTION },
+      featureFrom,
       { centrelineId: 13454835, centrelineType: CentrelineType.INTERSECTION },
       { centrelineId: 444715, centrelineType: CentrelineType.SEGMENT },
       featureTo,
@@ -191,7 +193,7 @@ test('RoutingDAO.routeFeatures', async () => {
   featureTo = { centrelineId: 444912, centrelineType: CentrelineType.SEGMENT };
   result = await RoutingDAO.routeFeatures(featureFrom, featureTo);
   expect(result).toEqual({
-    next: { centrelineId: 13454835, centrelineType: CentrelineType.INTERSECTION },
+    next: { centrelineId: 13455130, centrelineType: CentrelineType.INTERSECTION },
     route: [
       { centrelineId: 13455359, centrelineType: CentrelineType.INTERSECTION },
       { centrelineId: 445100, centrelineType: CentrelineType.SEGMENT },
@@ -259,6 +261,8 @@ test('RoutingDAO.routeCorridor', async () => {
     { centrelineId: 445100, centrelineType: CentrelineType.SEGMENT },
     { centrelineId: 13455130, centrelineType: CentrelineType.INTERSECTION },
     features[3],
+    { centrelineId: 13455130, centrelineType: CentrelineType.INTERSECTION },
+    features[3],
     { centrelineId: 13454835, centrelineType: CentrelineType.INTERSECTION },
     { centrelineId: 444715, centrelineType: CentrelineType.SEGMENT },
     features[4],
@@ -284,6 +288,8 @@ test('RoutingDAO.routeCorridor', async () => {
     features[3],
     { centrelineId: 13455359, centrelineType: CentrelineType.INTERSECTION },
     { centrelineId: 445100, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13455130, centrelineType: CentrelineType.INTERSECTION },
+    features[4],
     { centrelineId: 13455130, centrelineType: CentrelineType.INTERSECTION },
     features[4],
     { centrelineId: 13454835, centrelineType: CentrelineType.INTERSECTION },
@@ -314,6 +320,8 @@ test('RoutingDAO.routeCorridor', async () => {
     features[3],
     { centrelineId: 13455359, centrelineType: CentrelineType.INTERSECTION },
     { centrelineId: 445100, centrelineType: CentrelineType.SEGMENT },
+    { centrelineId: 13455130, centrelineType: CentrelineType.INTERSECTION },
+    features[4],
     { centrelineId: 13455130, centrelineType: CentrelineType.INTERSECTION },
     features[4],
     { centrelineId: 13454835, centrelineType: CentrelineType.INTERSECTION },


### PR DESCRIPTION
# Issue Addressed
This PR makes progress on #775 and #778 .

# Description
We update tests to match our test dataset after updating to TCL v2 and changing the collision buffer radius from 30m to 20m.  We also change the logic for determining when a collision is validated from `changed !== null` to `changed === -1`, to match the (apparent) behaviour of CRASH here.

# Tests
Updated to latest `flashcrow-dev-data.sql` in both local development and our `gitlab-runner` environment on AWS dev.  Ran `npm run ci:jest-coverage` to ensure all tests pass locally.  Used GitLab CI pipelines to ensure all tests pass there.