### PR TITLE
Move date range and day of week into common filters

### DIFF
--- a/lib/validation/ValidationsCollisionFilters.js
+++ b/lib/validation/ValidationsCollisionFilters.js
@@ -1,12 +1,4 @@
-import { requiredIf } from 'vuelidate/lib/validators';
-
 const ValidationsCollisionFilters = {
-  dateRangeStart: {
-    requiredIfApplyDateRange: requiredIf(({ applyDateRange }) => applyDateRange),
-  },
-  dateRangeEnd: {
-    requiredIfApplyDateRange: requiredIf(({ applyDateRange }) => applyDateRange),
-  },
   hoursOfDay: {
     fromBeforeTo(hoursOfDay) {
       const [fromHour, toHour] = hoursOfDay;

--- a/lib/validation/ValidationsCommonFilters.js
+++ b/lib/validation/ValidationsCommonFilters.js
@@ -1,6 +1,6 @@
 import { requiredIf } from 'vuelidate/lib/validators';
 
-const ValidationsStudyFilters = {
+const ValidationsCommonFilters = {
   dateRangeStart: {
     requiredIfApplyDateRange: requiredIf(({ applyDateRange }) => applyDateRange),
   },
@@ -9,4 +9,4 @@ const ValidationsStudyFilters = {
   },
 };
 
-export default ValidationsStudyFilters;
+export default ValidationsCommonFilters;

--- a/web/components/data/FcAggregateCollisions.vue
+++ b/web/components/data/FcAggregateCollisions.vue
@@ -22,7 +22,7 @@
               :a="collisionSummary[field.name]"
               :b="collisionSummaryUnfiltered[field.name]"
               class="flex-grow-0 flex-shrink-0 mr-5"
-              :show-b="hasFiltersCollision"
+              :show-b="hasFiltersCollision || hasFiltersCommon"
               small />
           </v-expansion-panel-header>
           <v-expansion-panel-content class="shading pt-1">
@@ -37,7 +37,7 @@
                   :a="collisionSummaryPerLocation[i][field.name]"
                   :b="collisionSummaryPerLocationUnfiltered[i][field.name]"
                   class="mr-9"
-                  :show-b="hasFiltersCollision"
+                  :show-b="hasFiltersCollision || hasFiltersCommon"
                   small />
               </template>
             </FcListLocationMulti>
@@ -97,7 +97,7 @@ export default {
     locationsIconProps() {
       return getLocationsIconProps(this.locations, this.locationsSelection.locations);
     },
-    ...mapGetters('viewData', ['hasFiltersCollision']),
+    ...mapGetters('viewData', ['hasFiltersCollision', 'hasFiltersCommon']),
   },
 };
 </script>

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -35,7 +35,7 @@
               :a="item.n"
               :b="item.nUnfiltered"
               class="flex-grow-0 flex-shrink-0 mr-5"
-              :show-b="hasFiltersStudy"
+              :show-b="hasFiltersCommon || hasFiltersStudy"
               small />
           </v-expansion-panel-header>
           <v-expansion-panel-content class="shading pt-1">
@@ -58,7 +58,7 @@
                     :a="itemsPerLocation[i][j].n"
                     :b="itemsPerLocation[i][j].nUnfiltered"
                     class="text-right"
-                    :show-b="hasFiltersStudy"
+                    :show-b="hasFiltersCommon || hasFiltersStudy"
                     small />
                   <div v-if="itemsPerLocation[i][j].n > 0">
                     <FcButton
@@ -150,7 +150,7 @@ export default {
     locationsIconProps() {
       return getLocationsIconProps(this.locations, this.locationsSelection.locations);
     },
-    ...mapGetters('viewData', ['hasFiltersStudy']),
+    ...mapGetters('viewData', ['hasFiltersCommon', 'hasFiltersStudy']),
   },
 };
 </script>

--- a/web/components/data/FcDetailCollisions.vue
+++ b/web/components/data/FcDetailCollisions.vue
@@ -14,7 +14,7 @@
               :a="collisionSummary.amount"
               :b="collisionSummaryUnfiltered.amount"
               class="mt-1"
-              :show-b="hasFiltersCollision" />
+              :show-b="hasFiltersCollision || hasFiltersCommon" />
           </dd>
         </div>
         <div class="flex-grow-1 flex-shrink-1">
@@ -26,7 +26,7 @@
               :a="collisionSummary.ksi"
               :b="collisionSummaryUnfiltered.ksi"
               class="mt-1"
-              :show-b="hasFiltersCollision" />
+              :show-b="hasFiltersCollision || hasFiltersCommon" />
           </dd>
         </div>
         <div class="fc-collisions-validated flex-grow-0 flex-shrink-0 mr-8">
@@ -38,7 +38,7 @@
               :a="collisionSummary.validated"
               :b="collisionSummaryUnfiltered.validated"
               class="mt-1"
-              :show-b="hasFiltersCollision" />
+              :show-b="hasFiltersCollision || hasFiltersCommon" />
           </dd>
         </div>
       </dl>
@@ -73,7 +73,7 @@ export default {
     loading: Boolean,
   },
   computed: {
-    ...mapGetters('viewData', ['hasFiltersCollision']),
+    ...mapGetters('viewData', ['hasFiltersCollision', 'hasFiltersCommon']),
   },
 };
 </script>

--- a/web/components/data/FcDetailStudies.vue
+++ b/web/components/data/FcDetailStudies.vue
@@ -35,7 +35,7 @@
             <FcTextSummaryFraction
               :a="item.n"
               :b="item.nUnfiltered"
-              :show-b="hasFiltersStudy" />
+              :show-b="hasFiltersCommon || hasFiltersStudy" />
           </div>
           <FcButton
             class="flex-grow-0 flex-shrink-0"
@@ -89,7 +89,7 @@ export default {
         };
       });
     },
