### PR TITLE
Global filters: stub UI for filter box, drawer

### DIFF
--- a/web/App.vue
+++ b/web/App.vue
@@ -18,6 +18,8 @@
     <v-main>
       <router-view></router-view>
     </v-main>
+    <FcGlobalFilterDrawer
+      v-model="internalFiltersOpen" />
   </v-app>
 </template>
 
@@ -40,6 +42,7 @@ import FcToastBackendError from '@/web/components/dialogs/FcToastBackendError.vu
 import FcToastError from '@/web/components/dialogs/FcToastError.vue';
 import FcToastInfo from '@/web/components/dialogs/FcToastInfo.vue';
 import FcToastJob from '@/web/components/dialogs/FcToastJob.vue';
+import FcGlobalFilterDrawer from '@/web/components/filters/FcGlobalFilterDrawer.vue';
 import FcAppbar from '@/web/components/nav/FcAppbar.vue';
 import FcNavbar from '@/web/components/nav/FcNavbar.vue';
 import FrontendEnv from '@/web/config/FrontendEnv';
@@ -47,11 +50,12 @@ import FrontendEnv from '@/web/config/FrontendEnv';
 export default {
   name: 'App',
   components: {
+    FcAppbar,
     FcDialogAlertStudyRequestUrgent,
     FcDialogAlertStudyRequestsUnactionable,
     FcDialogAlertStudyTypeUnactionable,
     FcDialogConfirmUnauthorized,
-    FcAppbar,
+    FcGlobalFilterDrawer,
     FcNavbar,
     FcToastBackendError,
     FcToastError,
@@ -82,11 +86,20 @@ export default {
         }
       },
     },
+    internalFiltersOpen: {
+      get() {
+        return this.filtersOpen;
+      },
+      set(filtersOpen) {
+        this.setFiltersOpen(filtersOpen);
+      },
+    },
     ...mapState([
       'ariaNotification',
       'auth',
       'dialog',
       'dialogData',
+      'filtersOpen',
       'frontendEnv',
       'toast',
       'toastData',
@@ -109,7 +122,7 @@ export default {
     },
   },
   methods: {
-    ...mapMutations(['clearDialog', 'clearToast']),
+    ...mapMutations(['clearDialog', 'clearToast', 'setFiltersOpen']),
   },
 };
 </script>

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -40,13 +40,21 @@
           v-if="locationMode === LocationMode.MULTI_EDIT"
           :locations="locationsEdit"
           :locations-selection="locationsEditSelection" />
-        <FcViewDataDetail
-          v-else-if="locationMode === LocationMode.SINGLE || detailView"
-          :location="locationActive" />
-        <FcViewDataAggregate
-          v-else
-          :locations="locations"
-          :locations-selection="locationsSelection" />
+        <template v-else>
+          <FcGlobalFilters
+            class="pa-5"
+            header-tag="h3" />
+
+          <v-divider></v-divider>
+
+          <FcViewDataDetail
+            v-if="locationMode === LocationMode.SINGLE || detailView"
+            :location="locationActive" />
+          <FcViewDataAggregate
+            v-else
+            :locations="locations"
+            :locations-selection="locationsSelection" />
+        </template>
       </template>
     </section>
   </div>
@@ -69,6 +77,7 @@ import FcViewDataAggregate from '@/web/components/data/FcViewDataAggregate.vue';
 import FcViewDataDetail from '@/web/components/data/FcViewDataDetail.vue';
 import FcViewDataMultiEdit from '@/web/components/data/FcViewDataMultiEdit.vue';
 import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
+import FcGlobalFilters from '@/web/components/filters/FcGlobalFilters.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcSelectorSingleLocation from '@/web/components/inputs/FcSelectorSingleLocation.vue';
 import FcSelectorMultiLocation from '@/web/components/inputs/FcSelectorMultiLocation.vue';
