### PR TITLE
Add some unit tests for ReportTimeUtils

### DIFF
--- a/lib/reports/ReportPeakHourFactor.js
+++ b/lib/reports/ReportPeakHourFactor.js
@@ -10,10 +10,9 @@ import ReportBaseFlow from '@/lib/reports/ReportBaseFlow';
 import ReportBaseFlowDirectional from '@/lib/reports/ReportBaseFlowDirectional';
 import ReportCountSummaryTurningMovement from '@/lib/reports/ReportCountSummaryTurningMovement';
 import {
-  indexRangeAm,
+  indexRangeHourOfDay,
   indexRangeMax,
   indexRangePeakHour,
-  indexRangePm,
   indexRangeSum,
 } from '@/lib/reports/time/ReportTimeUtils';
 import TimeFormatters from '@/lib/time/TimeFormatters';
@@ -104,10 +103,10 @@ class ReportPeakHourFactor extends ReportBaseFlow {
       countData,
     );
 
-    const amIndices = indexRangeAm(totaledData);
+    const amIndices = indexRangeHourOfDay(totaledData, 0, 12);
     const amPeak = ReportPeakHourFactor.getPeakData(totaledData, amIndices);
 
-    const pmIndices = indexRangePm(totaledData);
+    const pmIndices = indexRangeHourOfDay(totaledData, 12, 24);
     const pmPeak = ReportPeakHourFactor.getPeakData(totaledData, pmIndices);
 
     return {

--- a/lib/reports/time/ReportTimeUtils.js
+++ b/lib/reports/time/ReportTimeUtils.js
@@ -20,7 +20,7 @@
  * @property {number} lo - lower bound (inclusive)
  * @property {number} hi - upper bound (exclusive)
  * @example
- * const indexRange = indexRangeAm(countData);
+ * const indexRange = indexRangeHourOfDay(countData, 0, 12);
  * const { lo, hi } = indexRange;
  * for (let i = lo; i < hi; i++) {
  *   const { t, data } = countData[i];
@@ -30,33 +30,21 @@
 
 /**
  * @param {CountData} countData
- * @returns {number} first index of `countData` with `t` in PM, or `-1` if
- * no such index exists
+ * @param {number} start - hour of day to start from (inclusive)
+ * @param {number} end - hour of day to end at (exclusive)
+ * @returns {IndexRange} index range where `t.hour >= start && t.hour < end`
  */
-function indexLoPm(countData) {
-  const lo = countData.findIndex(({ t }) => t.hour >= 12);
-  if (lo === -1) {
-    return countData.length;
+function indexRangeHourOfDay(countData, start, end) {
+  const n = countData.length;
+  let lo = 0;
+  while (lo < n && countData[lo].t.hour < start) {
+    lo += 1;
   }
-  return lo;
-}
-
-/**
- * @param {CountData} countData
- * @returns {IndexRange} index range for AM
- */
-function indexRangeAm(countData) {
-  const hi = indexLoPm(countData);
-  return { lo: 0, hi };
-}
-
-/**
- * @param {CountData} countData
- * @returns {IndexRange} index range for PM
- */
-function indexRangePm(countData) {
-  const lo = indexLoPm(countData);
-  return { lo, hi: countData.length };
+  let hi = n;
+  while (hi > 0 && countData[hi - 1].t.hour >= end) {
+    hi -= 1;
+  }
+  return { lo, hi };
 }
 
 /**
@@ -172,20 +160,18 @@ function indexRangePeakHour(countData, indexRange, fnVolume) {
  * @namespace
  */
 const ReportTimeUtils = {
-  indexRangeAm,
+  indexRangeHourOfDay,
   indexRangeMax,
   indexRangePeakHour,
-  indexRangePm,
   indexRangeSum,
   indexRangesConsecutiveHours,
 };
 
 export {
   ReportTimeUtils as default,
-  indexRangeAm,
+  indexRangeHourOfDay,
   indexRangeMax,
   indexRangePeakHour,
-  indexRangePm,
   indexRangeSum,
   indexRangesConsecutiveHours,
 };

--- a/tests/jest/unit/reports/ReportPeakHourFactor.spec.js
+++ b/tests/jest/unit/reports/ReportPeakHourFactor.spec.js
@@ -16,8 +16,8 @@ expect.extend({
 });
 
 function expectPeakHourFactorsMatch(actual, expected) {
-  expect(actual.timeRange.start.equals(expected.timeRange.start)).toBe(true);
-  expect(actual.timeRange.end.equals(expected.timeRange.end)).toBe(true);
+  expect(actual.timeRange.start.toString()).toEqual(expected.timeRange.start.toString());
+  expect(actual.timeRange.end.toString()).toEqual(expected.timeRange.end.toString());
   Object.keys(expected.movement).forEach((key) => {
     expect(actual.movement[key]).toBeWithinTolerance(expected.movement[key], 0.001);
   });

--- a/tests/jest/unit/reports/time/ReportTimeUtils.spec.js
+++ b/tests/jest/unit/reports/time/ReportTimeUtils.spec.js
@@ -1,0 +1,45 @@
+import Random from '@/lib/Random';
+import { indexRangeHourOfDay } from '@/lib/reports/time/ReportTimeUtils';
+import DateTime from '@/lib/time/DateTime';
+
+test('ReportTimeUtils.indexRangeHourOfDay [empty test]', () => {
+  const countData = [];
+  expect(indexRangeHourOfDay(countData, 7, 10)).toEqual({ lo: 0, hi: 0 });
+});
+
+function getRandomCountData() {
+  const countData = [];
+  const k = Random.range(10, 20);
+  for (let i = 0; i < k; i++) {
+    const t = DateTime.fromObject({
+      year: 2012,
+      month: 4,
+      day: 1,
+      hour: Random.range(0, 24),
+      minute: Random.range(0, 60),
+    });
+    countData.push({ t });
+  }
+  countData.sort(({ t: ta }, { t: tb }) => ta.valueOf() - tb.valueOf());
+  return countData;
+}
+
+function getRandomHourOfDayRange() {
+  const a = Random.range(0, 24);
+  const b = Random.range(0, 24);
+  if (a < b) {
+    return { start: a, end: b };
+  }
+  return { start: b, end: a };
+}
+
+test('ReportTimeUtils.indexRangeHourOfDay [fuzz test]', () => {
+  for (let i = 0; i < 10; i++) {
+    const countData = getRandomCountData();
+    const { start, end } = getRandomHourOfDayRange();
+    const { lo, hi } = indexRangeHourOfDay(countData, start, end);
+    countData.forEach(({ t }, j) => {
+      expect(t.hour >= start && t.hour < end).toEqual(j >= lo && j < hi);
+    });
+  }
+});


### PR DESCRIPTION
# Issue Addressed
This PR closes #792 .

# Description
We start with `indexRangeHourOfDay`, which is used in `ReportPeakHourFactor`.  (We might eventually add more unit tests for other pieces of `ReportTimeUtils`, but that will have to come after Version 1.2 at this point; for now, it's enough to have the side-by-side test, and to start testing `ReportTimeUtils` functionality.)

# Tests
CI tests (including new `ReportTimeUtils` test and PHF side-by-side test), checked quickly in browser.
