### PR TITLE
Fix invage bug in ReportCollisionDirectory

### DIFF
--- a/lib/reports/ReportCollisionDirectory.js
+++ b/lib/reports/ReportCollisionDirectory.js
@@ -83,7 +83,7 @@ class ReportCollisionDirectory extends ReportBaseCrash {
       drivact: this.getCollisionFactorCode('drivact', drivact),
       drivcond: this.getCollisionFactorCode('drivcond', drivcond),
       initdir: this.getCollisionFactorCode('initdir', initdir),
-      invage: this.getCollisionFactorCode('invage', invage),
+      invage,
       manoeuver: this.getCollisionFactorCode('manoeuver', manoeuver),
     };
   }


### PR DESCRIPTION
# Issue Addressed
This PR closes #915 .

# Description
This was always showing up blank for CSV exports - turns out that we shouldn't use `this.getCollisionFactorCode` for `invage`, as it's not a coded field but rather a numeric one.

# Tests
Tested quickly in frontend, both before and after the fix (to repro, and then to verify that the fix had the intended effect.)