### PR TITLE
Use collision factors to show road surface condition filters

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -132,44 +132,6 @@ CollisionEmphasisArea.init({
 });
 
 /**
- * Road surface conditions for collisions.
- *
- * @param {number} code - MVCR code for this condition
- * @param {string} text - human-readable description of this code
- */
-class CollisionRoadSurfaceCondition extends Enum {}
-CollisionRoadSurfaceCondition.init({
-  CLEAR: {
-    code: 1,
-    text: 'Clear',
-  },
-  RAIN: {
-    code: 2,
-    text: 'Rain',
-  },
-  SNOW: {
-    code: 3,
-    text: 'Snow',
-  },
-  FREEZING_RAIN: {
-    code: 4,
-    text: 'Freezing Rain',
-  },
-  DRIFTING_SNOW: {
-    code: 5,
-    text: 'Drifting Snow',
-  },
-  STRONG_WIND: {
-    code: 6,
-    text: 'Strong Wind',
-  },
-  VISIBILITY_LIMITED: {
-    code: 7,
-    text: 'Fog, Mist, Smoke, Dust',
-  },
-});
-
-/**
  * Common HTTP status codes.  Used when you need to compare a status code, or to call
  * `Boom.boomify` on an `Error`.
  *
@@ -1111,7 +1073,6 @@ const Constants = {
   centrelineKey,
   CentrelineType,
   CollisionEmphasisArea,
-  CollisionRoadSurfaceCondition,
   FEATURE_CODES_INTERSECTION,
   FEATURE_CODES_SEGMENT,
   HttpStatus,
@@ -1152,7 +1113,6 @@ export {
   centrelineKey,
   CentrelineType,
   CollisionEmphasisArea,
-  CollisionRoadSurfaceCondition,
   FEATURE_CODES_INTERSECTION,
   FEATURE_CODES_SEGMENT,
   HttpStatus,

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -57,6 +57,32 @@ async function getCollisionByCollisionId(collisionId) {
   return CollisionEvent.read.validateAsync(collision);
 }
 
+async function getCollisionFactors() {
+  let collisionFactors = await apiClient.fetch('/collisions/factors');
+
+  const collisionFactorsSchema = Joi.array().items(
+    Joi.array().ordered(
+      Joi.string().required(),
+      Joi.array().items(
+        Joi.array().ordered(
+          Joi.number().integer().min(0).required(),
+          Joi.object().keys({
+            code: Joi.string().allow(null).required(),
+            description: Joi.string().required(),
+          }),
+        ),
+      ),
+    ),
+  );
+  collisionFactors = await collisionFactorsSchema.validateAsync(collisionFactors);
+
+  return new Map(
+    collisionFactors.map(
+      ([field, fieldEntries]) => [field, new Map(fieldEntries)],
+    ),
+  );
+}
+
 async function getCollisionsByCentreline(features, filters) {
   const s1 = CompositeId.encode(features);
   const data = { s1, ...filters };
@@ -603,6 +629,7 @@ const WebApi = {
   deleteStudyRequestComment,
   getAuth,
   getCollisionByCollisionId,
+  getCollisionFactors,
   getCollisionsByCentreline,
   getCollisionsByCentrelineSummary,
   getCollisionsByCentrelineSummaryPerLocation,
@@ -649,6 +676,7 @@ export {
   deleteStudyRequestComment,
   getAuth,
   getCollisionByCollisionId,
+  getCollisionFactors,
   getCollisionsByCentreline,
   getCollisionsByCentrelineSummary,
   getCollisionsByCentrelineSummaryPerLocation,

--- a/lib/controller/CollisionController.js
+++ b/lib/controller/CollisionController.js
@@ -1,6 +1,7 @@
 import Boom from '@hapi/boom';
 
 import CollisionDAO from '@/lib/db/CollisionDAO';
+import CollisionFactorDAO from '@/lib/db/CollisionFactorDAO';
 import CompositeId from '@/lib/io/CompositeId';
 import CollisionEvent from '@/lib/model/CollisionEvent';
 import CollisionFilters from '@/lib/model/CollisionFilters';
@@ -16,6 +17,47 @@ import CentrelineSelection from '@/lib/model/helpers/CentrelineSelection';
  * @type {Array<Hapi.ServerRoute>}
  */
 const CollisionController = [];
