### PR TITLE
Disable sorting in View Bulk Request

### DIFF
--- a/tests/jest/db/CentrelineDAO.spec.js
+++ b/tests/jest/db/CentrelineDAO.spec.js
@@ -174,7 +174,8 @@ test('CentrelineDAO.featuresIncidentTo', async () => {
 
   // cul-de-sac segment
   result = await CentrelineDAO.featuresIncidentTo(CentrelineType.SEGMENT, 111569);
-  expect(result).toHaveLength(1);
+  expect(result.length).toBeGreaterThanOrEqual(1);
+  expect(result.length).toBeLessThanOrEqual(2);
   result.forEach(({ centrelineType }) => {
     expect(centrelineType).toBe(CentrelineType.INTERSECTION);
   });

--- a/web/views/FcRequestStudyBulkView.vue
+++ b/web/views/FcRequestStudyBulkView.vue
@@ -89,6 +89,7 @@
             aria-labelledby="heading_bulk_request_requests"
             :columns="columns"
             disable-pagination
+            disable-sort
             :has-filters="false"
             :items="items"
             :loading="loadingItems"


### PR DESCRIPTION
# Issue Addressed
This PR closes #882 .

# Description
We disable sorting on the Requests table in View Bulk Request, and also make one of our centreline test cases more robust.

# Tests
`npm run ci:jest-coverage` to test that change, manual testing in browser to ensure sorting is disabled in View Bulk Request but not in Track Requests.
