### PR TITLE
Update school children definition, use Vision Zero flags in popups

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -166,7 +166,7 @@ CollisionEmphasisArea.init({
     field: 'motorcyclist',
     text: 'Motorcyclists',
     tooltip: `
-<span>Collisions where at least one driver of a motorcycle or moped was involved.</span>`,
+<span>Collisions where at least one motorcycle driver was involved.</span>`,
   },
   OLDER_ADULTS: {
     field: 'older_adult',
@@ -180,11 +180,13 @@ CollisionEmphasisArea.init({
 <span>Collisions where:</span>
 <ul>
   <li>at least one child of school age (4-19) was involved; and</li>
-  <li>that child was a cyclist or pedestrian; and</li>
-  <li>it was during school months (Sept-Jun); and</li>
-  <li>it was a weekday (Mon-Fri); and</li>
-  <li>the time of day was 7-9am, 11:30am-1pm, or 2-5pm.</li>
-</ul>`,
+  <li>that child was using an active mode of transportation.</li>
+</ul>
+<p></p>
+<p class="mb-0">
+  In keeping with Vision Zero priorities, we do not consider the time of
+  day, day of week, or month of the year.
+</p>`,
   },
 });
 

--- a/web/components/FcPaneMapPopup.vue
+++ b/web/components/FcPaneMapPopup.vue
@@ -83,13 +83,13 @@ function getCollisionDescription(feature, collision) {
     return description;
   }
 
-  collision.involved.forEach(({ invtype, invage }) => {
+  collision.involved.forEach(({ cyclist, invage, pedestrian }) => {
     const invageQuantized = Math.floor(invage / 5) * 5;
     const invageRange = `${invageQuantized} to ${invageQuantized + 5}`;
-    if (invtype === 3) {
-      description.push(`Pedestrian \u00b7 ${invageRange}`);
-    } else if (invtype === 4) {
+    if (cyclist) {
       description.push(`Cyclist \u00b7 ${invageRange}`);
+    } else if (pedestrian) {
+      description.push(`Pedestrian \u00b7 ${invageRange}`);
     }
   });
 
@@ -115,12 +115,12 @@ function getCollisionDescription(feature, collision) {
 function getCollisionIcon(feature, { involved }) {
   const n = involved.length;
   for (let i = 0; i < n; i++) {
-    const { invtype } = involved[i];
-    if (invtype === 3) {
-      return 'mdi-walk';
-    }
-    if (invtype === 4) {
+    const { cyclist, pedestrian } = involved[i];
+    if (cyclist) {
       return 'mdi-bike';
+    }
+    if (pedestrian) {
+      return 'mdi-walk';
     }
   }
   return null;


### PR DESCRIPTION
# Issue Addressed
This PR makes progress on #902 .

# Description
We update contextual help for Global Filters to match updates to the definition of school children (in the Vision Zero emphasis area sense) in our collision normalization data pipelines.

# Tests
Tested quickly in frontend.