-    ...mapGetters('viewData', ['hasFiltersStudy']),
+    ...mapGetters('viewData', ['hasFiltersCommon', 'hasFiltersStudy']),
   },
 };
 </script>

--- a/web/components/filters/FcCollisionFilters.vue
+++ b/web/components/filters/FcCollisionFilters.vue
@@ -13,40 +13,6 @@
         :value="emphasisArea"></v-checkbox>
     </fieldset>
 
-    <fieldset class="mt-6">
-      <legend class="headline">Date Range</legend>
-
-      <FcDatePicker
-        v-model="$v.internalValue.dateRangeStart.$model"
-        class="mt-2"
-        :error-messages="errorMessagesDateRangeStart"
-        hide-details="auto"
-        label="From (YYYY-MM-DD)"
-        :max="now">
-      </FcDatePicker>
-      <FcDatePicker
-        v-model="$v.internalValue.dateRangeEnd.$model"
-        class="mt-2"
-        :error-messages="errorMessagesDateRangeEnd"
-        hide-details="auto"
-        label="To (YYYY-MM-DD)"
-        :max="now">
-      </FcDatePicker>
-    </fieldset>
-
-    <fieldset class="mt-6">
-      <legend class="headline">Days of the Week</legend>
-
-      <v-checkbox
-        v-for="(label, i) in DAYS_OF_WEEK"
-        :key="i"
-        v-model="internalValue.daysOfWeek"
-        class="mt-2"
-        hide-details
-        :label="label"
-        :value="i"></v-checkbox>
-    </fieldset>
-
     <FcFilterHoursOfDay
       v-model="internalValue.hoursOfDay"
       class="mt-6"
@@ -68,66 +34,35 @@
 </template>
 
 <script>
-import { mapState } from 'vuex';
-
 import {
   CollisionEmphasisArea,
   CollisionRoadSurfaceCondition,
 } from '@/lib/Constants';
-import TimeFormatters from '@/lib/time/TimeFormatters';
-import ValidationsCollisionFilters from '@/lib/validation/ValidationsCollisionFilters';
 import FcFilterHoursOfDay from '@/web/components/filters/FcFilterHoursOfDay.vue';