+
+/**
+ * Fetch the entire `collision_factors` mapping of fields, their possible values, and
+ * human-readable descriptions for those values.
+ *
+ * Returns an array-based representation of said mapping; you can rebuild the original `Map`
+ * by iterating over the result and using the `Map` constructor.
+ *
+ * @memberof CollisionController
+ * @name getCollisionFactors
+ */
+CollisionController.push({
+  method: 'GET',
+  path: '/collisions/factors',
+  options: {
+    auth: { mode: 'try' },
+    description: 'Get information about possible codes for various MVCR fields',
+    response: {
+      schema: Joi.array().items(
+        Joi.array().ordered(
+          Joi.string().required(),
+          Joi.array().items(
+            Joi.array().ordered(
+              Joi.number().integer().min(0).required(),
+              Joi.object().keys({
+                code: Joi.string().allow(null).required(),
+                description: Joi.string().required(),
+              }),
+            ),
+          ),
+        ),
+      ),
+    },
+    tags: ['api'],
+  },
+  handler: async () => {
+    const collisionFactors = await CollisionFactorDAO.all();
+    return Array.from(collisionFactors)
+      .map(([field, fieldEntries]) => [field, Array.from(fieldEntries)]);
+  },
+});
 
 /**
  * Fetch details for the collision with the given `collision_id`.  These details include both

--- a/lib/db/CollisionDAO.js
+++ b/lib/db/CollisionDAO.js
@@ -198,7 +198,7 @@ function getCollisionFilters(features, collisionQuery) {
     filters.push('date_part(\'HOUR\', e.accdate) BETWEEN $(hourStart) AND $(hourEnd)');
   }
   if (roadSurfaceConditions !== null) {
-    params.roadSurfaceConditions = roadSurfaceConditions.map(({ code }) => code);
+    params.roadSurfaceConditions = roadSurfaceConditions;
     filters.push('e.rdsfcond IN ($(roadSurfaceConditions:csv))');
   }
   return { filters, params };

--- a/lib/model/CollisionFilters.js
+++ b/lib/model/CollisionFilters.js
@@ -1,6 +1,5 @@
 import {
   CollisionEmphasisArea,
-  CollisionRoadSurfaceCondition,
 } from '@/lib/Constants';
 import Joi from '@/lib/model/Joi';
 import TimeFormatters from '@/lib/time/TimeFormatters';
@@ -19,6 +18,6 @@ export default {
   hoursOfDayEnd: Joi.number().integer().min(0).optional(),
   hoursOfDayStart: Joi.number().integer().min(0).optional(),
   roadSurfaceConditions: Joi.array().single().items(
-    Joi.enum().ofType(CollisionRoadSurfaceCondition).required(),
+    Joi.number().integer().min(0).required(),
   ).default(null),
 };

--- a/tests/jest/api/CollisionController.spec.js
+++ b/tests/jest/api/CollisionController.spec.js
@@ -19,6 +19,19 @@ afterAll(async () => {
   db.$pool.end();
 }, 60000);
 
+test('CollisionController.getCollisionFactors', async () => {
+  const response = await client.fetch('/collisions/factors');
+  expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
+  const collisionFactors = new Map(
+    response.result.map(([field, fieldEntries]) => [field, new Map(fieldEntries)]),
+  );
+  expect(collisionFactors.get('acclass')).toBeInstanceOf(Map);
+  expect(collisionFactors.get('acclass').get(1)).toEqual({
+    code: 'FA',
+    description: 'Fatal',
+  });
+});
+
 test('CollisionController.getCollisionByCollisionId', async () => {
   let response = await client.fetch('/collisions/999999999');
   expect(response.statusCode).toBe(HttpStatus.NOT_FOUND.statusCode);

--- a/web/components/filters/FcCollisionFilters.vue
+++ b/web/components/filters/FcCollisionFilters.vue
@@ -19,25 +19,25 @@
       :error-messages="errorMessagesHoursOfDay" />
 
     <fieldset class="mt-6">
-      <legend class="headline">Weather</legend>
+      <legend class="headline">Road Surface Condition</legend>
 
       <v-checkbox
-        v-for="roadSurfaceCondition in CollisionRoadSurfaceCondition.enumValues"
-        :key="roadSurfaceCondition.name"
+        v-for="roadSurfaceCondition in itemsRoadSurfaceCondition"
+        :key="roadSurfaceCondition.value"
         v-model="internalValue.roadSurfaceConditions"
         class="mt-2"
         hide-details
         :label="roadSurfaceCondition.text"
-        :value="roadSurfaceCondition"></v-checkbox>
+        :value="roadSurfaceCondition.value"></v-checkbox>
     </fieldset>
   </div>
 </template>
 
 <script>
-import {
-  CollisionEmphasisArea,
-  CollisionRoadSurfaceCondition,
-} from '@/lib/Constants';
+import { mapState } from 'vuex';
+
+import ArrayUtils from '@/lib/ArrayUtils';
+import { CollisionEmphasisArea } from '@/lib/Constants';
 import FcFilterHoursOfDay from '@/web/components/filters/FcFilterHoursOfDay.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
@@ -53,7 +53,6 @@ export default {
   data() {
     return {
       CollisionEmphasisArea,
-      CollisionRoadSurfaceCondition,
     };
   },
   computed: {
@@ -64,6 +63,16 @@ export default {
       }
       return errors;
     },
+    itemsRoadSurfaceCondition() {
+      const fieldEntries = this.collisionFactors.get('rdsfcond');
+      const items = Array.from(fieldEntries)
+        .map(([value, { description }]) => ({
+          value,
+          text: description,
+        }));
+      return ArrayUtils.sortBy(items, ({ value }) => value);
+    },
+    ...mapState('viewData', ['collisionFactors']),
   },
 };
 </script>

--- a/web/components/filters/FcGlobalFilterDrawer.vue
+++ b/web/components/filters/FcGlobalFilterDrawer.vue
@@ -22,41 +22,46 @@
       <v-divider></v-divider>
 
       <div class="flex-grow-1 flex-shrink-1 overflow-y-auto">
-        <FcCommonFilters
-          v-if="internalFiltersCommon !== null"
-          v-model="internalFiltersCommon"
-          class="px-6 py-4"
-          :v="$v.internalFiltersCommon" />
+        <FcProgressLinear
+          v-if="loading"
+          aria-label="Loading global filters" />
+        <template v-else>
+          <FcCommonFilters
+            v-if="internalFiltersCommon !== null"
+            v-model="internalFiltersCommon"
+            class="px-6 py-4"
+            :v="$v.internalFiltersCommon" />
 
-        <v-expansion-panels
-          v-model="indexOpen"
-          accordion
-          flat
-          focusable>
-          <v-expansion-panel
-            v-if="internalFiltersCollision !== null"
-            class="fc-global-filters-panel">
-            <v-expansion-panel-header>
-              <span class="body-1">Collisions</span>
-            </v-expansion-panel-header>
-            <v-expansion-panel-content>
-              <FcCollisionFilters
-                v-model="internalFiltersCollision"
-                :v="$v.internalFiltersCollision" />
-            </v-expansion-panel-content>
-          </v-expansion-panel>
-          <v-expansion-panel
-            v-if="internalFiltersStudy !== null"
-            class="fc-global-filters-panel">
-            <v-expansion-panel-header>
-              <span class="body-1">Studies</span>
-            </v-expansion-panel-header>
-            <v-expansion-panel-content>
-              <FcStudyFilters
-                v-model="internalFiltersStudy" />
-            </v-expansion-panel-content>
-          </v-expansion-panel>
-        </v-expansion-panels>
+          <v-expansion-panels
+            v-model="indexOpen"
+            accordion
+            flat
+            focusable>
+            <v-expansion-panel
+              v-if="internalFiltersCollision !== null"
+              class="fc-global-filters-panel">
+              <v-expansion-panel-header>
+                <span class="body-1">Collisions</span>
+              </v-expansion-panel-header>
+              <v-expansion-panel-content>
+                <FcCollisionFilters
+                  v-model="internalFiltersCollision"
+                  :v="$v.internalFiltersCollision" />
+              </v-expansion-panel-content>
+            </v-expansion-panel>
+            <v-expansion-panel
+              v-if="internalFiltersStudy !== null"
+              class="fc-global-filters-panel">
+              <v-expansion-panel-header>
+                <span class="body-1">Studies</span>
+              </v-expansion-panel-header>
+              <v-expansion-panel-content>
+                <FcStudyFilters
+                  v-model="internalFiltersStudy" />
+              </v-expansion-panel-content>
+            </v-expansion-panel>
+          </v-expansion-panels>
+        </template>
       </div>
 
       <v-divider></v-divider>
@@ -80,10 +85,11 @@
 </template>
 
 <script>
-import { mapMutations, mapState } from 'vuex';
+import { mapActions, mapMutations, mapState } from 'vuex';
 
 import ValidationsCollisionFilters from '@/lib/validation/ValidationsCollisionFilters';
 import ValidationsCommonFilters from '@/lib/validation/ValidationsCommonFilters';
+import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcCollisionFilters from '@/web/components/filters/FcCollisionFilters.vue';
 import FcCommonFilters from '@/web/components/filters/FcCommonFilters.vue';
 import FcStudyFilters from '@/web/components/filters/FcStudyFilters.vue';
@@ -99,6 +105,7 @@ export default {
     FcButton,
     FcCollisionFilters,
     FcCommonFilters,
+    FcProgressLinear,
     FcStudyFilters,
   },
   data() {
@@ -119,6 +126,7 @@ export default {
         hours: [],
         studyTypes: [],
       },
+      loading: true,
       previousActiveElement: null,
     };
   },
@@ -141,6 +149,11 @@ export default {
         }
       }
     },
+  },
+  async created() {
+    this.loading = true;
+    await this.initCollisionFactors();
+    this.loading = false;
   },
   beforeDestroy() {
     this.unbind();
@@ -231,6 +244,7 @@ export default {
       'setFiltersCommon',
       'setFiltersStudy',
     ]),
+    ...mapActions('viewData', ['initCollisionFactors']),
   },
 };
 </script>

--- a/web/store/modules/viewData.js
+++ b/web/store/modules/viewData.js
@@ -1,9 +1,11 @@
+import { getCollisionFactors } from '@/lib/api/WebApi';
 import DateTime from '@/lib/time/DateTime';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 
 export default {
   namespaced: true,
   state: {
+    collisionFactors: new Map(),
     detailView: false,
     filtersCollision: {
       emphasisAreas: [],
@@ -68,7 +70,8 @@ export default {
         filterChipsCollision.push(filterChip);
       }
       roadSurfaceConditions.forEach((value) => {
-        const { text: label } = value;
+        const fieldEntries = state.collisionFactors.get('rdsfcond');
+        const { description: label } = fieldEntries.get(value);
         const filterChip = { filter: 'roadSurfaceConditions', label, value };
         filterChipsCollision.push(filterChip);
       });
@@ -178,11 +181,11 @@ export default {
     },
     removeFilterCommon(state, { filter, value }) {
       if (filter === 'dateRange') {
-        state.filtersCollision.applyDateRange = false;
-        state.filtersCollision.dateRangeStart = null;
-        state.filtersCollision.dateRangeEnd = null;
+        state.filtersCommon.applyDateRange = false;
+        state.filtersCommon.dateRangeStart = null;
+        state.filtersCommon.dateRangeEnd = null;
       } else {
-        const values = state.filtersCollision[filter];
+        const values = state.filtersCommon[filter];
         const i = values.indexOf(value);
         if (i !== -1) {
           values.splice(i, 1);
@@ -196,6 +199,9 @@ export default {
         values.splice(i, 1);
       }
     },
+    setCollisionFactors(state, collisionFactors) {
+      state.collisionFactors = collisionFactors;
+    },
     setDetailView(state, detailView) {
       state.detailView = detailView;
     },
@@ -207,6 +213,12 @@ export default {
     },
     setFiltersStudy(state, filtersStudy) {
       state.filtersStudy = filtersStudy;
+    },
+  },
+  actions: {
+    async initCollisionFactors({ commit }) {
+      const collisionFactors = await getCollisionFactors();
+      commit('setCollisionFactors', collisionFactors);
     },
   },
 };


### PR DESCRIPTION
# Issue Addressed
This PR closes #843 .

# Description
We add a new REST API endpoint `GET /api/collisions/factors` (`CollisionController.getCollisionFactors`), which returns `CollisionFactorDAO.all()` in a JSON-friendly array format.  We then add `WebApi.getCollisionFactors` to rebuild the collision factors `Map` in the frontend, wrap that method in a `vuex` action `initCollisionFactors` within the `viewData` module, and use `initCollisionFactors` from `FcGlobalFilterDrawer` to load this.  Finally, we change the `roadSurfaceConditions` field in `CollisionFilters` to just accept one or more numeric codes, and update both frontend and backend accordingly.

# Tests
Added REST API test for new endpoint.  Tested end-to-end filter UI and backend filtering quickly in the browser.
