### PR TITLE
Make TimeFormatters range functions null-safe

### DIFF
--- a/lib/time/TimeFormatters.js
+++ b/lib/time/TimeFormatters.js
@@ -149,10 +149,14 @@ class TimeFormatters {
   /**
    * Format a time range using dates (e.g. "04/01/2012 - 04/01/2018").
    *
-   * @param {TimeRange} timeRange
-   * @returns {string} the formatted date range
+   * @param {TimeRange?} timeRange
+   * @returns {string?} the formatted date range
    */
-  static formatRangeDate({ start, end }) {
+  static formatRangeDate(timeRange) {
+    if (timeRange === null) {
+      return null;
+    }
+    const { start, end } = timeRange;
     let startHuman = null;
     if (start !== null) {
       startHuman = TimeFormatters.formatDefault(start);
@@ -180,10 +184,14 @@ class TimeFormatters {
   /**
    * Format a time range using time of day (e.g. "08:00 - 09:00").
    *
-   * @param {TimeRange} timeRange
-   * @returns {string} the formatted time range, using time of day for both range endpoints
+   * @param {TimeRange?} timeRange
+   * @returns {string?} the formatted time range, using time of day for both range endpoints
    */
-  static formatRangeTimeOfDay({ start, end }) {
+  static formatRangeTimeOfDay(timeRange) {
+    if (timeRange === null) {
+      return null;
+    }
+    const { start, end } = timeRange;
     let startHuman = null;
     if (start !== null) {
       startHuman = TimeFormatters.formatTimeOfDay(start);

--- a/tests/jest/unit/time/TimeFormatters.spec.js
+++ b/tests/jest/unit/time/TimeFormatters.spec.js
@@ -88,9 +88,19 @@ test('TimeFormatters.formatTimeOfDay()', () => {
 });
 
 test('TimeFormatters.formatRangeDate()', () => {
+  expect(TimeFormatters.formatRangeDate(null)).toBeNull();
+
   let start = DateTime.fromSQL('1986-07-31 21:16:00');
   let end = DateTime.fromSQL('1986-07-31 22:16:00');
   expect(TimeFormatters.formatRangeDate({ start, end })).toEqual('1986-07-31');
+
+  start = DateTime.fromSQL('1986-07-31 21:16:00');
+  end = null;
+  expect(TimeFormatters.formatRangeDate({ start, end })).toEqual('Since 1986-07-31');
+
+  start = null;
+  end = DateTime.fromSQL('2000-01-01 01:23:45');
+  expect(TimeFormatters.formatRangeDate({ start, end })).toEqual('Until 2000-01-01');
 
   start = DateTime.fromSQL('1986-07-31 00:00:00');
   end = DateTime.fromSQL('2000-01-01 01:23:45');
@@ -98,9 +108,19 @@ test('TimeFormatters.formatRangeDate()', () => {
 });
 
 test('TimeFormatters.formatRangeTimeOfDay()', () => {
+  expect(TimeFormatters.formatRangeTimeOfDay(null)).toBeNull();
+
   let start = DateTime.fromSQL('1986-07-31 21:16:00');
   let end = DateTime.fromSQL('1986-07-31 22:16:00');
   expect(TimeFormatters.formatRangeTimeOfDay({ start, end })).toEqual('21:16\u201322:16');
+
+  start = DateTime.fromSQL('1986-07-31 21:16:00');
+  end = null;
+  expect(TimeFormatters.formatRangeTimeOfDay({ start, end })).toEqual('After 21:16');
+
+  start = null;
+  end = DateTime.fromSQL('1986-07-31 01:23:45');
+  expect(TimeFormatters.formatRangeTimeOfDay({ start, end })).toEqual('Before 01:23');
 
   start = DateTime.fromSQL('1986-07-31 00:00:00');
   end = DateTime.fromSQL('1986-07-31 01:23:45');

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -334,6 +334,6 @@ export default {
 }
 
 .drawer-open .fc-drawer-view-collision-reports {
-  max-height: calc(var(--full-height) - 64px);
+  max-height: calc(var(--full-height) - 4px);
 }
 </style>

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -478,6 +478,6 @@ export default {
 }
 
 .drawer-open .fc-drawer-view-study-reports {
-  max-height: calc(var(--full-height) - 64px);
+  max-height: calc(var(--full-height) - 4px);
 }
 </style>


### PR DESCRIPTION
# Issue Addressed
This PR closes #916 and closes #908 .

# Description
`TimeFormatters` range functions now accept `null` as their input `timeRange`, in which case they return `null`.  We also fix a small CSS bug in View Reports, where there was a 60px white bar at the bottom.

# Tests
Ran unit tests, tested quickly in frontend.