### PR TITLE
Use IS DISTINCT FROM operators to compare changed, mvaimg fields

### DIFF
--- a/lib/db/filters/CollisionFiltersSql.js
+++ b/lib/db/filters/CollisionFiltersSql.js
@@ -86,7 +86,7 @@ function getCollisionFilters(features, collisionQuery) {
     filters.push('i.manoeuver IN ($(manoeuver:csv))');
   }
   if (mvcr !== null) {
-    const op = mvcr ? '=' : '!=';
+    const op = mvcr ? 'IS NOT DISTINCT FROM' : 'IS DISTINCT FROM';
     filters.push(`e.mvaimg ${op} -1`);
   }
   if (rdsfcond.length > 0) {
@@ -94,7 +94,7 @@ function getCollisionFilters(features, collisionQuery) {
     filters.push('e.rdsfcond IN ($(rdsfcond:csv))');
   }
   if (validated !== null) {
-    const op = validated ? '=' : '!=';
+    const op = validated ? 'IS NOT DISTINCT FROM' : 'IS DISTINCT FROM';
     filters.push(`e.changed ${op} -1`);
   }
   if (vehtype.length > 0) {


### PR DESCRIPTION
# Issue Addressed
This PR closes #911 .

# Description
This works around an issue where `SELECT NULL != 1` returns `NULL`, which ends up filtering out more collisions than expected in View Data when a negative filter like "Not Validated" or "MVCR Missing" is applied.

# Tests
`npm run ci:jest-coverage` for DB tests, also tested against original bug report case in frontend.