### PR TITLE
Add Clear button to multi-location selector

### DIFF
--- a/lib/db/filters/CollisionFiltersSql.js
+++ b/lib/db/filters/CollisionFiltersSql.js
@@ -1,4 +1,7 @@
 function getCentrelineFilter(features) {
+  if (features.length === 0) {
+    return 'FALSE';
+  }
   const featureIds = features.map(
     ({ centrelineId, centrelineType }) => `(${centrelineType}, ${centrelineId})`,
   );

--- a/web/components/data/FcViewDataMultiEdit.vue
+++ b/web/components/data/FcViewDataMultiEdit.vue
@@ -1,8 +1,14 @@
 <template>
   <div class="fc-view-data-multi-edit">
     <FcProgressLinear
-      v-if="loading || locations.length === 0"
+      v-if="loading"
       aria-label="Loading multi-location edit mode for View Data" />
+    <p
+      v-else-if="locations.length === 0"
+      class="my-8 py-12 secondary--text text-center">
+      No locations selected,<br>
+      please select locations to view data
+    </p>
     <template v-else>
       <section
         aria-labelledby="heading_multi_edit_totals"
@@ -115,10 +121,6 @@ export default {
   },
   methods: {
     async syncLocations() {
-      if (this.locations.length === 0) {
-        return;
-      }
-
       this.loading = true;
 
       const tasks = [

--- a/web/components/filters/FcGlobalFilterBox.vue
+++ b/web/components/filters/FcGlobalFilterBox.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card width="472">
+  <v-card width="448">
     <v-card-text class="px-4 pa-3">
       <FcGlobalFilters :readonly="readonly" />
     </v-card-text>

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -6,6 +6,15 @@
     <FcDialogConfirmMultiLocationLeave
       v-model="showConfirmMultiLocationLeave" />
 
+    <FcButton
+      v-if="locationMode === LocationMode.MULTI"
+      class="btn-clear-all mr-5 mt-3"
+      type="secondary"
+      @click="actionClear">
+      <v-icon color="primary" left>mdi-map-marker-remove-variant</v-icon>
+      Clear
+    </FcButton>
+
     <div
       v-if="locationMode === LocationMode.MULTI_EDIT"
       class="align-start d-flex flex-grow-1 flex-shrink-1">
@@ -115,7 +124,7 @@
             Cancel
           </FcButton>
           <FcButton
-            :disabled="loading || locationsEditEmpty || hasError"
+            :disabled="loading || hasError"
             :loading="loading"
             type="secondary"
             @click="saveLocationsEdit">
@@ -302,7 +311,6 @@ export default {
       'locationActive',
       'locationsDescription',
       'locationsEditDescription',
-      'locationsEditEmpty',
       'locationsEditFull',
       'locationsForModeEmpty',
     ]),
@@ -332,6 +340,13 @@ export default {
       this.addLocationEdit(location);
       Vue.nextTick(() => this.autofocus());
     },
+    actionClear() {
+      this.setToastInfo('Cleared all selected locations.');
+      this.syncLocationsSelectionForMode({
+        locations: [],
+        selectionType: LocationSelectionType.POINTS,
+      });
+    },
     actionLocationNext() {
       if (this.locationsIndex <= this.locations.length - 1) {
         this.setLocationsIndex(this.locationsIndex + 1);
@@ -350,7 +365,7 @@ export default {
       this.removeLocationEdit(i);
       Vue.nextTick(() => this.autofocus());
     },
-    ...mapActions(['syncLocationsEdit']),
+    ...mapActions(['syncLocationsEdit', 'syncLocationsSelectionForMode']),
     ...mapMutations([
       'addLocationEdit',
       'cancelLocationsEdit',
@@ -370,8 +385,16 @@ export default {
 
 <style lang="scss">
 .fc-selector-multi-location {
+  position: relative;
+
+  & > .btn-clear-all {
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+
   & .fc-input-location-search-wrapper {
-    width: 472px;
+    width: 448px;
     & > .fc-input-location-search {
       &:not(:first-child) {
         border-top: 1px solid var(--v-border-base);

--- a/web/components/inputs/FcSelectorSingleLocation.vue
+++ b/web/components/inputs/FcSelectorSingleLocation.vue
@@ -58,7 +58,7 @@ export default {
 <style lang="scss">
 .fc-selector-single-location {
   & > .fc-input-location-search {
-    width: 472px;
+    width: 448px;
   }
 }
 </style>

--- a/web/views/FcLayoutRequestEditor.vue
+++ b/web/views/FcLayoutRequestEditor.vue
@@ -89,7 +89,7 @@ export default {
   width: 100%;
 
   & .fc-input-location-search {
-    width: 472px;
+    width: 448px;
   }
 
   & > .fc-pane-wrapper > div {

--- a/web/views/FcLayoutViewData.vue
+++ b/web/views/FcLayoutViewData.vue
@@ -361,7 +361,7 @@ export default {
     background-color: var(--v-shading-base);
     border-radius: 8px;
     height: 387px;
-    width: 664px;
+    width: 640px;
   }
 
   &.vertical {


### PR DESCRIPTION
# Issue Addressed
This PR closes #673 and closes #847 .

# Description
We add a "Clear" button to `FcSelectorMultiLocation`, fix a bug in `CollisionController.getCollisionsByCentrelineTotal` for empty location selections, and fix the endless loading state issue in `FcViewDataMultiEdit`.

# Tests
Tested quickly in frontend.