-import FcDatePicker from '@/web/components/inputs/FcDatePicker.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
 export default {
   name: 'FcCollisionFilters',
   mixins: [FcMixinVModelProxy(Object)],
   components: {
-    FcDatePicker,
     FcFilterHoursOfDay,
+  },
+  props: {
+    v: Object,
   },
   data() {
     return {
       CollisionEmphasisArea,
       CollisionRoadSurfaceCondition,
-      DAYS_OF_WEEK: TimeFormatters.DAYS_OF_WEEK,
     };
   },
   computed: {
-    applyDateRange() {
-      const { dateRangeStart, dateRangeEnd } = this.internalValue;
-      return dateRangeStart !== null || dateRangeEnd !== null;
-    },
-    errorMessagesDateRangeStart() {
-      const errors = [];
-      if (!this.$v.internalValue.dateRangeStart.requiredIfApplyDateRange) {
-        errors.push('Please provide a date in YYYY-MM-DD format.');
-      }
-      return errors;
-    },
-    errorMessagesDateRangeEnd() {
-      const errors = [];
-      if (!this.$v.internalValue.dateRangeEnd.requiredIfApplyDateRange) {
-        errors.push('Please provide a date in YYYY-MM-DD format.');
-      }
-      return errors;
-    },
     errorMessagesHoursOfDay() {
       const errors = [];
-      if (!this.$v.internalValue.hoursOfDay.fromBeforeTo) {
+      if (!this.v.hoursOfDay.fromBeforeTo) {
         errors.push('From hour must be before to hour');
       }
       return errors;
-    },
-    ...mapState(['now']),
-  },
-  validations: {
-    internalValue: ValidationsCollisionFilters,
-  },
-  watch: {
-    applyDateRange() {
-      this.internalValue.applyDateRange = this.applyDateRange;
     },
   },
 };

--- a/web/components/filters/FcCommonFilters.vue
+++ b/web/components/filters/FcCommonFilters.vue
@@ -1,0 +1,87 @@
+<template>
+  <div>
+    <fieldset class="mt-6">
+      <legend class="headline">Date Range</legend>
+
+      <FcDatePicker
+        v-model="v.dateRangeStart.$model"
+        class="mt-2"
+        :error-messages="errorMessagesDateRangeStart"
+        hide-details="auto"
+        label="From (YYYY-MM-DD)"
+        :max="now">
+      </FcDatePicker>
+      <FcDatePicker
+        v-model="v.dateRangeEnd.$model"
+        class="mt-2"
+        :error-messages="errorMessagesDateRangeEnd"
+        hide-details="auto"
+        label="To (YYYY-MM-DD)"
+        :max="now">
+      </FcDatePicker>
+    </fieldset>
+
+    <fieldset class="mt-6">
+      <legend class="headline">Days of the Week</legend>
+
+      <v-checkbox
+        v-for="(label, i) in DAYS_OF_WEEK"
+        :key="i"
+        v-model="internalValue.daysOfWeek"
+        class="mt-2"
+        hide-details
+        :label="label"
+        :value="i"></v-checkbox>
+    </fieldset>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+
+import TimeFormatters from '@/lib/time/TimeFormatters';
+import FcDatePicker from '@/web/components/inputs/FcDatePicker.vue';
+import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+
+export default {
+  name: 'FcCommonFilters',
+  mixins: [FcMixinVModelProxy(Object)],
+  components: {
+    FcDatePicker,
+  },
+  props: {
+    v: Object,
+  },
+  data() {
+    return {
+      DAYS_OF_WEEK: TimeFormatters.DAYS_OF_WEEK,
+    };
+  },
+  computed: {
+    applyDateRange() {
+      const { dateRangeStart, dateRangeEnd } = this.internalValue;
+      return dateRangeStart !== null || dateRangeEnd !== null;
+    },
+    errorMessagesDateRangeStart() {
+      const errors = [];
+      if (!this.v.dateRangeStart.requiredIfApplyDateRange) {
+        errors.push('Please provide a date in YYYY-MM-DD format.');
+      }
+      return errors;
+    },
+    errorMessagesDateRangeEnd() {
+      const errors = [];
+      if (!this.v.dateRangeEnd.requiredIfApplyDateRange) {
+        errors.push('Please provide a date in YYYY-MM-DD format.');
+      }
+      return errors;
+    },
+    ...mapState(['now']),
+  },
+  watch: {
+    applyDateRange() {
+      this.internalValue.applyDateRange = this.applyDateRange;
+    },
+  },
+};
+</script>

--- a/web/components/filters/FcGlobalFilters.vue
+++ b/web/components/filters/FcGlobalFilters.vue
@@ -87,11 +87,9 @@ export default {
     };
   },
   computed: {
-    filterChipsCommon() {
-      return [];
-    },
     ...mapGetters('viewData', [
       'filterChipsCollision',
+      'filterChipsCommon',
       'filterChipsStudy',
       'hasFilters',
     ]),
@@ -101,8 +99,10 @@ export default {
       this.removeFilterCollision(filter);
       this.setToastInfo(`Removed collision filter: ${filter.label}.`);
     },
-    actionRemoveFilterCommon() {
+    actionRemoveFilterCommon(filter) {
       // TODO: implement this
+      this.removeFilterCommon(filter);
+      this.setToastInfo(`Removed filter: ${filter.label}.`);
     },
     actionRemoveFilterStudy(filter) {
       this.removeFilterStudy(filter);
@@ -111,6 +111,7 @@ export default {
     ...mapMutations(['setFiltersOpen', 'setToastInfo']),
     ...mapMutations('viewData', [
       'removeFilterCollision',
+      'removeFilterCommon',
       'removeFilterStudy',
     ]),
   },

--- a/web/components/filters/FcStudyFilters.vue
+++ b/web/components/filters/FcStudyFilters.vue
@@ -16,40 +16,6 @@
     </fieldset>
 
     <fieldset class="mt-6">
-      <legend class="headline">Days of the Week</legend>
-
-      <v-checkbox
-        v-for="(label, i) in DAYS_OF_WEEK"
-        :key="i"
-        v-model="internalValue.daysOfWeek"
-        class="mt-2"
-        hide-details
-        :label="label"
-        :value="i"></v-checkbox>
-    </fieldset>
-
-    <fieldset class="mt-6">
-      <legend class="headline">Date Range</legend>
-
-      <FcDatePicker
-        v-model="$v.internalValue.dateRangeStart.$model"
-        class="mt-2"
-        :error-messages="errorMessagesDateRangeStart"
-        hide-details="auto"
-        label="From (YYYY-MM-DD)"
-        :max="now">
-      </FcDatePicker>
-      <FcDatePicker
-        v-model="$v.internalValue.dateRangeEnd.$model"
-        class="mt-2"
-        :error-messages="errorMessagesDateRangeEnd"
-        hide-details="auto"
-        label="To (YYYY-MM-DD)"
-        :max="now">
-      </FcDatePicker>
-    </fieldset>
-
-    <fieldset class="mt-6">
       <legend class="headline">Hours</legend>
 
       <v-checkbox
@@ -65,58 +31,20 @@
 </template>
 
 <script>
-import { mapState } from 'vuex';
-
 import {
   StudyHours,
   StudyType,
 } from '@/lib/Constants';
-import TimeFormatters from '@/lib/time/TimeFormatters';
-import ValidationsStudyFilters from '@/lib/validation/ValidationsStudyFilters';
-import FcDatePicker from '@/web/components/inputs/FcDatePicker.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
 export default {
   name: 'FcStudyFilters',
   mixins: [FcMixinVModelProxy(Object)],
-  components: {
-    FcDatePicker,
-  },
   data() {
     return {
-      DAYS_OF_WEEK: TimeFormatters.DAYS_OF_WEEK,
       StudyHours,
       StudyType,
     };
-  },
-  computed: {
-    applyDateRange() {
-      const { dateRangeStart, dateRangeEnd } = this.internalValue;
-      return dateRangeStart !== null || dateRangeEnd !== null;
-    },
-    errorMessagesDateRangeStart() {
-      const errors = [];
-      if (!this.$v.internalValue.dateRangeStart.requiredIfApplyDateRange) {
-        errors.push('Please provide a date in YYYY-MM-DD format.');
-      }
-      return errors;
-    },
-    errorMessagesDateRangeEnd() {
-      const errors = [];
-      if (!this.$v.internalValue.dateRangeEnd.requiredIfApplyDateRange) {
-        errors.push('Please provide a date in YYYY-MM-DD format.');
-      }
-      return errors;
-    },
-    ...mapState(['now']),
-  },
-  validations: {
-    internalValue: ValidationsStudyFilters,
-  },
-  watch: {
-    applyDateRange() {
-      this.internalValue.applyDateRange = this.applyDateRange;
-    },
   },
 };
 </script>


### PR DESCRIPTION
# Issue Addressed
This PR closes #842 .

# Description
We move the date range and day-of-week filters out of collision / study-specific filters and into a common filter area.  This involves changes to the `vuex` store, filter box, and filter drawer.

# Tests
Tested quickly in frontend: editing common filters, editing both common and collision / study filters, data is still fetched in View Data, filter chips show up in filter box as expected.  More testing to occur after more development.