### PR TITLE
Add version number to environment chip, show in all environments

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
     <meta name="description" content="Access City of Toronto collision and traffic volume data.">
     <meta name="csp-nonce" content="**CSP_NONCE**" />
+    <meta
+      name="application-name" content="MOVE"
+      data-version="<%= VERSION %>" />
     <link rel="icon" href="/favicon.ico">
     <title>MOVE</title>
   </head>

--- a/vue.config.js
+++ b/vue.config.js
@@ -3,6 +3,7 @@ const path = require('path');
 
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
+const packageJson = require('./package.json');
 const { ENV, DEV } = require('./lib/config/Env');
 
 const key = fs.readFileSync(path.join(__dirname, 'ssl', 'localhost.key'));
@@ -58,6 +59,18 @@ const vueConfig = {
       ignored: /node_modules/,
       poll: 2000,
     },
+  },
+  // see https://stackoverflow.com/questions/53285704/set-viewport-meta-tag-in-vue-js-application
+  chainWebpack: (config) => {
+    config
+      .plugin('html')
+      .tap((args) => {
+        const [htmlHead, ...restArgs] = args;
+        htmlHead.templateParameters = {
+          VERSION: packageJson.version,
+        };
+        return [htmlHead, ...restArgs];
+      });
   },
   // see https://medium.com/@kenneth_chau/speeding-up-webpack-typescript-incremental-builds-by-7x-3912ba4c1d15
   // see https://cli.vuejs.org/guide/webpack.html#simple-configuration

--- a/web/components/nav/FcAppbar.vue
+++ b/web/components/nav/FcAppbar.vue
@@ -8,12 +8,11 @@
     <FcDashboardNavBrand />
     <h1 class="headline ml-2">{{textH1}}</h1>
     <v-chip
-      v-if="frontendEnv !== FrontendEnv.PROD"
       class="ml-2"
       :color="frontendEnv.colorClass + ' darken-4'"
       dark
       small>
-      {{frontendEnv.name.toLowerCase()}}
+      {{frontendEnv.name.toLowerCase()}} v{{frontendMeta.version}}
     </v-chip>
 
     <v-spacer></v-spacer>
@@ -39,6 +38,7 @@ import { mapState } from 'vuex';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcDashboardNavBrand from '@/web/components/nav/FcDashboardNavBrand.vue';
 import FrontendEnv from '@/web/config/FrontendEnv';
+import FrontendMeta from '@/web/config/FrontendMeta';
 
 export default {
   name: 'FcAppbar',
@@ -47,21 +47,10 @@ export default {
     FcDashboardNavBrand,
   },
   data() {
-    return { FrontendEnv };
+    const frontendMeta = FrontendMeta.get();
+    return { FrontendEnv, frontendMeta };
   },
   computed: {
-    textEnv() {
-      if (this.frontendEnv === FrontendEnv.LOCAL) {
-        return 'local';
-      }
-      if (this.frontendEnv === FrontendEnv.DEV) {
-        return 'development';
-      }
-      if (this.frontendEnv === FrontendEnv.QA) {
-        return 'QA';
-      }
-      return '';
-    },
     textH1() {
       if (this.title === '') {
         return FrontendEnv.PROD.appTitle;

--- a/web/config/FrontendEnv.js
+++ b/web/config/FrontendEnv.js
@@ -37,7 +37,7 @@ FrontendEnv.init({
   PROD: {
     appClass: 'is-prod',
     appTitle: 'MOVE',
-    colorClass: null,
+    colorClass: 'grey',
   },
 });
 

--- a/web/config/FrontendMeta.js
+++ b/web/config/FrontendMeta.js
@@ -1,0 +1,14 @@
+class FrontendMeta {
+  static get() {
+    const $meta = document.head.querySelector('meta[name=application-name]');
+    const meta = {};
+    if ($meta !== null) {
+      Object.entries($meta.dataset).forEach(([key, value]) => {
+        meta[key] = value;
+      });
+    }
+    return meta;
+  }
+}
+
+export default FrontendMeta;


### PR DESCRIPTION
# Issue Addressed
This PR closes #890 .

# Description
We make it a bit more obvious what version of MOVE the user is on by adding the version number to a special `<meta name="application-name">` tag as a `data-version` attribute.

# Tests
Tested quickly in frontend.
