### PR TITLE
Update CI/CD configs to allow for manually-triggered prod deployments

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,19 +56,11 @@ deploy-qa:
   only:
     - deploy-qa
 
-# deploy staging automatically
-deploy-staging:
-  stage: deploy
-  script:
-    - echo deploy-staging
-  only:
-    - deploy-staging
-
 # deploy prod manually after approval
 deploy-prod:
   stage: deploy
   script:
-    - echo deploy-prod
+    - ./scripts/deployment/code-commit/deploy_code_commit.sh
   only:
     - deploy-prod
   when: manual

--- a/scripts/deployment/code-commit/deploy_code_commit.sh
+++ b/scripts/deployment/code-commit/deploy_code_commit.sh
@@ -7,6 +7,8 @@ if [ "${CI_COMMIT_REF_NAME}" = "master" ]; then
   TARGET_ENV="flashcrow-dev0"
 elif [ "${CI_COMMIT_REF_NAME}" = "deploy-qa" ]; then
   TARGET_ENV="flashcrow-qa0"
+elif [ "${CI_COMMIT_REF_NAME}" = "deploy-prod" ]; then
+  TARGET_ENV="flashcrow-prod0"
 else
   echo "Invalid branch for deployment: ${CI_COMMIT_REF_NAME}"
   exit 1


### PR DESCRIPTION
# Issue Addressed
This PR closes #772 .

# Description
We remove `deploy-staging` from our CI/CD configs, and update the `deploy-prod` config to run `deploy_code_commit.sh` when manually triggered.  This manual triggering is performed from the Gitlab admin console.

# Tests
We'll have to test this one with Version 1.2 deployment, but it's pretty straightforward.
