### PR TITLE
Offer filtering on additional MVCR fields

### DIFF
--- a/lib/db/CollisionDAO.js
+++ b/lib/db/CollisionDAO.js
@@ -173,6 +173,7 @@ function getCollisionFilters(features, collisionQuery) {
     daysOfWeek,
     emphasisAreas,
     hoursOfDay,
+    impactype,
     rdsfcond,
   } = collisionQuery;
   if (dateRange !== null) {
@@ -196,6 +197,10 @@ function getCollisionFilters(features, collisionQuery) {
     params.hourStart = hourStart;
     params.hourEnd = hourEnd - 1;
     filters.push('date_part(\'HOUR\', e.accdate) BETWEEN $(hourStart) AND $(hourEnd)');
+  }
+  if (impactype !== null) {
+    params.impactype = impactype;
+    filters.push('e.impactype IN ($(impactype:csv))');
   }
   if (rdsfcond !== null) {
     params.rdsfcond = rdsfcond;

--- a/lib/db/CollisionDAO.js
+++ b/lib/db/CollisionDAO.js
@@ -173,7 +173,7 @@ function getCollisionFilters(features, collisionQuery) {
     daysOfWeek,
     emphasisAreas,
     hoursOfDay,
-    roadSurfaceConditions,
+    rdsfcond,
   } = collisionQuery;
   if (dateRange !== null) {
     params.dateRangeStart = dateRange.start;
@@ -197,9 +197,9 @@ function getCollisionFilters(features, collisionQuery) {
     params.hourEnd = hourEnd - 1;
     filters.push('date_part(\'HOUR\', e.accdate) BETWEEN $(hourStart) AND $(hourEnd)');
   }
-  if (roadSurfaceConditions !== null) {
-    params.roadSurfaceConditions = roadSurfaceConditions;
-    filters.push('e.rdsfcond IN ($(roadSurfaceConditions:csv))');
+  if (rdsfcond !== null) {
+    params.rdsfcond = rdsfcond;
+    filters.push('e.rdsfcond IN ($(rdsfcond:csv))');
   }
   return { filters, params };
 }

--- a/lib/db/CollisionDAO.js
+++ b/lib/db/CollisionDAO.js
@@ -171,9 +171,13 @@ function getCollisionFilters(features, collisionQuery) {
   const {
     dateRange,
     daysOfWeek,
+    drivact,
+    drivcond,
     emphasisAreas,
     hoursOfDay,
     impactype,
+    initdir,
+    manoeuver,
     rdsfcond,
   } = collisionQuery;
   if (dateRange !== null) {
@@ -185,6 +189,14 @@ function getCollisionFilters(features, collisionQuery) {
   if (daysOfWeek !== null) {
     params.daysOfWeek = daysOfWeek;
     filters.push('date_part(\'DOW\', e.accdate) IN ($(daysOfWeek:csv))');
+  }
+  if (drivact !== null) {
+    params.drivact = drivact;
+    filters.push('i.drivact IN ($(drivact:csv))');
+  }
+  if (drivcond !== null) {
+    params.drivcond = drivcond;
+    filters.push('i.drivcond IN ($(drivcond:csv))');
   }
   if (emphasisAreas !== null) {
     const filterEmphasisAreas = emphasisAreas
@@ -201,6 +213,14 @@ function getCollisionFilters(features, collisionQuery) {
   if (impactype !== null) {
     params.impactype = impactype;
     filters.push('e.impactype IN ($(impactype:csv))');
+  }
+  if (initdir !== null) {
+    params.initdir = initdir;
+    filters.push('i.initdir IN ($(initdir:csv))');
+  }
+  if (manoeuver !== null) {
+    params.manoeuver = manoeuver;
+    filters.push('i.manoeuver IN ($(manoeuver:csv))');
   }
   if (rdsfcond !== null) {
     params.rdsfcond = rdsfcond;
@@ -228,6 +248,10 @@ class CollisionDAO {
   }
 
   static async byCollisionIds(collisionIds) {
+    if (collisionIds.length === 0) {
+      return [];
+    }
+
     const sqlEvents = `
 SELECT ${COLLISION_EVENTS_FIELDS}
 WHERE e.collision_id IN ($(collisionIds:csv))
@@ -274,6 +298,10 @@ WHERE ${collisionFilters}`;
     const rows = await db.manyOrNone(sqlCollisionIds, params);
     const collisionIds = rows.map(({ collisionId }) => collisionId);
 
+    if (collisionIds.length === 0) {
+      return { amount: 0, ksi: 0, validated: 0 };
+    }
+
     const sqlSummary = `
 SELECT
   COUNT(*) AS amount,
@@ -299,18 +327,22 @@ WHERE ${collisionFilters}`;
     const rowsCollisionIds = await db.manyOrNone(sqlCollisionIds, params);
     const collisionIds = rowsCollisionIds.map(({ collisionId }) => collisionId);
 
-    const sqlSummaryPerLocation = `
-SELECT
-  ec.centreline_type AS "centrelineType",
-  ec.centreline_id AS "centrelineId",
-  COUNT(*) AS amount,
-  COUNT(*) FILTER (WHERE e.ksi) AS ksi,
-  COUNT(*) FILTER (WHERE e.changed = -1) AS validated
-FROM collisions.events e
-JOIN collisions.events_centreline ec ON e.collision_id = ec.collision_id
-WHERE e.collision_id IN ($(collisionIds:csv))
-GROUP BY ec.centreline_type, ec.centreline_id`;
-    const rowsSummaryPerLocation = await db.manyOrNone(sqlSummaryPerLocation, { collisionIds });
+    let rowsSummaryPerLocation = [];
+    if (collisionIds.length > 0) {
+      const sqlSummaryPerLocation = `
+  SELECT
+    ec.centreline_type AS "centrelineType",
+    ec.centreline_id AS "centrelineId",
+    COUNT(*) AS amount,
+    COUNT(*) FILTER (WHERE e.ksi) AS ksi,
+    COUNT(*) FILTER (WHERE e.changed = -1) AS validated
+  FROM collisions.events e
+  JOIN collisions.events_centreline ec ON e.collision_id = ec.collision_id
+  WHERE e.collision_id IN ($(collisionIds:csv))
+  GROUP BY ec.centreline_type, ec.centreline_id`;
+      rowsSummaryPerLocation = await db.manyOrNone(sqlSummaryPerLocation, { collisionIds });
+    }
+
     const mapSummaryPerLocation = new Map(
       rowsSummaryPerLocation.map(({ centrelineId, centrelineType, ...summary }) => {
         const feature = { centrelineId, centrelineType };

--- a/lib/db/CollisionDAO.js
+++ b/lib/db/CollisionDAO.js
@@ -227,47 +227,79 @@ class CollisionDAO {
     return validateCollision(event, involved);
   }
 
+  static async byCollisionIds(collisionIds) {
+    const sqlEvents = `
+SELECT ${COLLISION_EVENTS_FIELDS}
+WHERE e.collision_id IN ($(collisionIds:csv))
+ORDER BY e.collision_id`;
+    const sqlInvolved = `
+SELECT ${COLLISION_INVOLVED_FIELDS}
+WHERE i.collision_id IN ($(collisionIds:csv))
+ORDER BY i.collision_id`;
+    const [events, involved] = await Promise.all([
+      db.manyOrNone(sqlEvents, { collisionIds }),
+      db.manyOrNone(sqlInvolved, { collisionIds }),
+    ]);
+    return validateCollisions(events, involved);
+  }
+
   static async byCentreline(features, collisionQuery) {
     const collisionQueryNormalized = normalizeCollisionQuery(collisionQuery);
     const { filters, params } = getCollisionFilters(features, collisionQueryNormalized);
     const collisionFilters = filters.join('\n  AND ');
-    const sqlEvents = `
-SELECT ${COLLISION_EVENTS_FIELDS}
-WHERE ${collisionFilters}
-ORDER BY e.collision_id`;
-    const sqlInvolved = `
-SELECT ${COLLISION_INVOLVED_FIELDS}
-JOIN collisions.events e ON i.collision_id = e.collision_id
-JOIN collisions.events_centreline ec ON i.collision_id = ec.collision_id
-WHERE ${collisionFilters}
-ORDER BY i.collision_id`;
-    const [events, involved] = await Promise.all([
-      db.manyOrNone(sqlEvents, params),
-      db.manyOrNone(sqlInvolved, params),
-    ]);
-    return validateCollisions(events, involved);
+
+    const sqlCollisionIds = `
+SELECT DISTINCT(e.collision_id) AS "collisionId"
+FROM collisions.events e
+JOIN collisions.involved i ON e.collision_id = i.collision_id
+JOIN collisions.events_centreline ec ON e.collision_id = ec.collision_id
+WHERE ${collisionFilters}`;
+    const rows = await db.manyOrNone(sqlCollisionIds, params);
+    const collisionIds = rows.map(({ collisionId }) => collisionId);
+
+    return CollisionDAO.byCollisionIds(collisionIds);
   }
 
   static async byCentrelineSummary(features, collisionQuery) {
     const collisionQueryNormalized = normalizeCollisionQuery(collisionQuery);
     const { filters, params } = getCollisionFilters(features, collisionQueryNormalized);
     const collisionFilters = filters.join('\n  AND ');
-    const sql = `
+
+    const sqlCollisionIds = `
+SELECT DISTINCT(e.collision_id) AS "collisionId"
+FROM collisions.events e
+JOIN collisions.involved i ON e.collision_id = i.collision_id
+JOIN collisions.events_centreline ec ON e.collision_id = ec.collision_id
+WHERE ${collisionFilters}`;
+    const rows = await db.manyOrNone(sqlCollisionIds, params);
+    const collisionIds = rows.map(({ collisionId }) => collisionId);
+
+    const sqlSummary = `
 SELECT
   COUNT(*) AS amount,
   COUNT(*) FILTER (WHERE e.ksi) AS ksi,
   COUNT(*) FILTER (WHERE e.changed = -1) AS validated
 FROM collisions.events e
 JOIN collisions.events_centreline ec ON e.collision_id = ec.collision_id
-WHERE ${collisionFilters}`;
-    return db.one(sql, params);
+WHERE e.collision_id IN ($(collisionIds:csv))`;
+    return db.one(sqlSummary, { collisionIds });
   }
 
   static async byCentrelineSummaryPerLocation(features, collisionQuery) {
     const collisionQueryNormalized = normalizeCollisionQuery(collisionQuery);
     const { filters, params } = getCollisionFilters(features, collisionQueryNormalized);
     const collisionFilters = filters.join('\n  AND ');
-    const sql = `
+
+    const sqlCollisionIds = `
+SELECT DISTINCT(e.collision_id) AS "collisionId"
+FROM collisions.events e
+JOIN collisions.involved i ON e.collision_id = i.collision_id
+JOIN collisions.events_centreline ec ON e.collision_id = ec.collision_id
+WHERE ${collisionFilters}`;
+    const rowsCollisionIds = await db.manyOrNone(sqlCollisionIds, params);
+    const collisionIds = rowsCollisionIds.map(({ collisionId }) => collisionId);
+
+    const sqlSummaryPerLocation = `
 SELECT
   ec.centreline_type AS "centrelineType",
   ec.centreline_id AS "centrelineId",
@@ -276,11 +308,11 @@ SELECT
   COUNT(*) FILTER (WHERE e.changed = -1) AS validated
 FROM collisions.events e
 JOIN collisions.events_centreline ec ON e.collision_id = ec.collision_id
-WHERE ${collisionFilters}
+WHERE e.collision_id IN ($(collisionIds:csv))
 GROUP BY ec.centreline_type, ec.centreline_id`;
-    const rows = await db.manyOrNone(sql, params);
+    const rowsSummaryPerLocation = await db.manyOrNone(sqlSummaryPerLocation, { collisionIds });
     const mapSummaryPerLocation = new Map(
-      rows.map(({ centrelineId, centrelineType, ...summary }) => {
+      rowsSummaryPerLocation.map(({ centrelineId, centrelineType, ...summary }) => {
         const feature = { centrelineId, centrelineType };
         const key = centrelineKey(feature);
         return [key, summary];

--- a/lib/model/CollisionFilters.js
+++ b/lib/model/CollisionFilters.js
@@ -17,7 +17,7 @@ export default {
   ).default(null),
   hoursOfDayEnd: Joi.number().integer().min(0).optional(),
   hoursOfDayStart: Joi.number().integer().min(0).optional(),
-  roadSurfaceConditions: Joi.array().single().items(
+  rdsfcond: Joi.array().single().items(
     Joi.number().integer().min(0).required(),
   ).default(null),
 };

--- a/lib/model/CollisionFilters.js
+++ b/lib/model/CollisionFilters.js
@@ -12,12 +12,24 @@ export default {
   daysOfWeek: Joi.array().single().items(
     Joi.number().valid(...DAYS_OF_WEEK_ALL).required(),
   ).default(null),
+  drivact: Joi.array().single().items(
+    Joi.number().integer().min(0).required(),
+  ).default(null),
+  drivcond: Joi.array().single().items(
+    Joi.number().integer().min(0).required(),
+  ).default(null),
   emphasisAreas: Joi.array().single().items(
     Joi.enum().ofType(CollisionEmphasisArea).required(),
   ).default(null),
   hoursOfDayEnd: Joi.number().integer().min(0).optional(),
   hoursOfDayStart: Joi.number().integer().min(0).optional(),
   impactype: Joi.array().single().items(
+    Joi.number().integer().min(0).required(),
+  ).default(null),
+  initdir: Joi.array().single().items(
+    Joi.number().integer().min(0).required(),
+  ).default(null),
+  manoeuver: Joi.array().single().items(
     Joi.number().integer().min(0).required(),
   ).default(null),
   rdsfcond: Joi.array().single().items(

--- a/lib/model/CollisionFilters.js
+++ b/lib/model/CollisionFilters.js
@@ -17,6 +17,9 @@ export default {
   ).default(null),
   hoursOfDayEnd: Joi.number().integer().min(0).optional(),
   hoursOfDayStart: Joi.number().integer().min(0).optional(),
+  impactype: Joi.array().single().items(
+    Joi.number().integer().min(0).required(),
+  ).default(null),
   rdsfcond: Joi.array().single().items(
     Joi.number().integer().min(0).required(),
   ).default(null),

--- a/tests/jest/db/CollisionDAO.spec.js
+++ b/tests/jest/db/CollisionDAO.spec.js
@@ -31,7 +31,7 @@ test('CollisionDAO.byCentreline', async () => {
     dateRangeStart,
     daysOfWeek: null,
     emphasisAreas: null,
-    roadSurfaceConditions: null,
+    rdsfcond: null,
   };
   let result = await CollisionDAO.byCentreline(features, collisionQuery);
   expect(result).toHaveLength(31);
@@ -44,7 +44,7 @@ test('CollisionDAO.byCentreline', async () => {
     dateRangeStart,
     daysOfWeek: null,
     emphasisAreas: null,
-    roadSurfaceConditions: null,
+    rdsfcond: null,
   };
   result = await CollisionDAO.byCentreline(features, collisionQuery);
   expect(result).toHaveLength(26);
@@ -62,7 +62,7 @@ test('CollisionDAO.byCentrelineSummary', async () => {
     dateRangeStart,
     daysOfWeek: null,
     emphasisAreas: null,
-    roadSurfaceConditions: null,
+    rdsfcond: null,
   };
   let result = await CollisionDAO.byCentrelineSummary(features, collisionQuery);
   expect(result).toEqual({ amount: 31, ksi: 0, validated: 7 });
@@ -93,7 +93,7 @@ test('CollisionDAO.byCentrelineSummaryPerLocation', async () => {
     dateRangeStart,
     daysOfWeek: null,
     emphasisAreas: null,
-    roadSurfaceConditions: null,
+    rdsfcond: null,
   };
   let result = await CollisionDAO.byCentrelineSummaryPerLocation(features, collisionQuery);
   expect(result).toEqual([{ amount: 31, ksi: 0, validated: 7 }]);

--- a/tests/jest/db/CollisionDAO.spec.js
+++ b/tests/jest/db/CollisionDAO.spec.js
@@ -30,8 +30,12 @@ test('CollisionDAO.byCentreline', async () => {
     dateRangeEnd,
     dateRangeStart,
     daysOfWeek: null,
+    drivact: null,
+    drivcond: null,
     emphasisAreas: null,
     impactype: null,
+    initdir: null,
+    manoeuver: null,
     rdsfcond: null,
   };
   let result = await CollisionDAO.byCentreline(features, collisionQuery);
@@ -44,8 +48,12 @@ test('CollisionDAO.byCentreline', async () => {
     dateRangeEnd,
     dateRangeStart,
     daysOfWeek: null,
+    drivact: null,
+    drivcond: null,
     emphasisAreas: null,
     impactype: null,
+    initdir: null,
+    manoeuver: null,
     rdsfcond: null,
   };
   result = await CollisionDAO.byCentreline(features, collisionQuery);
@@ -63,8 +71,12 @@ test('CollisionDAO.byCentrelineSummary', async () => {
     dateRangeEnd,
     dateRangeStart,
     daysOfWeek: null,
+    drivact: null,
+    drivcond: null,
     emphasisAreas: null,
     impactype: null,
+    initdir: null,
+    manoeuver: null,
     rdsfcond: null,
   };
   let result = await CollisionDAO.byCentrelineSummary(features, collisionQuery);
@@ -95,8 +107,12 @@ test('CollisionDAO.byCentrelineSummaryPerLocation', async () => {
     dateRangeEnd,
     dateRangeStart,
     daysOfWeek: null,
+    drivact: null,
+    drivcond: null,
     emphasisAreas: null,
     impactype: null,
+    initdir: null,
+    manoeuver: null,
     rdsfcond: null,
   };
   let result = await CollisionDAO.byCentrelineSummaryPerLocation(features, collisionQuery);

--- a/tests/jest/db/CollisionDAO.spec.js
+++ b/tests/jest/db/CollisionDAO.spec.js
@@ -31,6 +31,7 @@ test('CollisionDAO.byCentreline', async () => {
     dateRangeStart,
     daysOfWeek: null,
     emphasisAreas: null,
+    impactype: null,
     rdsfcond: null,
   };
   let result = await CollisionDAO.byCentreline(features, collisionQuery);
@@ -44,6 +45,7 @@ test('CollisionDAO.byCentreline', async () => {
     dateRangeStart,
     daysOfWeek: null,
     emphasisAreas: null,
+    impactype: null,
     rdsfcond: null,
   };
   result = await CollisionDAO.byCentreline(features, collisionQuery);
@@ -62,6 +64,7 @@ test('CollisionDAO.byCentrelineSummary', async () => {
     dateRangeStart,
     daysOfWeek: null,
     emphasisAreas: null,
+    impactype: null,
     rdsfcond: null,
   };
   let result = await CollisionDAO.byCentrelineSummary(features, collisionQuery);
@@ -93,6 +96,7 @@ test('CollisionDAO.byCentrelineSummaryPerLocation', async () => {
     dateRangeStart,
     daysOfWeek: null,
     emphasisAreas: null,
+    impactype: null,
     rdsfcond: null,
   };
   let result = await CollisionDAO.byCentrelineSummaryPerLocation(features, collisionQuery);

--- a/web/components/filters/FcCollisionFilters.vue
+++ b/web/components/filters/FcCollisionFilters.vue
@@ -24,7 +24,7 @@
       <v-checkbox
         v-for="roadSurfaceCondition in itemsRoadSurfaceCondition"
         :key="roadSurfaceCondition.value"
-        v-model="internalValue.roadSurfaceConditions"
+        v-model="internalValue.rdsfcond"
         class="mt-2"
         hide-details
         :label="roadSurfaceCondition.text"

--- a/web/components/filters/FcCollisionFilters.vue
+++ b/web/components/filters/FcCollisionFilters.vue
@@ -19,16 +19,29 @@
       :error-messages="errorMessagesHoursOfDay" />
 
     <fieldset class="mt-6">
+      <legend class="headline">Initial Impact Type</legend>
+
+      <v-checkbox
+        v-for="item in itemsImpactype"
+        :key="item.value"
+        v-model="internalValue.impactype"
+        class="mt-2"
+        hide-details
+        :label="item.text"
+        :value="item.value"></v-checkbox>
+    </fieldset>
+
+    <fieldset class="mt-6">
       <legend class="headline">Road Surface Condition</legend>
 
       <v-checkbox
-        v-for="roadSurfaceCondition in itemsRoadSurfaceCondition"
-        :key="roadSurfaceCondition.value"
+        v-for="item in itemsRdsfcond"
+        :key="item.value"
         v-model="internalValue.rdsfcond"
         class="mt-2"
         hide-details
-        :label="roadSurfaceCondition.text"
-        :value="roadSurfaceCondition.value"></v-checkbox>
+        :label="item.text"
+        :value="item.value"></v-checkbox>
     </fieldset>
   </div>
 </template>
@@ -63,7 +76,16 @@ export default {
       }
       return errors;
     },
-    itemsRoadSurfaceCondition() {
+    itemsImpactype() {
+      const fieldEntries = this.collisionFactors.get('impactype');
+      const items = Array.from(fieldEntries)
+        .map(([value, { description }]) => ({
+          value,
+          text: description,
+        }));
+      return ArrayUtils.sortBy(items, ({ value }) => value);
+    },
+    itemsRdsfcond() {
       const fieldEntries = this.collisionFactors.get('rdsfcond');
       const items = Array.from(fieldEntries)
         .map(([value, { description }]) => ({

--- a/web/components/filters/FcCollisionFilters.vue
+++ b/web/components/filters/FcCollisionFilters.vue
@@ -18,40 +18,48 @@
       class="mt-6"
       :error-messages="errorMessagesHoursOfDay" />
 
-    <fieldset class="mt-6">
-      <legend class="headline">Initial Impact Type</legend>
+    <FcMvcrFieldFilter
+      v-model="internalValue.drivact"
+      class="mt-6"
+      field-name="drivact"
+      title="Driver Action" />
 
-      <v-checkbox
-        v-for="item in itemsImpactype"
-        :key="item.value"
-        v-model="internalValue.impactype"
-        class="mt-2"
-        hide-details
-        :label="item.text"
-        :value="item.value"></v-checkbox>
-    </fieldset>
+    <FcMvcrFieldFilter
+      v-model="internalValue.drivcond"
+      class="mt-6"
+      field-name="drivcond"
+      title="Driver Condition" />
 
-    <fieldset class="mt-6">
-      <legend class="headline">Road Surface Condition</legend>
+    <FcMvcrFieldFilter
+      v-model="internalValue.initdir"
+      class="mt-6"
+      field-name="initdir"
+      title="Initial Direction of Travel" />
 
-      <v-checkbox
-        v-for="item in itemsRdsfcond"
-        :key="item.value"
-        v-model="internalValue.rdsfcond"
-        class="mt-2"
-        hide-details
-        :label="item.text"
-        :value="item.value"></v-checkbox>
-    </fieldset>
+    <FcMvcrFieldFilter
+      v-model="internalValue.impactype"
+      class="mt-6"
+      field-name="impactype"
+      title="Initial Impact Type" />
+
+    <FcMvcrFieldFilter
+      v-model="internalValue.manoeuver"
+      class="mt-6"
+      field-name="manoeuver"
+      title="Manoeuver" />
+
+    <FcMvcrFieldFilter
+      v-model="internalValue.rdsfcond"
+      class="mt-6"
+      field-name="rdsfcond"
+      title="Road Surface Condition" />
   </div>
 </template>
 
 <script>
-import { mapState } from 'vuex';
-
-import ArrayUtils from '@/lib/ArrayUtils';
 import { CollisionEmphasisArea } from '@/lib/Constants';
 import FcFilterHoursOfDay from '@/web/components/filters/FcFilterHoursOfDay.vue';
+import FcMvcrFieldFilter from '@/web/components/filters/FcMvcrFieldFilter.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
 export default {
@@ -59,6 +67,7 @@ export default {
   mixins: [FcMixinVModelProxy(Object)],
   components: {
     FcFilterHoursOfDay,
+    FcMvcrFieldFilter,
   },
   props: {
     v: Object,
@@ -76,25 +85,6 @@ export default {
       }
       return errors;
     },
-    itemsImpactype() {
-      const fieldEntries = this.collisionFactors.get('impactype');
-      const items = Array.from(fieldEntries)
-        .map(([value, { description }]) => ({
-          value,
-          text: description,
-        }));
-      return ArrayUtils.sortBy(items, ({ value }) => value);
-    },
-    itemsRdsfcond() {
-      const fieldEntries = this.collisionFactors.get('rdsfcond');
-      const items = Array.from(fieldEntries)
-        .map(([value, { description }]) => ({
-          value,
-          text: description,
-        }));
-      return ArrayUtils.sortBy(items, ({ value }) => value);
-    },
-    ...mapState('viewData', ['collisionFactors']),
   },
 };
 </script>

--- a/web/components/filters/FcGlobalFilterDrawer.vue
+++ b/web/components/filters/FcGlobalFilterDrawer.vue
@@ -112,9 +112,13 @@ export default {
     return {
       indexOpen: null,
       internalFiltersCollision: {
+        drivact: [],
+        drivcond: [],
         emphasisAreas: [],
         hoursOfDay: [0, 24],
         impactype: [],
+        initdir: [],
+        manoeuver: [],
         rdsfcond: [],
       },
       internalFiltersCommon: {
@@ -162,9 +166,13 @@ export default {
   methods: {
     actionClearAll() {
       this.internalFiltersCollision = {
+        drivact: [],
+        drivcond: [],
         emphasisAreas: [],
         hoursOfDay: [0, 24],
         impactype: [],
+        initdir: [],
+        manoeuver: [],
         rdsfcond: [],
       };
       this.internalFiltersCommon = {

--- a/web/components/filters/FcGlobalFilterDrawer.vue
+++ b/web/components/filters/FcGlobalFilterDrawer.vue
@@ -114,7 +114,7 @@ export default {
       internalFiltersCollision: {
         emphasisAreas: [],
         hoursOfDay: [0, 24],
-        roadSurfaceConditions: [],
+        rdsfcond: [],
       },
       internalFiltersCommon: {
         applyDateRange: false,
@@ -163,7 +163,7 @@ export default {
       this.internalFiltersCollision = {
         emphasisAreas: [],
         hoursOfDay: [0, 24],
-        roadSurfaceConditions: [],
+        rdsfcond: [],
       };
       this.internalFiltersCommon = {
         applyDateRange: false,

--- a/web/components/filters/FcGlobalFilterDrawer.vue
+++ b/web/components/filters/FcGlobalFilterDrawer.vue
@@ -114,6 +114,7 @@ export default {
       internalFiltersCollision: {
         emphasisAreas: [],
         hoursOfDay: [0, 24],
+        impactype: [],
         rdsfcond: [],
       },
       internalFiltersCommon: {
@@ -163,6 +164,7 @@ export default {
       this.internalFiltersCollision = {
         emphasisAreas: [],
         hoursOfDay: [0, 24],
+        impactype: [],
         rdsfcond: [],
       };
       this.internalFiltersCommon = {

--- a/web/components/filters/FcMvcrFieldFilter.vue
+++ b/web/components/filters/FcMvcrFieldFilter.vue
@@ -1,0 +1,42 @@
+<template>
+  <fieldset>
+    <legend class="headline">{{title}}</legend>
+
+    <v-checkbox
+      v-for="item in items"
+      :key="item.value"
+      v-model="internalValue"
+      class="mt-2"
+      hide-details
+      :label="item.text"
+      :value="item.value"></v-checkbox>
+  </fieldset>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+
+import ArrayUtils from '@/lib/ArrayUtils';
+import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+
+export default {
+  name: 'FcMvcrFieldFilter',
+  mixins: [FcMixinVModelProxy(Array)],
+  props: {
+    fieldName: String,
+    title: String,
+  },
+  computed: {
+    items() {
+      const fieldEntries = this.collisionFactors.get(this.fieldName);
+      const items = Array.from(fieldEntries)
+        .map(([value, { description }]) => ({
+          value,
+          text: description,
+        }));
+      return ArrayUtils.sortBy(items, ({ value }) => value);
+    },
+    ...mapState('viewData', ['collisionFactors']),
+  },
+};
+</script>

--- a/web/store/modules/viewData.js
+++ b/web/store/modules/viewData.js
@@ -10,7 +10,7 @@ export default {
     filtersCollision: {
       emphasisAreas: [],
       hoursOfDay: [0, 24],
-      roadSurfaceConditions: [],
+      rdsfcond: [],
     },
     filtersCommon: {
       applyDateRange: false,
@@ -52,7 +52,7 @@ export default {
       const {
         emphasisAreas,
         hoursOfDay,
-        roadSurfaceConditions,
+        rdsfcond,
       } = state.filtersCollision;
       const [start, end] = hoursOfDay;
       const filterChipsCollision = [];
@@ -69,10 +69,10 @@ export default {
         const filterChip = { filter: 'hoursOfDay', label, value };
         filterChipsCollision.push(filterChip);
       }
-      roadSurfaceConditions.forEach((value) => {
+      rdsfcond.forEach((value) => {
         const fieldEntries = state.collisionFactors.get('rdsfcond');
         const { description: label } = fieldEntries.get(value);
-        const filterChip = { filter: 'roadSurfaceConditions', label, value };
+        const filterChip = { filter: 'rdsfcond', label, value };
         filterChipsCollision.push(filterChip);
       });
       return filterChipsCollision;
@@ -105,7 +105,7 @@ export default {
       const {
         emphasisAreas,
         hoursOfDay: [hoursOfDayStart, hoursOfDayEnd],
-        roadSurfaceConditions,
+        rdsfcond,
       } = state.filtersCollision;
       const params = {};
       if (applyDateRange) {
@@ -122,8 +122,8 @@ export default {
         params.hoursOfDayStart = hoursOfDayStart;
         params.hoursOfDayEnd = hoursOfDayEnd;
       }
-      if (roadSurfaceConditions.length > 0) {
-        params.roadSurfaceConditions = roadSurfaceConditions;
+      if (rdsfcond.length > 0) {
+        params.rdsfcond = rdsfcond;
       }
       return params;
     },

--- a/web/store/modules/viewData.js
+++ b/web/store/modules/viewData.js
@@ -10,6 +10,7 @@ export default {
     filtersCollision: {
       emphasisAreas: [],
       hoursOfDay: [0, 24],
+      impactype: [],
       rdsfcond: [],
     },
     filtersCommon: {
@@ -52,6 +53,7 @@ export default {
       const {
         emphasisAreas,
         hoursOfDay,
+        impactype,
         rdsfcond,
       } = state.filtersCollision;
       const [start, end] = hoursOfDay;
@@ -69,6 +71,12 @@ export default {
         const filterChip = { filter: 'hoursOfDay', label, value };
         filterChipsCollision.push(filterChip);
       }
+      impactype.forEach((value) => {
+        const fieldEntries = state.collisionFactors.get('impactype');
+        const { description: label } = fieldEntries.get(value);
+        const filterChip = { filter: 'impactype', label, value };
+        filterChipsCollision.push(filterChip);
+      });
       rdsfcond.forEach((value) => {
         const fieldEntries = state.collisionFactors.get('rdsfcond');
         const { description: label } = fieldEntries.get(value);
@@ -105,6 +113,7 @@ export default {
       const {
         emphasisAreas,
         hoursOfDay: [hoursOfDayStart, hoursOfDayEnd],
+        impactype,
         rdsfcond,
       } = state.filtersCollision;
       const params = {};
@@ -121,6 +130,9 @@ export default {
       if (hoursOfDayStart !== 0 || hoursOfDayEnd !== 24) {
         params.hoursOfDayStart = hoursOfDayStart;
         params.hoursOfDayEnd = hoursOfDayEnd;
+      }
+      if (impactype.length > 0) {
+        params.impactype = impactype;
       }
       if (rdsfcond.length > 0) {
         params.rdsfcond = rdsfcond;

--- a/web/store/modules/viewData.js
+++ b/web/store/modules/viewData.js
@@ -8,9 +8,13 @@ export default {
     collisionFactors: new Map(),
     detailView: false,
     filtersCollision: {
+      drivact: [],
+      drivcond: [],
       emphasisAreas: [],
       hoursOfDay: [0, 24],
       impactype: [],
+      initdir: [],
+      manoeuver: [],
       rdsfcond: [],
     },
     filtersCommon: {
@@ -51,9 +55,13 @@ export default {
     },
     filterChipsCollision(state) {
       const {
+        drivact,
+        drivcond,
         emphasisAreas,
         hoursOfDay,
         impactype,
+        initdir,
+        manoeuver,
         rdsfcond,
       } = state.filtersCollision;
       const [start, end] = hoursOfDay;
@@ -71,10 +79,34 @@ export default {
         const filterChip = { filter: 'hoursOfDay', label, value };
         filterChipsCollision.push(filterChip);
       }
+      drivact.forEach((value) => {
+        const fieldEntries = state.collisionFactors.get('drivact');
+        const { description: label } = fieldEntries.get(value);
+        const filterChip = { filter: 'drivact', label, value };
+        filterChipsCollision.push(filterChip);
+      });
+      drivcond.forEach((value) => {
+        const fieldEntries = state.collisionFactors.get('drivcond');
+        const { description: label } = fieldEntries.get(value);
+        const filterChip = { filter: 'drivcond', label, value };
+        filterChipsCollision.push(filterChip);
+      });
       impactype.forEach((value) => {
         const fieldEntries = state.collisionFactors.get('impactype');
         const { description: label } = fieldEntries.get(value);
         const filterChip = { filter: 'impactype', label, value };
+        filterChipsCollision.push(filterChip);
+      });
+      initdir.forEach((value) => {
+        const fieldEntries = state.collisionFactors.get('initdir');
+        const { description: label } = fieldEntries.get(value);
+        const filterChip = { filter: 'initdir', label, value };
+        filterChipsCollision.push(filterChip);
+      });
+      manoeuver.forEach((value) => {
+        const fieldEntries = state.collisionFactors.get('manoeuver');
+        const { description: label } = fieldEntries.get(value);
+        const filterChip = { filter: 'manoeuver', label, value };
         filterChipsCollision.push(filterChip);
       });
       rdsfcond.forEach((value) => {
@@ -111,9 +143,13 @@ export default {
         daysOfWeek,
       } = state.filtersCommon;
       const {
+        drivact,
+        drivcond,
         emphasisAreas,
         hoursOfDay: [hoursOfDayStart, hoursOfDayEnd],
         impactype,
+        initdir,
+        manoeuver,
         rdsfcond,
       } = state.filtersCollision;
       const params = {};
@@ -124,6 +160,12 @@ export default {
       if (daysOfWeek.length > 0) {
         params.daysOfWeek = daysOfWeek;
       }
+      if (drivact.length > 0) {
+        params.drivact = drivact;
+      }
+      if (drivcond.length > 0) {
+        params.drivcond = drivcond;
+      }
       if (emphasisAreas.length > 0) {
         params.emphasisAreas = emphasisAreas;
       }
@@ -133,6 +175,12 @@ export default {
       }
       if (impactype.length > 0) {
         params.impactype = impactype;
+      }
+      if (initdir.length > 0) {
+        params.initdir = initdir;
+      }
+      if (manoeuver.length > 0) {
+        params.manoeuver = manoeuver;
       }
       if (rdsfcond.length > 0) {
         params.rdsfcond = rdsfcond;


### PR DESCRIPTION
# Issue Addressed
This PR closes #844 .

# Description
We add support for filtering on `drivact`, `drivcond`, `impactype`, `initdir`, and `manoeuver`.

# Tests
Updated DAO tests.  Tested quickly in frontend.
