### PR TITLE
Handle empty and stopwords-only queries without HTTP 500'ing

### DIFF
--- a/lib/db/LocationSearchDAO.js
+++ b/lib/db/LocationSearchDAO.js
@@ -66,6 +66,12 @@ WHERE arterycode = $(arterycode)`;
    * most `limit` results
    */
   static async intersectionSuggestions(query, limit) {
+    const sqlQuery = 'SELECT plainto_tsquery($(query))::text AS "queryNormalized"';
+    const { queryNormalized } = await db.one(sqlQuery, { query });
+    if (queryNormalized === '') {
+      return [];
+    }
+
     /*
      * For exact matches, we use `tsvector` and `tsquery` full-text support together with
      * these features:
@@ -93,7 +99,7 @@ WITH candidates AS (
     "centrelineId",
     ts_rank_cd(
       to_tsvector('english', "description"),
-      (plainto_tsquery($(query))::text || ':*')::tsquery,
+      ($(queryNormalized) || ':*')::tsquery,
       2 | 4
     ) AS f_rank_cd,
     CASE
@@ -102,7 +108,7 @@ WITH candidates AS (
     END AS f_substring_match,
     "featureCode" AS f_feature_code
   FROM location_search.intersections
-  WHERE to_tsvector('english', "description") @@ (plainto_tsquery($(query))::text || ':*')::tsquery
+  WHERE to_tsvector('english', "description") @@ ($(queryNormalized) || ':*')::tsquery
 )
 SELECT
   "centrelineId",
@@ -110,7 +116,7 @@ SELECT
 FROM candidates
 ORDER BY score DESC
 LIMIT $(limit);`;
-    const rowsExact = await db.manyOrNone(sqlExact, { limit, query });
+    const rowsExact = await db.manyOrNone(sqlExact, { limit, query, queryNormalized });
     /*
      * Although we don't currently surface the score anywhere in the frontend, we preserve
      * them in the results in case they prove helpful eventually.
@@ -142,7 +148,7 @@ LIMIT $(limit);`;
      *
      * This expression normalizes the query, removing stopwords and punctuation:
      *
-     *     replace(replace(plainto_tsquery($(query))::text, '''', ''), ' &', '')
+     *     replace(replace($(queryNormalized), '''', ''), ' &', '')
      */
     const sqlApprox = `
 SET pg_trgm.word_similarity_threshold = 0.3;
@@ -150,12 +156,12 @@ WITH candidates AS (
   SELECT
     "centrelineId",
     word_similarity(
-      replace(replace(plainto_tsquery($(query))::text, '''', ''), ' &', ''),
+      replace(replace($(queryNormalized), '''', ''), ' &', ''),
       "description"
     ) AS f_word_similarity,
     "featureCode" AS f_feature_code
   FROM location_search.intersections
-  WHERE replace(replace(plainto_tsquery($(query))::text, '''', ''), ' &', '') <% "description"
+  WHERE replace(replace($(queryNormalized), '''', ''), ' &', '') <% "description"
 )
 SELECT
   "centrelineId",
@@ -163,7 +169,7 @@ SELECT
 FROM candidates
 ORDER BY score DESC
 LIMIT $(limitApprox);`;
-    const rowsApprox = await db.manyOrNone(sqlApprox, { limitApprox, query });
+    const rowsApprox = await db.manyOrNone(sqlApprox, { limitApprox, query, queryNormalized });
     const featuresApprox = rowsApprox.map(({ centrelineId }) => ({
       centrelineId,
       centrelineType: CentrelineType.INTERSECTION,

--- a/tests/jest/db/LocationSearchDAO.spec.js
+++ b/tests/jest/db/LocationSearchDAO.spec.js
@@ -123,6 +123,16 @@ test('LocationSearchDAO.intersectionSuggestions', async () => {
   expectSuggestionsContain(result, CentrelineType.INTERSECTION, 13460034);
 });
 
+test('LocationSearchDAO.intersectionSuggestions [empty / stopwords]', async () => {
+  // empty query: returns empty result list
+  let result = await LocationSearchDAO.intersectionSuggestions('', 3);
+  expect(result).toEqual([]);
+
+  // only stopwords: returns empty result list
+  result = await LocationSearchDAO.intersectionSuggestions('and the', 3);
+  expect(result).toEqual([]);
+});
+
 test('LocationSearchDAO.trafficSignalSuggestions', async () => {
   let result = await LocationSearchDAO.trafficSignalSuggestions(-1);
   expect(result).toEqual([]);


### PR DESCRIPTION
# Issue Addressed
This PR closes #531 .

# Description
Now runs a separate `plainto_tsquery()` SQL query before the exact / approximate matching SQL queries, to double-check whether this normalized version of the query is empty or not.

# Tests
Added test cases to `LocationSearchDAO.spec.js`.  Tested quickly in frontend as well.
