### PR TITLE
Move map legend state to separate vuex module

### DIFF
--- a/lib/geo/GeoStyle.js
+++ b/lib/geo/GeoStyle.js
@@ -568,11 +568,14 @@ class GeoStyle {
     ];
   }
 
-  static getCollisionsLayers({ datesFrom, layers: { collisions } }) {
+  static getCollisionsLayers({ layers: { collisions } }) {
     const sourceLevel3 = 'collisionsLevel3:10';
     const sourceLevel2 = 'collisionsLevel2:10';
     const sourceLevel1 = 'collisionsLevel1';
     const visibility = collisions ? 'visible' : 'none';
+
+    // TODO: replace this with actual filtered settings
+    const datesFrom = 10;
     const datesFromYearsAgo = NOW.minus({ years: datesFrom });
     return [
       {
@@ -688,9 +691,12 @@ class GeoStyle {
     ];
   }
 
-  static getStudiesLayers({ datesFrom, layers: { studies } }) {
+  static getStudiesLayers({ layers: { studies } }) {
     const source = 'studies';
     const visibility = studies ? 'visible' : 'none';
+
+    // TODO: replace this with actual filtered settings
+    const datesFrom = 10;
     const datesFromYearsAgo = NOW.minus({ years: datesFrom });
     return [
       {

--- a/web/components/FcPaneMap.vue
+++ b/web/components/FcPaneMap.vue
@@ -40,7 +40,7 @@
       </div>
       <FcPaneMapLegend
         v-if="showLegend"
-        v-model="internalLegendOptions" />
+        v-model="internalLayers" />
       <div
         v-if="showModes"
         class="pane-map-mode">
@@ -315,12 +315,12 @@ export default {
       return this.locationMode === LocationMode.MULTI_EDIT
         || ROUTES_FOCUS_LOCATIONS.includes(this.$route.name);
     },
-    internalLegendOptions: {
+    internalLayers: {
       get() {
-        return this.legendOptionsForMode;
+        return this.layersForMode;
       },
-      set(legendOptions) {
-        this.setLegendOptions(legendOptions);
+      set(layers) {
+        this.setLayers(layers);
       },
     },
     locationsGeoJson() {
@@ -434,12 +434,12 @@ export default {
       };
     },
     mapOptions() {
-      const { aerial, internalLegendOptions } = this;
+      const { aerial, internalLayers } = this;
       const { dark } = this.$vuetify.theme;
       return {
         aerial,
         dark,
-        ...internalLegendOptions,
+        layers: { ...internalLayers },
       };
     },
     mapStyle() {
@@ -480,11 +480,13 @@ export default {
       'locationMode',
     ]),
     ...mapGetters([
-      'legendOptionsForMode',
       'locationActive',
       'locationsForMode',
       'locationsRouteParams',
       'locationsSelectionForMode',
+    ]),
+    ...mapGetters('mapLayers', [
+      'layersForMode',
     ]),
   },
   created() {
@@ -838,10 +840,12 @@ export default {
     },
     ...mapMutations([
       'setDrawerOpen',
-      'setLegendMode',
-      'setLegendOptions',
       'setLocationMode',
       'setToastInfo',
+    ]),
+    ...mapMutations('mapLayers', [
+      'setLayers',
+      'setLegendMode',
     ]),
   },
 };

--- a/web/components/inputs/FcPaneMapLegend.vue
+++ b/web/components/inputs/FcPaneMapLegend.vue
@@ -1,54 +1,40 @@
 <template>
   <v-card class="fc-pane-map-legend" width="200">
     <v-card-text class="default--text">
-      <section aria-labelledby="heading_map_settings">
-        <h2 class="display-1" id="heading_map_settings">Map settings</h2>
+      <fieldset>
+        <legend class="headline">Legend</legend>
 
-        <v-select
-          v-model="internalValue.datesFrom"
-          class="mt-4"
-          :items="itemsDatesFrom"
-          label="Show data from"
-          :messages="messagesDatesFrom" />
-
-        <fieldset class="mt-4">
-          <legend class="headline">Layers</legend>
-
+        <div
+          v-for="layerItem in layerItems"
+          :key="layerItem.value"
+          class="align-center d-flex my-2">
           <div
-            v-for="layer in layers"
-            :key="layer.value"
-            class="align-center d-flex my-2">
-            <div
-              :class="'icon-layer-' + layer.value"
-              class="mr-5"></div>
-            <div class="body-1 flex-grow-1 mt-1">{{layer.text}}</div>
-            <FcTooltip left>
-              <template v-slot:activator="{ on }">
-                <div v-on="on">
-                  <v-checkbox
-                    v-model="internalValue.layers[layer.value]"
-                    :aria-label="layerLabels[layer.value]"
-                    class="mt-0"
-                    color="secondary"
-                    hide-details
-                    off-icon="mdi-eye-off"
-                    on-icon="mdi-eye"
-                    v-on="on"></v-checkbox>
-                </div>
-              </template>
-              <span>{{layerLabels[layer.value]}}</span>
-            </FcTooltip>
-          </div>
-        </fieldset>
-      </section>
+            :class="'icon-layer-' + layerItem.value"
+            class="mr-5"></div>
+          <div class="body-1 flex-grow-1 mt-1">{{layerItem.text}}</div>
+          <FcTooltip left>
+            <template v-slot:activator="{ on }">
+              <div v-on="on">
+                <v-checkbox
+                  v-model="internalValue[layerItem.value]"
+                  :aria-label="layerLabels[layerItem.value]"
+                  class="mt-0"
+                  color="secondary"
+                  hide-details
+                  off-icon="mdi-eye-off"
+                  on-icon="mdi-eye"
+                  v-on="on"></v-checkbox>
+              </div>
+            </template>
+            <span>{{layerLabels[layerItem.value]}}</span>
+          </FcTooltip>
+        </div>
+      </fieldset>
     </v-card-text>
   </v-card>
 </template>
 
 <script>
-import { mapState } from 'vuex';
-
-import TimeFormatters from '@/lib/time/TimeFormatters';
 import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
@@ -59,38 +45,24 @@ export default {
     FcTooltip,
   },
   data() {
-    const itemsDatesFrom = [
-      { text: 'Last year', value: 1 },
-      { text: 'Last 3 years', value: 3 },
-      { text: 'Last 5 years', value: 5 },
-      { text: 'Last 10 years', value: 10 },
-    ];
-    const layers = [
+    const layerItems = [
       { text: 'Studies', value: 'studies' },
       { text: 'Collisions', value: 'collisions' },
     ];
     return {
-      itemsDatesFrom,
-      layers,
+      layerItems,
     };
   },
   computed: {
     layerLabels() {
       const layerLabels = {};
-      this.layers.forEach(({ text, value }) => {
-        const layerActive = this.internalValue.layers[value];
+      this.layerItems.forEach(({ text, value }) => {
+        const layerActive = this.internalValue[value];
         const prefix = layerActive ? 'Hide' : 'Show';
         layerLabels[value] = `${prefix} ${text}`;
       });
       return layerLabels;
     },
-    messagesDatesFrom() {
-      const { datesFrom } = this.internalValue;
-      const start = this.now.minus({ years: datesFrom });
-      const end = this.now;
-      return TimeFormatters.formatRangeDate({ start, end });
-    },
-    ...mapState(['now']),
   },
 };
 </script>

--- a/web/components/inputs/FcPaneMapLegend.vue
+++ b/web/components/inputs/FcPaneMapLegend.vue
@@ -8,9 +8,9 @@
           v-for="layerItem in layerItems"
           :key="layerItem.value"
           class="align-center d-flex my-2">
-          <div
-            :class="'icon-layer-' + layerItem.value"
-            class="mr-5"></div>
+          <component
+            :is="'FcLegendIcon' + layerItem.suffix"
+            class="mr-4" />
           <div class="body-1 flex-grow-1 mt-1">{{layerItem.text}}</div>
           <FcTooltip left>
             <template v-slot:activator="{ on }">
@@ -36,18 +36,22 @@
 
 <script>
 import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
+import FcLegendIconCollisions from '@/web/components/legend/FcLegendIconCollisions.vue';
+import FcLegendIconStudies from '@/web/components/legend/FcLegendIconStudies.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
 export default {
   name: 'FcPaneMapLegend',
   mixins: [FcMixinVModelProxy(Object)],
   components: {
+    FcLegendIconCollisions,
+    FcLegendIconStudies,
     FcTooltip,
   },
   data() {
     const layerItems = [
-      { text: 'Studies', value: 'studies' },
-      { text: 'Collisions', value: 'collisions' },
+      { suffix: 'Studies', text: 'Studies', value: 'studies' },
+      { suffix: 'Collisions', text: 'Collisions', value: 'collisions' },
     ];
     return {
       layerItems,
@@ -66,28 +70,3 @@ export default {
   },
 };
 </script>
-
-<style lang="scss">
-.fc-pane-map-legend {
-  & .icon-layer-studies {
-    background: linear-gradient(180deg, #9f92f3 0%, #5f48ef 100%);
-    border: 1px solid #fff;
-    border-radius: 12px;
-    height: 24px;
-    width: 24px;
-  }
-  & .icon-layer-collisions {
-    background: #ef4848;
-    border: 1px solid #733;
-    border-radius: 12px;
-    height: 24px;
-    width: 24px;
-  }
-  & .icon-layer-volume {
-    background-image: url('/icons/map/volume.png');
-    height: 9px;
-    margin-top: 2px;
-    width: 24px;
-  }
-}
-</style>

--- a/web/components/legend/FcLegendIconCollisions.vue
+++ b/web/components/legend/FcLegendIconCollisions.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="fc-legend-icon-collisions">
+    <div class="non-ksi"></div>
+    <div class="ksi"></div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'FcLegendIconCollisions',
+};
+</script>
+
+<style lang="scss">
+.fc-legend-icon-collisions {
+  height: 24px;
+  position: relative;
+  width: 24px;
+
+  & > .non-ksi {
+    background: #ef4848;
+    border: 1px solid #733;
+    border-radius: 6px;
+    height: 12px;
+    left: 4px;
+    position: absolute;
+    top: 4px;
+    width: 12px;
+  }
+
+  & > .ksi {
+    background: #ef4848;
+    border: 3px solid #733;
+    border-radius: 6px;
+    bottom: 4px;
+    height: 12px;
+    position: absolute;
+    right: 4px;
+    width: 12px;
+  }
+}
+</style>

--- a/web/components/legend/FcLegendIconStudies.vue
+++ b/web/components/legend/FcLegendIconStudies.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="fc-legend-icon-studies">
+    <div class="non-matching"></div>
+    <div class="matching"></div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'FcLegendIconStudies',
+};
+</script>
+
+<style lang="scss">
+.fc-legend-icon-studies {
+  height: 24px;
+  position: relative;
+  width: 24px;
+
+  & > .non-matching {
+    background: rgba(64, 64, 64, 0.4);
+    border: 1px solid #404040;
+    border-radius: 8px;
+    height: 16px;
+    left: 1px;
+    position: absolute;
+    top: 1px;
+    width: 16px;
+  }
+
+  & > .matching {
+    background: linear-gradient(180deg, #9f92f3 0%, #5f48ef 100%);
+    border: 1px solid #fff;
+    border-radius: 9px;
+    height: 18px;
+    bottom: 1px;
+    position: absolute;
+    right: 1px;
+    width: 18px;
+  }
+}
+</style>

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import Vuex from 'vuex';
 
 import {
-  LegendMode,
   LocationMode,
   LocationSelectionType,
   MAX_LOCATIONS,
@@ -25,6 +24,7 @@ import {
 import CompositeId from '@/lib/io/CompositeId';
 import DateTime from '@/lib/time/DateTime';
 import FrontendEnv from '@/web/config/FrontendEnv';
+import mapLayers from '@/web/store/modules/mapLayers';
 import trackRequests from '@/web/store/modules/trackRequests';
 import viewData from '@/web/store/modules/viewData';
 
@@ -32,6 +32,7 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
   modules: {
+    mapLayers,
     trackRequests,
     viewData,
   },
@@ -58,23 +59,6 @@ export default new Vuex.Store({
     // NAVIGATION
     backViewRequest: { name: 'requestsTrack' },
     // LOCATION
-    legendMode: LegendMode.NORMAL,
-    legendOptions: {
-      datesFrom: 10,
-      layers: {
-        collisions: true,
-        studies: true,
-        volume: false,
-      },
-    },
-    legendOptionsFocusLocations: {
-      datesFrom: 10,
-      layers: {
-        collisions: false,
-        studies: true,
-        volume: false,
-      },
-    },
     locations: [],
     locationsIndex: -1,
     locationsIndicesDeselected: [],
@@ -137,12 +121,6 @@ export default new Vuex.Store({
       return scope;
     },
     // LOCATION
-    legendOptionsForMode(state) {
-      if (state.legendMode === LegendMode.FOCUS_LOCATIONS) {
-        return state.legendOptionsFocusLocations;
-      }
-      return state.legendOptions;
-    },
     locationActive(state, getters) {
       if (state.locationMode === LocationMode.SINGLE) {
         if (getters.locationsEmpty) {
@@ -280,27 +258,6 @@ export default new Vuex.Store({
         Vue.set(state, 'locationMode', LocationMode.MULTI);
       } else {
         Vue.set(state, 'locationMode', LocationMode.SINGLE);
-      }
-    },
-    setLegendMode(state, legendMode) {
-      Vue.set(state, 'legendMode', legendMode);
-      if (legendMode === LegendMode.FOCUS_LOCATIONS) {
-        const { datesFrom, layers } = state.legendOptions;
-        const legendOptionsFocusLocations = {
-          datesFrom,
-          layers: {
-            ...layers,
-            collisions: false,
-          },
-        };
-        Vue.set(state, 'legendOptionsFocusLocations', legendOptionsFocusLocations);
-      }
-    },
-    setLegendOptions(state, legendOptions) {
-      if (state.legendMode === LegendMode.FOCUS_LOCATIONS) {
-        Vue.set(state, 'legendOptionsFocusLocations', legendOptions);
-      } else {
-        Vue.set(state, 'legendOptions', legendOptions);
       }
     },
     setLocationEdit(state, location) {

--- a/web/store/modules/mapLayers.js
+++ b/web/store/modules/mapLayers.js
@@ -1,0 +1,48 @@
+import {
+  LegendMode,
+} from '@/lib/Constants';
+
+export default {
+  namespaced: true,
+  state: {
+    layers: {
+      collisions: true,
+      studies: true,
+      volume: false,
+    },
+    layersFocusLocations: {
+      collisions: false,
+      studies: true,
+      volume: false,
+    },
+    legendMode: LegendMode.NORMAL,
+  },
+  getters: {
+    layersForMode(state) {
+      if (state.legendMode === LegendMode.FOCUS_LOCATIONS) {
+        return state.layersFocusLocations;
+      }
+      return state.layers;
+    },
+  },
+  mutations: {
+    setLegendMode(state, legendMode) {
+      state.legendMode = legendMode;
+      if (legendMode === LegendMode.FOCUS_LOCATIONS) {
+        const { layers } = state;
+        const layersFocusLocations = {
+          ...layers,
+          collisions: false,
+        };
+        state.layersFocusLocations = layersFocusLocations;
+      }
+    },
+    setLayers(state, layers) {
+      if (state.legendMode === LegendMode.FOCUS_LOCATIONS) {
+        state.layersFocusLocations = layers;
+      } else {
+        state.layers = layers;
+      }
+    },
+  },
+};


### PR DESCRIPTION
# Issue Addressed
This PR closes #845 .

# Description
We move `legendMode`, `legendOptions`, and `legendOptionsFocusLocations` into a new `mapLayers` module of our `vuex` store, rework options to only contain layers, and update `GeoStyle` and `FcPaneMap` accordingly.  We also update map legend icons to show different states of studies / collisions, to make it clearer what the various elements on the map mean.

# Tests
Tested quickly in frontend, including both normal and focus-locations modes.