### PR TITLE
Use pseudo-vertices for routing in web application server

### DIFF
--- a/lib/db/RoutingDAO.js
+++ b/lib/db/RoutingDAO.js
@@ -1,7 +1,6 @@
 import ArrayUtils from '@/lib/ArrayUtils';
 import { centrelineKey, CentrelineType } from '@/lib/Constants';
 import db from '@/lib/db/db';
-import CentrelineDAO from '@/lib/db/CentrelineDAO';
 
 /**
  * @typedef {Object} IntersectionRoutingResult
@@ -147,8 +146,17 @@ ORDER BY seq ASC, path_seq ASC`;
     if (centrelineType === CentrelineType.INTERSECTION) {
       return [centrelineId];
     }
-    const intersections = await CentrelineDAO.intersectionsIncidentTo(centrelineId);
-    return intersections.map(intersection => intersection.centrelineId);
+
+    const sql = `
+SELECT source, target
+FROM centreline.routing_edges
+WHERE id = $(centrelineId)`;
+    const row = await db.oneOrNone(sql, { centrelineId });
+    if (row === null) {
+      return [];
+    }
+    const { source, target } = row;
+    return [source, target];
   }
 
   /**

--- a/lib/reports/ReportBaseFlowDirectional.js
+++ b/lib/reports/ReportBaseFlowDirectional.js
@@ -400,6 +400,12 @@ class ReportBaseFlowDirectional extends ReportBaseFlow {
     if (centrelineType === CentrelineType.INTERSECTION) {
       tasks.push(CentrelineDAO.featuresIncidentTo(centrelineType, centrelineId));
     }
+    /*
+     * It is possible to have TMCs along midblocks, but we can't rely on centreline geometry
+     * to infer road directions in that case.  As such, to avoid errors from
+     * `GeometryUtils.getDirectionCandidatesFrom`, we default to the empty list of incident
+     * segments here.
+     */
     const [intersection, segments = []] = await Promise.all(tasks);
 
     return {

--- a/lib/reports/ReportBaseFlowDirectional.js
+++ b/lib/reports/ReportBaseFlowDirectional.js
@@ -2,6 +2,7 @@
 import ArrayUtils from '@/lib/ArrayUtils';
 import {
   CardinalDirection,
+  CentrelineType,
   TMC_MODES_NON_VEHICLE,
   TMC_MODES_VEHICLE,
   TurningMovement,
@@ -394,10 +395,12 @@ class ReportBaseFlowDirectional extends ReportBaseFlow {
      */
     const { centrelineId, centrelineType } = study;
     const feature = { centrelineId, centrelineType };
-    const [intersection, segments] = await Promise.all([
-      CentrelineDAO.byFeature(feature),
-      CentrelineDAO.featuresIncidentTo(centrelineType, centrelineId),
-    ]);
+
+    const tasks = [CentrelineDAO.byFeature(feature)];
+    if (centrelineType === CentrelineType.INTERSECTION) {
+      tasks.push(CentrelineDAO.featuresIncidentTo(centrelineType, centrelineId));
+    }
+    const [intersection, segments = []] = await Promise.all(tasks);
 
     return {
       count,

--- a/tests/jest/db/RoutingDAO.spec.js
+++ b/tests/jest/db/RoutingDAO.spec.js
@@ -161,7 +161,7 @@ test('RoutingDAO.routeFeatures', async () => {
   featureTo = { centrelineId: 444912, centrelineType: CentrelineType.SEGMENT };
   result = await RoutingDAO.routeFeatures(featureFrom, featureTo);
   expect(result).toEqual({
-    next: { centrelineId: 13455130, centrelineType: CentrelineType.INTERSECTION },
+    next: { centrelineId: 13454835, centrelineType: CentrelineType.INTERSECTION },
     route: [
       { centrelineId: 445623, centrelineType: CentrelineType.SEGMENT },
       { centrelineId: 13455700, centrelineType: CentrelineType.INTERSECTION },
@@ -180,8 +180,6 @@ test('RoutingDAO.routeFeatures', async () => {
   expect(result).toEqual({
     next: featureTo,
     route: [
-      { centrelineId: 13455130, centrelineType: CentrelineType.INTERSECTION },
-      featureFrom,
       { centrelineId: 13454835, centrelineType: CentrelineType.INTERSECTION },
       { centrelineId: 444715, centrelineType: CentrelineType.SEGMENT },
       featureTo,
@@ -193,7 +191,7 @@ test('RoutingDAO.routeFeatures', async () => {
   featureTo = { centrelineId: 444912, centrelineType: CentrelineType.SEGMENT };
   result = await RoutingDAO.routeFeatures(featureFrom, featureTo);
   expect(result).toEqual({
-    next: { centrelineId: 13455130, centrelineType: CentrelineType.INTERSECTION },
+    next: { centrelineId: 13454835, centrelineType: CentrelineType.INTERSECTION },
     route: [
       { centrelineId: 13455359, centrelineType: CentrelineType.INTERSECTION },
       { centrelineId: 445100, centrelineType: CentrelineType.SEGMENT },
@@ -261,8 +259,6 @@ test('RoutingDAO.routeCorridor', async () => {
     { centrelineId: 445100, centrelineType: CentrelineType.SEGMENT },
     { centrelineId: 13455130, centrelineType: CentrelineType.INTERSECTION },
     features[3],
-    { centrelineId: 13455130, centrelineType: CentrelineType.INTERSECTION },
-    features[3],
     { centrelineId: 13454835, centrelineType: CentrelineType.INTERSECTION },
     { centrelineId: 444715, centrelineType: CentrelineType.SEGMENT },
     features[4],
@@ -288,8 +284,6 @@ test('RoutingDAO.routeCorridor', async () => {
     features[3],
     { centrelineId: 13455359, centrelineType: CentrelineType.INTERSECTION },
     { centrelineId: 445100, centrelineType: CentrelineType.SEGMENT },
-    { centrelineId: 13455130, centrelineType: CentrelineType.INTERSECTION },
-    features[4],
     { centrelineId: 13455130, centrelineType: CentrelineType.INTERSECTION },
     features[4],
     { centrelineId: 13454835, centrelineType: CentrelineType.INTERSECTION },
@@ -320,8 +314,6 @@ test('RoutingDAO.routeCorridor', async () => {
     features[3],
     { centrelineId: 13455359, centrelineType: CentrelineType.INTERSECTION },
     { centrelineId: 445100, centrelineType: CentrelineType.SEGMENT },
-    { centrelineId: 13455130, centrelineType: CentrelineType.INTERSECTION },
-    features[4],
     { centrelineId: 13455130, centrelineType: CentrelineType.INTERSECTION },
     features[4],
     { centrelineId: 13454835, centrelineType: CentrelineType.INTERSECTION },


### PR DESCRIPTION
# Issue Addressed
This PR closes #755 .

# Description
We update `RoutingDAO` to use `source` and `target` from `centreline.routing_edges` when computing available routing intersections on a midblock, as opposed to `CentrelineDAO.intersectionsIncidentTo` (which uses the conflation target instead, not the routing target).  We then update `RoutingDAO` tests accordingly.

We also fix a bug with `ReportBaseFlowDirectional` for midblock TMCs, where `CentrelineDAO.featuresIncidentTo` will return the _intersections_ at each end of the midblock - this breaks `GeometryUtils.getDirectionCandidatesFrom`, which assumes it's working with LineStrings (i.e. midblocks).

# Tests
Ran CI tests.  Tested the Mt. Pleasant and High Park corridors mentioned in #755 , and verified that these now route correctly.  Tested Intersection Summary Report for midblock TMCs, and verified that these are now generated.