@@ -83,6 +92,7 @@ export default {
   ],
   components: {
     FcButton,
+    FcGlobalFilters,
     FcHeaderSingleLocation,
     FcProgressLinear,
     FcSelectorMultiLocation,

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -32,6 +32,9 @@
         <FcSelectorSingleLocation
           v-else
           class="mt-5 ml-5" />
+
+        <FcGlobalFilterBox
+          class="mt-5 ml-5" />
       </div>
       <FcPaneMapLegend
         v-if="showLegend"
@@ -122,6 +125,7 @@ import FcPaneMapPopup from '@/web/components/FcPaneMapPopup.vue';
 import FcDialogConfirmMultiLocationLeave
   from '@/web/components/dialogs/FcDialogConfirmMultiLocationLeave.vue';
 import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
+import FcGlobalFilterBox from '@/web/components/filters/FcGlobalFilterBox.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcButtonAria from '@/web/components/inputs/FcButtonAria.vue';
 import FcPaneMapLegend from '@/web/components/inputs/FcPaneMapLegend.vue';
@@ -194,6 +198,7 @@ export default {
     FcButton,
     FcButtonAria,
     FcDialogConfirmMultiLocationLeave,
+    FcGlobalFilterBox,
     FcPaneMapLegend,
     FcPaneMapPopup,
     FcProgressLinear,

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -35,7 +35,8 @@
 
         <FcGlobalFilterBox
           v-if="showFilters"
-          class="mt-5 ml-5" />
+          class="mt-5 ml-5"
+          :readonly="filtersReadonly" />
       </div>
       <FcPaneMapLegend
         v-if="showLegend"
@@ -138,6 +139,11 @@ const BOUNDS_TORONTO = new mapboxgl.LngLatBounds(
   new mapboxgl.LngLat(-79.639264937, 43.580995995),
   new mapboxgl.LngLat(-79.115243191, 43.855457183),
 );
+
+const ROUTES_EDIT_FILTERS = [
+  'viewData',
+  'viewDataAtLocation',
+];
 
 const ROUTES_FOCUS_LOCATIONS = [
   'requestStudyBulkEdit',
@@ -301,6 +307,9 @@ export default {
     },
     featureKeySelected() {
       return getFeatureKey(this.selectedFeature);
+    },
+    filtersReadonly() {
+      return !ROUTES_EDIT_FILTERS.includes(this.$route.name);
     },
     focusLocations() {
       return this.locationMode === LocationMode.MULTI_EDIT

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -34,6 +34,7 @@
           class="mt-5 ml-5" />
 
         <FcGlobalFilterBox
+          v-if="showFilters"
           class="mt-5 ml-5" />
       </div>
       <FcPaneMapLegend
@@ -218,6 +219,10 @@ export default {
     background: {
       type: Boolean,
       default: false,
+    },
+    showFilters: {
+      type: Boolean,
+      default: true,
     },
     showLegend: {
       type: Boolean,

--- a/web/components/data/FcHeaderCollisions.vue
+++ b/web/components/data/FcHeaderCollisions.vue
@@ -1,7 +1,7 @@
 <template>
   <header class="pa-5">
     <div class="align-center d-flex">
-      <h3 class="display-2">Collisions</h3>
+      <h3 class="headline">Collisions</h3>
       <v-spacer></v-spacer>
       <FcDialogCollisionFilters
         v-if="showFiltersCollision"

--- a/web/components/data/FcHeaderStudies.vue
+++ b/web/components/data/FcHeaderStudies.vue
@@ -1,7 +1,7 @@
 <template>
   <header class="pa-5">
     <div class="align-center d-flex">
-      <h3 class="display-2">Studies</h3>
+      <h3 class="headline">Studies</h3>
       <v-spacer></v-spacer>
       <FcDialogStudyFilters
         v-if="showFiltersStudy"

--- a/web/components/filters/FcGlobalFilterBox.vue
+++ b/web/components/filters/FcGlobalFilterBox.vue
@@ -1,0 +1,92 @@
+<template>
+  <v-card width="392">
+    <v-card-title>
+      <h2 class="headline">Filters</h2>
+      <v-spacer></v-spacer>
+      <FcButton
+        v-if="!readonly"
+        type="tertiary"
+        @click="actionEdit">
+        Edit
+      </FcButton>
+    </v-card-title>
+
+    <v-card-text>
+      <div>
+        <FcListFilterChips
+          :filter-chips="filterChipsCommon"
+          :readonly="readonly" />
+      </div>
+      <div class="mt-2">
+        <FcListFilterChips
+          :filter-chips="filterChipsCollision"
+          :readonly="readonly" />
+      </div>
+      <div class="mt-2">
+        <FcListFilterChips
+          :filter-chips="filterChipsStudy"
+          :readonly="readonly" />
+      </div>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script>
+import { StudyType } from '@/lib/Constants';
+import DateTime from '@/lib/time/DateTime';
+import TimeFormatters from '@/lib/time/TimeFormatters';
+import FcListFilterChips from '@/web/components/filters/FcListFilterChips.vue';
+import FcButton from '@/web/components/inputs/FcButton.vue';
+
+export default {
+  name: 'FcGlobalFilterBox',
+  components: {
+    FcButton,
+    FcListFilterChips,
+  },
+  props: {
+    readonly: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  computed: {
+    // TODO: use actual chips
+    filterChipsCollision() {
+      return [
+        { filter: 'emphasisAreas', label: 'KSI', value: null },
+      ];
+    },
+    filterChipsCommon() {
+      const dateRangeStart = DateTime.fromObject({
+        year: 2002,
+        month: 12,
+        day: 1,
+      });
+      const dateRangeEnd = DateTime.fromObject({
+        year: 2020,
+        month: 12,
+        day: 1,
+      });
+      const label = TimeFormatters.formatRangeDate({
+        start: dateRangeStart,
+        end: dateRangeEnd,
+      });
+      const value = { dateRangeStart, dateRangeEnd };
+      return [
+        { filter: 'dateRange', label, value },
+      ];
+    },
+    filterChipsStudy() {
+      return [
+        { filter: 'studyTypes', label: 'TMC', value: StudyType.TMC },
+      ];
+    },
+  },
+  methods: {
+    actionEdit() {
+      // TODO: implement this
+    },
+  },
+};
+</script>

--- a/web/components/filters/FcGlobalFilterBox.vue
+++ b/web/components/filters/FcGlobalFilterBox.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-card width="392">
-    <v-card-title>
+  <v-card width="472">
+    <v-card-title class="pb-0">
       <h2 class="headline">Filters</h2>
       <v-spacer></v-spacer>
       <FcButton
@@ -12,18 +12,26 @@
     </v-card-title>
 
     <v-card-text>
-      <div>
+      <div class="align-center d-flex mt-2">
         <FcListFilterChips
           :filter-chips="filterChipsCommon"
           :readonly="readonly" />
       </div>
-      <div class="mt-2">
+      <div class="align-center d-flex mt-2">
+        <span class="font-weight-regular headline">
+          Collisions &#x2022;
+        </span>
         <FcListFilterChips
+          class="ml-1"
           :filter-chips="filterChipsCollision"
           :readonly="readonly" />
       </div>
-      <div class="mt-2">
+      <div class="align-center d-flex mt-2">
+        <span class="font-weight-regular headline">
+          Studies &#x2022;
+        </span>
         <FcListFilterChips
+          class="ml-1"
           :filter-chips="filterChipsStudy"
           :readonly="readonly" />
       </div>

--- a/web/components/filters/FcGlobalFilterBox.vue
+++ b/web/components/filters/FcGlobalFilterBox.vue
@@ -1,99 +1,23 @@
 <template>
   <v-card width="472">
-    <v-card-title class="pb-0">
-      <h2 class="headline">Filters</h2>
-      <v-spacer></v-spacer>
-      <FcButton
-        v-if="!readonly"
-        type="tertiary"
-        @click="actionEdit">
-        Edit
-      </FcButton>
-    </v-card-title>
-
     <v-card-text>
-      <div class="align-center d-flex mt-2">
-        <FcListFilterChips
-          :filter-chips="filterChipsCommon"
-          :readonly="readonly" />
-      </div>
-      <div class="align-center d-flex mt-2">
-        <span class="font-weight-regular headline">
-          Collisions &#x2022;
-        </span>
-        <FcListFilterChips
-          class="ml-1"
-          :filter-chips="filterChipsCollision"
-          :readonly="readonly" />
-      </div>
-      <div class="align-center d-flex mt-2">
-        <span class="font-weight-regular headline">
-          Studies &#x2022;
-        </span>
-        <FcListFilterChips
-          class="ml-1"
-          :filter-chips="filterChipsStudy"
-          :readonly="readonly" />
-      </div>
+      <FcGlobalFilters :readonly="readonly" />
     </v-card-text>
   </v-card>
 </template>
 
 <script>
-import { StudyType } from '@/lib/Constants';
-import DateTime from '@/lib/time/DateTime';
-import TimeFormatters from '@/lib/time/TimeFormatters';
-import FcListFilterChips from '@/web/components/filters/FcListFilterChips.vue';
-import FcButton from '@/web/components/inputs/FcButton.vue';
+import FcGlobalFilters from '@/web/components/filters/FcGlobalFilters.vue';
 
 export default {
   name: 'FcGlobalFilterBox',
   components: {
-    FcButton,
-    FcListFilterChips,
+    FcGlobalFilters,
   },
   props: {
     readonly: {
       type: Boolean,
       default: false,
-    },
-  },
-  computed: {
-    // TODO: use actual chips
-    filterChipsCollision() {
-      return [
-        { filter: 'emphasisAreas', label: 'KSI', value: null },
-      ];
-    },
-    filterChipsCommon() {
-      const dateRangeStart = DateTime.fromObject({
-        year: 2002,
-        month: 12,
-        day: 1,
-      });
-      const dateRangeEnd = DateTime.fromObject({
-        year: 2020,
-        month: 12,
-        day: 1,
-      });
-      const label = TimeFormatters.formatRangeDate({
-        start: dateRangeStart,
-        end: dateRangeEnd,
-      });
-      const value = { dateRangeStart, dateRangeEnd };
-      return [
-        { filter: 'dateRange', label, value },
-      ];
-    },
-    filterChipsStudy() {
-      return [
-        { filter: 'studyTypes', label: 'TMC', value: StudyType.TMC },
-      ];
-    },
-  },
-  methods: {
-    actionEdit() {
-      // TODO: implement this
     },
   },
 };

--- a/web/components/filters/FcGlobalFilterDrawer.vue
+++ b/web/components/filters/FcGlobalFilterDrawer.vue
@@ -6,15 +6,61 @@
     right
     temporary
     :width="280">
+    <div class="d-flex fill-height flex-column">
+      <div class="align-center d-flex flex-grow-0 flex-shrink-0 px-4 py-3 shading">
+        <h2 class="display-1">Filter</h2>
+        <v-spacer></v-spacer>
+        <FcButton
+          type="secondary"
+          @click="actionClearAll">
+          Clear All
+        </FcButton>
+      </div>
+
+      <v-divider></v-divider>
+
+      <div class="flex-grow-1 flex-shrink-1">
+        TODO: filters body
+      </div>
+
+      <v-divider></v-divider>
+
+      <div class="d-flex flex-grow-0 flex-shrink-0 px-4 py-2 shading">
+        <v-spacer></v-spacer>
+        <FcButton
+          type="tertiary"
+          @click="internalValue = false">
+          Cancel
+        </FcButton>
+        <FcButton
+          type="tertiary"
+          @click="actionSave">
+          Save
+        </FcButton>
+      </div>
+    </div>
   </v-navigation-drawer>
 </template>
 
 <script>
+import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
 export default {
   name: 'FcGlobalFilterDrawer',
   mixins: [FcMixinVModelProxy(Boolean)],
+  components: {
+    FcButton,
+  },
+  methods: {
+    actionClearAll() {
+
+    },
+    actionSave() {
+      // TODO: implement this
+      this.internalValue = false;
+    },
+  },
 };
 </script>
 

--- a/web/components/filters/FcGlobalFilterDrawer.vue
+++ b/web/components/filters/FcGlobalFilterDrawer.vue
@@ -1,0 +1,25 @@
+<template>
+  <v-navigation-drawer
+    v-model="internalValue"
+    absolute
+    class="fc-global-filter-drawer"
+    right
+    temporary
+    :width="280">
+  </v-navigation-drawer>
+</template>
+
+<script>
+import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+
+export default {
+  name: 'FcGlobalFilterDrawer',
+  mixins: [FcMixinVModelProxy(Boolean)],
+};
+</script>
+
+<style lang="scss">
+.fc-global-filter-drawer.v-navigation-drawer--temporary {
+  z-index: 400;
+}
+</style>

--- a/web/components/filters/FcGlobalFilterDrawer.vue
+++ b/web/components/filters/FcGlobalFilterDrawer.vue
@@ -6,7 +6,9 @@
     right
     temporary
     :width="280">
-    <div class="d-flex fill-height flex-column">
+    <div
+      ref="content"
+      class="d-flex fill-height flex-column">
       <div class="align-center d-flex flex-grow-0 flex-shrink-0 px-4 py-3 shading">
         <h2 class="display-1">Filter</h2>
         <v-spacer></v-spacer>
@@ -48,9 +50,31 @@ import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
 export default {
   name: 'FcGlobalFilterDrawer',
-  mixins: [FcMixinVModelProxy(Boolean)],
+  mixins: [
+    FcMixinVModelProxy(Boolean),
+  ],
   components: {
     FcButton,
+  },
+  data() {
+    return {
+      previousActiveElement: null,
+    };
+  },
+  watch: {
+    internalValue() {
+      if (this.internalValue) {
+        this.show();
+      } else {
+        this.unbind();
+        if (this.previousActiveElement !== null) {
+          this.previousActiveElement.focus();
+        }
+      }
+    },
+  },
+  beforeDestroy() {
+    this.unbind();
   },
   methods: {
     actionClearAll() {
@@ -59,6 +83,50 @@ export default {
     actionSave() {
       // TODO: implement this
       this.internalValue = false;
+    },
+    /*
+     * These methods ensure that focus is trapped within the navigation drawer.  This
+     * implementation is borrowed from `<v-dialog>`, which also relies on focus-trapping;
+     * unfortunately, Vuetify does not make that functionality available to other
+     * components.
+     */
+    bind() {
+      window.addEventListener('focusin', this.onFocusin);
+    },
+    onFocusin(evt) {
+      if (!evt) {
+        return;
+      }
+      const { target } = evt;
+      if (
+        !!target
+        // It isn't the document or the dialog body
+        && ![document, this.$refs.content].includes(target)
+        // It isn't inside the dialog body
+        && !this.$refs.content.contains(target)
+      ) {
+        // Find and focus the first available element inside the dialog
+        const focusable = this.$refs.content.querySelectorAll(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        );
+        const el = [...focusable].find(elFocusable => !elFocusable.hasAttribute('disabled'));
+        if (el) {
+          el.focus();
+        }
+      }
+    },
+    show() {
+      // Double nextTick to wait for lazy content to be generated
+      this.$nextTick(() => {
+        this.$nextTick(() => {
+          this.previousActiveElement = document.activeElement;
+          this.$refs.content.focus();
+          this.bind();
+        });
+      });
+    },
+    unbind() {
+      window.removeEventListener('focusin', this.onFocusin);
     },
   },
 };

--- a/web/components/filters/FcGlobalFilters.vue
+++ b/web/components/filters/FcGlobalFilters.vue
@@ -12,7 +12,7 @@
       <FcButton
         v-if="!readonly"
         type="tertiary"
-        @click="actionEdit">
+        @click="setFiltersOpen(true)">
         Edit
       </FcButton>
     </div>
@@ -43,6 +43,8 @@
 </template>
 
 <script>
+import { mapMutations } from 'vuex';
+
 import { StudyType } from '@/lib/Constants';
 import DateTime from '@/lib/time/DateTime';
 import TimeFormatters from '@/lib/time/TimeFormatters';
@@ -99,9 +101,7 @@ export default {
     },
   },
   methods: {
-    actionEdit() {
-      // TODO: implement this
-    },
+    ...mapMutations(['setFiltersOpen']),
   },
 };
 </script>

--- a/web/components/filters/FcGlobalFilters.vue
+++ b/web/components/filters/FcGlobalFilters.vue
@@ -1,0 +1,107 @@
+<template>
+  <section
+    aria-labelledby="heading_global_filters"
+    class="fc-global-filters default--text">
+    <div class="align-center d-flex">
+      <component
+        :is="headerTag"
+        class="headline" id="heading_global_filters">
+        Filters
+      </component>
+      <v-spacer></v-spacer>
+      <FcButton
+        v-if="!readonly"
+        type="tertiary"
+        @click="actionEdit">
+        Edit
+      </FcButton>
+    </div>
+    <div class="align-center d-flex mt-2">
+      <FcListFilterChips
+        :filter-chips="filterChipsCommon"
+        :readonly="readonly" />
+    </div>
+    <div class="align-center d-flex mt-2">
+      <span class="font-weight-regular headline secondary--text">
+        Collisions &#x2022;
+      </span>
+      <FcListFilterChips
+        class="ml-1"
+        :filter-chips="filterChipsCollision"
+        :readonly="readonly" />
+    </div>
+    <div class="align-center d-flex mt-2">
+      <span class="font-weight-regular headline secondary--text">
+        Studies &#x2022;
+      </span>
+      <FcListFilterChips
+        class="ml-1"
+        :filter-chips="filterChipsStudy"
+        :readonly="readonly" />
+    </div>
+  </section>
+</template>
+
+<script>
+import { StudyType } from '@/lib/Constants';
+import DateTime from '@/lib/time/DateTime';
+import TimeFormatters from '@/lib/time/TimeFormatters';
+import FcListFilterChips from '@/web/components/filters/FcListFilterChips.vue';
+import FcButton from '@/web/components/inputs/FcButton.vue';
+
+export default {
+  name: 'FcGlobalFilters',
+  components: {
+    FcButton,
+    FcListFilterChips,
+  },
+  props: {
+    headerTag: {
+      type: String,
+      default: 'h2',
+    },
+    readonly: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  computed: {
+    // TODO: use actual chips
+    filterChipsCollision() {
+      return [
+        { filter: 'emphasisAreas', label: 'KSI', value: null },
+      ];
+    },
+    filterChipsCommon() {
+      const dateRangeStart = DateTime.fromObject({
+        year: 2002,
+        month: 12,
+        day: 1,
+      });
+      const dateRangeEnd = DateTime.fromObject({
+        year: 2020,
+        month: 12,
+        day: 1,
+      });
+      const label = TimeFormatters.formatRangeDate({
+        start: dateRangeStart,
+        end: dateRangeEnd,
+      });
+      const value = { dateRangeStart, dateRangeEnd };
+      return [
+        { filter: 'dateRange', label, value },
+      ];
+    },
+    filterChipsStudy() {
+      return [
+        { filter: 'studyTypes', label: 'TMC', value: StudyType.TMC },
+      ];
+    },
+  },
+  methods: {
+    actionEdit() {
+      // TODO: implement this
+    },
+  },
+};
+</script>

--- a/web/components/filters/FcGlobalFilters.vue
+++ b/web/components/filters/FcGlobalFilters.vue
@@ -1,11 +1,11 @@
 <template>
   <section
-    aria-labelledby="heading_global_filters"
+    :aria-labelledby="headingId"
     class="fc-global-filters default--text">
     <div class="align-center d-flex">
       <component
         :is="headerTag"
-        class="headline" id="heading_global_filters">
+        class="headline" :id="headingId">
         Filters
       </component>
       <v-spacer></v-spacer>
@@ -51,6 +51,8 @@ import TimeFormatters from '@/lib/time/TimeFormatters';
 import FcListFilterChips from '@/web/components/filters/FcListFilterChips.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 
+let HEADING_ID_SUFFIX = 0;
+
 export default {
   name: 'FcGlobalFilters',
   components: {
@@ -66,6 +68,14 @@ export default {
       type: Boolean,
       default: false,
     },
+  },
+  data() {
+    const suffix = HEADING_ID_SUFFIX;
+    const headingId = `heading_global_filters_${suffix}`;
+    HEADING_ID_SUFFIX += 1;
+    return {
+      headingId,
+    };
   },
   computed: {
     // TODO: use actual chips

--- a/web/components/filters/FcListFilterChips.vue
+++ b/web/components/filters/FcListFilterChips.vue
@@ -33,7 +33,6 @@ export default {
       if (this.readonly) {
         return {
           filter: true,
-          inputValue: true,
         };
       }
       return { color: 'light-blue lighten-5' };

--- a/web/components/inputs/FcSelectorSingleLocation.vue
+++ b/web/components/inputs/FcSelectorSingleLocation.vue
@@ -51,7 +51,7 @@ export default {
 <style lang="scss">
 .fc-selector-single-location {
   & > .fc-input-location-search {
-    width: 392px;
+    width: 472px;
   }
 }
 </style>

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -51,6 +51,7 @@ export default new Vuex.Store({
     dialog: null,
     dialogData: {},
     drawerOpen: false,
+    filtersOpen: false,
     toast: null,
     toastData: {},
     toastKey: 0,
@@ -218,6 +219,9 @@ export default new Vuex.Store({
     },
     setDrawerOpen(state, drawerOpen) {
       Vue.set(state, 'drawerOpen', drawerOpen);
+    },
+    setFiltersOpen(state, filtersOpen) {
+      Vue.set(state, 'filtersOpen', filtersOpen);
     },
     setToast(state, { toast, toastData = {} }) {
       Vue.set(state, 'toast', toast);

--- a/web/views/FcRequestStudyBulkView.vue
+++ b/web/views/FcRequestStudyBulkView.vue
@@ -38,6 +38,7 @@
           <v-col cols="6">
             <FcPaneMap
               class="mx-5"
+              :show-filters="false"
               :show-legend="false"
               :show-location-selection="false"
               :show-modes="false"

--- a/web/views/FcRequestStudyView.vue
+++ b/web/views/FcRequestStudyView.vue
@@ -49,6 +49,7 @@
           <v-col cols="6">
             <FcPaneMap
               class="mx-5"
+              :show-filters="false"
               :show-legend="false"
               :show-location-selection="false"
               :show-modes="false"


### PR DESCRIPTION
# Issue Addressed
This PR closes #840 .

# Description
We introduce `FcGlobalFilterBox` and `FcGlobalFilterDrawer`, and integrate these with the rest of the MOVE web frontend.  For now, these just contain stub filter chips; these will be replaced with actual filter chips in future PRs.

# Tests
Tested interactions quickly in frontend: drawer open / hide, different pages, `readonly` state, "Edit" button opens drawer, focus-trapping in drawer.  (We'll continue testing this more and more throughout implementation!)
