### PR TITLE
Allow viewing / editing study requests with missing or invalid centreline details

### DIFF
--- a/lib/db/filters/StudyFiltersSql.js
+++ b/lib/db/filters/StudyFiltersSql.js
@@ -9,6 +9,9 @@ function toCategoryIds(studyTypes, categories) {
 }
 
 function getCentrelineFilter(features) {
+  if (features.length === 0) {
+    return 'FALSE';
+  }
   const featureIds = features.map(
     ({ centrelineId, centrelineType }) => `(${centrelineType}, ${centrelineId})`,
   );

--- a/lib/geo/CentrelineUtils.js
+++ b/lib/geo/CentrelineUtils.js
@@ -161,6 +161,25 @@ function getMaplibreGlFeature(location) {
   };
 }
 
+function getStudyRequestLocation(studyRequest, location) {
+  if (studyRequest === null) {
+    return null;
+  }
+  if (location !== null) {
+    return location;
+  }
+  const { geom } = studyRequest;
+  const [lng, lat] = geom.coordinates;
+  return {
+    centrelineId: null,
+    centrelineType: null,
+    description: `${lng.toFixed(6)}, ${lat.toFixed(6)}`,
+    geom,
+    lat,
+    lng,
+  };
+}
+
 /**
  * @namespace
  */
@@ -173,6 +192,7 @@ const CentrelineUtils = {
   getLocationsSelectionDescription,
   getLocationsWaypointIndices,
   getMaplibreGlFeature,
+  getStudyRequestLocation,
 };
 
 export {
@@ -185,4 +205,5 @@ export {
   getLocationsSelectionDescription,
   getLocationsWaypointIndices,
   getMaplibreGlFeature,
+  getStudyRequestLocation,
 };

--- a/web/components/requests/nav/FcNavStudyRequest.vue
+++ b/web/components/requests/nav/FcNavStudyRequest.vue
@@ -35,6 +35,7 @@ import { mapGetters, mapState } from 'vuex';
 
 import { AuthScope } from '@/lib/Constants';
 import { getLocationByCentreline } from '@/lib/api/WebApi';
+import { getStudyRequestLocation } from '@/lib/geo/CentrelineUtils';
 import { bulkStatus } from '@/lib/requests/RequestStudyBulkUtils';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcBreadcrumbsStudyRequest from '@/web/components/requests/nav/FcBreadcrumbsStudyRequest.vue';
@@ -81,10 +82,14 @@ export default {
       return name === 'requestStudyBulkView' || name === 'requestStudyBulkEdit';
     },
     locationDescription() {
-      if (this.location === null) {
+      if (this.isBulk) {
         return null;
       }
-      return this.location.description;
+      const location = getStudyRequestLocation(this.studyRequest, this.location);
+      if (location === null) {
+        return null;
+      }
+      return location.description;
     },
     routeNavigateBack() {
       const { name } = this.$route;

--- a/web/views/FcRequestStudyBulkView.vue
+++ b/web/views/FcRequestStudyBulkView.vue
@@ -109,6 +109,7 @@ import { mapActions } from 'vuex';
 
 import { AuthScope, centrelineKey } from '@/lib/Constants';
 import { getStudyRequestBulk } from '@/lib/api/WebApi';
+import { getStudyRequestLocation } from '@/lib/geo/CentrelineUtils';
 import { getStudyRequestItem } from '@/lib/requests/RequestItems';
 import RequestDataTableColumns from '@/lib/requests/RequestDataTableColumns';
 import { bulkStatus } from '@/lib/requests/RequestStudyBulkUtils';
@@ -190,10 +191,11 @@ export default {
       const locationsState = [];
       this.studyRequestBulk.studyRequests.forEach((studyRequest) => {
         const key = centrelineKey(studyRequest);
-        if (!this.studyRequestLocations.has(key)) {
-          return;
+        let location = null;
+        if (this.studyRequestLocations.has(key)) {
+          location = this.studyRequestLocations.get(key);
         }
-        const location = this.studyRequestLocations.get(key);
+        location = getStudyRequestLocation(studyRequest, location);
         const state = {
           deselected: false,
           locationIndex: -1,

--- a/web/views/FcRequestStudyView.vue
+++ b/web/views/FcRequestStudyView.vue
@@ -79,6 +79,7 @@
 import { mapActions, mapMutations } from 'vuex';
 
 import { getStudyRequest, getStudyRequestBulkName } from '@/lib/api/WebApi';
+import { getStudyRequestLocation } from '@/lib/geo/CentrelineUtils';
 import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcMap from '@/web/components/geo/map/FcMap.vue';
 import FcCommentsStudyRequest from '@/web/components/requests/FcCommentsStudyRequest.vue';
@@ -119,13 +120,10 @@ export default {
   },
   computed: {
     locationsState() {
-      if (this.studyRequest === null) {
+      const location = getStudyRequestLocation(this.studyRequest, this.studyRequestLocation);
+      if (location === null) {
         return [];
       }
-      if (this.studyRequestLocation === null) {
-        return [];
-      }
-      const location = this.studyRequestLocation;
       const state = {
         deselected: false,
         locationIndex: -1,


### PR DESCRIPTION
# Issue Addressed
This PR closes #903 .

# Description
We introduce a new utility function, `getStudyRequestLocation`, that allows us to construct a location-like Object for study requests that have a valid `geom` but invalid `centrelineId` / `centrelineType` (e.g. because the centreline feature in question was removed in a centreline update).

We then use that function to provide a safe fallback in our View Request and Edit Request flows, which unbreaks those flows for study requests with missing or invalid centreline details.

# Tests
Tested quickly in frontend: manually updated a study request to have a non-existent `centrelineId` (but did not touch `geom`); verified that a map pin is shown as expected; verified that View Request loads successfully and functions; verified that Edit Request loads successfully and functions; verified that the location can be fixed using the new Set Location functionality of Edit Request.