### PR TITLE
Remove Undo button / action from background jobs

### DIFF
--- a/web/components/dialogs/FcToast.vue
+++ b/web/components/dialogs/FcToast.vue
@@ -3,7 +3,7 @@
     v-model="internalValue"
     bottom
     class="fc-toast pb-5 pl-7"
-    :color="color + ' darker-1'"
+    :color="color + ' darker-4'"
     :timeout="timeout">
     <slot name="icon"></slot>
     <span class="body-1">{{text}}</span>

--- a/web/components/dialogs/FcToastJob.vue
+++ b/web/components/dialogs/FcToastJob.vue
@@ -11,7 +11,7 @@
 import { saveAs } from 'file-saver';
 import { mapState } from 'vuex';
 
-import { getStorage, putJobCancel, putJobDismiss } from '@/lib/api/WebApi';
+import { getStorage, putJobDismiss } from '@/lib/api/WebApi';
 import JobPoller from '@/lib/jobs/JobPoller';
 import FcToast from '@/web/components/dialogs/FcToast.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
@@ -46,13 +46,10 @@ export default {
   computed: {
     action() {
       const { state } = this.internalJob;
-      if (state === 'created' || state === 'active') {
-        return 'Undo';
-      }
       if (state === 'completed') {
         return 'Download';
       }
-      return 'Close';
+      return null;
     },
     color() {
       const { state } = this.internalJob;
@@ -79,15 +76,9 @@ export default {
     },
     actionToast() {
       const { state } = this.internalJob;
-      if (state === 'created' || state === 'active') {
-        this.actionUndo();
-      } else if (state === 'completed') {
+      if (state === 'completed') {
         this.actionDownload();
       }
-    },
-    async actionUndo() {
-      const job = await putJobCancel(this.auth.csrf, this.internalJob);
-      this.internalJob = job;
     },
     onUpdateJobStatus() {
       const { job, textStatus } = this.jobPoller;

--- a/web/components/jobs/FcCardJob.vue
+++ b/web/components/jobs/FcCardJob.vue
@@ -36,7 +36,7 @@
 import { saveAs } from 'file-saver';
 import { mapState } from 'vuex';
 
-import { getStorage, putJobCancel, putJobDismiss } from '@/lib/api/WebApi';
+import { getStorage, putJobDismiss } from '@/lib/api/WebApi';
 import JobPoller from '@/lib/jobs/JobPoller';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 
@@ -69,9 +69,6 @@ export default {
   computed: {
     action() {
       const { state } = this.internalJob;
-      if (state === 'created' || state === 'active') {
-        return 'Undo';
-      }
       if (state === 'completed') {
         return 'Download';
       }
@@ -79,9 +76,6 @@ export default {
     },
     iconAction() {
       const { state } = this.internalJob;
-      if (state === 'created' || state === 'active') {
-        return 'mdi-undo';
-      }
       if (state === 'completed') {
         return 'mdi-download';
       }
@@ -127,15 +121,9 @@ export default {
     },
     actionCard() {
       const { state } = this.internalJob;
-      if (state === 'created' || state === 'active') {
-        this.actionUndo();
-      } else if (state === 'completed') {
+      if (state === 'completed') {
         this.actionDownload();
       }
-    },
-    async actionUndo() {
-      const job = await putJobCancel(this.auth.csrf, this.internalJob);
-      this.internalJob = job;
     },
     onUpdateJobStatus() {
       const { job, textStatus } = this.jobPoller;


### PR DESCRIPTION
# Issue Addressed
This PR closes #927 .

# Description
We remove the "Undo" button from both `FcToastJob` and `FcCardJob` (in Manage Downloads), since it is currently broken as implemented.  (Best guess at what it would take to fix it: we need cancellation to be respected by `JobRunnerBase`, which should also stop execution of the background job.) 

# Tests
Tested quickly in frontend: selected a corridor with a few studies, exported all reports as PDFs; neither the toast nor Manage Downloads shows the Undo button anymore during job execution.
