### PR TITLE
Download paginated requests: selected, all

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -443,16 +443,21 @@ ReportParameter.init({
  *
  * @param {boolean} disabled - this report type is disabled if it hasn't been
  * implemented in MOVE Reporter yet
- * @param {Array<ReportFormat>}  formats - formats supported for this report type
+ * @param {Array<ReportFormat>} formats - formats supported for this report type
  * @param {string} label - human-readable name of this report type
  * @param {Object?} options - user-supplied options for this report type
- * @param {PageOrientation} orientation - page orientation for PDF documents
- * @param {ReportExportMode} reportExportMode - whether this is collision-related
- * or study-related
- * @param {boolean} tmcRelated - does this report type require TMC data?
- * @param {PageSize} size - page size for PDF documents
- * @param {boolean} speedRelated - does this report type require speed data?
+ * @param {PageOrientation?} orientation - page orientation for PDF documents
+ * (only if `ReportFormat.PDF` available)
+ * @param {ReportExportMode?} reportExportMode - whether this is collision-related
+ * or study-related (only if intended for viewing from View Reports)
+ * @param {Array<AuthScope>?} scope - authorization scopes required (if any required)
+ * @param {PageSize?} size - page size for PDF documents (only if `ReportFormat.PDF`
+ * available)
+ * @param {boolean?} speedRelated - does this report type require speed data? (only if
+ * study-related)
  * @param {string} suffix - suffix used for component names
+ * @param {boolean?} tmcRelated - does this report type require TMC data? (only if
+ * study-related)
  */
 class ReportType extends Enum {}
 ReportType.init({
@@ -480,10 +485,10 @@ ReportType.init({
     label: '24-Hour Summary Report',
     orientation: PageOrientation.LANDSCAPE,
     reportExportMode: ReportExportMode.STUDIES,
-    tmcRelated: false,
     size: PageSize.LETTER,
     speedRelated: false,
     suffix: 'CountSummary24h',
+    tmcRelated: false,
   },
   COUNT_SUMMARY_24H_DETAILED: {
     disabled: false,
@@ -491,10 +496,10 @@ ReportType.init({
     label: '24-Hour Detailed Report',
     orientation: PageOrientation.PORTRAIT,
     reportExportMode: ReportExportMode.STUDIES,
-    tmcRelated: false,
     size: PageSize.LETTER,
     speedRelated: false,
     suffix: 'CountSummary24hDetailed',
+    tmcRelated: false,
   },
   COUNT_SUMMARY_24H_GRAPHICAL: {
     disabled: false,
@@ -502,10 +507,10 @@ ReportType.init({
     label: '24-Hour Graphical Report',
     orientation: PageOrientation.LANDSCAPE,
     reportExportMode: ReportExportMode.STUDIES,
-    tmcRelated: false,
     size: PageSize.LETTER,
     speedRelated: false,
     suffix: 'CountSummary24hGraphical',
+    tmcRelated: false,
   },
   COUNT_SUMMARY_TURNING_MOVEMENT: {
     disabled: false,
@@ -513,10 +518,10 @@ ReportType.init({
     label: 'TMC Summary Report',
     orientation: PageOrientation.LANDSCAPE,
     reportExportMode: ReportExportMode.STUDIES,
-    tmcRelated: true,
     size: PageSize.LETTER,
     speedRelated: false,
     suffix: 'CountSummaryTurningMovement',
+    tmcRelated: true,
   },
   COUNT_SUMMARY_TURNING_MOVEMENT_DETAILED: {
     disabled: false,
@@ -524,10 +529,10 @@ ReportType.init({
     label: 'TMC Detailed Report',
     orientation: PageOrientation.PORTRAIT,
     reportExportMode: ReportExportMode.STUDIES,
-    tmcRelated: true,
     size: PageSize.LETTER,
     speedRelated: false,
     suffix: 'CountSummaryTurningMovementDetailed',
+    tmcRelated: true,
   },
   COUNT_SUMMARY_TURNING_MOVEMENT_ILLUSTRATED: {
     disabled: true,
@@ -535,10 +540,10 @@ ReportType.init({
     label: 'TMC Illustrated Report',
     orientation: PageOrientation.PORTRAIT,
     reportExportMode: ReportExportMode.STUDIES,
-    tmcRelated: true,
     size: PageSize.LETTER,
     speedRelated: false,
     suffix: 'CountSummaryTurningMovementIllustrated',
+    tmcRelated: true,
   },
   CROSSWALK_OBSERVANCE_SUMMARY: {
     disabled: true,
@@ -546,10 +551,10 @@ ReportType.init({
     label: 'Crosswalk Observation Report',
     orientation: PageOrientation.LANDSCAPE,
     reportExportMode: ReportExportMode.STUDIES,
-    tmcRelated: false,
     size: PageSize.LETTER,
     speedRelated: false,
     suffix: 'CrosswalkObservanceSummary',
+    tmcRelated: false,
   },
   INTERSECTION_SUMMARY: {
     disabled: false,
@@ -557,10 +562,10 @@ ReportType.init({
     label: 'Intersection Summary Report',
     orientation: PageOrientation.LANDSCAPE,
     reportExportMode: ReportExportMode.STUDIES,
-    tmcRelated: true,
     size: PageSize.LETTER,
     speedRelated: false,
     suffix: 'IntersectionSummary',
+    tmcRelated: true,
   },
   PEAK_HOUR_FACTOR: {
     disabled: false,
@@ -568,10 +573,10 @@ ReportType.init({
     label: 'Peak Hour Factor Report',
     orientation: PageOrientation.LANDSCAPE,
     reportExportMode: ReportExportMode.STUDIES,
-    tmcRelated: true,
     size: PageSize.LETTER,
     speedRelated: false,
     suffix: 'PeakHourFactor',
+    tmcRelated: true,
   },
   PED_DELAY_SUMMARY: {
     disabled: true,
@@ -579,10 +584,10 @@ ReportType.init({
     label: 'Ped Delay Summary',
     orientation: PageOrientation.LANDSCAPE,
     reportExportMode: ReportExportMode.STUDIES,
-    tmcRelated: false,
     size: PageSize.LETTER,
     speedRelated: false,
     suffix: 'PedDelaySummary',
+    tmcRelated: false,
   },
   SPEED_PERCENTILE: {
     disabled: false,
@@ -590,10 +595,17 @@ ReportType.init({
     label: 'Speed Percentile Report',
     orientation: PageOrientation.LANDSCAPE,
     reportExportMode: ReportExportMode.STUDIES,
-    tmcRelated: false,
     size: PageSize.LETTER,
     speedRelated: true,
     suffix: 'SpeedPercentile',
+    tmcRelated: false,
+  },
+  TRACK_REQUESTS: {
+    disabled: false,
+    formats: [ReportFormat.CSV],
+    label: 'Track Requests',
+    scope: [AuthScope.STUDY_REQUESTS],
+    suffix: 'TrackRequests',
   },
   WARRANT_TRAFFIC_SIGNAL_CONTROL: {
     disabled: false,
@@ -608,10 +620,10 @@ ReportType.init({
     },
     orientation: PageOrientation.PORTRAIT,
     reportExportMode: ReportExportMode.STUDIES,
-    tmcRelated: true,
     size: PageSize.LETTER,
     speedRelated: false,
     suffix: 'WarrantTrafficSignalControl',
+    tmcRelated: true,
   },
 });
 

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -603,9 +603,16 @@ ReportType.init({
   TRACK_REQUESTS: {
     disabled: false,
     formats: [ReportFormat.CSV],
-    label: 'Track Requests',
+    label: 'Track Requests: Download All',
     scope: [AuthScope.STUDY_REQUESTS],
     suffix: 'TrackRequests',
+  },
+  TRACK_REQUESTS_SELECTED: {
+    disabled: false,
+    formats: [ReportFormat.CSV],
+    label: 'Track Requests: Download Selected',
+    scope: [AuthScope.STUDY_REQUESTS],
+    suffix: 'TrackRequestsSelected',
   },
   WARRANT_TRAFFIC_SIGNAL_CONTROL: {
     disabled: false,

--- a/lib/controller/ReportController.js
+++ b/lib/controller/ReportController.js
@@ -6,10 +6,12 @@ import {
   ReportParameter,
   ReportType,
 } from '@/lib/Constants';
+import { hasAuthScope } from '@/lib/auth/ScopeMatcher';
 import { EnumValueError } from '@/lib/error/MoveErrors';
 import StoragePath from '@/lib/io/storage/StoragePath';
 import CollisionFilters from '@/lib/model/CollisionFilters';
 import Joi from '@/lib/model/Joi';
+import StudyRequestFilters from '@/lib/model/StudyRequestFilters';
 import ReportFactory from '@/lib/reports/ReportFactory';
 
 /**
@@ -52,6 +54,9 @@ function getSchemaForReportType(reportType) {
     || reportType === ReportType.COLLISION_TABULATION) {
     return Joi.object().keys(CollisionFilters);
   }
+  if (reportType === ReportType.TRACK_REQUESTS) {
+    return Joi.object().keys(StudyRequestFilters);
+  }
   const { options = {} } = reportType;
   const schema = {};
   Object.entries(options).forEach(([name, reportParameter]) => {
@@ -89,6 +94,7 @@ ReportController.push({
   method: 'GET',
   path: '/reports',
   options: {
+    auth: { mode: 'try' },
     description: 'Generate reports in various formats',
     tags: ['api'],
     validate: {
@@ -107,6 +113,11 @@ ReportController.push({
       ...options
     } = request.query;
 
+    const user = request.auth.credentials;
+    if (reportType.scope && !hasAuthScope(user, reportType.scope)) {
+      return Boom.forbidden(`not authorized to generate reports of type ${reportType.name}`);
+    }
+
     let reportOptions;
     try {
       const reportTypeParameterSchema = getSchemaForReportType(reportType);
@@ -117,9 +128,9 @@ ReportController.push({
     }
 
     const reportInstance = ReportFactory.getInstance(reportType);
-    const reportStream = await reportInstance.generate(id, reportFormat, reportOptions);
+    const reportStream = await reportInstance.generate(id, reportFormat, reportOptions, user);
     const response = h.response(reportStream)
-      .type(reportType.mimeType);
+      .type(reportFormat.mimeType);
 
     if (reportFormat.download) {
       const report = {

--- a/lib/db/StudyRequestItemDAO.js
+++ b/lib/db/StudyRequestItemDAO.js
@@ -5,6 +5,12 @@ import {
 } from '@/lib/db/filters/StudyRequestFiltersSql';
 
 /**
+ * @typedef {Object} StudyRequestItemKey
+ * @property {boolean} bulk - does this key represent a bulk study request?
+ * @property {number} id - ID of the given study request (bulk or non-bulk)
+ */
+
+/**
  * Data Access Object for study request items, which are used in Track Requests to show study
  * requests together with related location and requester metadata.
  */
@@ -146,6 +152,7 @@ ON CONFLICT (bulk, id) DO UPDATE SET
    * @param {Object} studyRequestQuery - query representing filter, search, sort, and
    * pagination parameters
    * @param {Object} user - user making the query; used for the `userOnly` filter
+   * @returns {Array<StudyRequestItemKey>} paginated items matching the given query
    */
   static async byQuery(studyRequestQuery, user) {
     const { filters, params } = getStudyRequestFilters(studyRequestQuery, user);

--- a/lib/io/storage/StoragePath.js
+++ b/lib/io/storage/StoragePath.js
@@ -300,7 +300,7 @@ class StoragePath {
     const partTimestamp = StoragePath.getTimestamp();
     const partOptionsHash = StoragePath.getOptionsHash(options);
     const { extension } = format;
-    const key = `${partReportType}_${partTimestamp}_${partOptionsHash}.${extension}`;
+    const key = `${partReportType}_${partTimestamp}${partOptionsHash}.${extension}`;
     return { namespace: StoragePath.NAMESPACE_REPORTS_STUDY_REQUEST, key };
   }
 

--- a/lib/io/storage/StoragePath.js
+++ b/lib/io/storage/StoragePath.js
@@ -311,7 +311,7 @@ class StoragePath {
    */
   static async forReport(report) {
     const { type } = report;
-    if (type === ReportType.TRACK_REQUESTS) {
+    if (type === ReportType.TRACK_REQUESTS || type === ReportType.TRACK_REQUESTS_SELECTED) {
       return StoragePath.forStudyRequestReport(report);
     }
     if (type.reportExportMode === ReportExportMode.COLLISIONS) {

--- a/lib/io/storage/StoragePath.js
+++ b/lib/io/storage/StoragePath.js
@@ -5,6 +5,7 @@ import {
   CentrelineType,
   LocationSelectionType,
   ReportExportMode,
+  ReportType,
 } from '@/lib/Constants';
 import { mapBy } from '@/lib/MapUtils';
 import ObjectUtils from '@/lib/ObjectUtils';
@@ -14,6 +15,7 @@ import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import { InvalidReportExportModeError } from '@/lib/error/MoveErrors';
 import CompositeId from '@/lib/io/CompositeId';
 import { parseCollisionReportId, parseStudyReportId } from '@/lib/reports/ReportIdParser';
+import DateTime from '@/lib/time/DateTime';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 
 /**
@@ -207,6 +209,15 @@ class StoragePath {
 
   /**
    *
+   * @returns {string}
+   */
+  static getTimestamp() {
+    const dt = DateTime.local();
+    return dt.toISO().slice(0, 16).replace(/[-T:]/g, '');
+  }
+
+  /**
+   *
    * @param {Array<StoragePathResponse>} storagePaths
    * @returns {string}
    */
@@ -282,6 +293,17 @@ class StoragePath {
     return { namespace: StoragePath.NAMESPACE_REPORTS_STUDY, key };
   }
 
+  static async forStudyRequestReport(report) {
+    const { type, format, ...options } = report;
+
+    const partReportType = StoragePath.getReportType(type);
+    const partTimestamp = StoragePath.getTimestamp();
+    const partOptionsHash = StoragePath.getOptionsHash(options);
+    const { extension } = format;
+    const key = `${partReportType}_${partTimestamp}_${partOptionsHash}.${extension}`;
+    return { namespace: StoragePath.NAMESPACE_REPORTS_STUDY_REQUEST, key };
+  }
+
   /**
    *
    * @param {Object} report
@@ -289,6 +311,9 @@ class StoragePath {
    */
   static async forReport(report) {
     const { type } = report;
+    if (type === ReportType.TRACK_REQUESTS) {
+      return StoragePath.forStudyRequestReport(report);
+    }
     if (type.reportExportMode === ReportExportMode.COLLISIONS) {
       return StoragePath.forCollisionReport(report);
     }
@@ -365,5 +390,10 @@ StoragePath.NAMESPACE_REPORTS_COLLISION = 'reportsCollision';
  * @type {string}
  */
 StoragePath.NAMESPACE_REPORTS_STUDY = 'reportsStudy';
+
+/**
+ * @type {string}
+ */
+StoragePath.NAMESPACE_REPORTS_STUDY_REQUEST = 'reportsStudyRequest';
 
 export default StoragePath;

--- a/lib/reports/ReportBase.js
+++ b/lib/reports/ReportBase.js
@@ -53,7 +53,7 @@ class ReportBase {
    * verify that the corresponding entry exists.
    *
    * @abstract
-   * @param {string} id - ID of report to generate.
+   * @param {string} id - ID of report to generate
    * @returns {Object} ID with relevant parts parsed out
    * @throws {InvalidReportIdError} if the given ID is invalid for this report type
    */
@@ -69,9 +69,10 @@ class ReportBase {
    * @param {Object} parsedId - ID as parsed for convenience by {@link parseId}
    * @param {Object} options - extra report-specific options parsed from
    * {@link ReportController#getReport}
+   * @param {Object} user - user context for report generation
    * @returns {*} data for the given ID and options
    */
-  async fetchRawData(parsedId, options) {
+  async fetchRawData(parsedId, options, user) {
     throw new NotImplementedError();
   }
 
@@ -116,13 +117,15 @@ class ReportBase {
    *
    * @param {string} id - ID to generate report for
    * @param {ReportFormat} format - format to generate report in
+   * @param {Object} options - additional report options
+   * @param {Object} user - user context for report generation
    * @returns {stream.Duplex} stream
    * @throws {InvalidReportFormatError} if this report type does not support
    * the given format
    */
-  async generate(id, format, options) {
+  async generate(id, format, options, user) {
     const parsedId = await this.parseId(id);
-    const rawData = await this.fetchRawData(parsedId, options);
+    const rawData = await this.fetchRawData(parsedId, options, user);
     const transformedData = this.transformData(parsedId, rawData, options);
     if (format === ReportFormat.JSON) {
       return {

--- a/lib/reports/ReportBaseTrackRequests.js
+++ b/lib/reports/ReportBaseTrackRequests.js
@@ -1,0 +1,155 @@
+/* eslint-disable class-methods-use-this */
+import ArrayUtils from '@/lib/ArrayUtils';
+import { centrelineKey } from '@/lib/Constants';
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import UserDAO from '@/lib/db/UserDAO';
+import { NotImplementedError } from '@/lib/error/MoveErrors';
+import CompositeId from '@/lib/io/CompositeId';
+import ReportBase from '@/lib/reports/ReportBase';
+import {
+  getStudyRequestItem,
+  getStudyRequestBulkItem,
+} from '@/lib/requests/RequestItems';
+import RequestItemExport from '@/lib/requests/RequestItemExport';
+
+/**
+ * Base class for all study-request-related reports, i.e. those reports that export study
+ * requests from our study request management tools.
+ *
+ * @see https://github.com/CityofToronto/bdit_flashcrow/issues/866
+ */
+class ReportBaseTrackRequests extends ReportBase {
+  // STUDY REQUEST METADATA
+
+  async getStudyRequestItemsAndBulk() {
+    throw new NotImplementedError();
+  }
+
+  getStudyRequests(studyRequestItems) {
+    const studyRequests = [];
+    studyRequestItems.forEach(({ bulk, request }) => {
+      if (bulk) {
+        studyRequests.push(...request.studyRequests);
+      } else {
+        studyRequests.push(request);
+      }
+    });
+    return studyRequests;
+  }
+
+  async getStudyRequestLocations(studyRequests) {
+    const studyRequestLocations = new Map();
+
+    const centrelineKeys = new Set();
+    const features = [];
+    studyRequests.forEach(({ centrelineId, centrelineType }) => {
+      const feature = { centrelineId, centrelineType };
+      const key = centrelineKey(feature);
+      if (!centrelineKeys.has(key)) {
+        centrelineKeys.add(key);
+        features.push(feature);
+      }
+    });
+
+    const featureChunks = ArrayUtils.chunk(features, ReportBaseTrackRequests.CHUNK_SIZE);
+    for (let i = 0; i < featureChunks.length; i++) {
+      const featureChunk = featureChunks[i];
+      /* eslint-disable-next-line no-await-in-loop */
+      const locations = await CentrelineDAO.byFeatures(featureChunk);
+      locations.forEach((location) => {
+        if (location === null) {
+          return;
+        }
+        const key = centrelineKey(location);
+        studyRequestLocations.set(key, location);
+      });
+    }
+
+    return studyRequestLocations;
+  }
+
+  async getStudyRequestUsers(studyRequests) {
+    const studyRequestUsers = new Map();
+
+    let userIds = new Set();
+    studyRequests.forEach(({ userId }) => {
+      userIds.add(userId);
+    });
+    userIds = Array.from(userIds);
+
+    const userIdChunks = ArrayUtils.chunk(userIds, ReportBaseTrackRequests.CHUNK_SIZE);
+    for (let i = 0; i < userIdChunks.length; i++) {
+      const userIdChunk = userIdChunks[i];
+      /* eslint-disable-next-line no-await-in-loop */
+      const users = await UserDAO.byIds(userIdChunk);
+      users.forEach((user, userId) => {
+        studyRequestUsers.set(userId, user);
+      });
+    }
+
+    return studyRequestUsers;
+  }
+
+  // REPORT METHODS
+
+  async fetchRawData(ids, filters, user) {
+    const {
+      studyRequestItems,
+      studyRequestsBulk,
+    } = await this.getStudyRequestItemsAndBulk(ids, filters, user);
+
+    const studyRequests = this.getStudyRequests(studyRequestItems);
+    const [
+      studyRequestLocations,
+      studyRequestUsers,
+    ] = await Promise.all([
+      this.getStudyRequestLocations(studyRequests),
+      this.getStudyRequestUsers(studyRequests),
+    ]);
+
+    return {
+      studyRequestItems,
+      studyRequestLocations,
+      studyRequestUsers,
+      studyRequestsBulk,
+    };
+  }
+
+  transformData(parsedId, {
+    studyRequestItems,
+    studyRequestLocations,
+    studyRequestUsers,
+    studyRequestsBulk,
+  }) {
+    const items = [];
+    studyRequestItems.forEach(({ bulk, request }) => {
+      if (bulk) {
+        const itemBulk = getStudyRequestBulkItem(
+          studyRequestLocations,
+          studyRequestUsers,
+          request,
+        );
+        items.push(...itemBulk.studyRequestBulk.studyRequests);
+      } else {
+        const item = getStudyRequestItem(
+          studyRequestLocations,
+          studyRequestUsers,
+          request,
+        );
+        items.push(item);
+      }
+    });
+    return { items, studyRequestsBulk };
+  }
+
+  generateCsv(parsedId, { items, studyRequestsBulk }) {
+    return RequestItemExport.get(items, studyRequestsBulk);
+  }
+}
+
+/**
+ * @type {number}
+ */
+ReportBaseTrackRequests.CHUNK_SIZE = Math.min(100, CompositeId.MAX_FEATURES);
+
+export default ReportBaseTrackRequests;

--- a/lib/reports/ReportFactory.js
+++ b/lib/reports/ReportFactory.js
@@ -10,6 +10,7 @@ import ReportCountSummaryTurningMovementDetailed
 import ReportIntersectionSummary from '@/lib/reports/ReportIntersectionSummary';
 import ReportPeakHourFactor from '@/lib/reports/ReportPeakHourFactor';
 import ReportSpeedPercentile from '@/lib/reports/ReportSpeedPercentile';
+import ReportTrackRequests from '@/lib/reports/ReportTrackRequests';
 import ReportWarrantTrafficSignalControl from '@/lib/reports/ReportWarrantTrafficSignalControl';
 
 /**
@@ -63,6 +64,7 @@ ReportFactory.registerInstance(new ReportCountSummaryTurningMovementDetailed());
 ReportFactory.registerInstance(new ReportIntersectionSummary());
 ReportFactory.registerInstance(new ReportPeakHourFactor());
 ReportFactory.registerInstance(new ReportSpeedPercentile());
+ReportFactory.registerInstance(new ReportTrackRequests());
 ReportFactory.registerInstance(new ReportWarrantTrafficSignalControl());
 
 export default ReportFactory;

--- a/lib/reports/ReportFactory.js
+++ b/lib/reports/ReportFactory.js
@@ -11,6 +11,7 @@ import ReportIntersectionSummary from '@/lib/reports/ReportIntersectionSummary';
 import ReportPeakHourFactor from '@/lib/reports/ReportPeakHourFactor';
 import ReportSpeedPercentile from '@/lib/reports/ReportSpeedPercentile';
 import ReportTrackRequests from '@/lib/reports/ReportTrackRequests';
+import ReportTrackRequestsSelected from '@/lib/reports/ReportTrackRequestsSelected';
 import ReportWarrantTrafficSignalControl from '@/lib/reports/ReportWarrantTrafficSignalControl';
 
 /**
@@ -65,6 +66,7 @@ ReportFactory.registerInstance(new ReportIntersectionSummary());
 ReportFactory.registerInstance(new ReportPeakHourFactor());
 ReportFactory.registerInstance(new ReportSpeedPercentile());
 ReportFactory.registerInstance(new ReportTrackRequests());
+ReportFactory.registerInstance(new ReportTrackRequestsSelected());
 ReportFactory.registerInstance(new ReportWarrantTrafficSignalControl());
 
 export default ReportFactory;

--- a/lib/reports/ReportIdParser.js
+++ b/lib/reports/ReportIdParser.js
@@ -115,16 +115,51 @@ async function parseStudyReportId(type, rawId) {
   };
 }
 
+async function parseStudyRequestReportId(type, rawId) {
+  const parts = rawId.split('/');
+  if (parts.length !== 2) {
+    throw new InvalidReportIdError(rawId);
+  }
+
+  const idType = parts.shift();
+  if (idType === 'ids') {
+    const studyRequestIdsStr = parts.shift();
+    const ids = [];
+    const idStrs = studyRequestIdsStr.split(',');
+    idStrs.forEach((idStr) => {
+      const id = parseInt(idStr, 10);
+      if (Number.isNaN(idStr)) {
+        throw new InvalidReportIdError(rawId);
+      }
+      ids.push(id);
+    });
+    return {
+      ids,
+      uuid: null,
+    };
+  }
+  if (idType === 'uuid') {
+    const uuid = parts.shift();
+    return {
+      ids: null,
+      uuid,
+    };
+  }
+  throw new InvalidReportIdError(rawId);
+}
+
 /**
  * @namespace
  */
 const ReportIdParser = {
   parseCollisionReportId,
   parseStudyReportId,
+  parseStudyRequestReportId,
 };
 
 export {
   ReportIdParser as default,
   parseCollisionReportId,
   parseStudyReportId,
+  parseStudyRequestReportId,
 };

--- a/lib/reports/ReportIdParser.js
+++ b/lib/reports/ReportIdParser.js
@@ -115,51 +115,16 @@ async function parseStudyReportId(type, rawId) {
   };
 }
 
-async function parseStudyRequestReportId(type, rawId) {
-  const parts = rawId.split('/');
-  if (parts.length !== 2) {
-    throw new InvalidReportIdError(rawId);
-  }
-
-  const idType = parts.shift();
-  if (idType === 'ids') {
-    const studyRequestIdsStr = parts.shift();
-    const ids = [];
-    const idStrs = studyRequestIdsStr.split(',');
-    idStrs.forEach((idStr) => {
-      const id = parseInt(idStr, 10);
-      if (Number.isNaN(idStr)) {
-        throw new InvalidReportIdError(rawId);
-      }
-      ids.push(id);
-    });
-    return {
-      ids,
-      uuid: null,
-    };
-  }
-  if (idType === 'uuid') {
-    const uuid = parts.shift();
-    return {
-      ids: null,
-      uuid,
-    };
-  }
-  throw new InvalidReportIdError(rawId);
-}
-
 /**
  * @namespace
  */
 const ReportIdParser = {
   parseCollisionReportId,
   parseStudyReportId,
-  parseStudyRequestReportId,
 };
 
 export {
   ReportIdParser as default,
   parseCollisionReportId,
   parseStudyReportId,
-  parseStudyRequestReportId,
 };

--- a/lib/reports/ReportTrackRequests.js
+++ b/lib/reports/ReportTrackRequests.js
@@ -1,36 +1,22 @@
 /* eslint-disable class-methods-use-this */
-import ArrayUtils from '@/lib/ArrayUtils';
-import { centrelineKey, ReportType } from '@/lib/Constants';
+import { ReportType } from '@/lib/Constants';
 import { mapBy } from '@/lib/MapUtils';
-import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import StudyRequestDAO from '@/lib/db/StudyRequestDAO';
 import StudyRequestBulkDAO from '@/lib/db/StudyRequestBulkDAO';
 import StudyRequestItemDAO from '@/lib/db/StudyRequestItemDAO';
-import UserDAO from '@/lib/db/UserDAO';
 import CompositeId from '@/lib/io/CompositeId';
-import ReportBase from '@/lib/reports/ReportBase';
-import { parseStudyRequestReportId } from '@/lib/reports/ReportIdParser';
-import {
-  getStudyRequestItem,
-  getStudyRequestBulkItem,
-} from '@/lib/requests/RequestItems';
-import RequestItemExport from '@/lib/requests/RequestItemExport';
+import ReportBaseTrackRequests from '@/lib/reports/ReportBaseTrackRequests';
 
 const CHUNK_SIZE = Math.min(100, CompositeId.MAX_FEATURES);
 
 /**
- * Subclass of {@link ReportBase} for exporting study requests from Track Requests.
+ * Subclass of {@link ReportBaseTrackRequests} for exporting study requests from Track Requests.
  *
  * @see https://github.com/CityofToronto/bdit_flashcrow/issues/866
  */
-class ReportTrackRequests extends ReportBase {
+class ReportTrackRequests extends ReportBaseTrackRequests {
   type() {
     return ReportType.TRACK_REQUESTS;
-  }
-
-  async parseId(rawId) {
-    const { ids } = await parseStudyRequestReportId(this.type(), rawId);
-    return ids;
   }
 
   async getStudyRequestItemsForFilters(filters, user) {
@@ -79,154 +65,16 @@ class ReportTrackRequests extends ReportBase {
     return studyRequestItems;
   }
 
-  async getStudyRequestItemsAndBulk(ids, filters, user) {
-    if (ids === null) {
-      const studyRequestItems = await this.getStudyRequestItemsForFilters(filters, user);
-      const studyRequestsBulk = studyRequestItems
-        .filter(({ bulk }) => bulk)
-        .map(({ request }) => request);
-      return { studyRequestItems, studyRequestsBulk };
-    }
-
-    /*
-     * In this case, all IDs are assumed to refer to individual study requests selected in the
-     * frontend.  (Under the hood, selecting a bulk request actually selects all individual
-     * study requests in that bulk request.)
-     */
-    const studyRequests = await StudyRequestDAO.byIds(ids);
-    const studyRequestItems = studyRequests.map(request => ({ bulk: false, request }));
-
-    /*
-     * This also means that, unlike in the filtered download case, we need to look up associated
-     * bulk study requests in a second pass, so that we have those to populate the project name
-     * column.
-     */
-    let studyRequestBulkIds = new Set();
-    studyRequests.forEach(({ studyRequestBulkId }) => {
-      studyRequestBulkIds.add(studyRequestBulkId);
-    });
-    studyRequestBulkIds = Array.from(studyRequestBulkIds);
-    const studyRequestsBulk = await StudyRequestBulkDAO.byIds(studyRequestBulkIds);
+  async getStudyRequestItemsAndBulk(parsedId, filters, user) {
+    const studyRequestItems = await this.getStudyRequestItemsForFilters(filters, user);
+    const studyRequestsBulk = studyRequestItems
+      .filter(({ bulk }) => bulk)
+      .map(({ request }) => request);
     return { studyRequestItems, studyRequestsBulk };
   }
 
-  getStudyRequests(studyRequestItems) {
-    const studyRequests = [];
-    studyRequestItems.forEach(({ bulk, request }) => {
-      if (bulk) {
-        studyRequests.push(...request.studyRequests);
-      } else {
-        studyRequests.push(request);
-      }
-    });
-    return studyRequests;
-  }
-
-  async getStudyRequestLocations(studyRequests) {
-    const studyRequestLocations = new Map();
-
-    const centrelineKeys = new Set();
-    const features = [];
-    studyRequests.forEach(({ centrelineId, centrelineType }) => {
-      const feature = { centrelineId, centrelineType };
-      const key = centrelineKey(feature);
-      if (!centrelineKeys.has(key)) {
-        centrelineKeys.add(key);
-        features.push(feature);
-      }
-    });
-
-    const featureChunks = ArrayUtils.chunk(features, CHUNK_SIZE);
-    for (let i = 0; i < featureChunks.length; i++) {
-      const featureChunk = featureChunks[i];
-      /* eslint-disable-next-line no-await-in-loop */
-      const locations = await CentrelineDAO.byFeatures(featureChunk);
-      locations.forEach((location) => {
-        if (location === null) {
-          return;
-        }
-        const key = centrelineKey(location);
-        studyRequestLocations.set(key, location);
-      });
-    }
-
-    return studyRequestLocations;
-  }
-
-  async getStudyRequestUsers(studyRequests) {
-    const studyRequestUsers = new Map();
-
-    let userIds = new Set();
-    studyRequests.forEach(({ userId }) => {
-      userIds.add(userId);
-    });
-    userIds = Array.from(userIds);
-
-    const userIdChunks = ArrayUtils.chunk(userIds, CHUNK_SIZE);
-    for (let i = 0; i < userIdChunks.length; i++) {
-      const userIdChunk = userIdChunks[i];
-      /* eslint-disable-next-line no-await-in-loop */
-      const users = await UserDAO.byIds(userIdChunk);
-      users.forEach((user, userId) => {
-        studyRequestUsers.set(userId, user);
-      });
-    }
-
-    return studyRequestUsers;
-  }
-
-  async fetchRawData(ids, filters, user) {
-    const {
-      studyRequestItems,
-      studyRequestsBulk,
-    } = await this.getStudyRequestItemsAndBulk(ids, filters, user);
-
-    const studyRequests = this.getStudyRequests(studyRequestItems);
-    const [
-      studyRequestLocations,
-      studyRequestUsers,
-    ] = await Promise.all([
-      this.getStudyRequestLocations(studyRequests),
-      this.getStudyRequestUsers(studyRequests),
-    ]);
-
-    return {
-      studyRequestItems,
-      studyRequestLocations,
-      studyRequestUsers,
-      studyRequestsBulk,
-    };
-  }
-
-  transformData(uuid, {
-    studyRequestItems,
-    studyRequestLocations,
-    studyRequestUsers,
-    studyRequestsBulk,
-  }) {
-    const items = [];
-    studyRequestItems.forEach(({ bulk, request }) => {
-      if (bulk) {
-        const itemBulk = getStudyRequestBulkItem(
-          studyRequestLocations,
-          studyRequestUsers,
-          request,
-        );
-        items.push(...itemBulk.studyRequestBulk.studyRequests);
-      } else {
-        const item = getStudyRequestItem(
-          studyRequestLocations,
-          studyRequestUsers,
-          request,
-        );
-        items.push(item);
-      }
-    });
-    return { items, studyRequestsBulk };
-  }
-
-  generateCsv(parsedId, { items, studyRequestsBulk }) {
-    return RequestItemExport.get(items, studyRequestsBulk);
+  async parseId(rawId) {
+    return rawId;
   }
 }
 

--- a/lib/reports/ReportTrackRequests.js
+++ b/lib/reports/ReportTrackRequests.js
@@ -1,15 +1,21 @@
 /* eslint-disable class-methods-use-this */
-import { ReportType } from '@/lib/Constants';
+import ArrayUtils from '@/lib/ArrayUtils';
+import { centrelineKey, ReportType } from '@/lib/Constants';
 import { mapBy } from '@/lib/MapUtils';
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import StudyRequestDAO from '@/lib/db/StudyRequestDAO';
 import StudyRequestBulkDAO from '@/lib/db/StudyRequestBulkDAO';
 import StudyRequestItemDAO from '@/lib/db/StudyRequestItemDAO';
+import UserDAO from '@/lib/db/UserDAO';
+import CompositeId from '@/lib/io/CompositeId';
 import ReportBase from '@/lib/reports/ReportBase';
 import {
   getStudyRequestItem,
   getStudyRequestBulkItem,
 } from '@/lib/requests/RequestItems';
 import RequestItemExport from '@/lib/requests/RequestItemExport';
+
+const CHUNK_SIZE = Math.min(100, CompositeId.MAX_FEATURES);
 
 /**
  * Subclass of {@link ReportBase} for exporting study requests from Track Requests.
@@ -28,18 +34,14 @@ class ReportTrackRequests extends ReportBase {
     return uuid;
   }
 
-  async fetchRawData(uuid, filters, user) {
+  async getStudyRequestItems(filters, user) {
     const studyRequestItems = [];
-    const studyRequestLocations = new Map();
-    const studyRequestUsers = new Map();
-    const studyRequestsBulk = [];
 
-    const limit = 100;
     const total = await StudyRequestItemDAO.byQueryTotal(filters, user);
-    for (let i = 0; i < total; i += limit) {
+    for (let i = 0; i < total; i += CHUNK_SIZE) {
       const queryPage = {
         ...filters,
-        limit,
+        limit: CHUNK_SIZE,
         offset: i,
       };
       /* eslint-disable-next-line no-await-in-loop */
@@ -73,15 +75,91 @@ class ReportTrackRequests extends ReportBase {
         const studyRequestItem = { bulk, request: itemRequest };
         studyRequestItems.push(studyRequestItem);
       });
-
-      // fetch dependent locations, users
     }
+
+    return studyRequestItems;
+  }
+
+  getStudyRequests(studyRequestItems) {
+    const studyRequests = [];
+    studyRequestItems.forEach(({ bulk, request }) => {
+      if (bulk) {
+        studyRequests.push(...request.studyRequests);
+      } else {
+        studyRequests.push(request);
+      }
+    });
+    return studyRequests;
+  }
+
+  async getStudyRequestLocations(studyRequests) {
+    const studyRequestLocations = new Map();
+
+    const centrelineKeys = new Set();
+    const features = [];
+    studyRequests.forEach(({ centrelineId, centrelineType }) => {
+      const feature = { centrelineId, centrelineType };
+      const key = centrelineKey(feature);
+      if (!centrelineKeys.has(key)) {
+        centrelineKeys.add(key);
+        features.push(feature);
+      }
+    });
+
+    const featureChunks = ArrayUtils.chunk(features, CHUNK_SIZE);
+    for (let i = 0; i < featureChunks.length; i++) {
+      const featureChunk = featureChunks[i];
+      /* eslint-disable-next-line no-await-in-loop */
+      const locations = await CentrelineDAO.byFeatures(featureChunk);
+      locations.forEach((location) => {
+        if (location === null) {
+          return;
+        }
+        const key = centrelineKey(location);
+        studyRequestLocations.set(key, location);
+      });
+    }
+
+    return studyRequestLocations;
+  }
+
+  async getStudyRequestUsers(studyRequests) {
+    const studyRequestUsers = new Map();
+
+    let userIds = new Set();
+    studyRequests.forEach(({ userId }) => {
+      userIds.add(userId);
+    });
+    userIds = Array.from(userIds);
+
+    const userIdChunks = ArrayUtils.chunk(userIds, CHUNK_SIZE);
+    for (let i = 0; i < userIdChunks.length; i++) {
+      const userIdChunk = userIdChunks[i];
+      /* eslint-disable-next-line no-await-in-loop */
+      const users = await UserDAO.byIds(userIdChunk);
+      users.forEach((user, userId) => {
+        studyRequestUsers.set(userId, user);
+      });
+    }
+
+    return studyRequestUsers;
+  }
+
+  async fetchRawData(uuid, filters, user) {
+    const studyRequestItems = await this.getStudyRequestItems(filters, user);
+    const studyRequests = this.getStudyRequests(studyRequestItems);
+    const [
+      studyRequestLocations,
+      studyRequestUsers,
+    ] = await Promise.all([
+      this.getStudyRequestLocations(studyRequests),
+      this.getStudyRequestUsers(studyRequests),
+    ]);
 
     return {
       studyRequestItems,
       studyRequestLocations,
       studyRequestUsers,
-      studyRequestsBulk,
     };
   }
 
@@ -89,27 +167,33 @@ class ReportTrackRequests extends ReportBase {
     studyRequestItems,
     studyRequestLocations,
     studyRequestUsers,
-    studyRequestsBulk,
   }) {
-    const items = studyRequestItems.map(({ bulk, request }) => {
+    const items = [];
+    studyRequestItems.forEach(({ bulk, request }) => {
       if (bulk) {
-        return getStudyRequestBulkItem(
+        const itemBulk = getStudyRequestBulkItem(
           studyRequestLocations,
           studyRequestUsers,
           request,
         );
+        items.push(...itemBulk.studyRequestBulk.studyRequests);
+      } else {
+        const item = getStudyRequestItem(
+          studyRequestLocations,
+          studyRequestUsers,
+          request,
+        );
+        items.push(item);
       }
-      return getStudyRequestItem(
-        studyRequestLocations,
-        studyRequestUsers,
-        request,
-      );
     });
+    const studyRequestsBulk = studyRequestItems
+      .filter(({ bulk }) => bulk)
+      .map(({ request }) => request);
 
     return { items, studyRequestsBulk };
   }
 
-  generateCsv({ items, studyRequestsBulk }) {
+  generateCsv(uuid, { items, studyRequestsBulk }) {
     return RequestItemExport.get(items, studyRequestsBulk);
   }
 }

--- a/lib/reports/ReportTrackRequests.js
+++ b/lib/reports/ReportTrackRequests.js
@@ -4,15 +4,12 @@ import { mapBy } from '@/lib/MapUtils';
 import StudyRequestDAO from '@/lib/db/StudyRequestDAO';
 import StudyRequestBulkDAO from '@/lib/db/StudyRequestBulkDAO';
 import StudyRequestItemDAO from '@/lib/db/StudyRequestItemDAO';
-import CompositeId from '@/lib/io/CompositeId';
 import ReportBaseTrackRequests from '@/lib/reports/ReportBaseTrackRequests';
-
-const CHUNK_SIZE = Math.min(100, CompositeId.MAX_FEATURES);
 
 /**
  * Subclass of {@link ReportBaseTrackRequests} for exporting study requests from Track Requests.
- *
- * @see https://github.com/CityofToronto/bdit_flashcrow/issues/866
+ * This report type exports all study requests that match a given set of `StudyRequestFilters`,
+ * including those requests that are not shown on the current page in Track Requests.
  */
 class ReportTrackRequests extends ReportBaseTrackRequests {
   type() {
@@ -23,10 +20,10 @@ class ReportTrackRequests extends ReportBaseTrackRequests {
     const studyRequestItems = [];
 
     const total = await StudyRequestItemDAO.byQueryTotal(filters, user);
-    for (let i = 0; i < total; i += CHUNK_SIZE) {
+    for (let i = 0; i < total; i += ReportBaseTrackRequests.CHUNK_SIZE) {
       const queryPage = {
         ...filters,
-        limit: CHUNK_SIZE,
+        limit: ReportBaseTrackRequests.CHUNK_SIZE,
         offset: i,
       };
       /* eslint-disable-next-line no-await-in-loop */

--- a/lib/reports/ReportTrackRequests.js
+++ b/lib/reports/ReportTrackRequests.js
@@ -1,0 +1,117 @@
+/* eslint-disable class-methods-use-this */
+import { ReportType } from '@/lib/Constants';
+import { mapBy } from '@/lib/MapUtils';
+import StudyRequestDAO from '@/lib/db/StudyRequestDAO';
+import StudyRequestBulkDAO from '@/lib/db/StudyRequestBulkDAO';
+import StudyRequestItemDAO from '@/lib/db/StudyRequestItemDAO';
+import ReportBase from '@/lib/reports/ReportBase';
+import {
+  getStudyRequestItem,
+  getStudyRequestBulkItem,
+} from '@/lib/requests/RequestItems';
+import RequestItemExport from '@/lib/requests/RequestItemExport';
+
+/**
+ * Subclass of {@link ReportBase} for exporting study requests from Track Requests.
+ *
+ * @see https://github.com/CityofToronto/bdit_flashcrow/issues/866
+ */
+class ReportTrackRequests extends ReportBase {
+  type() {
+    return ReportType.TRACK_REQUESTS;
+  }
+
+  async parseId(uuid) {
+    /**
+     * The ID here is just a random UUID, to keep each download separate.
+     */
+    return uuid;
+  }
+
+  async fetchRawData(uuid, filters, user) {
+    const studyRequestItems = [];
+    const studyRequestLocations = new Map();
+    const studyRequestUsers = new Map();
+    const studyRequestsBulk = [];
+
+    const limit = 100;
+    const total = await StudyRequestItemDAO.byQueryTotal(filters, user);
+    for (let i = 0; i < total; i += limit) {
+      const queryPage = {
+        ...filters,
+        limit,
+        offset: i,
+      };
+      /* eslint-disable-next-line no-await-in-loop */
+      const itemKeys = await StudyRequestItemDAO.byQuery(queryPage, user);
+
+      const studyRequestIds = [];
+      const studyRequestBulkIds = [];
+      itemKeys.forEach(({ bulk, id }) => {
+        if (bulk) {
+          studyRequestBulkIds.push(id);
+        } else {
+          studyRequestIds.push(id);
+        }
+      });
+
+      /* eslint-disable-next-line no-await-in-loop */
+      const [studyRequestsPage, studyRequestsBulkPage] = await Promise.all([
+        StudyRequestDAO.byIds(studyRequestIds),
+        StudyRequestBulkDAO.byIds(studyRequestBulkIds),
+      ]);
+      const studyRequestsPageById = mapBy(studyRequestsPage, ({ id }) => id);
+      const studyRequestsPageBulkById = mapBy(studyRequestsBulkPage, ({ id }) => id);
+
+      itemKeys.forEach(({ bulk, id }) => {
+        let itemRequest;
+        if (bulk) {
+          itemRequest = studyRequestsPageBulkById.get(id);
+        } else {
+          itemRequest = studyRequestsPageById.get(id);
+        }
+        const studyRequestItem = { bulk, request: itemRequest };
+        studyRequestItems.push(studyRequestItem);
+      });
+
+      // fetch dependent locations, users
+    }
+
+    return {
+      studyRequestItems,
+      studyRequestLocations,
+      studyRequestUsers,
+      studyRequestsBulk,
+    };
+  }
+
+  transformData(uuid, {
+    studyRequestItems,
+    studyRequestLocations,
+    studyRequestUsers,
+    studyRequestsBulk,
+  }) {
+    const items = studyRequestItems.map(({ bulk, request }) => {
+      if (bulk) {
+        return getStudyRequestBulkItem(
+          studyRequestLocations,
+          studyRequestUsers,
+          request,
+        );
+      }
+      return getStudyRequestItem(
+        studyRequestLocations,
+        studyRequestUsers,
+        request,
+      );
+    });
+
+    return { items, studyRequestsBulk };
+  }
+
+  generateCsv({ items, studyRequestsBulk }) {
+    return RequestItemExport.get(items, studyRequestsBulk);
+  }
+}
+
+export default ReportTrackRequests;

--- a/lib/reports/ReportTrackRequests.js
+++ b/lib/reports/ReportTrackRequests.js
@@ -9,6 +9,7 @@ import StudyRequestItemDAO from '@/lib/db/StudyRequestItemDAO';
 import UserDAO from '@/lib/db/UserDAO';
 import CompositeId from '@/lib/io/CompositeId';
 import ReportBase from '@/lib/reports/ReportBase';
+import { parseStudyRequestReportId } from '@/lib/reports/ReportIdParser';
 import {
   getStudyRequestItem,
   getStudyRequestBulkItem,
@@ -27,14 +28,12 @@ class ReportTrackRequests extends ReportBase {
     return ReportType.TRACK_REQUESTS;
   }
 
-  async parseId(uuid) {
-    /**
-     * The ID here is just a random UUID, to keep each download separate.
-     */
-    return uuid;
+  async parseId(rawId) {
+    const { ids } = await parseStudyRequestReportId(this.type(), rawId);
+    return ids;
   }
 
-  async getStudyRequestItems(filters, user) {
+  async getStudyRequestItemsForFilters(filters, user) {
     const studyRequestItems = [];
 
     const total = await StudyRequestItemDAO.byQueryTotal(filters, user);
@@ -78,6 +77,37 @@ class ReportTrackRequests extends ReportBase {
     }
 
     return studyRequestItems;
+  }
+
+  async getStudyRequestItemsAndBulk(ids, filters, user) {
+    if (ids === null) {
+      const studyRequestItems = await this.getStudyRequestItemsForFilters(filters, user);
+      const studyRequestsBulk = studyRequestItems
+        .filter(({ bulk }) => bulk)
+        .map(({ request }) => request);
+      return { studyRequestItems, studyRequestsBulk };
+    }
+
+    /*
+     * In this case, all IDs are assumed to refer to individual study requests selected in the
+     * frontend.  (Under the hood, selecting a bulk request actually selects all individual
+     * study requests in that bulk request.)
+     */
+    const studyRequests = await StudyRequestDAO.byIds(ids);
+    const studyRequestItems = studyRequests.map(request => ({ bulk: false, request }));
+
+    /*
+     * This also means that, unlike in the filtered download case, we need to look up associated
+     * bulk study requests in a second pass, so that we have those to populate the project name
+     * column.
+     */
+    let studyRequestBulkIds = new Set();
+    studyRequests.forEach(({ studyRequestBulkId }) => {
+      studyRequestBulkIds.add(studyRequestBulkId);
+    });
+    studyRequestBulkIds = Array.from(studyRequestBulkIds);
+    const studyRequestsBulk = await StudyRequestBulkDAO.byIds(studyRequestBulkIds);
+    return { studyRequestItems, studyRequestsBulk };
   }
 
   getStudyRequests(studyRequestItems) {
@@ -145,8 +175,12 @@ class ReportTrackRequests extends ReportBase {
     return studyRequestUsers;
   }
 
-  async fetchRawData(uuid, filters, user) {
-    const studyRequestItems = await this.getStudyRequestItems(filters, user);
+  async fetchRawData(ids, filters, user) {
+    const {
+      studyRequestItems,
+      studyRequestsBulk,
+    } = await this.getStudyRequestItemsAndBulk(ids, filters, user);
+
     const studyRequests = this.getStudyRequests(studyRequestItems);
     const [
       studyRequestLocations,
@@ -160,6 +194,7 @@ class ReportTrackRequests extends ReportBase {
       studyRequestItems,
       studyRequestLocations,
       studyRequestUsers,
+      studyRequestsBulk,
     };
   }
 
@@ -167,6 +202,7 @@ class ReportTrackRequests extends ReportBase {
     studyRequestItems,
     studyRequestLocations,
     studyRequestUsers,
+    studyRequestsBulk,
   }) {
     const items = [];
     studyRequestItems.forEach(({ bulk, request }) => {
@@ -186,14 +222,10 @@ class ReportTrackRequests extends ReportBase {
         items.push(item);
       }
     });
-    const studyRequestsBulk = studyRequestItems
-      .filter(({ bulk }) => bulk)
-      .map(({ request }) => request);
-
     return { items, studyRequestsBulk };
   }
 
-  generateCsv(uuid, { items, studyRequestsBulk }) {
+  generateCsv(parsedId, { items, studyRequestsBulk }) {
     return RequestItemExport.get(items, studyRequestsBulk);
   }
 }

--- a/lib/reports/ReportTrackRequestsSelected.js
+++ b/lib/reports/ReportTrackRequestsSelected.js
@@ -1,0 +1,58 @@
+/* eslint-disable class-methods-use-this */
+import { ReportType } from '@/lib/Constants';
+import StudyRequestDAO from '@/lib/db/StudyRequestDAO';
+import StudyRequestBulkDAO from '@/lib/db/StudyRequestBulkDAO';
+import { InvalidReportIdError } from '@/lib/error/MoveErrors';
+import ReportBaseTrackRequests from '@/lib/reports/ReportBaseTrackRequests';
+
+/**
+ * Subclass of {@link ReportBase} for exporting study requests from Track Requests.
+ *
+ * @see https://github.com/CityofToronto/bdit_flashcrow/issues/866
+ */
+class ReportTrackRequestsSelected extends ReportBaseTrackRequests {
+  type() {
+    return ReportType.TRACK_REQUESTS_SELECTED;
+  }
+
+  async getStudyRequestItemsAndBulk(ids) {
+    /*
+     * In this case, all IDs are assumed to refer to individual study requests selected in the
+     * frontend.  (Under the hood, selecting a bulk request actually selects all individual
+     * study requests in that bulk request.)
+     */
+    const studyRequests = await StudyRequestDAO.byIds(ids);
+    const studyRequestItems = studyRequests.map(request => ({ bulk: false, request }));
+
+    /*
+     * This also means that, unlike in the filtered download case, we need to look up associated
+     * bulk study requests in a second pass, so that we have those to populate the project name
+     * column.
+     */
+    let studyRequestBulkIds = new Set();
+    studyRequests.forEach(({ studyRequestBulkId }) => {
+      studyRequestBulkIds.add(studyRequestBulkId);
+    });
+    studyRequestBulkIds = Array.from(studyRequestBulkIds);
+    const studyRequestsBulk = await StudyRequestBulkDAO.byIds(studyRequestBulkIds);
+    return { studyRequestItems, studyRequestsBulk };
+  }
+
+  async parseId(rawId) {
+    const ids = [];
+    const idStrs = rawId.split(',');
+    idStrs.forEach((idStr) => {
+      const id = parseInt(idStr, 10);
+      if (Number.isNaN(idStr)) {
+        throw new InvalidReportIdError(rawId);
+      }
+      ids.push(id);
+    });
+    if (ids.length === 0) {
+      throw new InvalidReportIdError(rawId);
+    }
+    return ids;
+  }
+}
+
+export default ReportTrackRequestsSelected;

--- a/lib/reports/ReportTrackRequestsSelected.js
+++ b/lib/reports/ReportTrackRequestsSelected.js
@@ -6,9 +6,8 @@ import { InvalidReportIdError } from '@/lib/error/MoveErrors';
 import ReportBaseTrackRequests from '@/lib/reports/ReportBaseTrackRequests';
 
 /**
- * Subclass of {@link ReportBase} for exporting study requests from Track Requests.
- *
- * @see https://github.com/CityofToronto/bdit_flashcrow/issues/866
+ * Subclass of {@link ReportBaseTrackRequests} for exporting study requests from Track Requests.
+ * This report type exports only selected study requests from the current page in Track Requests.
  */
 class ReportTrackRequestsSelected extends ReportBaseTrackRequests {
   type() {

--- a/lib/requests/RequestItemExport.js
+++ b/lib/requests/RequestItemExport.js
@@ -71,10 +71,7 @@ class RequestItemExport {
   }
 
   static getItemRow(item, studyRequestsBulkById) {
-    const idAdjusted = item.studyRequest.id + ID_DATA_COLLECTION_ADJUST;
-    const { origin } = window.location;
-    const url = `${origin}/requests/study/${item.studyRequest.id}`;
-    const reqId = `=HYPERLINK("${url}", "${idAdjusted}")`;
+    const reqId = item.studyRequest.id + ID_DATA_COLLECTION_ADJUST;
 
     let client = null;
     if (item.requestedBy !== null) {

--- a/lib/requests/RequestItemExport.js
+++ b/lib/requests/RequestItemExport.js
@@ -1,6 +1,3 @@
-import { csvFormatRows } from 'd3-dsv';
-
-import ArrayUtils from '@/lib/ArrayUtils';
 import { mapBy } from '@/lib/MapUtils';
 import { formatUsername } from '@/lib/StringFormatters';
 import TimeFormatters from '@/lib/time/TimeFormatters';
@@ -131,15 +128,11 @@ class RequestItemExport {
   }
 
   static get(items, studyRequestsBulk) {
-    const itemsSorted = ArrayUtils.sortBy(items, item => item.studyRequest.id);
     const studyRequestsBulkById = mapBy(studyRequestsBulk, ({ id }) => id);
-    const csvRows = [
-      CSV_COLUMNS,
-      ...itemsSorted.map(
-        item => RequestItemExport.getItemRow(item, studyRequestsBulkById),
-      ),
-    ];
-    return csvFormatRows(csvRows);
+    const rows = items.map(
+      item => RequestItemExport.getItemRow(item, studyRequestsBulkById),
+    );
+    return { columns: CSV_COLUMNS, rows };
   }
 }
 

--- a/reporter/ReporterServer.js
+++ b/reporter/ReporterServer.js
@@ -9,6 +9,7 @@ class ReporterServer extends MoveServer {
     this
       .addInitModule(MovePdfGenerator)
       .addController(ReportController)
+      .enableAuth({ csrf: false })
       .enableDocs('/reporter');
   }
 }

--- a/tests/jest/unit/auth/ScopeMatcher.spec.js
+++ b/tests/jest/unit/auth/ScopeMatcher.spec.js
@@ -4,12 +4,14 @@ import { hasAuthScope } from '@/lib/auth/ScopeMatcher';
 test('ScopeMatcher.hasAuthScope', () => {
   let user = null;
   expect(hasAuthScope(user, [])).toBe(false);
+  expect(hasAuthScope(user, AuthScope.STUDY_REQUESTS)).toBe(false);
   expect(hasAuthScope(user, [AuthScope.STUDY_REQUESTS])).toBe(false);
 
   user = {
     scope: [AuthScope.STUDY_REQUESTS],
   };
   expect(hasAuthScope(user, [])).toBe(true);
+  expect(hasAuthScope(user, AuthScope.STUDY_REQUESTS)).toBe(true);
   expect(hasAuthScope(user, [AuthScope.STUDY_REQUESTS])).toBe(true);
   expect(hasAuthScope(user, [AuthScope.STUDY_REQUESTS_ADMIN])).toBe(false);
   expect(hasAuthScope(user, [
@@ -28,6 +30,7 @@ test('ScopeMatcher.hasAuthScope', () => {
     ],
   };
   expect(hasAuthScope(user, [])).toBe(true);
+  expect(hasAuthScope(user, AuthScope.STUDY_REQUESTS)).toBe(true);
   expect(hasAuthScope(user, [AuthScope.STUDY_REQUESTS])).toBe(true);
   expect(hasAuthScope(user, [AuthScope.STUDY_REQUESTS_ADMIN])).toBe(true);
   expect(hasAuthScope(user, [

--- a/tests/jest/unit/reports/ReportIdParser.spec.js
+++ b/tests/jest/unit/reports/ReportIdParser.spec.js
@@ -10,7 +10,6 @@ import { InvalidReportIdError } from '@/lib/error/MoveErrors';
 import {
   parseCollisionReportId,
   parseStudyReportId,
-  parseStudyRequestReportId,
 } from '@/lib/reports/ReportIdParser';
 
 jest.mock('@/lib/db/CentrelineDAO');
@@ -130,32 +129,5 @@ test('ReportIdParser.parseStudyReportId [neither speed- nor TMC-related]', async
     categoryId: 1,
     countGroupId: 5678,
     study: resolvedValue,
-  });
-});
-
-test('ReportIdParser.parseStudyRequestReportId [invalid]', async () => {
-  expect(parseStudyRequestReportId('')).rejects.toBeInstanceOf(InvalidReportIdError);
-  expect(parseStudyRequestReportId('/')).rejects.toBeInstanceOf(InvalidReportIdError);
-  expect(parseStudyRequestReportId('ids')).rejects.toBeInstanceOf(InvalidReportIdError);
-  expect(parseStudyRequestReportId('ids/')).rejects.toBeInstanceOf(InvalidReportIdError);
-  expect(parseStudyRequestReportId('ids/a,b,c')).rejects.toBeInstanceOf(InvalidReportIdError);
-  expect(parseStudyRequestReportId('foo/bar')).rejects.toBeInstanceOf(InvalidReportIdError);
-});
-
-test('ReportIdParser.parseStudyRequestReportId [ids]', async () => {
-  expect(parseStudyRequestReportId('ids/42')).resolves.toEqual({
-    ids: [42],
-    uuid: null,
-  });
-  expect(parseStudyRequestReportId('ids/6,17,73')).resolves.toEqual({
-    ids: [6, 17, 73],
-    uuid: null,
-  });
-});
-
-test('ReportIdParser.parseStudyRequestReportId [uuid]', async () => {
-  expect(parseStudyRequestReportId('uuid/aa73e91b-6aaf-43c7-a368-19a2c81e527e')).resolves.toEqual({
-    ids: null,
-    uuid: 'aa73e91b-6aaf-43c7-a368-19a2c81e527e',
   });
 });

--- a/tests/jest/unit/reports/ReportIdParser.spec.js
+++ b/tests/jest/unit/reports/ReportIdParser.spec.js
@@ -7,7 +7,11 @@ import {
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import StudyDAO from '@/lib/db/StudyDAO';
 import { InvalidReportIdError } from '@/lib/error/MoveErrors';
-import { parseCollisionReportId, parseStudyReportId } from '@/lib/reports/ReportIdParser';
+import {
+  parseCollisionReportId,
+  parseStudyReportId,
+  parseStudyRequestReportId,
+} from '@/lib/reports/ReportIdParser';
 
 jest.mock('@/lib/db/CentrelineDAO');
 jest.mock('@/lib/db/StudyDAO');
@@ -126,5 +130,32 @@ test('ReportIdParser.parseStudyReportId [neither speed- nor TMC-related]', async
     categoryId: 1,
     countGroupId: 5678,
     study: resolvedValue,
+  });
+});
+
+test('ReportIdParser.parseStudyRequestReportId [invalid]', async () => {
+  expect(parseStudyRequestReportId('')).rejects.toBeInstanceOf(InvalidReportIdError);
+  expect(parseStudyRequestReportId('/')).rejects.toBeInstanceOf(InvalidReportIdError);
+  expect(parseStudyRequestReportId('ids')).rejects.toBeInstanceOf(InvalidReportIdError);
+  expect(parseStudyRequestReportId('ids/')).rejects.toBeInstanceOf(InvalidReportIdError);
+  expect(parseStudyRequestReportId('ids/a,b,c')).rejects.toBeInstanceOf(InvalidReportIdError);
+  expect(parseStudyRequestReportId('foo/bar')).rejects.toBeInstanceOf(InvalidReportIdError);
+});
+
+test('ReportIdParser.parseStudyRequestReportId [ids]', async () => {
+  expect(parseStudyRequestReportId('ids/42')).resolves.toEqual({
+    ids: [42],
+    uuid: null,
+  });
+  expect(parseStudyRequestReportId('ids/6,17,73')).resolves.toEqual({
+    ids: [6, 17, 73],
+    uuid: null,
+  });
+});
+
+test('ReportIdParser.parseStudyRequestReportId [uuid]', async () => {
+  expect(parseStudyRequestReportId('uuid/aa73e91b-6aaf-43c7-a368-19a2c81e527e')).resolves.toEqual({
+    ids: null,
+    uuid: 'aa73e91b-6aaf-43c7-a368-19a2c81e527e',
   });
 });

--- a/web/components/requests/download/FcMenuDownloadTrackRequests.vue
+++ b/web/components/requests/download/FcMenuDownloadTrackRequests.vue
@@ -1,0 +1,55 @@
+<template>
+  <v-menu>
+    <template v-slot:activator="{ on, attrs }">
+      <FcButton
+        v-bind="attrs"
+        v-on="on"
+        class="ml-2"
+        :loading="loading"
+        type="secondary">
+        <v-icon color="primary" left>mdi-cloud-download</v-icon>
+        Download
+        <span class="sr-only">Requests</span>
+        <v-icon right>mdi-menu-down</v-icon>
+      </FcButton>
+    </template>
+    <v-list two-line>
+      <v-list-item
+        :disabled="selectedItems.length === 0"
+        @click="$emit('action-download', true)">
+        <v-list-item-content>
+          <v-list-item-title>Selected ({{selectedItems.length}})</v-list-item-title>
+          <v-list-item-subtitle v-if="selectedItems.length > 0">
+            Download only the selected study requests.
+          </v-list-item-subtitle>
+        </v-list-item-content>
+      </v-list-item>
+      <v-list-item @click="$emit('action-download', false)">
+        <v-list-item-content>
+          <v-list-item-title>All</v-list-item-title>
+          <v-list-item-subtitle>
+            Download all study requests that match the active filters.
+          </v-list-item-subtitle>
+        </v-list-item-content>
+      </v-list-item>
+    </v-list>
+  </v-menu>
+</template>
+
+<script>
+import FcButton from '@/web/components/inputs/FcButton.vue';
+
+export default {
+  name: 'FcMenuDownloadTrackRequests',
+  components: {
+    FcButton,
+  },
+  props: {
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+    selectedItems: Array,
+  },
+};
+</script>

--- a/web/views/FcRequestsTrack.vue
+++ b/web/views/FcRequestsTrack.vue
@@ -38,7 +38,6 @@
 
             <FcButton
               class="ml-2"
-              :disabled="selectAll === false"
               type="secondary"
               @click="actionDownload(selectedItems)">
               <v-icon color="primary" left>mdi-cloud-download</v-icon>
@@ -106,7 +105,7 @@
 </template>
 
 <script>
-import { saveAs } from 'file-saver';
+import { v4 as uuidv4 } from 'uuid';
 import { Ripple } from 'vuetify/lib/directives';
 import {
   mapActions,
@@ -115,15 +114,18 @@ import {
   mapState,
 } from 'vuex';
 
-import { AuthScope } from '@/lib/Constants';
+import { AuthScope, ReportFormat, ReportType } from '@/lib/Constants';
 import { debounce } from '@/lib/FunctionUtils';
-import { getStudyRequestItems, getStudyRequestItemsTotal } from '@/lib/api/WebApi';
+import {
+  getReportDownload,
+  getStudyRequestItems,
+  getStudyRequestItemsTotal,
+} from '@/lib/api/WebApi';
 import {
   getStudyRequestItem,
   getStudyRequestBulkItem,
 } from '@/lib/requests/RequestItems';
 import RequestDataTableColumns from '@/lib/requests/RequestDataTableColumns';
-import RequestItemExport from '@/lib/requests/RequestItemExport';
 import { ItemType } from '@/lib/requests/RequestStudyBulkUtils';
 import FcDataTableRequests from '@/web/components/FcDataTableRequests.vue';
 import FcProgressCircular from '@/web/components/dialogs/FcProgressCircular.vue';
@@ -290,10 +292,18 @@ export default {
     this.setFiltersRequestUserOnly(userOnly);
   },
   methods: {
-    actionDownload(items) {
-      const csvStr = RequestItemExport.get(items, this.studyRequestsBulk);
-      const csvData = new Blob([csvStr], { type: 'text/csv' });
-      saveAs(csvData, 'requests.csv');
+    async actionDownload(/* items */) {
+      // TODO: download selected
+
+      const id = uuidv4();
+      this.loadingDownload = true;
+      getReportDownload(
+        ReportType.TRACK_REQUESTS,
+        id,
+        ReportFormat.CSV,
+        this.filterParamsRequestWithPagination,
+      );
+      this.loadingDownload = false;
     },
     async actionUpdateItem(item) {
       this.loading = true;


### PR DESCRIPTION
# Issue Addressed
This PR closes #866 .

# Description
We introduce two new report types: `TRACK_REQUESTS` (download all) and `TRACK_REQUESTS_SELECTED` (download selected).  We then implement those two report types as new report modules that subclass `ReportBaseTrackRequests`.  In the process, we move `RequestItemExport` logic out of the frontend and into the backend, reusing it to form the core of these reports.

# Tests
Tested quickly in frontend - this could likely use more unit testing, but it's also important to ensure we can get it through QA testing before deployment.
