### PR TITLE
Send individual cancellation emails when updating bulk request

### DIFF
--- a/lib/controller/StudyRequestBulkController.js
+++ b/lib/controller/StudyRequestBulkController.js
@@ -7,7 +7,7 @@ import StudyRequestChangeDAO from '@/lib/db/StudyRequestChangeDAO';
 import EmailStudyRequestBulkRequested from '@/lib/email/EmailStudyRequestBulkRequested';
 import EmailStudyRequestBulkRequestedAdmin from '@/lib/email/EmailStudyRequestBulkRequestedAdmin';
 import {
-  getStudyRequestBulkUpdateEmails,
+  getStudyRequestBulkUpdateEmailsDeep,
   sendEmailsSafe,
 } from '@/lib/email/MailUtils';
 import Joi from '@/lib/model/Joi';
@@ -253,7 +253,7 @@ StudyRequestBulkController.push({
     }
     const [studyRequestBulk] = await Promise.all(tasks);
 
-    const emails = await getStudyRequestBulkUpdateEmails(
+    const emails = await getStudyRequestBulkUpdateEmailsDeep(
       studyRequestBulkNew,
       studyRequestBulkOld,
     );

--- a/lib/email/MailUtils.js
+++ b/lib/email/MailUtils.js
@@ -93,6 +93,29 @@ async function getStudyRequestUpdateEmailsDeep(studyRequestNew, studyRequestOld)
   return emails;
 }
 
+async function getStudyRequestBulkUpdateEmailsDeep(studyRequestBulkNew, studyRequestBulkOld) {
+  const emails = [];
+
+  const n = studyRequestBulkNew.studyRequests.length;
+  for (let i = 0; i < n; i++) {
+    const studyRequestNew = studyRequestBulkNew.studyRequests[i];
+    if (studyRequestNew.status === StudyRequestStatus.CANCELLED) {
+      /*
+       * When an individual study request is cancelled, we always send an email notification,
+       * regardless of whether it's part of a larger bulk request or not.
+       */
+      const studyRequestOld = studyRequestBulkOld.studyRequests[i];
+      const emailsCancelled = getStudyRequestUpdateEmails(studyRequestNew, studyRequestOld);
+      emails.push(...emailsCancelled);
+    }
+  }
+
+  const emailsBulk = getStudyRequestBulkUpdateEmails(studyRequestBulkNew, studyRequestBulkOld);
+  emails.push(...emailsBulk);
+
+  return emails;
+}
+
 async function sendEmailSafe(request, email) {
   try {
     const emailOptions = await email.getOptions();
@@ -116,6 +139,7 @@ async function sendEmailsSafe(request, emails) {
 
 const MailUtils = {
   getStudyRequestBulkUpdateEmails,
+  getStudyRequestBulkUpdateEmailsDeep,
   getStudyRequestUpdateEmails,
   getStudyRequestUpdateEmailsDeep,
   sendEmailSafe,
@@ -125,6 +149,7 @@ const MailUtils = {
 export {
   MailUtils as default,
   getStudyRequestBulkUpdateEmails,
+  getStudyRequestBulkUpdateEmailsDeep,
   getStudyRequestUpdateEmails,
   getStudyRequestUpdateEmailsDeep,
   sendEmailSafe,


### PR DESCRIPTION
# Issue Addressed
This PR closes #825 .

# Description
We introduce `getStudyRequestBulkUpdateEmailsDeep` in `MailUtils`, which also looks for individual study requests being cancelled and ensures we send notification emails for those.  We then use this instead of the non-deep version from `StudyRequestBulkController`, to capture status updates from the table at bottom of View Bulk Request.

# Tests
Added test cases to `MailUtils` unit tests, and ensured these pass.  Will need end-to-end testing in AWS dev / QA.
