### PR TITLE
Fix issues with study types in latest QA version

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -1024,14 +1024,14 @@ StudyType.init({
     reportTypes: OPTIONS_REPORTS_ATR_VOLUME,
   },
   OTHER_AUTOMATIC: {
-    label: 'Other - Automatic',
+    label: 'Other',
     automatic: true,
     dataAvailable: false,
     other: true,
     reportTypes: [],
   },
   OTHER_MANUAL: {
-    label: 'Other - Manual',
+    label: 'Other',
     automatic: false,
     dataAvailable: false,
     other: true,

--- a/lib/geo/CentrelineUtils.js
+++ b/lib/geo/CentrelineUtils.js
@@ -24,7 +24,7 @@ function getLocationFeatureType(location) {
   throw new InvalidCentrelineTypeError(centrelineType);
 }
 
-function getLocationStudyTypesNonOther(location) {
+function getLocationStudyTypes(location) {
   const locationFeatureType = getLocationFeatureType(location);
   if (locationFeatureType instanceof RoadIntersectionType) {
     return [
@@ -61,15 +61,6 @@ function getLocationStudyTypesNonOther(location) {
     StudyType.PED_DELAY,
     StudyType.PXO_OBSERVE,
     StudyType.TMC,
-  ];
-}
-
-function getLocationStudyTypes(location) {
-  const studyTypesNonOther = getLocationStudyTypesNonOther(location);
-  return [
-    ...studyTypesNonOther,
-    StudyType.OTHER_AUTOMATIC,
-    StudyType.OTHER_MANUAL,
   ];
 }
 

--- a/lib/validation/ValidationsStudyRequest.js
+++ b/lib/validation/ValidationsStudyRequest.js
@@ -48,7 +48,9 @@ const ValidationsStudyRequest = {
     required,
   },
   studyTypeOther: {
-    requiredIfOtherStudyType: requiredIf(({ studyType }) => studyType.other),
+    requiredIfOtherStudyType: requiredIf(
+      ({ studyType }) => studyType !== null && studyType.other,
+    ),
   },
   urgent: {},
   urgentReason: {

--- a/tests/jest/unit/geo/CentrelineUtils.spec.js
+++ b/tests/jest/unit/geo/CentrelineUtils.spec.js
@@ -54,8 +54,6 @@ test('CentrelineUtils.getLocationStudyTypes', () => {
     expect(getLocationStudyTypes(location)).toEqual([
       StudyType.PED_DELAY,
       StudyType.TMC,
-      StudyType.OTHER_AUTOMATIC,
-      StudyType.OTHER_MANUAL,
     ]);
   });
   RoadSegmentType.enumValues.forEach(({ featureCode }) => {
@@ -65,16 +63,16 @@ test('CentrelineUtils.getLocationStudyTypes', () => {
     };
     const studyTypes = getLocationStudyTypes(location);
     expect(studyTypes).toBeInstanceOf(Array);
-    expect(getLocationStudyTypes(location)).toContain(StudyType.OTHER_AUTOMATIC);
-    expect(getLocationStudyTypes(location)).toContain(StudyType.OTHER_MANUAL);
+    expect(getLocationStudyTypes(location)).not.toContain(StudyType.OTHER_AUTOMATIC);
+    expect(getLocationStudyTypes(location)).not.toContain(StudyType.OTHER_MANUAL);
   });
   let location = {
     centrelineType: CentrelineType.SEGMENT,
     featureCode: null,
   };
   expect(getLocationStudyTypes(location)).toBeInstanceOf(Array);
-  expect(getLocationStudyTypes(location)).toContain(StudyType.OTHER_AUTOMATIC);
-  expect(getLocationStudyTypes(location)).toContain(StudyType.OTHER_MANUAL);
+  expect(getLocationStudyTypes(location)).not.toContain(StudyType.OTHER_AUTOMATIC);
+  expect(getLocationStudyTypes(location)).not.toContain(StudyType.OTHER_MANUAL);
 
   location = {
     centrelineType: CentrelineType.SEGMENT,

--- a/web/components/nav/FcDashboardNavUser.vue
+++ b/web/components/nav/FcDashboardNavUser.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="text-center pb-2">
+  <div
+    class="fc-dashboard-nav-user text-center pb-2">
     <div class="d-none">
       <form
         v-if="auth.loggedIn"
@@ -20,7 +21,7 @@
       v-if="auth.loggedIn"
       :attach="$el"
       :min-width="140"
-      top
+      right
       :z-index="100">
       <template v-slot:activator="{ attrs: attrsMenu, on: onMenu }">
         <FcTooltip right>
@@ -110,6 +111,10 @@ export default {
 </script>
 
 <style lang="scss">
+.fc-dashboard-nav-user {
+  position: relative;
+}
+
 #fc_menu_user {
   background: white;
 }

--- a/web/components/requests/FcCardStudyRequestConfirm.vue
+++ b/web/components/requests/FcCardStudyRequestConfirm.vue
@@ -20,7 +20,7 @@
             </dt>
             <dd class="mt-1 display-1">
               {{studyRequest.studyType.label}}
-              <span v-if="study.studyType.other">
+              <span v-if="studyRequest.studyType.other">
                 ({{studyRequest.studyTypeOther}})
               </span>
             </dd>

--- a/web/components/requests/FcCreateStudyRequestBulk.vue
+++ b/web/components/requests/FcCreateStudyRequestBulk.vue
@@ -161,7 +161,8 @@ function cardStudyRequestInvalid(v) {
     || v.duration.$invalid
     || v.hours.$invalid
     || v.notes.$invalid
-    || v.studyType.$invalid;
+    || v.studyType.$invalid
+    || v.studyTypeOther.$invalid;
 }
 
 export default {

--- a/web/components/requests/FcHeaderStudyRequestBulkLocations.vue
+++ b/web/components/requests/FcHeaderStudyRequestBulkLocations.vue
@@ -116,20 +116,25 @@ export default {
       });
     },
     itemsStudyType() {
-      const itemsStudyType = this.locationsStudyTypes.map((studyType) => {
+      return this.locationsStudyTypes.map((studyType) => {
         const { label } = studyType;
         return { text: label, value: studyType };
       });
-      return ArrayUtils.sortBy(itemsStudyType, ({ label }) => label);
     },
     locationsStudyTypes() {
       let locationIndices = this.indices;
       if (this.internalValue.length > 0) {
         locationIndices = this.internalValue;
       }
-      return StudyType.enumValues.filter(studyType => locationIndices.some(
-        i => getLocationStudyTypes(this.locations[i]).includes(studyType),
-      ));
+      const locationsStudyTypes = StudyType.enumValues.filter(
+        studyType => locationIndices.some(
+          i => getLocationStudyTypes(this.locations[i]).includes(studyType),
+        ),
+      );
+      return [
+        ...locationsStudyTypes,
+        StudyType.OTHER_MANUAL,
+      ];
     },
     selectAll: {
       get() {
@@ -205,7 +210,7 @@ export default {
       const indicesUnactionable = [];
       this.internalValue.forEach((i) => {
         const studyTypes = getLocationStudyTypes(this.locations[i]);
-        if (studyTypes.includes(studyType)) {
+        if (studyType.other || studyTypes.includes(studyType)) {
           this.studyRequests[i].studyType = studyType;
         } else {
           indicesUnactionable.push(i);

--- a/web/components/requests/fields/FcStudyRequestStudyType.vue
+++ b/web/components/requests/fields/FcStudyRequestStudyType.vue
@@ -1,25 +1,46 @@
 <template>
   <div>
-    <FcSelectEnum
-      v-model="v.studyType.$model"
+    <v-select
+      v-model="internalStudyType"
       :error-messages="errorMessagesStudyType"
-      :items="items"
-      item-text="label"
+      hide-details="auto"
+      :items="itemsStudyType"
       label="Study Type"
       :of-type="StudyType"
       outlined
       v-bind="$attrs" />
 
-    <v-text-field
-      v-if="v.studyType.$model.other"
-      v-model="v.studyTypeOther.$model"
-      class="mt-4"
-      :error-messages="errorMessagesStudyTypeOther"
-      hide-details="auto"
-      label="Other Study Type"
-      outlined
-      :success="v.studyTypeOther.$model && !v.studyTypeOther.$invalid"
-      v-bind="$attrs" />
+    <template
+      v-if="v.studyType.$model !== null && v.studyType.$model.other"
+      class="mt-4">
+      <v-text-field
+        v-model="v.studyTypeOther.$model"
+        class="mt-4"
+        :error-messages="errorMessagesStudyTypeOther"
+        hide-details="auto"
+        label="Other Study Type"
+        outlined
+        :success="v.studyTypeOther.$model && !v.studyTypeOther.$invalid"
+        v-bind="$attrs" />
+      <FcRadioGroup
+        v-model="automaticOther"
+        class="mt-2"
+        hide-details
+        :items="[
+          {
+            hint: 'Data is collected manually by on-site staff or contractors.',
+            label: 'Manual',
+            value: false,
+          },
+          {
+            hint: 'Data is collected by tubes, cameras, radar, or similar automated equipment.',
+            label: 'Automatic',
+            value: true,
+          },
+        ]"
+        label="Data Collection Method"
+        v-bind="$attrs" />
+    </template>
   </div>
 </template>
 
@@ -30,12 +51,34 @@ import {
   REQUEST_STUDY_REQUIRES_STUDY_TYPE,
   REQUEST_STUDY_REQUIRES_STUDY_TYPE_OTHER,
 } from '@/lib/i18n/Strings';
-import FcSelectEnum from '@/web/components/inputs/FcSelectEnum.vue';
+import FcRadioGroup from '@/web/components/inputs/FcRadioGroup.vue';
+
+const INTERNAL_STUDY_TYPE_OTHER = 'OTHER';
+
+function toInternalStudyType(studyType) {
+  if (studyType === null) {
+    return null;
+  }
+  if (studyType.other) {
+    return INTERNAL_STUDY_TYPE_OTHER;
+  }
+  return studyType.name;
+}
+
+function fromInternalStudyType(internalStudyType, automaticOther) {
+  if (internalStudyType === null) {
+    return null;
+  }
+  if (internalStudyType === INTERNAL_STUDY_TYPE_OTHER) {
+    return automaticOther ? StudyType.OTHER_AUTOMATIC : StudyType.OTHER_MANUAL;
+  }
+  return StudyType.enumValueOf(internalStudyType);
+}
 
 export default {
   name: 'FcStudyRequestStudyType',
   components: {
-    FcSelectEnum,
+    FcRadioGroup,
   },
   props: {
     location: Object,
@@ -43,6 +86,7 @@ export default {
   },
   data() {
     return {
+      automaticOther: false,
       studyTypeOther: null,
       StudyType,
     };
@@ -62,16 +106,37 @@ export default {
       }
       return errors;
     },
-    items() {
-      return getLocationStudyTypes(this.location);
+    internalStudyType: {
+      get() {
+        return toInternalStudyType(this.v.studyType.$model);
+      },
+      set(internalStudyType) {
+        this.v.studyType.$model = fromInternalStudyType(
+          internalStudyType,
+          this.automaticOther,
+        );
+      },
+    },
+    itemsStudyType() {
+      const locationStudyTypes = getLocationStudyTypes(this.location);
+      return [
+        ...locationStudyTypes.map(({ label, name }) => ({ text: label, value: name })),
+        { text: 'Other', value: INTERNAL_STUDY_TYPE_OTHER },
+      ];
     },
   },
   watch: {
-    'v.studyType.$model': function watchStudyType(studyType) {
-      if (studyType.other) {
+    automaticOther() {
+      this.v.studyType.$model = fromInternalStudyType(
+        this.internalStudyType,
+        this.automaticOther,
+      );
+    },
+    'v.studyType.$model.other': function watchStudyTypeOther(other) {
+      if (other) {
         this.v.studyTypeOther.$model = this.studyTypeOther;
       } else {
-        this.studyTypeOther = this.v.studyType.$model;
+        this.studyTypeOther = this.v.studyTypeOther.$model;
         this.v.studyTypeOther.$model = null;
       }
     },


### PR DESCRIPTION
# Issue Addressed
This PR closes #819 , closes #824 , and closes #826 .

# Description
We fix a couple of one-liner bugs in the input and display of study type details.  While we're at it, we change the study type dropdown to only have a single "Other" type, and add a new radio control below the `studyTypeOther` text field to allow the user to select between manual and automatic - this gives the user a bit of a chance to see what these options do!

Finally, to help test this in our various study management flows, we also fix a bug with the positioning of the sign out menu (so that we can more easily sign in as different users).

# Tests
Tested quickly in frontend: that the control works in its initial `null` state for midblocks; that the control works in both other and non-other states; that the control updates the `studyType` field of the study request as expected (using Vue devtools in browser); that the sign out menu is positioned properly now.