### PR TITLE
Ped Delay Summary Report

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -646,7 +646,7 @@ ReportType.init({
   },
   PED_DELAY_SUMMARY: {
     dataType: ReportDataType.PED_DELAY,
-    disabled: true,
+    disabled: false,
     formats: [ReportFormat.CSV, ReportFormat.PDF],
     label: 'Ped Delay Summary',
     orientation: PageOrientation.LANDSCAPE,

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -1076,8 +1076,20 @@ StudyRequestStatus.init({
  */
 class StudyType extends Enum {
   get reportTypes() {
-    return ReportType.enumValues
-      .filter(({ dataType }) => this.dataType.canBeUsedAs(dataType));
+    const reportTypesExact = [];
+    const reportTypesCompatible = [];
+    ReportType.enumValues.forEach((reportType) => {
+      const { dataType, disabled } = reportType;
+      if (disabled || !this.dataType.canBeUsedAs(dataType)) {
+        return;
+      }
+      if (this.dataType === dataType) {
+        reportTypesExact.push(reportType);
+      } else {
+        reportTypesCompatible.push(reportType);
+      }
+    });
+    return [...reportTypesExact, ...reportTypesCompatible];
   }
 }
 StudyType.init({

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -617,7 +617,7 @@ ReportType.init({
   COUNT_SUMMARY_TURNING_MOVEMENT_ILLUSTRATED: {
     dataType: ReportDataType.TMC,
     disabled: true,
-    formats: [],
+    formats: [ReportFormat.PDF],
     label: 'TMC Illustrated Report',
     orientation: PageOrientation.PORTRAIT,
     reportExportMode: ReportExportMode.STUDIES,
@@ -647,7 +647,7 @@ ReportType.init({
   PED_DELAY_SUMMARY: {
     dataType: ReportDataType.PED_DELAY,
     disabled: true,
-    formats: [],
+    formats: [ReportFormat.CSV, ReportFormat.PDF],
     label: 'Ped Delay Summary',
     orientation: PageOrientation.LANDSCAPE,
     reportExportMode: ReportExportMode.STUDIES,

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -596,17 +596,6 @@ ReportType.init({
     suffix: 'CountSummaryTurningMovementIllustrated',
     tmcRelated: true,
   },
-  CROSSWALK_OBSERVANCE_SUMMARY: {
-    disabled: true,
-    formats: [ReportFormat.CSV, ReportFormat.PDF],
-    label: 'Crosswalk Observation Report',
-    orientation: PageOrientation.LANDSCAPE,
-    reportExportMode: ReportExportMode.STUDIES,
-    size: PageSize.LETTER,
-    speedRelated: false,
-    suffix: 'CrosswalkObservanceSummary',
-    tmcRelated: false,
-  },
   INTERSECTION_SUMMARY: {
     disabled: false,
     formats: [ReportFormat.CSV, ReportFormat.PDF],
@@ -638,6 +627,17 @@ ReportType.init({
     size: PageSize.LETTER,
     speedRelated: false,
     suffix: 'PedDelaySummary',
+    tmcRelated: false,
+  },
+  PXO_OBSERVE_SUMMARY: {
+    disabled: true,
+    formats: [ReportFormat.CSV, ReportFormat.PDF],
+    label: 'Crosswalk Observation Report',
+    orientation: PageOrientation.LANDSCAPE,
+    reportExportMode: ReportExportMode.STUDIES,
+    size: PageSize.LETTER,
+    speedRelated: false,
+    suffix: 'CrosswalkObservanceSummary',
     tmcRelated: false,
   },
   SPEED_PERCENTILE: {
@@ -1110,7 +1110,7 @@ StudyType.init({
     dataAvailable: false,
     other: false,
     reportTypes: [
-      ReportType.CROSSWALK_OBSERVANCE_SUMMARY,
+      ReportType.PXO_OBSERVE_SUMMARY,
     ],
   },
   RESCU: {
@@ -1132,6 +1132,13 @@ StudyType.init({
       ReportType.PEAK_HOUR_FACTOR,
       ReportType.WARRANT_TRAFFIC_SIGNAL_CONTROL,
     ],
+  },
+  VEHICLE_CLASS: {
+    label: 'Vehicle Classification',
+    automatic: false,
+    dataAvailable: false,
+    other: false,
+    reportTypes: [],
   },
 });
 

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -417,6 +417,41 @@ ReportBlock.init({
 });
 
 /**
+ * Possible data types for reports.  Each report type requires data in a specific representation.
+ * For instance, collision reports require collision data, while study-related reports require
+ * data from specific types of studies.
+ *
+ * This enum also captures compatibility relations, which can be non-symmetric.  For instance,
+ * speed / volume ATR data can be used as though it were volume ATR data, but the reverse is
+ * not true.
+ */
+class ReportDataType extends Enum {
+  canBeUsedAs(reportDataType) {
+    if (this === ReportDataType.OTHER || reportDataType === ReportDataType.OTHER) {
+      return false;
+    }
+    if (this === reportDataType) {
+      return true;
+    }
+    if (this === ReportDataType.ATR_SPEED_VOLUME) {
+      return reportDataType === ReportDataType.ATR_VOLUME;
+    }
+    return false;
+  }
+}
+ReportDataType.init([
+  'ATR_SPEED_VOLUME',
+  'ATR_VOLUME',
+  'COLLISION',
+  'OTHER',
+  'PED_DELAY',
+  'PXO_OBSERVE',
+  'STUDY_REQUEST',
+  'TMC',
+  'VEHICLE_CLASS',
+]);
+
+/**
  * Report export modes available in Aggregate View on the View Data page.  This identifies
  * whether collision or study reports are being exported.
  *
@@ -492,6 +527,7 @@ ReportParameter.init({
 /**
  * Report types available from MOVE Reporter.
  *
+ * @param {ReportDataType} dataType - what type of data this report requires
  * @param {boolean} disabled - this report type is disabled if it hasn't been
  * implemented in MOVE Reporter yet
  * @param {Array<ReportFormat>} formats - formats supported for this report type
@@ -504,15 +540,12 @@ ReportParameter.init({
  * @param {Array<AuthScope>?} scope - authorization scopes required (if any required)
  * @param {PageSize?} size - page size for PDF documents (only if `ReportFormat.PDF`
  * available)
- * @param {boolean?} speedRelated - does this report type require speed data? (only if
- * study-related)
  * @param {string} suffix - suffix used for component names
- * @param {boolean?} tmcRelated - does this report type require TMC data? (only if
- * study-related)
  */
 class ReportType extends Enum {}
 ReportType.init({
   COLLISION_DIRECTORY: {
+    dataType: ReportDataType.COLLISION,
     disabled: false,
     formats: [ReportFormat.CSV, ReportFormat.PDF],
     label: 'Directory Report',
@@ -522,6 +555,7 @@ ReportType.init({
     suffix: 'CollisionDirectory',
   },
   COLLISION_TABULATION: {
+    dataType: ReportDataType.COLLISION,
     disabled: false,
     formats: [ReportFormat.CSV, ReportFormat.PDF],
     label: 'Tabulation Report',
@@ -531,127 +565,117 @@ ReportType.init({
     suffix: 'CollisionTabulation',
   },
   COUNT_SUMMARY_24H: {
+    dataType: ReportDataType.ATR_VOLUME,
     disabled: false,
     formats: [ReportFormat.CSV, ReportFormat.PDF],
     label: '24-Hour Summary Report',
     orientation: PageOrientation.LANDSCAPE,
     reportExportMode: ReportExportMode.STUDIES,
     size: PageSize.LETTER,
-    speedRelated: false,
     suffix: 'CountSummary24h',
-    tmcRelated: false,
   },
   COUNT_SUMMARY_24H_DETAILED: {
+    dataType: ReportDataType.ATR_VOLUME,
     disabled: false,
     formats: [ReportFormat.CSV, ReportFormat.PDF],
     label: '24-Hour Detailed Report',
     orientation: PageOrientation.PORTRAIT,
     reportExportMode: ReportExportMode.STUDIES,
     size: PageSize.LETTER,
-    speedRelated: false,
     suffix: 'CountSummary24hDetailed',
-    tmcRelated: false,
   },
   COUNT_SUMMARY_24H_GRAPHICAL: {
+    dataType: ReportDataType.ATR_VOLUME,
     disabled: false,
     formats: [ReportFormat.CSV, ReportFormat.PDF],
     label: '24-Hour Graphical Report',
     orientation: PageOrientation.LANDSCAPE,
     reportExportMode: ReportExportMode.STUDIES,
     size: PageSize.LETTER,
-    speedRelated: false,
     suffix: 'CountSummary24hGraphical',
-    tmcRelated: false,
   },
   COUNT_SUMMARY_TURNING_MOVEMENT: {
+    dataType: ReportDataType.TMC,
     disabled: false,
     formats: [ReportFormat.CSV, ReportFormat.PDF],
     label: 'TMC Summary Report',
     orientation: PageOrientation.LANDSCAPE,
     reportExportMode: ReportExportMode.STUDIES,
     size: PageSize.LETTER,
-    speedRelated: false,
     suffix: 'CountSummaryTurningMovement',
-    tmcRelated: true,
   },
   COUNT_SUMMARY_TURNING_MOVEMENT_DETAILED: {
+    dataType: ReportDataType.TMC,
     disabled: false,
     formats: [ReportFormat.CSV, ReportFormat.PDF],
     label: 'TMC Detailed Report',
     orientation: PageOrientation.PORTRAIT,
     reportExportMode: ReportExportMode.STUDIES,
     size: PageSize.LETTER,
-    speedRelated: false,
     suffix: 'CountSummaryTurningMovementDetailed',
-    tmcRelated: true,
   },
   COUNT_SUMMARY_TURNING_MOVEMENT_ILLUSTRATED: {
+    dataType: ReportDataType.TMC,
     disabled: true,
     formats: [],
     label: 'TMC Illustrated Report',
     orientation: PageOrientation.PORTRAIT,
     reportExportMode: ReportExportMode.STUDIES,
     size: PageSize.LETTER,
-    speedRelated: false,
     suffix: 'CountSummaryTurningMovementIllustrated',
-    tmcRelated: true,
   },
   INTERSECTION_SUMMARY: {
+    dataType: ReportDataType.TMC,
     disabled: false,
     formats: [ReportFormat.CSV, ReportFormat.PDF],
     label: 'Intersection Summary Report',
     orientation: PageOrientation.LANDSCAPE,
     reportExportMode: ReportExportMode.STUDIES,
     size: PageSize.LETTER,
-    speedRelated: false,
     suffix: 'IntersectionSummary',
-    tmcRelated: true,
   },
   PEAK_HOUR_FACTOR: {
+    dataType: ReportDataType.TMC,
     disabled: false,
     formats: [ReportFormat.CSV, ReportFormat.PDF],
     label: 'Peak Hour Factor Report',
     orientation: PageOrientation.LANDSCAPE,
     reportExportMode: ReportExportMode.STUDIES,
     size: PageSize.LETTER,
-    speedRelated: false,
     suffix: 'PeakHourFactor',
-    tmcRelated: true,
   },
   PED_DELAY_SUMMARY: {
+    dataType: ReportDataType.PED_DELAY,
     disabled: true,
     formats: [],
     label: 'Ped Delay Summary',
     orientation: PageOrientation.LANDSCAPE,
     reportExportMode: ReportExportMode.STUDIES,
     size: PageSize.LETTER,
-    speedRelated: false,
     suffix: 'PedDelaySummary',
-    tmcRelated: false,
   },
   PXO_OBSERVE_SUMMARY: {
+    dataType: ReportDataType.PXO_OBSERVE,
     disabled: true,
     formats: [ReportFormat.CSV, ReportFormat.PDF],
     label: 'Crosswalk Observation Report',
     orientation: PageOrientation.LANDSCAPE,
     reportExportMode: ReportExportMode.STUDIES,
     size: PageSize.LETTER,
-    speedRelated: false,
     suffix: 'CrosswalkObservanceSummary',
-    tmcRelated: false,
   },
   SPEED_PERCENTILE: {
+    dataType: ReportDataType.ATR_SPEED_VOLUME,
     disabled: false,
     formats: [ReportFormat.CSV, ReportFormat.PDF],
     label: 'Speed Percentile Report',
     orientation: PageOrientation.LANDSCAPE,
     reportExportMode: ReportExportMode.STUDIES,
     size: PageSize.LETTER,
-    speedRelated: true,
     suffix: 'SpeedPercentile',
-    tmcRelated: false,
   },
   TRACK_REQUESTS: {
+    dataType: ReportDataType.STUDY_REQUEST,
     disabled: false,
     formats: [ReportFormat.CSV],
     label: 'Track Requests: Download All',
@@ -659,6 +683,7 @@ ReportType.init({
     suffix: 'TrackRequests',
   },
   TRACK_REQUESTS_SELECTED: {
+    dataType: ReportDataType.STUDY_REQUEST,
     disabled: false,
     formats: [ReportFormat.CSV],
     label: 'Track Requests: Download Selected',
@@ -666,6 +691,7 @@ ReportType.init({
     suffix: 'TrackRequestsSelected',
   },
   WARRANT_TRAFFIC_SIGNAL_CONTROL: {
+    dataType: ReportDataType.TMC,
     disabled: false,
     formats: [ReportFormat.PDF],
     label: 'Warrant: Traffic Control Signal',
@@ -679,9 +705,7 @@ ReportType.init({
     orientation: PageOrientation.PORTRAIT,
     reportExportMode: ReportExportMode.STUDIES,
     size: PageSize.LETTER,
-    speedRelated: false,
     suffix: 'WarrantTrafficSignalControl',
-    tmcRelated: true,
   },
 });
 
@@ -1034,12 +1058,6 @@ StudyRequestStatus.init({
   },
 });
 
-const OPTIONS_REPORTS_ATR_VOLUME = [
-  ReportType.COUNT_SUMMARY_24H_GRAPHICAL,
-  ReportType.COUNT_SUMMARY_24H_DETAILED,
-  ReportType.COUNT_SUMMARY_24H,
-];
-
 /**
  * Types of studies that can be performed.  This list includes two "other" types,
  * `OTHER_AUTOMATIC` and `OTHER_MANUAL`, that allow staff to request studies that aren't covered
@@ -1052,93 +1070,86 @@ const OPTIONS_REPORTS_ATR_VOLUME = [
  * @param {boolean} automatic - whether data for this study type is collected automatically
  * (or, if `false`, manually)
  * @param {boolean} dataAvailable - whether data for this study type is available in MOVE
+ * @param {StudyDataType} dataType - what type of data this study produces
  * @param {boolean} other - whether this study type is an "other" type
  * @param {Array<ReportType>} reportTypes - report types that are available for this study type
  */
-class StudyType extends Enum {}
+class StudyType extends Enum {
+  get reportTypes() {
+    return ReportType.enumValues
+      .filter(({ dataType }) => this.dataType.canBeUsedAs(dataType));
+  }
+}
 StudyType.init({
   ATR_SPEED_VOLUME: {
     label: 'Speed / Volume ATR',
     automatic: true,
     dataAvailable: true,
+    dataType: ReportDataType.ATR_SPEED_VOLUME,
     other: false,
-    reportTypes: [
-      ReportType.SPEED_PERCENTILE,
-      ...OPTIONS_REPORTS_ATR_VOLUME,
-    ],
   },
   ATR_VOLUME: {
     label: 'Volume ATR',
     automatic: true,
     dataAvailable: true,
+    dataType: ReportDataType.ATR_VOLUME,
     other: false,
-    reportTypes: OPTIONS_REPORTS_ATR_VOLUME,
   },
   ATR_VOLUME_BICYCLE: {
     label: 'Bicycle Volume ATR',
     automatic: true,
     dataAvailable: true,
+    dataType: ReportDataType.ATR_VOLUME,
     other: false,
-    reportTypes: OPTIONS_REPORTS_ATR_VOLUME,
   },
   OTHER_AUTOMATIC: {
     label: 'Other',
     automatic: true,
     dataAvailable: false,
+    dataType: ReportDataType.OTHER,
     other: true,
-    reportTypes: [],
   },
   OTHER_MANUAL: {
     label: 'Other',
     automatic: false,
     dataAvailable: false,
+    dataType: ReportDataType.OTHER,
     other: true,
-    reportTypes: [],
   },
   PED_DELAY: {
     label: 'Ped Delay and Classification',
     automatic: false,
     dataAvailable: true,
+    dataType: ReportDataType.PED_DELAY,
     other: false,
-    reportTypes: [
-      ReportType.PED_DELAY_SUMMARY,
-    ],
   },
   PXO_OBSERVE: {
     label: 'Ped Crossover Observation',
     automatic: false,
     dataAvailable: false,
+    dataType: ReportDataType.PXO_OBSERVE,
     other: false,
-    reportTypes: [
-      ReportType.PXO_OBSERVE_SUMMARY,
-    ],
   },
   RESCU: {
     label: 'RESCU (Highway / Ramp)',
     automatic: true,
     dataAvailable: true,
+    dataType: ReportDataType.ATR_VOLUME,
     other: false,
-    reportTypes: OPTIONS_REPORTS_ATR_VOLUME,
   },
   TMC: {
     label: 'Turning Movement Count',
     automatic: false,
     dataAvailable: true,
+    dataType: ReportDataType.TMC,
     other: false,
-    reportTypes: [
-      ReportType.COUNT_SUMMARY_TURNING_MOVEMENT,
-      ReportType.COUNT_SUMMARY_TURNING_MOVEMENT_DETAILED,
-      ReportType.INTERSECTION_SUMMARY,
-      ReportType.PEAK_HOUR_FACTOR,
-      ReportType.WARRANT_TRAFFIC_SIGNAL_CONTROL,
-    ],
   },
   VEHICLE_CLASS: {
     label: 'Vehicle Classification',
     automatic: false,
     dataAvailable: false,
+    dataType: ReportDataType.VEHICLE_CLASS,
     other: false,
-    reportTypes: [],
   },
 });
 

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -1098,7 +1098,7 @@ StudyType.init({
   PED_DELAY: {
     label: 'Ped Delay and Classification',
     automatic: false,
-    dataAvailable: false,
+    dataAvailable: true,
     other: false,
     reportTypes: [
       ReportType.PED_DELAY_SUMMARY,

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -5,12 +5,12 @@ import {
   ReportBlock,
   ReportFormat,
   ReportType,
+  StudyType,
 } from '@/lib/Constants';
 import { mapBy } from '@/lib/MapUtils';
 import AxiosBackendClient from '@/lib/api/AxiosBackendClient';
 import CompositeId from '@/lib/io/CompositeId';
 import AuthState from '@/lib/model/AuthState';
-import Category from '@/lib/model/Category';
 import CollisionEvent from '@/lib/model/CollisionEvent';
 import Joi from '@/lib/model/Joi';
 import Study from '@/lib/model/Study';
@@ -277,9 +277,9 @@ async function getStudiesByCentrelineSummary(features, filters) {
   const studySummary = await apiClient.fetch('/studies/byCentreline/summary', options);
   const studySummarySchema = Joi.array().items(
     Joi.object().keys({
-      category: Category.read,
       mostRecent: Study.read,
       n: Joi.number().integer().positive().required(),
+      studyType: Joi.enum().ofType(StudyType).required(),
     }),
   );
   return studySummarySchema.validateAsync(studySummary);
@@ -295,13 +295,13 @@ async function getStudiesByCentrelineSummaryPerLocation(features, filters) {
   );
   const studySummaryPerLocationSchema = Joi.array().items(
     Joi.object().keys({
-      category: Category.read,
       perLocation: Joi.array().items(
         Joi.object().keys({
           mostRecent: Study.read.allow(null),
           n: Joi.number().integer().min(0).required(),
         }),
       ),
+      studyType: Joi.enum().ofType(StudyType).required(),
     }),
   );
   return studySummaryPerLocationSchema.validateAsync(studySummaryPerLocation);

--- a/lib/controller/StudyController.js
+++ b/lib/controller/StudyController.js
@@ -1,8 +1,8 @@
 import Boom from '@hapi/boom';
 
+import { StudyType } from '@/lib/Constants';
 import StudyDAO from '@/lib/db/StudyDAO';
 import CompositeId from '@/lib/io/CompositeId';
-import Category from '@/lib/model/Category';
 import Joi from '@/lib/model/Joi';
 import Study from '@/lib/model/Study';
 import StudyFilters from '@/lib/model/StudyFilters';
@@ -96,9 +96,9 @@ StudyController.push({
     response: {
       schema: Joi.array().items(
         Joi.object().keys({
-          category: Category.read,
           mostRecent: Study.read,
           n: Joi.number().integer().positive().required(),
+          studyType: Joi.enum().ofType(StudyType).required(),
         }),
       ),
     },
@@ -155,13 +155,13 @@ StudyController.push({
     response: {
       schema: Joi.array().items(
         Joi.object().keys({
-          category: Category.read,
           perLocation: Joi.array().items(
             Joi.object().keys({
               mostRecent: Study.read.allow(null),
               n: Joi.number().integer().min(0).required(),
             }),
           ),
+          studyType: Joi.enum().ofType(StudyType).required(),
         }),
       ),
     },

--- a/lib/db/ArteryDAO.js
+++ b/lib/db/ArteryDAO.js
@@ -9,6 +9,11 @@ import db from '@/lib/db/db';
  * While it's usually enough to access counts, sometimes you need the additional
  * metadata (e.g. direction of travel) stored here.  For instance, {@link ReportCountSummary24h}
  * uses this metadata as part of the 24-Hour Count Summary Report.
+ *
+ * With recent work on loading counts directly into MOVE, this will soon be replaced
+ * by {@link CountLocationDAO}.
+ *
+ * @deprecated
  */
 class ArteryDAO {
   /**

--- a/lib/db/ArteryDAO.js
+++ b/lib/db/ArteryDAO.js
@@ -102,13 +102,12 @@ class ArteryDAO {
 WITH arterycodes AS (
   SELECT arterycode
   FROM counts.arteries_groups
-  WHERE group_id = $(arteryGroupId)
+  WHERE group_id = $(countLocationId)
 )
 SELECT ${ArteryDAO.ARTERYDATA_FIELDS}
 JOIN arterycodes a ON ad."ARTERYCODE" = a.arterycode
 ORDER BY a.arterycode ASC`;
-    const { arteryGroupId } = study;
-    const rows = await db.manyOrNone(sql, { arteryGroupId });
+    const rows = await db.manyOrNone(sql, study);
     return rows.map(ArteryDAO.arteryDataToArtery);
   }
 }

--- a/lib/db/CategoryDAO.js
+++ b/lib/db/CategoryDAO.js
@@ -1,7 +1,6 @@
 import { StudyType } from '@/lib/Constants';
 import db from '@/lib/db/db';
 
-
 /*
  * TODO: eventually figure out what the right taxonomy is here - it's possible we're
  * lumping together things that don't belong together.
@@ -19,7 +18,7 @@ const CATEGORY_STUDY_TYPES = {
   'SENSYS SPEED': null,
 };
 
-/**
+/*
  * Since the set of categories is small and static, we cache it here to reduce
  * DB load.
  */
@@ -35,6 +34,14 @@ async function init() {
   });
 }
 
+/**
+ * Data access object for "categories", as listed in `TRAFFIC.CATEGORY`.  These are types of
+ * counts that legacy FLOW knows about.  With the introduction of new study types in MOVE, this
+ * is being replaced by the use of {@link StudyType} in the new `counts2` database
+ * schema.
+ *
+ * @deprecated
+ */
 class CategoryDAO {
   static isInited() {
     return CACHE !== null;

--- a/lib/db/CountDAO.js
+++ b/lib/db/CountDAO.js
@@ -12,7 +12,7 @@ import Joi from '@/lib/model/Joi';
  */
 const COUNTINFO_LEGACY_FIELDS = `
   ci."COUNT_INFO_ID", ci."COUNT_DATE", ci."COMMENT_",
-  ad."STAT_CODE", ac.direction
+  ad."ARTERYCODE", ad."STAT_CODE", ac.direction
   FROM "TRAFFIC"."COUNTINFO" ci
   JOIN "TRAFFIC"."ARTERYDATA" ad ON ci."ARTERYCODE" = ad."ARTERYCODE"
   JOIN counts.arteries_centreline ac ON ci."ARTERYCODE" = ac.arterycode`;
@@ -26,10 +26,9 @@ const COUNTINFO_LEGACY_FIELDS = `
  */
 const COUNTINFOMICS_LEGACY_FIELDS = `
   cim."COUNT_INFO_ID", cim."COUNT_TYPE", cim."COUNT_DATE", cim."COMMENT_",
-  ad."STAT_CODE", ac.direction
+  ad."ARTERYCODE", ad."STAT_CODE"
   FROM "TRAFFIC"."COUNTINFOMICS" cim
-  JOIN "TRAFFIC"."ARTERYDATA" ad ON ci."ARTERYCODE" = ad."ARTERYCODE"
-  JOIN counts.arteries_centreline ac ON cim."ARTERYCODE" = ac.arterycode`;
+  JOIN "TRAFFIC"."ARTERYDATA" ad ON ci."ARTERYCODE" = ad."ARTERYCODE"`;
 
 /**
  * Defines the fields fetched for non-legacy counts, using the `counts2` schema.
@@ -82,6 +81,7 @@ function countInfoLegacyToCount(row, study) {
     COUNT_DATE: date,
     COMMENT_: notes,
     direction: directionStr,
+    ARTERYCODE: arteryCode,
     STAT_CODE: stationCode,
   } = row;
   const direction = getApproachDirection(directionStr);
@@ -98,7 +98,7 @@ function countInfoLegacyToCount(row, study) {
     notes: notesNormalized,
     countLocationId,
     direction,
-    extraMetadata: { stationCode },
+    extraMetadata: { arteryCode, stationCode },
   };
 }
 
@@ -114,10 +114,9 @@ function countInfomicsLegacyToCount(row, study) {
     COUNT_DATE: date,
     COUNT_TYPE,
     COMMENT_: notes,
-    direction: directionStr,
+    ARTERYCODE: arteryCode,
     STAT_CODE: stationCode,
   } = row;
-  const direction = getApproachDirection(directionStr);
   const hours = StudyHours.enumValueOf(COUNT_TYPE, 'countType');
   const notesNormalized = notes === null ? null : notes.trim();
 
@@ -131,8 +130,8 @@ function countInfomicsLegacyToCount(row, study) {
     date,
     notes: notesNormalized,
     countLocationId,
-    direction,
-    extraMetadata: { stationCode },
+    direction: null,
+    extraMetadata: { arteryCode, stationCode },
   };
 }
 

--- a/lib/db/CountDAO.js
+++ b/lib/db/CountDAO.js
@@ -170,7 +170,7 @@ class CountDAO {
 WITH arterycodes AS (
   SELECT arterycode
   FROM counts.arteries_groups
-  WHERE group_id = $(arteryGroupId)
+  WHERE group_id = $(countLocationId)
 ), count_info_ids AS (
   SELECT cmr."COUNT_INFO_ID"
   FROM counts.counts_multiday_runs cmr
@@ -184,13 +184,13 @@ SELECT ${COUNTINFO_LEGACY_FIELDS}
 JOIN count_info_ids cii ON ci."COUNT_INFO_ID" = cii."COUNT_INFO_ID"
 ORDER BY ci."ARTERYCODE" ASC, ci."COUNT_DATE" ASC`;
     const {
-      arteryGroupId,
+      countLocationId,
       endDate,
       startDate,
       studyType,
     } = study;
     const rows = await db.manyOrNone(sql, {
-      arteryGroupId,
+      countLocationId,
       endDate,
       startDate,
       studyType,
@@ -209,7 +209,7 @@ ORDER BY ci."ARTERYCODE" ASC, ci."COUNT_DATE" ASC`;
 WITH arterycodes AS (
   SELECT arterycode
   FROM counts.arteries_groups
-  WHERE group_id = $(arteryGroupId)
+  WHERE group_id = $(countLocationId)
 ), count_info_ids AS (
   SELECT cmr."COUNT_INFO_ID"
   FROM counts.counts_multiday_runs cmr
@@ -223,13 +223,13 @@ SELECT ${COUNTINFOMICS_LEGACY_FIELDS}
 JOIN count_info_ids cii ON cim."COUNT_INFO_ID" = cii."COUNT_INFO_ID"
 ORDER BY cim."ARTERYCODE" ASC, cim."COUNT_DATE" ASC`;
     const {
-      arteryGroupId,
+      countLocationId,
       endDate,
       startDate,
       studyType,
     } = study;
     const rows = await db.manyOrNone(sql, {
-      arteryGroupId,
+      countLocationId,
       endDate,
       startDate,
       studyType,

--- a/lib/db/CountDAO.js
+++ b/lib/db/CountDAO.js
@@ -28,7 +28,7 @@ const COUNTINFOMICS_LEGACY_FIELDS = `
   cim."COUNT_INFO_ID", cim."COUNT_TYPE", cim."COUNT_DATE", cim."COMMENT_",
   ad."ARTERYCODE", ad."STAT_CODE"
   FROM "TRAFFIC"."COUNTINFOMICS" cim
-  JOIN "TRAFFIC"."ARTERYDATA" ad ON ci."ARTERYCODE" = ad."ARTERYCODE"`;
+  JOIN "TRAFFIC"."ARTERYDATA" ad ON cim."ARTERYCODE" = ad."ARTERYCODE"`;
 
 /**
  * Defines the fields fetched for non-legacy counts, using the `counts2` schema.
@@ -141,7 +141,7 @@ function countInfoToCount(row) {
     ...rowRest
   } = row;
   const direction = getApproachDirection(directionStr);
-  return { direction, ...rowRest };
+  return { legacy: false, direction, ...rowRest };
 }
 
 async function validateCounts(counts) {

--- a/lib/db/CountDAO.js
+++ b/lib/db/CountDAO.js
@@ -1,38 +1,74 @@
-import { StudyHours, StudyType } from '@/lib/Constants';
+import { CardinalDirection, StudyHours, StudyType } from '@/lib/Constants';
 import db from '@/lib/db/db';
-import CategoryDAO from '@/lib/db/CategoryDAO';
+import Count from '@/lib/model/Count';
+import Joi from '@/lib/model/Joi';
 
 /**
- * Defines the fields fetched for non-TMC counts, and the tables that those
+ * Defines the fields fetched for legacy non-TMC counts, and the tables that those
  * fields come from.
  *
  * @memberof CountDAO
  * @type {string}
  */
-const COUNTINFO_FIELDS = `
-  ci."COUNT_INFO_ID", ci."ARTERYCODE", ci."COUNT_DATE",
-  ci."CATEGORY_ID", ci."COMMENT_",
-  ad."LOCATION", ad."STAT_CODE",
-  ac.centreline_id, ac.centreline_type, ST_AsGeoJSON(ac.geom)::json AS geom
+const COUNTINFO_LEGACY_FIELDS = `
+  ci."COUNT_INFO_ID", ci."COUNT_DATE", ci."COMMENT_",
+  ad."STAT_CODE", ac.direction
   FROM "TRAFFIC"."COUNTINFO" ci
   JOIN "TRAFFIC"."ARTERYDATA" ad ON ci."ARTERYCODE" = ad."ARTERYCODE"
   JOIN counts.arteries_centreline ac ON ci."ARTERYCODE" = ac.arterycode`;
 
 /**
- * Defines the fields fetched for TMC counts, and the tables that those
+ * Defines the fields fetched for legacy TMC counts, and the tables that those
  * fields come from.
  *
  * @memberof CountDAO
  * @type {string}
  */
-const COUNTINFOMICS_FIELDS = `
-  cim."COUNT_INFO_ID", cim."ARTERYCODE", cim."COUNT_TYPE", cim."COUNT_DATE",
-  cim."CATEGORY_ID", cim."COMMENT_",
-  ad."LOCATION", ad."STAT_CODE",
-  ac.centreline_id, ac.centreline_type, ST_AsGeoJSON(ac.geom)::json AS geom
+const COUNTINFOMICS_LEGACY_FIELDS = `
+  cim."COUNT_INFO_ID", cim."COUNT_TYPE", cim."COUNT_DATE", cim."COMMENT_",
+  ad."STAT_CODE", ac.direction
   FROM "TRAFFIC"."COUNTINFOMICS" cim
-  JOIN "TRAFFIC"."ARTERYDATA" ad ON cim."ARTERYCODE" = ad."ARTERYCODE"
+  JOIN "TRAFFIC"."ARTERYDATA" ad ON ci."ARTERYCODE" = ad."ARTERYCODE"
   JOIN counts.arteries_centreline ac ON cim."ARTERYCODE" = ac.arterycode`;
+
+/**
+ * Defines the fields fetched for non-legacy counts, using the `counts2` schema.
+ *
+ * @memberof CountDAO
+ * @type {string}
+ */
+const COUNTINFO_FIELDS = `
+  "id",
+  "studyType",
+  "hours",
+  "date",
+  "notes",
+  "countLocationId",
+  "direction",
+  "extraMetadata"
+  FROM counts2.count_info`;
+
+/**
+ *
+ * @param {string} direction - `direction` column from `counts.arteries_midblock_direction`
+ * @returns {CardinalDirection} direction of approach for the given side of intersection
+ *
+ * @memberof CountDAO
+ */
+function getApproachDirection(direction) {
+  switch (direction) {
+    case 'N':
+      return CardinalDirection.NORTH;
+    case 'E':
+      return CardinalDirection.EAST;
+    case 'S':
+      return CardinalDirection.SOUTH;
+    case 'W':
+      return CardinalDirection.WEST;
+    default:
+      return null;
+  }
+}
 
 /**
  * Convert a row fetched using {@link CountDAO.COUNTINFO_FIELDS} to a count
@@ -40,33 +76,29 @@ const COUNTINFOMICS_FIELDS = `
  *
  * @memberof CountDAO
  */
-function countInfoToCount({
-  COUNT_INFO_ID: id,
-  ARTERYCODE: arteryCode,
-  COUNT_DATE: date,
-  CATEGORY_ID,
-  COMMENT_: notes,
-  LOCATION: locationDesc,
-  STAT_CODE: stationCode,
-  centreline_id: centrelineId,
-  centreline_type: centrelineType,
-  geom,
-}, categories) {
-  const type = categories.get(CATEGORY_ID);
+function countInfoLegacyToCount(row, study) {
+  const {
+    COUNT_INFO_ID: id,
+    COUNT_DATE: date,
+    COMMENT_: notes,
+    direction: directionStr,
+    STAT_CODE: stationCode,
+  } = row;
+  const direction = getApproachDirection(directionStr);
   const notesNormalized = notes === null ? null : notes.trim();
+
+  const { countLocationId, studyType } = study;
+
   return {
     id,
-    arteryCode,
-    stationCode,
-    date,
+    legacy: true,
+    studyType,
     hours: null,
-    duration: 24,
-    type,
-    locationDesc,
-    centrelineId,
-    centrelineType,
+    date,
     notes: notesNormalized,
-    geom,
+    countLocationId,
+    direction,
+    extraMetadata: { stationCode },
   };
 }
 
@@ -76,35 +108,46 @@ function countInfoToCount({
  *
  * @memberof CountDAO
  */
-function countInfomicsToCount({
-  COUNT_INFO_ID: id,
-  ARTERYCODE: arteryCode,
-  COUNT_DATE: date,
-  COUNT_TYPE,
-  CATEGORY_ID,
-  COMMENT_: notes,
-  LOCATION: locationDesc,
-  STAT_CODE: stationCode,
-  centreline_id: centrelineId,
-  centreline_type: centrelineType,
-  geom,
-}, categories) {
-  const type = categories.get(CATEGORY_ID);
+function countInfomicsLegacyToCount(row, study) {
+  const {
+    COUNT_INFO_ID: id,
+    COUNT_DATE: date,
+    COUNT_TYPE,
+    COMMENT_: notes,
+    direction: directionStr,
+    STAT_CODE: stationCode,
+  } = row;
+  const direction = getApproachDirection(directionStr);
   const hours = StudyHours.enumValueOf(COUNT_TYPE, 'countType');
+  const notesNormalized = notes === null ? null : notes.trim();
+
+  const { countLocationId, studyType } = study;
+
   return {
     id,
-    arteryCode,
-    stationCode,
-    date,
+    legacy: true,
+    studyType,
     hours,
-    duration: null,
-    type,
-    locationDesc,
-    centrelineId,
-    centrelineType,
-    notes,
-    geom,
+    date,
+    notes: notesNormalized,
+    countLocationId,
+    direction,
+    extraMetadata: { stationCode },
   };
+}
+
+function countInfoToCount(row) {
+  const {
+    direction: directionStr,
+    ...rowRest
+  } = row;
+  const direction = getApproachDirection(directionStr);
+  return { direction, ...rowRest };
+}
+
+async function validateCounts(counts) {
+  const countsSchema = Joi.array().items(Count.read);
+  return countsSchema.validateAsync(counts);
 }
 
 /**
@@ -116,14 +159,14 @@ function countInfomicsToCount({
  * to {@link StudyDataDAO}.
  */
 class CountDAO {
-  // COUNTINFO
+  // LEGACY TABLES
 
   /**
    * Fetch all non-TMC counts for the given study.
    *
    * @param {number} study - study to fetch non-TMC counts for
    */
-  static async countInfoByStudy(study) {
+  static async countInfoLegacyByStudy(study) {
     const sql = `
 WITH arterycodes AS (
   SELECT arterycode
@@ -133,37 +176,36 @@ WITH arterycodes AS (
   SELECT cmr."COUNT_INFO_ID"
   FROM counts.counts_multiday_runs cmr
   JOIN arterycodes a ON cmr."ARTERYCODE" = a.arterycode
-  WHERE cmr."CATEGORY_ID" = $(categoryId)
+  JOIN counts2.category_study_type cst USING ("CATEGORY_ID")
+  WHERE cst."studyType" = $(studyType)
   AND cmr."COUNT_DATE" >= $(startDate)
   AND cmr."COUNT_DATE" <= $(endDate)
 )
-SELECT ${COUNTINFO_FIELDS}
+SELECT ${COUNTINFO_LEGACY_FIELDS}
 JOIN count_info_ids cii ON ci."COUNT_INFO_ID" = cii."COUNT_INFO_ID"
 ORDER BY ci."ARTERYCODE" ASC, ci."COUNT_DATE" ASC`;
     const {
       arteryGroupId,
       endDate,
       startDate,
-      type: { id: categoryId },
+      studyType,
     } = study;
-    const categories = await CategoryDAO.all();
     const rows = await db.manyOrNone(sql, {
       arteryGroupId,
-      categoryId,
       endDate,
       startDate,
+      studyType,
     });
-    return rows.map(row => countInfoToCount(row, categories));
+    const counts = rows.map(row => countInfoLegacyToCount(row, study));
+    return validateCounts(counts);
   }
-
-  // COUNTINFOMICS
 
   /**
    * Fetch all TMC counts for the given study.
    *
    * @param {number} study - study to fetch TMC counts for
    */
-  static async countInfomicsByStudy(study) {
+  static async countInfomicsLegacyByStudy(study) {
     const sql = `
 WITH arterycodes AS (
   SELECT arterycode
@@ -173,27 +215,39 @@ WITH arterycodes AS (
   SELECT cmr."COUNT_INFO_ID"
   FROM counts.counts_multiday_runs cmr
   JOIN arterycodes a ON cmr."ARTERYCODE" = a.arterycode
-  WHERE cmr."CATEGORY_ID" = $(categoryId)
+  JOIN counts2.category_study_type cst USING ("CATEGORY_ID")
+  WHERE cst."studyType" = $(studyType)
   AND cmr."COUNT_DATE" >= $(startDate)
   AND cmr."COUNT_DATE" <= $(endDate)
 )
-SELECT ${COUNTINFOMICS_FIELDS}
+SELECT ${COUNTINFOMICS_LEGACY_FIELDS}
 JOIN count_info_ids cii ON cim."COUNT_INFO_ID" = cii."COUNT_INFO_ID"
 ORDER BY cim."ARTERYCODE" ASC, cim."COUNT_DATE" ASC`;
     const {
       arteryGroupId,
       endDate,
       startDate,
-      type: { id: categoryId },
+      studyType,
     } = study;
-    const categories = await CategoryDAO.all();
     const rows = await db.manyOrNone(sql, {
       arteryGroupId,
-      categoryId,
       endDate,
       startDate,
+      studyType,
     });
-    return rows.map(row => countInfomicsToCount(row, categories));
+    const counts = rows.map(row => countInfomicsLegacyToCount(row, study));
+    return validateCounts(counts);
+  }
+
+  // NEW TABLES
+
+  static async countInfoByStudy(study) {
+    // TODO: support multi-count studies in `counts2`
+    const { countGroupId: id } = study;
+    const sql = `SELECT ${COUNTINFO_FIELDS} WHERE id = $(id)`;
+    const rows = await db.manyOrNone(sql, { id });
+    const counts = rows.map(countInfoToCount);
+    return validateCounts(counts);
   }
 
   // COMBINED
@@ -204,9 +258,12 @@ ORDER BY cim."ARTERYCODE" ASC, cim."COUNT_DATE" ASC`;
    * @param {number} study - study to fetch counts for
    */
   static async byStudy(study) {
-    const { studyType } = study.type;
-    if (studyType === StudyType.TMC) {
-      return CountDAO.countInfomicsByStudy(study);
+    const { legacy, studyType } = study;
+    if (legacy) {
+      if (studyType === StudyType.TMC) {
+        return CountDAO.countInfomicsLegacyByStudy(study);
+      }
+      return CountDAO.countInfoLegacyByStudy(study);
     }
     return CountDAO.countInfoByStudy(study);
   }

--- a/lib/db/CountLocationDAO.js
+++ b/lib/db/CountLocationDAO.js
@@ -60,11 +60,11 @@ class CountLocationDAO {
 
   /**
    *
-   * @param {number} countLocationId - ID of count location (i.e. arterycode group) to fetch
+   * @param {Object} study - legacy study to fetch count location for
    * @returns {Object}
    */
-  static async byStudyLegacy(countLocationId) {
-    const arteries = await ArteryDAO.byStudy({ arteryGroupId: countLocationId });
+  static async byStudyLegacy(study) {
+    const arteries = await ArteryDAO.byStudy(study);
     if (arteries.length === 0) {
       return null;
     }
@@ -72,13 +72,13 @@ class CountLocationDAO {
     const location = await CentrelineDAO.byFeature(artery);
     const description = CountLocationDAO.getArteryDescription(artery, location);
     const {
-      id,
       centrelineId,
       centrelineType,
+      countLocationId,
       geom,
-    } = location;
+    } = study;
     const countLocation = {
-      id,
+      id: countLocationId,
       legacy: true,
       description,
       centrelineId,
@@ -94,15 +94,14 @@ class CountLocationDAO {
    * @returns {Object}
    */
   static async byStudy(study) {
-    const { countLocationId, legacy } = study;
-    if (legacy) {
-      return CountLocationDAO.byStudyLegacy(countLocationId);
+    if (study.legacy) {
+      return CountLocationDAO.byStudyLegacy(study);
     }
 
     const sql = `
 SELECT ${COUNT_LOCATION_FIELDS}
 WHERE "id" = $(countLocationId)`;
-    const countLocation = await db.oneOrNone(sql, { countLocationId });
+    const countLocation = await db.oneOrNone(sql, study);
     return validateCountLocation(countLocation);
   }
 }

--- a/lib/db/CountLocationDAO.js
+++ b/lib/db/CountLocationDAO.js
@@ -1,0 +1,110 @@
+import { CardinalDirection } from '@/lib/Constants';
+import db from '@/lib/db/db';
+import ArteryDAO from '@/lib/db/ArteryDAO';
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import CountLocation from '@/lib/model/CountLocation';
+
+const COUNT_LOCATION_FIELDS = `
+  cl."id",
+  cl."description",
+  cl."centrelineId",
+  cl."centrelineType",
+  ST_AsGeoJSON(cl."geom")::json AS "geom"
+  FROM counts2.count_locations cl`;
+
+const REGEX_DIRECTION_BOUND = / [NESW]\/B/;
+
+async function validateCountLocation(countLocation) {
+  if (countLocation === null) {
+    return null;
+  }
+  return CountLocation.read.validateAsync(countLocation);
+}
+
+/**
+ * Data access object for count locations, i.e. locations at which counts have been conducted.
+ * This is used in the new `counts2` schema.
+ *
+ * To help transition from the now-deprecated {@link ArteryDAO} to this, we fetch both legacy
+ * arterycodes and new `counts2.count_locations` records here, adapting the former into the same
+ * data model as the latter.
+ */
+class CountLocationDAO {
+  /**
+   *
+   * @param {string} direction - `direction` column from `counts.arteries_midblock_direction`
+   * @returns direction of approach for the given side of intersection
+   */
+  static getApproachDirection(direction) {
+    switch (direction) {
+      case 'N':
+        return CardinalDirection.NORTH;
+      case 'E':
+        return CardinalDirection.EAST;
+      case 'S':
+        return CardinalDirection.SOUTH;
+      case 'W':
+        return CardinalDirection.WEST;
+      default:
+        return null;
+    }
+  }
+
+  static getArteryDescription(artery, location) {
+    const { locationDesc } = artery;
+    if (locationDesc === null) {
+      return location.description;
+    }
+    return locationDesc.replace(REGEX_DIRECTION_BOUND, '');
+  }
+
+  /**
+   *
+   * @param {number} countLocationId - ID of count location (i.e. arterycode group) to fetch
+   * @returns {Object}
+   */
+  static async byStudyLegacy(countLocationId) {
+    const arteries = await ArteryDAO.byStudy({ arteryGroupId: countLocationId });
+    if (arteries.length === 0) {
+      return null;
+    }
+    const [artery] = arteries;
+    const location = await CentrelineDAO.byFeature(artery);
+    const description = CountLocationDAO.getArteryDescription(artery, location);
+    const {
+      id,
+      centrelineId,
+      centrelineType,
+      geom,
+    } = location;
+    const countLocation = {
+      id,
+      legacy: true,
+      description,
+      centrelineId,
+      centrelineType,
+      geom,
+    };
+    return validateCountLocation(countLocation);
+  }
+
+  /**
+   *
+   * @param {number} study - study to get count location for
+   * @returns {Object}
+   */
+  static async byStudy(study) {
+    const { countLocationId, legacy } = study;
+    if (legacy) {
+      return CountLocationDAO.byStudyLegacy(countLocationId);
+    }
+
+    const sql = `
+SELECT ${COUNT_LOCATION_FIELDS}
+WHERE "id" = $(countLocationId)`;
+    const countLocation = await db.oneOrNone(sql, { countLocationId });
+    return validateCountLocation(countLocation);
+  }
+}
+
+export default CountLocationDAO;

--- a/lib/db/CountLocationDAO.js
+++ b/lib/db/CountLocationDAO.js
@@ -5,6 +5,7 @@ import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import CountLocation from '@/lib/model/CountLocation';
 
 const COUNT_LOCATION_FIELDS = `
+  FALSE AS "legacy",
   cl."id",
   cl."description",
   cl."centrelineId",

--- a/lib/db/DynamicTileDAO.js
+++ b/lib/db/DynamicTileDAO.js
@@ -1,5 +1,4 @@
 import db from '@/lib/db/db';
-import CategoryDAO from '@/lib/db/CategoryDAO';
 import { InvalidDynamicTileLayerError } from '@/lib/error/MoveErrors';
 import VectorTile from '@/lib/geo/VectorTile';
 
@@ -7,26 +6,19 @@ const EPSG_3857_MAX = 20037508.3427892;
 const EPSG_3857_MIN = -EPSG_3857_MAX;
 const EPSG_3857_SIZE = EPSG_3857_MAX - EPSG_3857_MIN;
 
-function normalizeStudyFeature(studyFeature, categories) {
+function normalizeStudyFeature(studyFeature) {
   const {
-    CATEGORY_ID,
     hours,
+    studyType,
     ...studyFeatureRest
   } = studyFeature;
 
-  const type = categories.get(CATEGORY_ID);
-  const { studyType } = type;
-  let studyTypeName = null;
-  if (studyType !== null) {
-    studyTypeName = studyType.name;
-  }
-
-  const studyFeatureNormalized = { ...studyFeatureRest };
+  const studyFeatureNormalized = {
+    studyType: studyType.name,
+    ...studyFeatureRest,
+  };
   if (hours !== null) {
     studyFeatureNormalized.hours = hours;
-  }
-  if (studyTypeName !== null) {
-    studyFeatureNormalized.studyType = studyTypeName;
   }
   return studyFeatureNormalized;
 }
@@ -211,23 +203,23 @@ FROM schools`;
     return db.manyOrNone(sql, tileInfo);
   }
 
-  static async getCountsStudiesFeatures(tileInfo) {
+  static async getStudiesFeatures(tileInfo) {
     const sql = `
 WITH studies AS (
   SELECT
-    "CATEGORY_ID",
-    centreline_id,
-    centreline_type,
+    "studyType",
+    "centrelineId",
+    "centrelineType",
     concat('|', array_to_string("daysOfWeek", '|'), '|') AS "daysOfWeek",
-    geom,
-    hours,
-    start_date
-  FROM counts.studies
+    "geom",
+    "hours",
+    "startDate"
+  FROM counts2.studies
   WHERE ST_Intersects(
     ST_Transform(geom, 3857),
     ST_MakeEnvelope($(xmin), $(ymin), $(xmax), $(ymax), 3857)
   )
-  AND centreline_id IS NOT NULL AND centreline_type IS NOT NULL
+  AND "centrelineId" IS NOT NULL AND "centrelineType" IS NOT NULL
 )
 SELECT ST_AsGeoJSON(
   ST_SnapToGrid(
@@ -240,73 +232,16 @@ SELECT ST_AsGeoJSON(
     0, 0, 1, 1
   )
 )::json AS geom,
-centreline_type * 1000000000 + centreline_id AS id,
-"CATEGORY_ID",
-centreline_id AS "centrelineId",
-centreline_type AS "centrelineType",
+"centrelineType" * 1000000000 + "centrelineId" AS id,
+"studyType",
+"centrelineId",
+"centrelineType",
 "daysOfWeek",
-hours,
-start_date AS "startDate"
+"hours",
+"startDate"
 FROM studies`;
     const studyFeatures = await db.manyOrNone(sql, tileInfo);
-    const categories = await CategoryDAO.all();
-    return studyFeatures.map(studyFeature => normalizeStudyFeature(studyFeature, categories));
-  }
-
-  static async getCounts2CountInfoFeatures(tileInfo) {
-    const sql = `
-WITH studies AS (
-  SELECT
-    cl."centrelineId" AS centreline_id,
-    cl."centrelineType" AS centreline_type,
-    CAST(date_part('DOW', "date") AS TEXT) AS "daysOfWeek",
-    cl."geom",
-    ci."hours",
-    ci."date" AS start_date,
-    ci."studyType"
-  FROM counts2.count_info ci
-  JOIN counts2.count_locations cl ON ci."countLocationId" = cl."id"
-  WHERE ST_Intersects(
-    ST_Transform(cl.geom, 3857),
-    ST_MakeEnvelope($(xmin), $(ymin), $(xmax), $(ymax), 3857)
-  )
-  AND cl."centrelineId" IS NOT NULL AND cl."centrelineType" IS NOT NULL
-)
-SELECT ST_AsGeoJSON(
-  ST_SnapToGrid(
-    ST_Affine(
-      ST_Transform(geom, 3857),
-      $(fx), 0,
-      0, $(fy),
-      $(xoff), $(yoff)
-    ),
-    0, 0, 1, 1
-  )
-)::json AS geom,
-centreline_type * 1000000000 + centreline_id AS id,
-centreline_id AS "centrelineId",
-centreline_type AS "centrelineType",
-"daysOfWeek",
-hours,
-start_date AS "startDate",
-"studyType"
-FROM studies`;
-    const studyFeatures = await db.manyOrNone(sql, tileInfo);
-    return studyFeatures.map(({ hours, ...studyFeatureRest }) => {
-      const studyFeatureNormalized = { ...studyFeatureRest };
-      if (hours !== null) {
-        studyFeatureNormalized.hours = hours;
-      }
-      return studyFeatureNormalized;
-    });
-  }
-
-  static async getStudiesFeatures(tileInfo) {
-    const [countsStudiesFeatures, counts2CountInfoFeatures] = await Promise.all([
-      DynamicTileDAO.getCountsStudiesFeatures(tileInfo),
-      DynamicTileDAO.getCounts2CountInfoFeatures(tileInfo),
-    ]);
-    return [...countsStudiesFeatures, ...counts2CountInfoFeatures];
+    return studyFeatures.map(normalizeStudyFeature);
   }
 
   static async getTileFeatures(layerName, z, x, y) {

--- a/lib/db/DynamicTileDAO.js
+++ b/lib/db/DynamicTileDAO.js
@@ -6,23 +6,6 @@ const EPSG_3857_MAX = 20037508.3427892;
 const EPSG_3857_MIN = -EPSG_3857_MAX;
 const EPSG_3857_SIZE = EPSG_3857_MAX - EPSG_3857_MIN;
 
-function normalizeStudyFeature(studyFeature) {
-  const {
-    hours,
-    studyType,
-    ...studyFeatureRest
-  } = studyFeature;
-
-  const studyFeatureNormalized = {
-    studyType: studyType.name,
-    ...studyFeatureRest,
-  };
-  if (hours !== null) {
-    studyFeatureNormalized.hours = hours;
-  }
-  return studyFeatureNormalized;
-}
-
 class DynamicTileDAO {
   static getTileInfo(z, x, y) {
     const bmin = -VectorTile.BUFFER;
@@ -207,13 +190,13 @@ FROM schools`;
     const sql = `
 WITH studies AS (
   SELECT
-    "studyType",
     "centrelineId",
     "centrelineType",
     concat('|', array_to_string("daysOfWeek", '|'), '|') AS "daysOfWeek",
     "geom",
     "hours",
-    "startDate"
+    "startDate",
+    "studyType"
   FROM counts2.studies
   WHERE ST_Intersects(
     ST_Transform(geom, 3857),
@@ -233,15 +216,14 @@ SELECT ST_AsGeoJSON(
   )
 )::json AS geom,
 "centrelineType" * 1000000000 + "centrelineId" AS id,
-"studyType",
 "centrelineId",
 "centrelineType",
 "daysOfWeek",
 "hours",
-"startDate"
+"startDate",
+"studyType"
 FROM studies`;
-    const studyFeatures = await db.manyOrNone(sql, tileInfo);
-    return studyFeatures.map(normalizeStudyFeature);
+    return db.manyOrNone(sql, tileInfo);
   }
 
   static async getTileFeatures(layerName, z, x, y) {

--- a/lib/db/DynamicTileDAO.js
+++ b/lib/db/DynamicTileDAO.js
@@ -211,7 +211,7 @@ FROM schools`;
     return db.manyOrNone(sql, tileInfo);
   }
 
-  static async getStudiesFeatures(tileInfo) {
+  static async getCountsStudiesFeatures(tileInfo) {
     const sql = `
 WITH studies AS (
   SELECT
@@ -251,6 +251,62 @@ FROM studies`;
     const studyFeatures = await db.manyOrNone(sql, tileInfo);
     const categories = await CategoryDAO.all();
     return studyFeatures.map(studyFeature => normalizeStudyFeature(studyFeature, categories));
+  }
+
+  static async getCounts2CountInfoFeatures(tileInfo) {
+    const sql = `
+WITH studies AS (
+  SELECT
+    cl."centrelineId" AS centreline_id,
+    cl."centrelineType" AS centreline_type,
+    CAST(date_part('DOW', "date") AS TEXT) AS "daysOfWeek",
+    cl."geom",
+    ci."hours",
+    ci."date" AS start_date,
+    ci."studyType"
+  FROM counts2.count_info ci
+  JOIN counts2.count_locations cl ON ci."countLocationId" = cl."id"
+  WHERE ST_Intersects(
+    ST_Transform(cl.geom, 3857),
+    ST_MakeEnvelope($(xmin), $(ymin), $(xmax), $(ymax), 3857)
+  )
+  AND cl."centrelineId" IS NOT NULL AND cl."centrelineType" IS NOT NULL
+)
+SELECT ST_AsGeoJSON(
+  ST_SnapToGrid(
+    ST_Affine(
+      ST_Transform(geom, 3857),
+      $(fx), 0,
+      0, $(fy),
+      $(xoff), $(yoff)
+    ),
+    0, 0, 1, 1
+  )
+)::json AS geom,
+centreline_type * 1000000000 + centreline_id AS id,
+centreline_id AS "centrelineId",
+centreline_type AS "centrelineType",
+"daysOfWeek",
+hours,
+start_date AS "startDate",
+"studyType"
+FROM studies`;
+    const studyFeatures = await db.manyOrNone(sql, tileInfo);
+    return studyFeatures.map(({ hours, ...studyFeatureRest }) => {
+      const studyFeatureNormalized = { ...studyFeatureRest };
+      if (hours !== null) {
+        studyFeatureNormalized.hours = hours;
+      }
+      return studyFeatureNormalized;
+    });
+  }
+
+  static async getStudiesFeatures(tileInfo) {
+    const [countsStudiesFeatures, counts2CountInfoFeatures] = await Promise.all([
+      DynamicTileDAO.getCountsStudiesFeatures(tileInfo),
+      DynamicTileDAO.getCounts2CountInfoFeatures(tileInfo),
+    ]);
+    return [...countsStudiesFeatures, ...counts2CountInfoFeatures];
   }
 
   static async getTileFeatures(layerName, z, x, y) {

--- a/lib/db/LocationSearchDAO.js
+++ b/lib/db/LocationSearchDAO.js
@@ -27,7 +27,6 @@ class LocationSearchDAO {
    * to the given artery if found, empty array otherwise
    */
   static async arterySuggestions(arterycode) {
-    // TODO: implement using counts.arteries_centreline
     const sql = `
 SELECT
   centreline_id AS "centrelineId",

--- a/lib/db/ReportDAO.js
+++ b/lib/db/ReportDAO.js
@@ -12,9 +12,8 @@ const LIMIT = 100;
 
 class ReportDAO {
   static getReportsForStudy(study, reportFormat) {
-    const { countGroupId, type } = study;
-    const { id: categoryId, studyType } = type;
-    const id = `${categoryId}/${countGroupId}`;
+    const { countGroupId, studyType } = study;
+    const id = `${studyType.name}/${countGroupId}`;
     /*
      * To simplify bulk report generation, we only generate reports of types that do not
      * have user-supplied parameters.

--- a/lib/db/StudyDAO.js
+++ b/lib/db/StudyDAO.js
@@ -1,7 +1,6 @@
-import { centrelineKey } from '@/lib/Constants';
+import { centrelineKey, StudyType } from '@/lib/Constants';
 import { setdefault } from '@/lib/MapUtils';
 import db from '@/lib/db/db';
-import CategoryDAO from '@/lib/db/CategoryDAO';
 import {
   getCentrelineFilter,
   getStudyFilters,
@@ -10,44 +9,35 @@ import Joi from '@/lib/model/Joi';
 import Study from '@/lib/model/Study';
 
 const STUDIES_FIELDS = `
-  artery_group_id AS "arteryGroupId",
-  "CATEGORY_ID",
-  centreline_id AS "centrelineId",
-  centreline_type AS "centrelineType",
-  count_group_id AS "countGroupId",
-  duration,
+  "legacy",
+  "countLocationId",
+  "studyType",
+  "countGroupId",
+  "startDate",
+  "endDate",
+  "duration",
   "daysOfWeek",
-  end_date AS "endDate",
-  ST_AsGeoJSON(geom)::json AS geom,
-  hours,
-  start_date AS "startDate"
-  FROM counts.studies`;
+  "hours",
+  "centrelineType",
+  "centrelineId",
+  ST_AsGeoJSON("geom")::json AS geom
+  FROM counts2.studies`;
 
-function normalizeStudy(study, categories) {
-  const {
-    __row,
-    CATEGORY_ID,
-    ...studyRest
-  } = study;
-  const type = categories.get(CATEGORY_ID);
-  return {
-    ...studyRest,
-    type,
-  };
+function normalizeStudy(study) {
+  const { __row, ...studyRest } = study;
+  return { ...studyRest };
 }
 
-async function validateStudy(study, categories) {
+async function validateStudy(study) {
   if (study === null) {
     return null;
   }
-  const studyNormalized = normalizeStudy(study, categories);
+  const studyNormalized = normalizeStudy(study);
   return Study.read.validateAsync(studyNormalized);
 }
 
-async function validateStudies(studies, categories) {
-  const studiesNormalized = studies.map(
-    study => normalizeStudy(study, categories),
-  );
+async function validateStudies(studies) {
+  const studiesNormalized = studies.map(normalizeStudy);
   const studiesSchema = Joi.array().items(Study.read);
   return studiesSchema.validateAsync(studiesNormalized);
 }
@@ -56,16 +46,24 @@ class StudyDAO {
   static async byCategoryAndCountGroup(categoryId, countGroupId) {
     const sql = `
 SELECT ${STUDIES_FIELDS}
-WHERE "CATEGORY_ID" = $(categoryId)
-AND count_group_id = $(countGroupId)`;
+JOIN counts2.category_study_type cst USING ("studyType")
+WHERE cst."CATEGORY_ID" = $(categoryId)
+AND "countGroupId" = $(countGroupId)`;
     const study = await db.oneOrNone(sql, { categoryId, countGroupId });
-    const categories = await CategoryDAO.all();
-    return validateStudy(study, categories);
+    return validateStudy(study);
+  }
+
+  static async byStudyTypeAndCountGroup(studyType, countGroupId) {
+    const sql = `
+SELECT ${STUDIES_FIELDS}
+WHERE "studyType" = $(studyType)
+AND "countGroupId" = $(countGroupId)`;
+    const study = await db.oneOrNone(sql, { countGroupId, studyType });
+    return validateStudy(study);
   }
 
   static async byCentreline(features, studyQuery, pagination) {
-    const categories = await CategoryDAO.all();
-    const { filters, params } = getStudyFilters(features, studyQuery, categories);
+    const { filters, params } = getStudyFilters(features, studyQuery);
     const studyFilters = filters.join('\n  AND ');
 
     const sql = `
@@ -77,85 +75,82 @@ AND count_group_id = $(countGroupId)`;
       ...params,
       ...pagination,
     });
-    return validateStudies(rows, categories);
+    return validateStudies(rows);
   }
 
   static async byCentrelineSummary(features, studyQuery) {
-    const categories = await CategoryDAO.all();
-    const { filters, params } = getStudyFilters(features, studyQuery, categories);
+    const { filters, params } = getStudyFilters(features, studyQuery);
     const studyFilters = filters.join('\n  AND ');
 
     const sqlMostRecent = `
 SELECT * FROM (
   SELECT
-    ROW_NUMBER() OVER (PARTITION BY "CATEGORY_ID" ORDER BY start_date DESC) __row,
+    ROW_NUMBER() OVER (PARTITION BY "studyType" ORDER BY "startDate" DESC) __row,
     ${STUDIES_FIELDS}
   WHERE ${studyFilters}
 ) x
 WHERE x.__row = 1`;
-    const sqlNumPerCategory = `
-SELECT COUNT(*) AS n, "CATEGORY_ID"
-FROM counts.studies
+    const sqlNumPerStudyType = `
+SELECT COUNT(*) AS n, "studyType"
+FROM counts2.studies
 WHERE ${studyFilters}
-GROUP BY "CATEGORY_ID"`;
+GROUP BY "studyType"`;
 
-    const [rowsMostRecent, rowsNumPerCategory] = await Promise.all([
+    const [rowsMostRecent, rowsNumPerStudyType] = await Promise.all([
       db.manyOrNone(sqlMostRecent, params),
-      db.manyOrNone(sqlNumPerCategory, params),
+      db.manyOrNone(sqlNumPerStudyType, params),
     ]);
 
-    const studies = await validateStudies(rowsMostRecent, categories);
-    const mapNumPerCategory = new Map(
-      rowsNumPerCategory.map(({ n, CATEGORY_ID }) => [CATEGORY_ID, n]),
+    const studies = await validateStudies(rowsMostRecent);
+    const mapNumPerStudyType = new Map(
+      rowsNumPerStudyType.map(({ n, studyType }) => [studyType, n]),
     );
     return studies.map((mostRecent) => {
-      const category = mostRecent.type;
-      const n = mapNumPerCategory.get(category.id);
-      return { category, mostRecent, n };
+      const { studyType } = mostRecent;
+      const n = mapNumPerStudyType.get(studyType.name);
+      return { mostRecent, n, studyType };
     });
   }
 
   static async byCentrelineSummaryPerLocation(features, studyQuery) {
-    const categories = await CategoryDAO.all();
-    const { filters, params } = getStudyFilters(features, studyQuery, categories);
+    const { filters, params } = getStudyFilters(features, studyQuery);
     const studyFilters = filters.join('\n  AND ');
 
     const sqlMostRecent = `
 SELECT * FROM (
   SELECT
     ROW_NUMBER() OVER (
-      PARTITION BY "CATEGORY_ID", "centreline_type", "centreline_id"
-      ORDER BY start_date DESC
+      PARTITION BY "studyType", "centrelineType", "centrelineId"
+      ORDER BY "startDate" DESC
     ) __row,
     ${STUDIES_FIELDS}
   WHERE ${studyFilters}
 ) x
 WHERE x.__row = 1`;
-    const sqlNumPerCategory = `
+    const sqlNumPerStudyType = `
 SELECT COUNT(*) AS n,
-"CATEGORY_ID",
-"centreline_type" AS "centrelineType",
-"centreline_id" AS "centrelineId"
-FROM counts.studies
+"studyType",
+"centrelineType",
+"centrelineId"
+FROM counts2.studies
 WHERE ${studyFilters}
-GROUP BY "CATEGORY_ID", "centreline_type", "centreline_id"`;
+GROUP BY "studyType", "centrelineType", "centrelineId"`;
 
-    const [rowsMostRecent, rowsNumPerCategory] = await Promise.all([
+    const [rowsMostRecent, rowsNumPerStudyType] = await Promise.all([
       db.manyOrNone(sqlMostRecent, params),
-      db.manyOrNone(sqlNumPerCategory, params),
+      db.manyOrNone(sqlNumPerStudyType, params),
     ]);
 
-    const studies = await validateStudies(rowsMostRecent, categories);
-    const mapCategories = new Map();
-    const mapStudiesPerCategoryAndLocation = new Map();
+    const studies = await validateStudies(rowsMostRecent);
+    const setStudyTypes = new Map();
+    const mapStudiesPerStudyTypeAndLocation = new Map();
     studies.forEach((study) => {
-      const { centrelineId, centrelineType, type } = study;
-      const { id: categoryId } = type;
-      mapCategories.set(categoryId, type);
+      const { centrelineId, centrelineType, studyType } = study;
+      setStudyTypes.add(studyType);
 
       const mapStudiesPerLocation = setdefault(
-        mapStudiesPerCategoryAndLocation,
-        categoryId,
+        mapStudiesPerStudyTypeAndLocation,
+        studyType,
         new Map(),
       );
       const feature = { centrelineId, centrelineType };
@@ -163,16 +158,17 @@ GROUP BY "CATEGORY_ID", "centreline_type", "centreline_id"`;
       mapStudiesPerLocation.set(key, study);
     });
 
-    const mapNumPerCategoryAndLocation = new Map();
-    rowsNumPerCategory.forEach(({
-      CATEGORY_ID,
+    const mapNumPerStudyTypeAndLocation = new Map();
+    rowsNumPerStudyType.forEach(({
       centrelineId,
       centrelineType,
+      studyType: studyTypeName,
       n,
     }) => {
+      const studyType = StudyType.enumValueOf(studyTypeName);
       const mapNumPerLocation = setdefault(
-        mapNumPerCategoryAndLocation,
-        CATEGORY_ID,
+        mapNumPerStudyTypeAndLocation,
+        studyType,
         new Map(),
       );
       const feature = { centrelineId, centrelineType };
@@ -180,11 +176,10 @@ GROUP BY "CATEGORY_ID", "centreline_type", "centreline_id"`;
       mapNumPerLocation.set(key, n);
     });
 
-    const categoriesWithStudies = Array.from(mapCategories.values());
-    return categoriesWithStudies.map((category) => {
-      const { id: categoryId } = category;
-      const mapStudiesPerLocation = mapStudiesPerCategoryAndLocation.get(categoryId);
-      const mapNumPerLocation = mapNumPerCategoryAndLocation.get(categoryId);
+    const studyTypesWithStudies = Array.from(setStudyTypes);
+    return studyTypesWithStudies.map((studyType) => {
+      const mapStudiesPerLocation = mapStudiesPerStudyTypeAndLocation.get(studyType);
+      const mapNumPerLocation = mapNumPerStudyTypeAndLocation.get(studyType);
       const perLocation = features.map((feature) => {
         const key = centrelineKey(feature);
         if (mapStudiesPerLocation.has(key)) {
@@ -194,7 +189,7 @@ GROUP BY "CATEGORY_ID", "centreline_type", "centreline_id"`;
         }
         return { mostRecent: null, n: 0 };
       });
-      return { category, perLocation };
+      return { perLocation, studyType };
     });
   }
 
@@ -202,7 +197,7 @@ GROUP BY "CATEGORY_ID", "centreline_type", "centreline_id"`;
     const centrelineFilter = getCentrelineFilter(features);
     const sql = `
 SELECT COUNT(*) AS total
-FROM counts.studies
+FROM counts2.studies
 WHERE ${centrelineFilter}`;
     const { total } = await db.one(sql);
     return total;

--- a/lib/db/StudyDAO.js
+++ b/lib/db/StudyDAO.js
@@ -69,7 +69,7 @@ AND "countGroupId" = $(countGroupId)`;
     const sql = `
   SELECT ${STUDIES_FIELDS}
   WHERE ${studyFilters}
-  ORDER BY start_date DESC
+  ORDER BY "startDate" DESC
   LIMIT $(limit) OFFSET $(offset)`;
     const rows = await db.manyOrNone(sql, {
       ...params,

--- a/lib/db/StudyDAO.js
+++ b/lib/db/StudyDAO.js
@@ -42,7 +42,19 @@ async function validateStudies(studies) {
   return studiesSchema.validateAsync(studiesNormalized);
 }
 
+/**
+ * Data access object for "studies".  A study is a set of one or more counts conducted at the same
+ * location, on the same set of consecutive days, and for the same purpose.
+ *
+ * For some study types (e.g. TMC, Ped Delays), studies will only contain a single count.  For
+ * others (e.g. ATRs), studies can contain several counts: for instance, a volume ATR study might
+ * take place over 3 days on an East-West road with traffic in both directions, for a total of 6
+ * counts.
+ */
 class StudyDAO {
+  /**
+   * @deprecated
+   */
   static async byCategoryAndCountGroup(categoryId, countGroupId) {
     const sql = `
 SELECT ${STUDIES_FIELDS}

--- a/lib/db/StudyDAO.js
+++ b/lib/db/StudyDAO.js
@@ -154,7 +154,7 @@ GROUP BY "studyType", "centrelineType", "centrelineId"`;
     ]);
 
     const studies = await validateStudies(rowsMostRecent);
-    const setStudyTypes = new Map();
+    const setStudyTypes = new Set();
     const mapStudiesPerStudyTypeAndLocation = new Map();
     studies.forEach((study) => {
       const { centrelineId, centrelineType, studyType } = study;

--- a/lib/db/StudyDataDAO.js
+++ b/lib/db/StudyDataDAO.js
@@ -83,7 +83,7 @@ ORDER BY "start" ASC`;
     if (counts.length === 0) {
       return [];
     }
-    const { studyType } = study.type;
+    const { studyType } = study;
     const countInfoIds = counts.map(({ id }) => id);
     if (studyType === StudyType.ATR_SPEED_VOLUME) {
       return StudyDataDAO.atrSpeedByCounts(countInfoIds);

--- a/lib/db/StudyDataDAO.js
+++ b/lib/db/StudyDataDAO.js
@@ -45,7 +45,7 @@ class StudyDataDAO {
 SELECT "COUNT_INFO_ID", "TIMECOUNT", "COUNT", "SPEED_CLASS"
 FROM "TRAFFIC"."CNT_DET"
 WHERE "COUNT_INFO_ID" IN ($(countInfoIds:csv))
-ORDER BY "TIMECOUNT" ASC, "SPEED_CLASS" ASC`;
+ORDER BY "COUNT_INFO_ID" ASC, "TIMECOUNT" ASC, "SPEED_CLASS" ASC`;
     const rows = await db.manyOrNone(sql, { countInfoIds });
     return rows.map(normalizeCntDetRow);
   }
@@ -55,7 +55,7 @@ ORDER BY "TIMECOUNT" ASC, "SPEED_CLASS" ASC`;
 SELECT "COUNT_INFO_ID", "TIMECOUNT", "COUNT"
 FROM "TRAFFIC"."CNT_DET"
 WHERE "COUNT_INFO_ID" IN ($(countInfoIds:csv))
-ORDER BY "TIMECOUNT" ASC`;
+ORDER BY "COUNT_INFO_ID" ASC, "TIMECOUNT" ASC`;
     const rows = await db.manyOrNone(sql, { countInfoIds });
     return rows.map(normalizeCntDetRow);
   }
@@ -65,7 +65,7 @@ ORDER BY "TIMECOUNT" ASC`;
 SELECT *
 FROM counts2.count_data_ped_delay
 WHERE "countInfoId" IN ($(countInfoIds:csv))
-ORDER BY "start" ASC`;
+ORDER BY "countInfoId" ASC, "zone" ASC, "start" ASC`;
     const rows = await db.manyOrNone(sql, { countInfoIds });
     return rows.map(normalizeCountDataPedDelayRow);
   }
@@ -74,7 +74,7 @@ ORDER BY "start" ASC`;
     const sql = `
   SELECT * FROM "TRAFFIC"."DET"
   WHERE "COUNT_INFO_ID" IN ($(countInfoIds:csv))
-  ORDER BY "COUNT_TIME" ASC`;
+  ORDER BY "COUNT_INFO_ID" ASC, "COUNT_TIME" ASC`;
     const rows = await db.manyOrNone(sql, { countInfoIds });
     return rows.map(normalizeDetRow);
   }

--- a/lib/db/StudyDataDAO.js
+++ b/lib/db/StudyDataDAO.js
@@ -1,8 +1,7 @@
 import { StudyType } from '@/lib/Constants';
-import { mapBy } from '@/lib/MapUtils';
 import db from '@/lib/db/db';
-import ArteryDAO from '@/lib/db/ArteryDAO';
 import CountDAO from '@/lib/db/CountDAO';
+import CountLocationDAO from '@/lib/db/CountLocationDAO';
 
 function normalizeCntDetRow({
   COUNT_INFO_ID: countInfoId,
@@ -24,6 +23,16 @@ function normalizeDetRow({
   return { countInfoId, t, data };
 }
 
+function normalizeCountDataPedDelayRow({
+  countInfoId,
+  start,
+  end,
+  ...data
+}) {
+  // TODO: build time ranges here
+  return { countInfoId, t: start, data };
+}
+
 /**
  * Data access layer for study data.  Note that many of these accessors require
  * study metadata as fetched using {@link StudyDAO}; those metadata objects can
@@ -33,22 +42,32 @@ function normalizeDetRow({
 class StudyDataDAO {
   static async atrSpeedByCounts(countInfoIds) {
     const sql = `
-  SELECT "COUNT_INFO_ID", "TIMECOUNT", "COUNT", "SPEED_CLASS"
-  FROM "TRAFFIC"."CNT_DET"
-  WHERE "COUNT_INFO_ID" IN ($(countInfoIds:csv))
-  ORDER BY "TIMECOUNT" ASC, "SPEED_CLASS" ASC`;
+SELECT "COUNT_INFO_ID", "TIMECOUNT", "COUNT", "SPEED_CLASS"
+FROM "TRAFFIC"."CNT_DET"
+WHERE "COUNT_INFO_ID" IN ($(countInfoIds:csv))
+ORDER BY "TIMECOUNT" ASC, "SPEED_CLASS" ASC`;
     const rows = await db.manyOrNone(sql, { countInfoIds });
     return rows.map(normalizeCntDetRow);
   }
 
   static async atrVolumeByCounts(countInfoIds) {
     const sql = `
-  SELECT "COUNT_INFO_ID", "TIMECOUNT", "COUNT"
-  FROM "TRAFFIC"."CNT_DET"
-  WHERE "COUNT_INFO_ID" IN ($(countInfoIds:csv))
-  ORDER BY "TIMECOUNT" ASC`;
+SELECT "COUNT_INFO_ID", "TIMECOUNT", "COUNT"
+FROM "TRAFFIC"."CNT_DET"
+WHERE "COUNT_INFO_ID" IN ($(countInfoIds:csv))
+ORDER BY "TIMECOUNT" ASC`;
     const rows = await db.manyOrNone(sql, { countInfoIds });
     return rows.map(normalizeCntDetRow);
+  }
+
+  static async pedDelayByCounts(countInfoIds) {
+    const sql = `
+SELECT *
+FROM counts2.count_data_ped_delay
+WHERE "countInfoId" IN ($(countInfoIds:csv))
+ORDER BY "start" ASC`;
+    const rows = await db.manyOrNone(sql, { countInfoIds });
+    return rows.map(normalizeCountDataPedDelayRow);
   }
 
   static async tmcByCounts(countInfoIds) {
@@ -66,11 +85,14 @@ class StudyDataDAO {
     }
     const { studyType } = study.type;
     const countInfoIds = counts.map(({ id }) => id);
-    if (studyType === StudyType.TMC) {
-      return StudyDataDAO.tmcByCounts(countInfoIds);
-    }
     if (studyType === StudyType.ATR_SPEED_VOLUME) {
       return StudyDataDAO.atrSpeedByCounts(countInfoIds);
+    }
+    if (studyType === StudyType.PED_DELAY) {
+      return StudyDataDAO.pedDelayByCounts(countInfoIds);
+    }
+    if (studyType === StudyType.TMC) {
+      return StudyDataDAO.tmcByCounts(countInfoIds);
     }
     return StudyDataDAO.atrVolumeByCounts(countInfoIds);
   }
@@ -87,18 +109,17 @@ class StudyDataDAO {
   }
 
   static async byStudy(study) {
-    const [arteries, counts] = await Promise.all([
-      ArteryDAO.byStudy(study),
+    const [counts, countLocation] = await Promise.all([
       CountDAO.byStudy(study),
+      CountLocationDAO.byStudy(study),
     ]);
-    const arteriesByCode = mapBy(arteries, ({ arteryCode }) => arteryCode);
 
     const dataRows = await StudyDataDAO.dataRowsByCounts(study, counts);
     const studyData = StudyDataDAO.groupDataRows(counts, dataRows);
 
     return {
-      arteries: arteriesByCode,
       counts,
+      countLocation,
       studyData,
     };
   }

--- a/lib/db/filters/StudyFiltersSql.js
+++ b/lib/db/filters/StudyFiltersSql.js
@@ -1,13 +1,3 @@
-function toCategoryIds(studyTypes, categories) {
-  const categoryIds = [];
-  categories.forEach(({ studyType }, categoryId) => {
-    if (studyTypes.includes(studyType)) {
-      categoryIds.push(categoryId);
-    }
-  });
-  return categoryIds;
-}
-
 function getCentrelineFilter(features) {
   if (features.length === 0) {
     return 'FALSE';
@@ -16,10 +6,10 @@ function getCentrelineFilter(features) {
     ({ centrelineId, centrelineType }) => `(${centrelineType}, ${centrelineId})`,
   );
   const featureIdsStr = featureIds.join(', ');
-  return `(centreline_type, centreline_id) IN (${featureIdsStr})`;
+  return `("centrelineType", "centrelineId") IN (${featureIdsStr})`;
 }
 
-function getStudyFilters(features, studyQuery, categories) {
+function getStudyFilters(features, studyQuery) {
   const centrelineFilter = getCentrelineFilter(features);
   const filters = [centrelineFilter];
   const params = {};
@@ -32,11 +22,11 @@ function getStudyFilters(features, studyQuery, categories) {
   } = studyQuery;
   if (dateRangeStart !== null) {
     params.dateRangeStart = dateRangeStart;
-    filters.push('start_date >= $(dateRangeStart)');
+    filters.push('"startDate" >= $(dateRangeStart)');
   }
   if (dateRangeEnd !== null) {
     params.dateRangeEnd = dateRangeEnd;
-    filters.push('start_date < $(dateRangeEnd)');
+    filters.push('"startDate" < $(dateRangeEnd)');
   }
   if (daysOfWeek.length > 0) {
     params.daysOfWeek = daysOfWeek;
@@ -44,16 +34,11 @@ function getStudyFilters(features, studyQuery, categories) {
   }
   if (hours.length > 0) {
     params.hours = hours;
-    filters.push('hours IN ($(hours:csv))');
+    filters.push('"hours" IN ($(hours:csv))');
   }
   if (studyTypes.length > 0) {
-    const categoryIds = toCategoryIds(studyTypes, categories);
-    if (categoryIds.length === 0) {
-      // TODO: better error handling
-      return { filters, params };
-    }
-    params.categoryIds = categoryIds;
-    filters.push('"CATEGORY_ID" IN ($(categoryIds:csv))');
+    params.studyTypes = studyTypes;
+    filters.push('"studyType" IN ($(studyTypes:csv))');
   }
   return { filters, params };
 }

--- a/lib/io/storage/StoragePath.js
+++ b/lib/io/storage/StoragePath.js
@@ -7,9 +7,7 @@ import {
   ReportExportMode,
   ReportType,
 } from '@/lib/Constants';
-import { mapBy } from '@/lib/MapUtils';
 import ObjectUtils from '@/lib/ObjectUtils';
-import ArteryDAO from '@/lib/db/ArteryDAO';
 import CountDAO from '@/lib/db/CountDAO';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import { InvalidReportExportModeError } from '@/lib/error/MoveErrors';
@@ -56,18 +54,11 @@ class StoragePath {
   /**
    *
    * @param {Object} study
-   * @returns {string}
+   * @returns {Promise<string>}
    */
   static async getDirectionsFromStudy(study) {
-    const [arteries, counts] = await Promise.all([
-      ArteryDAO.byStudy(study),
-      CountDAO.byStudy(study),
-    ]);
-    const arteriesByCode = mapBy(arteries, ({ arteryCode }) => arteryCode);
-    const countDirections = counts.map(({ arteryCode }) => {
-      const artery = arteriesByCode.get(arteryCode);
-      return artery.approachDir;
-    });
+    const counts = await CountDAO.byStudy(study);
+    const countDirections = counts.map(({ direction }) => direction);
     const directions = CardinalDirection.enumValues.filter(
       direction => countDirections.some(countDirection => countDirection === direction),
     );
@@ -88,7 +79,7 @@ class StoragePath {
   /**
    *
    * @param {Object} study
-   * @returns {string}
+   * @returns {Promise<string>}
    */
   static async getLocationFromStudy(study) {
     const location = await CentrelineDAO.byFeature(study);
@@ -114,7 +105,7 @@ class StoragePath {
   /**
    *
    * @param {Object} data
-   * @returns {string}
+   * @returns {Promise<string>}
    */
   static async getLocationsSelection(data) {
     const { s1, selectionType } = data;
@@ -249,7 +240,7 @@ class StoragePath {
   /**
    *
    * @param {Object} report
-   * @returns {StoragePathResponse} storage path for given collision report
+   * @returns {Promise<StoragePathResponse>} storage path for given collision report
    */
   static async forCollisionReport(report) {
     const {
@@ -272,7 +263,7 @@ class StoragePath {
   /**
    *
    * @param {Object} report
-   * @returns {StoragePathResponse} storage path for given study report
+   * @returns {Promise<StoragePathResponse>} storage path for given study report
    */
   static async forStudyReport(report) {
     const {
@@ -307,7 +298,7 @@ class StoragePath {
   /**
    *
    * @param {Object} report
-   * @returns {StoragePathResponse} storage path for given report
+   * @returns {Promise<StoragePathResponse>} storage path for given report
    */
   static async forReport(report) {
     const { type } = report;
@@ -327,7 +318,7 @@ class StoragePath {
    *
    * @param {Object} data
    * @param {Array<StoragePathResponse>} storagePaths
-   * @returns {StoragePathResponse} storage path for given collision report archive
+   * @returns {Promise<StoragePathResponse>} storage path for given collision report archive
    */
   static async forCollisionReportZip(data, storagePaths) {
     const { s1, selectionType } = data;
@@ -342,7 +333,7 @@ class StoragePath {
    *
    * @param {Object} data
    * @param {Array<StoragePathResponse>} storagePaths
-   * @returns {StoragePathResponse} storage path for given study report archive
+   * @returns {Promise<StoragePathResponse>} storage path for given study report archive
    */
   static async forStudyReportZip(data, storagePaths) {
     const { s1, selectionType } = data;
@@ -358,7 +349,7 @@ class StoragePath {
    * @param {Object} data - data provided during job creation
    * @param {Array<StoragePathResponse>} storagePaths - storage paths previously generated via
    * {@link StoragePath.forReport}
-   * @returns {StoragePathResponse} storage path for given report ZIP archive
+   * @returns {Promise<StoragePathResponse>} storage path for given report ZIP archive
    */
   static async forReportZip(data, storagePaths) {
     const { reportExportMode } = data;

--- a/lib/model/Count.js
+++ b/lib/model/Count.js
@@ -1,29 +1,16 @@
-import { CentrelineType, StudyHours } from '@/lib/Constants';
-import Category from '@/lib/model/Category';
+import { CardinalDirection, StudyHours, StudyType } from '@/lib/Constants';
 import Joi from '@/lib/model/Joi';
-import GeoJson from '@/lib/model/helpers/GeoJson';
 
 const COLUMNS = {
   id: Joi.number().integer().positive().required(),
-  arteryCode: Joi.number().integer().positive().required(),
-  stationCode: Joi.string().required(),
-  date: Joi.dateTime().required(),
+  legacy: Joi.boolean().required(),
+  studyType: Joi.enum().ofType(StudyType).required(),
   hours: Joi.enum().ofType(StudyHours).allow(null).required(),
-  duration: Joi
-    .number()
-    .integer()
-    .positive()
-    .allow(null)
-    .required(),
-  type: Category.read,
-  locationDesc: Joi.string().required(),
-  centrelineId: Joi.number().integer().positive().required(),
-  centrelineType: Joi.number().valid(
-    CentrelineType.SEGMENT,
-    CentrelineType.INTERSECTION,
-  ).required(),
+  date: Joi.dateTime().required(),
   notes: Joi.string().allow(null).required(),
-  geom: GeoJson.Point,
+  countLocationId: Joi.number().integer().positive(),
+  direction: Joi.enum().ofType(CardinalDirection).allow(null).required(),
+  extraMetadata: Joi.object().unknown(),
 };
 
 export default {

--- a/lib/model/CountLocation.js
+++ b/lib/model/CountLocation.js
@@ -1,0 +1,19 @@
+import { CentrelineType } from '@/lib/Constants';
+import Joi from '@/lib/model/Joi';
+import { Point } from '@/lib/model/helpers/GeoJson';
+
+const COLUMNS = {
+  id: Joi.number().integer().positive().required(),
+  legacy: Joi.boolean().required(),
+  description: Joi.string().required(),
+  centrelineId: Joi.number().integer().positive().required(),
+  centrelineType: Joi.number().valid(
+    CentrelineType.SEGMENT,
+    CentrelineType.INTERSECTION,
+  ).required(),
+  geom: Point,
+};
+
+export default {
+  read: Joi.object().keys(COLUMNS),
+};

--- a/lib/model/Study.js
+++ b/lib/model/Study.js
@@ -1,5 +1,4 @@
-import { CentrelineType, StudyHours } from '@/lib/Constants';
-import Category from '@/lib/model/Category';
+import { CentrelineType, StudyHours, StudyType } from '@/lib/Constants';
 import Joi from '@/lib/model/Joi';
 import { Point } from '@/lib/model/helpers/GeoJson';
 import TimeFormatters from '@/lib/time/TimeFormatters';
@@ -8,21 +7,22 @@ const DAYS_OF_WEEK_ALL = TimeFormatters.DAYS_OF_WEEK.map((_, i) => i);
 
 export default {
   read: Joi.object().keys({
-    arteryGroupId: Joi.number().integer().positive(),
+    legacy: Joi.boolean().required(),
+    countLocationId: Joi.number().integer().positive(),
+    studyType: Joi.enum().ofType(StudyType).required(),
+    countGroupId: Joi.number().integer().positive(),
+    startDate: Joi.dateTime(),
+    endDate: Joi.dateTime(),
+    duration: Joi.number().integer().multiple(24).allow(null),
+    daysOfWeek: Joi.array().single().items(
+      Joi.number().valid(...DAYS_OF_WEEK_ALL).required(),
+    ).default(null),
+    hours: Joi.enum().ofType(StudyHours).allow(null),
     centrelineId: Joi.number().integer().positive(),
     centrelineType: Joi.number().valid(
       CentrelineType.INTERSECTION,
       CentrelineType.SEGMENT,
     ),
-    countGroupId: Joi.number().integer().positive(),
-    daysOfWeek: Joi.array().single().items(
-      Joi.number().valid(...DAYS_OF_WEEK_ALL).required(),
-    ).default(null),
-    duration: Joi.number().integer().multiple(24).allow(null),
     geom: Point,
-    hours: Joi.enum().ofType(StudyHours).allow(null),
-    endDate: Joi.dateTime(),
-    startDate: Joi.dateTime(),
-    type: Category.read,
   }),
 };

--- a/lib/reports/ReportBaseFlow.js
+++ b/lib/reports/ReportBaseFlow.js
@@ -1,5 +1,5 @@
 /* eslint-disable class-methods-use-this */
-import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import CountLocationDAO from '@/lib/db/CountLocationDAO';
 import StudyDataDAO from '@/lib/db/StudyDataDAO';
 import ReportBase from '@/lib/reports/ReportBase';
 import { parseStudyReportId } from '@/lib/reports/ReportIdParser';
@@ -26,20 +26,32 @@ class ReportBaseFlow extends ReportBase {
     return StudyDataDAO.byStudy(study);
   }
 
-  async generateLayoutHeader(study) {
-    const location = await CentrelineDAO.byFeature(study);
-
-    let info;
-    if (location === null) {
-      /*
-       * Fallback in case this study refers to an old centreline feature that no longer exists.
-       */
-      const { centrelineId, centrelineType } = study;
-      info = `${centrelineType}_${centrelineId}`;
-    } else {
-      info = location.description;
+  static async getCountLocation(study) {
+    const countLocation = await CountLocationDAO.byStudy(study);
+    if (countLocation !== null) {
+      return countLocation;
     }
+    const {
+      centrelineId,
+      centrelineType,
+      countLocationId,
+      geom,
+      legacy,
+    } = study;
+    const [lng, lat] = geom.coordinates;
+    return {
+      id: countLocationId,
+      legacy,
+      description: `${lng.toFixed(6)}, ${lat.toFixed(6)}`,
+      centrelineId,
+      centrelineType,
+      geom,
+    };
+  }
 
+  async generateLayoutHeader(study) {
+    const countLocation = await ReportBaseFlow.getCountLocation(study);
+    const info = countLocation.description;
     const { startDate: start, endDate: end } = study;
     const subinfo = TimeFormatters.formatRangeDate({ start, end });
     return { info, subinfo };

--- a/lib/reports/ReportBaseFlow.js
+++ b/lib/reports/ReportBaseFlow.js
@@ -11,7 +11,7 @@ import TimeFormatters from '@/lib/time/TimeFormatters';
  */
 class ReportBaseFlow extends ReportBase {
   /**
-   * Parses an ID in the format `{categoryId}/{id}`, and returns it as a
+   * Parses an ID in the format `{studyType}/{id}`, and returns it as a
    * {@link Count}.
    *
    * @param {string} rawId - ID to parse

--- a/lib/reports/ReportBaseFlowDirectional.js
+++ b/lib/reports/ReportBaseFlowDirectional.js
@@ -402,7 +402,7 @@ class ReportBaseFlowDirectional extends ReportBaseFlow {
   }
 
   async fetchRawData(study) {
-    const { counts, studyData } = await super.fetchRawData(study);
+    const { countLocation, counts, studyData } = await super.fetchRawData(study);
     if (counts.length === 0) {
       return null;
     }
@@ -417,24 +417,22 @@ class ReportBaseFlowDirectional extends ReportBaseFlow {
      * We start by identifying the segments incident on the intersection under study.
      */
     const { centrelineId, centrelineType } = study;
-    const feature = { centrelineId, centrelineType };
 
-    const tasks = [CentrelineDAO.byFeature(feature)];
-    if (centrelineType === CentrelineType.INTERSECTION) {
-      tasks.push(CentrelineDAO.featuresIncidentTo(centrelineType, centrelineId));
-    }
     /*
      * It is possible to have TMCs along midblocks, but we can't rely on centreline geometry
      * to infer road directions in that case.  As such, to avoid errors from
      * `GeometryUtils.getDirectionCandidatesFrom`, we default to the empty list of incident
      * segments here.
      */
-    const [intersection, segments = []] = await Promise.all(tasks);
+    let segments = [];
+    if (centrelineType === CentrelineType.INTERSECTION) {
+      segments = await CentrelineDAO.featuresIncidentTo(centrelineType, centrelineId);
+    }
 
     return {
       count,
       countData,
-      intersection,
+      intersection: countLocation,
       segments,
     };
   }

--- a/lib/reports/ReportCountSummary24h.js
+++ b/lib/reports/ReportCountSummary24h.js
@@ -246,7 +246,7 @@ class ReportCountSummary24h extends ReportBaseFlow {
         },
         { value: 'Station Code' },
         { value: 'Artery Code' },
-        { value: 'Category' },
+        { value: 'Study Type' },
         { value: 'Count Date', style: { br: true } },
         { value: 'AM Peak' },
         { value: 'AM Peak Hour', style: { br: true } },
@@ -291,7 +291,7 @@ class ReportCountSummary24h extends ReportBaseFlow {
     const {
       stationCode,
       arteryCode,
-      category,
+      studyType,
       date,
       dayOfWeek,
       amPeak: {
@@ -317,7 +317,7 @@ class ReportCountSummary24h extends ReportBaseFlow {
       { value: countLocation.description, style: { br: true } },
       { value: stationCode },
       { value: arteryCode.toString() },
-      { value: category },
+      { value: studyType },
       { value: countDateHuman, style: { br: true } },
       { value: amPeakCount },
       { value: amPeakTimeRangeHuman, style: { br: true } },

--- a/lib/reports/ReportCountSummary24h.js
+++ b/lib/reports/ReportCountSummary24h.js
@@ -33,7 +33,7 @@ class ReportCountSummary24h extends ReportBaseFlow {
     };
   }
 
-  static transformCountData({ artery, count, countData }) {
+  static transformCountData({ count, countData }) {
     const totaledData = sumByTime(countData);
     const n = totaledData.length;
     const total = indexRangeSum(totaledData, { lo: 0, hi: n }, ({ COUNT }) => COUNT);
@@ -68,10 +68,9 @@ class ReportCountSummary24h extends ReportBaseFlow {
     const offPeak = ReportCountSummary24h.sumSection(count, totaledData, indicesOffPeak);
 
     return {
-      location: count.locationDesc,
-      category: count.type.studyType.label,
-      stationCode: artery.stationCode,
-      arteryCode: artery.arteryCode,
+      studyType: count.studyType.label,
+      stationCode: count.extraMetadata.stationCode,
+      arteryCode: count.extraMetadata.arteryCode,
       date: count.date,
       dayOfWeek,
       amPeak,
@@ -102,7 +101,7 @@ class ReportCountSummary24h extends ReportBaseFlow {
     };
   }
 
-  transformData(study, { arteries, counts, studyData }) {
+  transformData(study, { countLocation, counts, studyData }) {
     if (counts.length === 0) {
       return [];
     }
@@ -111,13 +110,11 @@ class ReportCountSummary24h extends ReportBaseFlow {
     CardinalDirection.enumValues.forEach((direction) => {
       let groupCounts = [];
       counts.forEach((count) => {
-        const { arteryCode, id } = count;
-        const artery = arteries.get(arteryCode);
-        if (artery.approachDir !== direction) {
+        if (count.direction !== direction) {
           return;
         }
-        const countData = studyData.get(id);
-        groupCounts.push({ artery, count, countData });
+        const countData = studyData.get(count.id);
+        groupCounts.push({ count, countData });
       });
       if (groupCounts.length > 0) {
         groupCounts = groupCounts.map(ReportCountSummary24h.transformCountData);
@@ -137,17 +134,70 @@ class ReportCountSummary24h extends ReportBaseFlow {
       counts.length,
     );
 
-    const firstArtery = arteries.get(counts[0].arteryCode);
-    return [
+    const sections = [
       {
-        title: firstArtery.street1,
+        title: countLocation.description,
         directionGroups,
         totals,
       },
     ];
+    return { countLocation, sections };
   }
 
-  generateCsv(parsedId, sections) {
+  static generateCsvCountRow(countLocation, titleSection, titleDirectionGroup, count) {
+    const {
+      studyType,
+      stationCode,
+      arteryCode,
+      date,
+      dayOfWeek,
+      amPeak: {
+        sum: amPeakCount,
+        timeRange: {
+          start: amPeakStart,
+          end: amPeakEnd,
+        },
+      },
+      pmPeak: {
+        sum: pmPeakCount,
+        timeRange: {
+          start: pmPeakStart,
+          end: pmPeakEnd,
+        },
+      },
+      offPeak: {
+        sum: offPeakCount,
+        timeRange: {
+          start: offPeakStart,
+          end: offPeakEnd,
+        },
+      },
+      total: totalCount,
+    } = count;
+
+    return {
+      section: titleSection,
+      direction: titleDirectionGroup,
+      location: countLocation.description,
+      date,
+      dayOfWeek,
+      stationCode,
+      arteryCode,
+      studyType,
+      amPeakStart,
+      amPeakEnd,
+      amPeakCount,
+      pmPeakStart,
+      pmPeakEnd,
+      pmPeakCount,
+      offPeakStart,
+      offPeakEnd,
+      offPeakCount,
+      count: totalCount,
+    };
+  }
+
+  generateCsv(parsedId, { countLocation, sections }) {
     const columns = [
       { key: 'section', header: 'Section' },
       { key: 'direction', header: 'Direction' },
@@ -156,7 +206,7 @@ class ReportCountSummary24h extends ReportBaseFlow {
       { key: 'dayOfWeek', header: 'DayOfWeek' },
       { key: 'stationCode', header: 'StationCode' },
       { key: 'arteryCode', header: 'ArteryCode' },
-      { key: 'category', header: 'Category' },
+      { key: 'studyType', header: 'StudyType' },
       { key: 'amPeakStart', header: 'AmPeakStart' },
       { key: 'amPeakEnd', header: 'AmPeakEnd' },
       { key: 'amPeakCount', header: 'AmPeakCount' },
@@ -169,59 +219,16 @@ class ReportCountSummary24h extends ReportBaseFlow {
       { key: 'count', header: 'Count' },
     ];
     const rows = [];
-    sections.forEach(({ title: section, directionGroups }) => {
-      directionGroups.forEach(({ title: direction, counts }) => {
-        counts.forEach(({
-          location,
-          date,
-          dayOfWeek,
-          stationCode,
-          arteryCode,
-          category,
-          amPeak: {
-            sum: amPeakCount,
-            timeRange: {
-              start: amPeakStart,
-              end: amPeakEnd,
-            },
-          },
-          pmPeak: {
-            sum: pmPeakCount,
-            timeRange: {
-              start: pmPeakStart,
-              end: pmPeakEnd,
-            },
-          },
-          offPeak: {
-            sum: offPeakCount,
-            timeRange: {
-              start: offPeakStart,
-              end: offPeakEnd,
-            },
-          },
-          total: count,
-        }) => {
-          const row = {
-            section,
-            direction,
-            location,
-            date,
-            dayOfWeek,
-            stationCode,
-            arteryCode,
-            category,
-            amPeakStart,
-            amPeakEnd,
-            amPeakCount,
-            pmPeakStart,
-            pmPeakEnd,
-            pmPeakCount,
-            offPeakStart,
-            offPeakEnd,
-            offPeakCount,
+    sections.forEach(({ directionGroups, title: titleSection }) => {
+      directionGroups.forEach(({ counts, title: titleDirectionGroup }) => {
+        counts.forEach((count) => {
+          const rowCount = ReportCountSummary24h.generateCsvCountRow(
+            countLocation,
+            titleSection,
+            titleDirectionGroup,
             count,
-          };
-          rows.push(row);
+          );
+          rows.push(rowCount);
         });
       });
     });
@@ -280,34 +287,34 @@ class ReportCountSummary24h extends ReportBaseFlow {
     ];
   }
 
-  static getCountRow({
-    location,
-    stationCode,
-    arteryCode,
-    category,
-    date,
-    dayOfWeek,
-    amPeak: {
-      sum: amPeakCount,
-      timeRange: amPeakTimeRange,
-    },
-    pmPeak: {
-      sum: pmPeakCount,
-      timeRange: pmPeakTimeRange,
-    },
-    offPeak: {
-      sum: offPeakCount,
-      timeRange: offPeakTimeRange,
-    },
-    total,
-  }) {
+  static getCountRow(countLocation, count) {
+    const {
+      stationCode,
+      arteryCode,
+      category,
+      date,
+      dayOfWeek,
+      amPeak: {
+        sum: amPeakCount,
+        timeRange: amPeakTimeRange,
+      },
+      pmPeak: {
+        sum: pmPeakCount,
+        timeRange: pmPeakTimeRange,
+      },
+      offPeak: {
+        sum: offPeakCount,
+        timeRange: offPeakTimeRange,
+      },
+      total,
+    } = count;
     const dateHuman = TimeFormatters.formatDefault(date);
     const countDateHuman = `${dateHuman} (${dayOfWeek})`;
     const amPeakTimeRangeHuman = TimeFormatters.formatRangeTimeOfDay(amPeakTimeRange);
     const pmPeakTimeRangeHuman = TimeFormatters.formatRangeTimeOfDay(pmPeakTimeRange);
     const offPeakTimeRangeHuman = TimeFormatters.formatRangeTimeOfDay(offPeakTimeRange);
     return [
-      { value: location, style: { br: true } },
+      { value: countLocation.description, style: { br: true } },
       { value: stationCode },
       { value: arteryCode.toString() },
       { value: category },
@@ -322,24 +329,26 @@ class ReportCountSummary24h extends ReportBaseFlow {
     ];
   }
 
-  static getDirectionGroupRows({
-    title: directionGroupTitle,
-    counts,
-    totals: {
-      sum: {
-        amPeak: sumAmPeak,
-        pmPeak: sumPmPeak,
-        offPeak: sumOffPeak,
-        total: sumTotal,
+  static getDirectionGroupRows(countLocation, directionGroup) {
+    const {
+      title: directionGroupTitle,
+      counts,
+      totals: {
+        sum: {
+          amPeak: sumAmPeak,
+          pmPeak: sumPmPeak,
+          offPeak: sumOffPeak,
+          total: sumTotal,
+        },
+        avg: {
+          amPeak: avgAmPeak,
+          pmPeak: avgPmPeak,
+          offPeak: avgOffPeak,
+          total: avgTotal,
+        },
       },
-      avg: {
-        amPeak: avgAmPeak,
-        pmPeak: avgPmPeak,
-        offPeak: avgOffPeak,
-        total: avgTotal,
-      },
-    },
-  }) {
+    } = directionGroup;
+
     const headerRow = [
       {
         value: directionGroupTitle,
@@ -384,34 +393,38 @@ class ReportCountSummary24h extends ReportBaseFlow {
     ];
     return [
       headerRow,
-      ...counts.map(ReportCountSummary24h.getCountRow),
+      ...counts.map(count => ReportCountSummary24h.getCountRow(countLocation, count)),
       ...footerRows,
     ];
   }
 
-  static getSectionLayout({
-    title: sectionTitle,
-    directionGroups,
-    totals,
-  }) {
+  static getSectionLayout(countLocation, section) {
+    const {
+      title: sectionTitle,
+      directionGroups,
+      totals,
+    } = section;
     const header = ReportCountSummary24h.getSectionHeader(sectionTitle);
     const body = Array.prototype.concat.apply(
       [],
-      directionGroups.map(ReportCountSummary24h.getDirectionGroupRows),
+      directionGroups.map(directionGroup => ReportCountSummary24h.getDirectionGroupRows(
+        countLocation,
+        directionGroup,
+      )),
     );
     const footer = ReportCountSummary24h.getSectionFooter(sectionTitle, totals);
     return { header, body, footer };
   }
 
-  static getTableBlocks(reportData) {
-    return reportData.map((section) => {
-      const options = ReportCountSummary24h.getSectionLayout(section);
+  static getTableBlocks({ countLocation, sections }) {
+    return sections.map((section) => {
+      const options = ReportCountSummary24h.getSectionLayout(countLocation, section);
       return { type: ReportBlock.TABLE, options };
     });
   }
 
-  generateLayoutContent(study, rawData) {
-    return ReportCountSummary24h.getTableBlocks(rawData);
+  generateLayoutContent(study, transformedData) {
+    return ReportCountSummary24h.getTableBlocks(transformedData);
   }
 }
 

--- a/lib/reports/ReportCountSummary24hDetailed.js
+++ b/lib/reports/ReportCountSummary24hDetailed.js
@@ -23,11 +23,9 @@ class ReportCountSummary24hDetailed extends ReportBaseFlow {
     });
   }
 
-  transformData(study, { arteries, counts, studyData }) {
+  transformData(study, { counts, studyData }) {
     return counts.map((count) => {
-      const { arteryCode, date, id } = count;
-      const artery = arteries.get(arteryCode);
-      const direction = artery.approachDir;
+      const { date, direction, id } = count;
       const countData = studyData.get(id);
 
       const totaledData = ReportCountSummary24hDetailed.transformCountData(count, countData);

--- a/lib/reports/ReportCountSummary24hGraphical.js
+++ b/lib/reports/ReportCountSummary24hGraphical.js
@@ -24,11 +24,9 @@ class ReportCountSummary24hGraphical extends ReportBaseFlow {
     return volumeByHour;
   }
 
-  transformData(study, { arteries, counts, studyData }) {
+  transformData(study, { counts, studyData }) {
     return counts.map((count) => {
-      const { arteryCode, date, id } = count;
-      const artery = arteries.get(arteryCode);
-      const direction = artery.approachDir;
+      const { date, direction, id } = count;
       const countData = studyData.get(id);
 
       const volumeByHour = ReportCountSummary24hGraphical.getVolumeByHour(countData);

--- a/lib/reports/ReportCountSummaryTurningMovement.js
+++ b/lib/reports/ReportCountSummaryTurningMovement.js
@@ -161,11 +161,12 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
     };
   }
 
-  static getTrafficSignalId({ locationDesc = null }) {
-    if (locationDesc === null) {
+  static getTrafficSignalId(countLocation) {
+    if (countLocation === null) {
       return null;
     }
-    const match = REGEX_PX.exec(locationDesc);
+    const { description } = countLocation;
+    const match = REGEX_PX.exec(description);
     if (match === null) {
       return null;
     }
@@ -176,13 +177,13 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
     return px;
   }
 
-  transformData(study, { counts, studyData }) {
+  transformData(study, { countLocation, counts, studyData }) {
     if (counts.length === 0) {
       return [];
     }
     const [count] = counts;
     const { date, hours, id } = count;
-    const px = ReportCountSummaryTurningMovement.getTrafficSignalId(count);
+    const px = ReportCountSummaryTurningMovement.getTrafficSignalId(countLocation);
     const countData = studyData.get(id);
     const stats = ReportCountSummaryTurningMovement.transformCountData(countData);
 

--- a/lib/reports/ReportCountSummaryTurningMovementDetailed.js
+++ b/lib/reports/ReportCountSummaryTurningMovementDetailed.js
@@ -16,13 +16,13 @@ class ReportCountSummaryTurningMovementDetailed extends ReportBaseFlow {
     return ReportType.COUNT_SUMMARY_TURNING_MOVEMENT_DETAILED;
   }
 
-  transformData(study, { counts, studyData }) {
+  transformData(study, { countLocation, counts, studyData }) {
     if (counts.length === 0) {
       return [];
     }
     const [count] = counts;
     const { date, hours, id } = count;
-    const px = ReportCountSummaryTurningMovement.getTrafficSignalId(count);
+    const px = ReportCountSummaryTurningMovement.getTrafficSignalId(countLocation);
     const countData = studyData.get(id);
 
     const rawData = countData.map(({ data }) => data);

--- a/lib/reports/ReportFactory.js
+++ b/lib/reports/ReportFactory.js
@@ -9,6 +9,7 @@ import ReportCountSummaryTurningMovementDetailed
   from '@/lib/reports/ReportCountSummaryTurningMovementDetailed';
 import ReportIntersectionSummary from '@/lib/reports/ReportIntersectionSummary';
 import ReportPeakHourFactor from '@/lib/reports/ReportPeakHourFactor';
+import ReportPedDelaySummary from '@/lib/reports/ReportPedDelaySummary';
 import ReportSpeedPercentile from '@/lib/reports/ReportSpeedPercentile';
 import ReportTrackRequests from '@/lib/reports/ReportTrackRequests';
 import ReportTrackRequestsSelected from '@/lib/reports/ReportTrackRequestsSelected';
@@ -64,6 +65,7 @@ ReportFactory.registerInstance(new ReportCountSummaryTurningMovement());
 ReportFactory.registerInstance(new ReportCountSummaryTurningMovementDetailed());
 ReportFactory.registerInstance(new ReportIntersectionSummary());
 ReportFactory.registerInstance(new ReportPeakHourFactor());
+ReportFactory.registerInstance(new ReportPedDelaySummary());
 ReportFactory.registerInstance(new ReportSpeedPercentile());
 ReportFactory.registerInstance(new ReportTrackRequests());
 ReportFactory.registerInstance(new ReportTrackRequestsSelected());

--- a/lib/reports/ReportIdParser.js
+++ b/lib/reports/ReportIdParser.js
@@ -14,7 +14,7 @@ import CompositeId from '@/lib/io/CompositeId';
 async function parseCollisionReportId(rawId) {
   const parts = rawId.split('/');
   if (parts.length !== 2) {
-    throw new InvalidReportIdError(rawId);
+    throw new InvalidReportIdError(`invalid number of parts: ${rawId}`);
   }
 
   const s1 = parts.shift();
@@ -23,7 +23,7 @@ async function parseCollisionReportId(rawId) {
     features = CompositeId.decode(s1);
   } catch (err) {
     if (err instanceof InvalidCompositeIdError) {
-      throw new InvalidReportIdError(rawId);
+      throw new InvalidReportIdError(`invalid s1: ${rawId}`);
     }
     throw err;
   }
@@ -34,7 +34,7 @@ async function parseCollisionReportId(rawId) {
     selectionType = LocationSelectionType.enumValueOf(selectionTypeStr);
   } catch (err) {
     if (err instanceof EnumValueError) {
-      throw new InvalidReportIdError(rawId);
+      throw new InvalidReportIdError(`invalid selectionType: ${rawId}`);
     }
     throw err;
   }
@@ -48,7 +48,7 @@ async function parseCollisionReportId(rawId) {
     features = await FeatureResolver.byFeaturesSelection(featuresSelection);
   } catch (err) {
     if (err instanceof InvalidFeaturesSelectionError) {
-      throw new InvalidReportIdError(rawId);
+      throw new InvalidReportIdError(`could not route location selection: ${rawId}`);
     }
     throw err;
   }
@@ -61,56 +61,45 @@ async function parseCollisionReportId(rawId) {
   };
 }
 
-async function parseStudyReportId(type, rawId) {
+async function parseStudyReportId(reportType, rawId) {
   const parts = rawId.split('/');
   if (parts.length !== 2) {
-    throw new InvalidReportIdError(rawId);
+    throw new InvalidReportIdError(`invalid number of parts: ${rawId}`);
   }
 
-  let categoryId = parts.shift();
-  categoryId = parseInt(categoryId, 10);
-  if (Number.isNaN(categoryId)) {
-    throw new InvalidReportIdError(rawId);
+  const studyTypeName = parts.shift();
+  let studyType;
+  try {
+    studyType = StudyType.enumValueOf(studyTypeName);
+  } catch (err) {
+    if (err instanceof EnumValueError) {
+      throw new InvalidReportIdError(`invalid studyType: ${rawId}`);
+    }
+    throw err;
   }
 
   let countGroupId = parts.shift();
   countGroupId = parseInt(countGroupId, 10);
   if (Number.isNaN(countGroupId)) {
-    throw new InvalidReportIdError(rawId);
+    throw new InvalidReportIdError(`invalid countGroupId: ${rawId}`);
   }
 
-  const study = await StudyDAO.byCategoryAndCountGroup(categoryId, countGroupId);
+  const study = await StudyDAO.byStudyTypeAndCountGroup(studyType, countGroupId);
   if (study === null) {
-    throw new InvalidReportIdError(rawId);
+    throw new InvalidReportIdError(`study does not exist: ${rawId}`);
   }
-  const { studyType } = study.type;
-  const { speedRelated, tmcRelated } = type;
-  if (speedRelated) {
+  if (study.studyType !== studyType) {
+    throw new InvalidReportIdError(`study type mismatch: ${rawId}`);
+  }
+  if (!study.studyType.reportTypes.includes(reportType)) {
     /*
-     * Speed reports MUST have speed data, as the speed class calculations depend on it.
-     * Without that, many of those calculations will return `NaN`.
+     * Check if the report type is actually compatible with the given study.
      */
-    if (studyType !== StudyType.ATR_SPEED_VOLUME) {
-      throw new InvalidReportIdError(rawId);
-    }
-  } else if (tmcRelated) {
-    /*
-     * TMC reports MUST have TMC data, as the various turning movement totals depend on it.
-     * Without that, many of those calculations will return `NaN`.
-     */
-    if (studyType !== StudyType.TMC) {
-      throw new InvalidReportIdError(rawId);
-    }
-  } else if (studyType === StudyType.TMC) {
-    /*
-     * Other reports MUST NOT have TMC data, as they expect data in the volume-data format
-     * in `"TRAFFIC"."CNT_DET"`.
-     */
-    throw new InvalidReportIdError(rawId);
+    throw new InvalidReportIdError(`report not available for study: ${rawId}`);
   }
   return {
-    categoryId,
     countGroupId,
+    studyType,
     study,
   };
 }

--- a/lib/reports/ReportIntersectionSummary.js
+++ b/lib/reports/ReportIntersectionSummary.js
@@ -197,7 +197,7 @@ class ReportIntersectionSummary extends ReportBaseFlowDirectional {
     const totalsRounded = ReportIntersectionSummary.getRoundedTotals(hourlyTotals);
 
     const { date, hours } = count;
-    const px = ReportCountSummaryTurningMovement.getTrafficSignalId(count);
+    const px = ReportCountSummaryTurningMovement.getTrafficSignalId(intersection);
     return {
       date,
       hours,

--- a/lib/reports/ReportPeakHourFactor.js
+++ b/lib/reports/ReportPeakHourFactor.js
@@ -96,13 +96,13 @@ class ReportPeakHourFactor extends ReportBaseFlow {
     return peakData;
   }
 
-  transformData(study, { counts, studyData }) {
+  transformData(study, { countLocation, counts, studyData }) {
     if (counts.length === 0) {
       return [];
     }
     const [count] = counts;
     const { date, hours, id } = count;
-    const px = ReportCountSummaryTurningMovement.getTrafficSignalId(count);
+    const px = ReportCountSummaryTurningMovement.getTrafficSignalId(countLocation);
     const countData = studyData.get(id);
 
     const totaledData = ReportBaseFlowDirectional.computeAllMovementAndVehicleTotals(

--- a/lib/reports/ReportPedDelaySummary.js
+++ b/lib/reports/ReportPedDelaySummary.js
@@ -58,18 +58,38 @@ class ReportPedDelaySummary extends ReportBaseFlow {
   }
 
   static computePedDelayTotals(rawData) {
-    const data = {};
-    let total = 0;
+    const data = {
+      crossings: rawData.crossings,
+      total: 0,
+      total_f: 0,
+    };
+    PedDelay.enumValues.forEach((pedDelay) => {
+      const keyDelay = pedDelay.short;
+      data[keyDelay] = 0;
+
+      const keyDelayFactored = `${keyDelay}_f`;
+      data[keyDelayFactored] = 0;
+    });
     PedClass.enumValues.forEach((pedClass) => {
       PedDelay.enumValues.forEach((pedDelay) => {
         const key = `${pedClass.short}_${pedDelay.short}`;
         const value = rawData[key];
         data[key] = value;
-        total += value;
+
+        const keyFactored = `${key}_f`;
+        const valueFactored = value * pedClass.factor;
+        data[keyFactored] = valueFactored;
+
+        const keyDelay = pedDelay.short;
+        data[keyDelay] += value;
+
+        const keyDelayFactored = `${keyDelay}_f`;
+        data[keyDelayFactored] += valueFactored;
+
+        data.total += value;
+        data.total_f += valueFactored;
       });
     });
-    data.crossings = rawData.crossings;
-    data.total = total;
     return data;
   }
 
@@ -78,6 +98,13 @@ class ReportPedDelaySummary extends ReportBaseFlow {
       const data = ReportPedDelaySummary.computePedDelayTotals(rawData);
       return { t, data };
     });
+  }
+
+  static computePercentSafe(a, b) {
+    if (b === 0) {
+      return 0;
+    }
+    return 100 * a / b;
   }
 
   static transformCountData(countData) {
@@ -89,6 +116,31 @@ class ReportPedDelaySummary extends ReportBaseFlow {
       return { label, rows, totals };
     });
     const totals = ArrayUtils.sumObjects(zones.map(zone => zone.totals));
+
+    /*
+     * After computing actual and factored totals, we then calculate the share of
+     * non-delayed vs. delayed pedestrians.
+     */
+    zones.forEach((zone) => {
+      const { totals: zoneTotals } = zone;
+      zoneTotals.nd_f_pct = ReportPedDelaySummary.computePercentSafe(
+        zoneTotals.nd_f,
+        zoneTotals.total_f,
+      );
+      zoneTotals.d_f_pct = ReportPedDelaySummary.computePercentSafe(
+        zoneTotals.d_f,
+        zoneTotals.total_f,
+      );
+    });
+    totals.nd_f_pct = ReportPedDelaySummary.computePercentSafe(
+      totals.nd_f,
+      totals.total_f,
+    );
+    totals.d_f_pct = ReportPedDelaySummary.computePercentSafe(
+      totals.d_f,
+      totals.total_f,
+    );
+
     return { totals, zones };
   }
 
@@ -116,30 +168,215 @@ class ReportPedDelaySummary extends ReportBaseFlow {
 
   // CSV GENERATION
 
-  generateCsv(/* study, transformedData */) {
+  static generateCsvZoneRow(zone, row) {
+    const { label } = zone;
+    const { t, data } = row;
+    return {
+      zone: label,
+      start: t,
+      end: t.plus({ minutes: 15 }),
+      ...data,
+    };
+  }
+
+  generateCsv(study, { stats }) {
     const columns = [
       { key: 'zone', header: 'Zone' },
       { key: 'start', header: 'Start' },
       { key: 'end', header: 'End' },
-      { key: 'ac_d', header: 'Assisted Children <=10 sec' },
-      { key: 'ac_nd', header: 'Assisted Children >10 sec' },
-      { key: 'uc_d', header: 'Unassisted Children <=10 sec' },
-      { key: 'uc_nd', header: 'Unassisted Children >10 sec' },
-      { key: 'ya_d', header: 'Youth and Adults <=10 sec' },
-      { key: 'ya_nd', header: 'Youth and Adults >10 sec' },
-      { key: 'sc_d', header: 'Senior Citizens <=10 sec' },
-      { key: 'sc_nd', header: 'Senior Citizens >10 sec' },
-      { key: 'pwd_d', header: 'Persons with Disabilities <=10 sec' },
-      { key: 'pwd_nd', header: 'Persons with Disabilities >10 sec' },
+      ...Array.prototype.concat.apply([], PedClass.enumValues.map(
+        pedClass => PedDelay.enumValues.map(
+          pedDelay => ({
+            key: `${pedClass.short}_${pedDelay.short}`,
+            header: `${pedClass.description} ${pedDelay.description}`,
+          }),
+        ),
+      )),
       { key: 'total', header: 'Total Pedestrians' },
       { key: 'crossings', header: 'Number of Crossings' },
     ];
-    // TODO: implement this
-    const rows = [];
+    const rows = Array.prototype.concat.apply([], stats.zones.map(
+      zone => zone.rows.map(
+        row => ReportPedDelaySummary.generateCsvZoneRow(zone, row),
+      ),
+    ));
     return { columns, rows };
   }
 
   // PDF GENERATION
+
+  static getFactoredSummaryTableRow(label, row, style) {
+    return [
+      { value: label, header: true, style: { br: true, ...style } },
+      { value: row.nd_f, style },
+      { value: row.nd_f_pct.toFixed(2), style: { br: true, ...style } },
+      { value: row.d_f, style },
+      { value: row.d_f_pct.toFixed(2), style: { br: true, ...style } },
+      { value: row.total_f, style },
+    ];
+  }
+
+  static getFactoredSummaryTableOptions(stats) {
+    return {
+      autoWidthTable: true,
+      title: 'Factored Summary',
+      columnStyles: [
+        { c: 0, style: { width: '3xl' } },
+        { c: 1, style: { width: '3xl' } },
+        { c: 2, style: { width: '3xl' } },
+        { c: 3, style: { width: '3xl' } },
+        { c: 4, style: { width: '3xl' } },
+        { c: 5, style: { width: '3xl' } },
+      ],
+      header: [
+        [
+          { value: null, style: { br: true, bold: true } },
+          { value: `Delay ${PedDelay.NOT_DELAYED.description}` },
+          { value: 'Percent of Total', style: { br: true } },
+          { value: `Delay ${PedDelay.DELAYED.description}` },
+          { value: 'Percent of Total', style: { br: true } },
+          { value: 'Combined Totals' },
+        ],
+      ],
+      body: [
+        ...stats.zones.map(
+          (zone, i) => ReportPedDelaySummary.getFactoredSummaryTableRow(
+            `Zone ${zone.label}`,
+            zone.totals,
+            { shade: i % 2 === 1 },
+          ),
+        ),
+        ReportPedDelaySummary.getFactoredSummaryTableRow(
+          'All Zones',
+          stats.totals,
+          { bt: true },
+        ),
+      ],
+    };
+  }
+
+  static getFirstZoneTableOptions(stats) {
+    // TODO: implement this
+    return ReportPedDelaySummary.getZoneTableOptions(stats.zones[0]);
+  }
+
+  static getZoneTableRow(label, data, style) {
+    return [
+      { value: label, header: true, style: { br: true, ...style } },
+      ...Array.prototype.concat.apply([], PedClass.enumValues.map(
+        pedClass => PedDelay.enumValues.map((pedDelay, j) => {
+          const key = `${pedClass.short}_${pedDelay.short}`;
+          return {
+            value: data[key],
+            style: { br: j === PedDelay.enumValues.length - 1, ...style },
+          };
+        }),
+      )),
+      { value: data.total, style: { br: true, ...style } },
+      { value: data.crossings, style },
+    ];
+  }
+
+  static getZoneTableRowFactored(label, data, style) {
+    return [
+      { value: label, header: true, style: { br: true, ...style } },
+      ...Array.prototype.concat.apply([], PedClass.enumValues.map(
+        pedClass => PedDelay.enumValues.map((pedDelay, j) => {
+          const key = `${pedClass.short}_${pedDelay.short}_f`;
+          return {
+            value: data[key],
+            style: { br: j === PedDelay.enumValues.length - 1, ...style },
+          };
+        }),
+      )),
+      { value: data.total_f, style: { br: true, ...style } },
+      { value: data.crossings, style },
+    ];
+  }
+
+  static getZoneTableDataRow(row, i) {
+    const { t, data } = row;
+    const start = t;
+    const end = t.plus({ minutes: ReportBaseFlow.MINUTES_PER_ROW });
+    const timeRange = { start, end };
+    const timeRangeHuman = TimeFormatters.formatRangeTimeOfDay(timeRange);
+    return ReportPedDelaySummary.getZoneTableRow(
+      timeRangeHuman,
+      data,
+      { shade: i % 2 === 1 },
+    );
+  }
+
+  static getZoneTableTotalsRows(zone) {
+    const n = zone.rows.length;
+    return [
+      ReportPedDelaySummary.getZoneTableRow(
+        'Actual Totals',
+        zone.totals,
+        { bt: true, shade: n % 2 === 1 },
+      ),
+      ReportPedDelaySummary.getZoneTableRowFactored(
+        'Factored Totals',
+        zone.totals,
+        { shade: n % 2 === 0 },
+      ),
+    ];
+  }
+
+  static getZoneTableOptions(zone) {
+    return {
+      autoWidthTable: true,
+      title: `Zone ${zone.label}`,
+      columnStyles: [
+        { c: 0, style: { width: '3xl' } },
+        { c: 1, style: { width: '2xl' } },
+        { c: 2, style: { width: '2xl' } },
+        { c: 3, style: { width: '2xl' } },
+        { c: 4, style: { width: '2xl' } },
+        { c: 5, style: { width: '2xl' } },
+        { c: 6, style: { width: '2xl' } },
+        { c: 7, style: { width: '2xl' } },
+        { c: 8, style: { width: '2xl' } },
+        { c: 9, style: { width: '2xl' } },
+        { c: 10, style: { width: '2xl' } },
+        { c: 11, style: { width: '3xl' } },
+        { c: 12, style: { width: '3xl' } },
+      ],
+      header: [
+        [
+          { value: null, rowspan: 2, style: { br: true } },
+          { value: 'Pedestrian Types', colspan: 10, style: { bb: true, br: true } },
+          { value: 'Total Pedestrians', rowspan: 3, style: { br: true } },
+          { value: 'Number of Crossings', rowspan: 3 },
+        ],
+        [
+          // rowspan: 2
+          ...PedClass.enumValues.map(
+            pedClass => ({ value: pedClass.description, colspan: 2, style: { br: true } }),
+          ),
+          // rowspan: 3
+          // rowspan: 3
+        ],
+        [
+          { value: 'Time Period', style: { br: true } },
+          ...Array.prototype.concat.apply([], PedClass.enumValues.map(
+            () => PedDelay.enumValues.map(
+              (pedDelay, i) => ({
+                value: pedDelay.description,
+                style: { br: i === PedDelay.enumValues.length - 1 },
+              }),
+            ),
+          )),
+          // rowspan: 3
+          // rowspan: 3
+        ],
+      ],
+      body: [
+        ...zone.rows.map(ReportPedDelaySummary.getZoneTableDataRow),
+        ...ReportPedDelaySummary.getZoneTableTotalsRows(zone),
+      ],
+    };
+  }
 
   static getCountMetadataOptions({
     date,
@@ -170,8 +407,16 @@ class ReportPedDelaySummary extends ReportBaseFlow {
 
   generateLayoutContent(study, reportData) {
     const countMetadataOptions = ReportPedDelaySummary.getCountMetadataOptions(reportData);
+    const { stats } = reportData;
+    const factoredSummaryTableOptions = ReportPedDelaySummary
+      .getFactoredSummaryTableOptions(stats);
+    const firstZoneTableOptions = ReportPedDelaySummary.getFirstZoneTableOptions(stats);
+    const zoneTablesOptions = stats.zones.slice(1).map(ReportPedDelaySummary.getZoneTableOptions);
     return [
       { type: ReportBlock.METADATA, options: countMetadataOptions },
+      { type: ReportBlock.TABLE, options: factoredSummaryTableOptions },
+      { type: ReportBlock.TABLE, options: firstZoneTableOptions },
+      ...zoneTablesOptions.map(options => ({ type: ReportBlock.TABLE, options })),
     ];
   }
 }

--- a/lib/reports/ReportPedDelaySummary.js
+++ b/lib/reports/ReportPedDelaySummary.js
@@ -141,7 +141,19 @@ class ReportPedDelaySummary extends ReportBaseFlow {
       totals.total_f,
     );
 
-    return { totals, zones };
+    /*
+     * Finally, we compute per-time-bucket totals, assuming that all zones have the same time
+     * buckets for data collection.
+     */
+    const n = zones[0].rows.length;
+    const byTime = new Array(n).fill(0);
+    zones.forEach(({ rows }) => {
+      rows.slice(0, n).forEach(({ data }, i) => {
+        byTime[i] += data.total;
+      });
+    });
+
+    return { byTime, totals, zones };
   }
 
   transformData(study, { counts, studyData }) {
@@ -192,7 +204,7 @@ class ReportPedDelaySummary extends ReportBaseFlow {
           }),
         ),
       )),
-      { key: 'total', header: 'Total Pedestrians' },
+      { key: 'total', header: 'Total Peds' },
       { key: 'crossings', header: 'Number of Crossings' },
     ];
     const rows = Array.prototype.concat.apply([], stats.zones.map(
@@ -256,8 +268,32 @@ class ReportPedDelaySummary extends ReportBaseFlow {
   }
 
   static getFirstZoneTableOptions(stats) {
-    // TODO: implement this
-    return ReportPedDelaySummary.getZoneTableOptions(stats.zones[0]);
+    const tableOptions = ReportPedDelaySummary.getZoneTableOptions(stats.zones[0]);
+
+    tableOptions.columnStyles.push({ c: 13, style: { width: '3xl' } });
+
+    tableOptions.header[0].push({
+      value: 'Total Peds: All Zones',
+      rowspan: 3,
+      style: { bl: true },
+    });
+
+    stats.byTime.forEach((value, i) => {
+      const shade = i % 2 === 1;
+      tableOptions.body[i].push({ value, style: { bl: true, shade } });
+    });
+
+    const n = stats.zones[0].rows.length;
+    tableOptions.body[n].push({
+      value: stats.totals.total,
+      style: { bl: true, bt: true, shade: n % 2 === 1 },
+    });
+    tableOptions.body[n + 1].push({
+      value: stats.totals.total_f,
+      style: { bl: true, shade: n % 2 === 0 },
+    });
+
+    return tableOptions;
   }
 
   static getZoneTableRow(label, data, style) {
@@ -327,26 +363,17 @@ class ReportPedDelaySummary extends ReportBaseFlow {
     return {
       autoWidthTable: true,
       title: `Zone ${zone.label}`,
+      tableStyle: { fontSize: '2xs' },
       columnStyles: [
         { c: 0, style: { width: '3xl' } },
-        { c: 1, style: { width: '2xl' } },
-        { c: 2, style: { width: '2xl' } },
-        { c: 3, style: { width: '2xl' } },
-        { c: 4, style: { width: '2xl' } },
-        { c: 5, style: { width: '2xl' } },
-        { c: 6, style: { width: '2xl' } },
-        { c: 7, style: { width: '2xl' } },
-        { c: 8, style: { width: '2xl' } },
-        { c: 9, style: { width: '2xl' } },
-        { c: 10, style: { width: '2xl' } },
-        { c: 11, style: { width: '3xl' } },
-        { c: 12, style: { width: '3xl' } },
+        { c: 11, style: { width: '2xl' } },
+        { c: 12, style: { width: '2xl' } },
       ],
       header: [
         [
           { value: null, rowspan: 2, style: { br: true } },
-          { value: 'Pedestrian Types', colspan: 10, style: { bb: true, br: true } },
-          { value: 'Total Pedestrians', rowspan: 3, style: { br: true } },
+          { value: 'Ped Types', colspan: 10, style: { bb: true, br: true } },
+          { value: 'Total Peds', rowspan: 3, style: { br: true } },
           { value: 'Number of Crossings', rowspan: 3 },
         ],
         [
@@ -415,8 +442,12 @@ class ReportPedDelaySummary extends ReportBaseFlow {
     return [
       { type: ReportBlock.METADATA, options: countMetadataOptions },
       { type: ReportBlock.TABLE, options: factoredSummaryTableOptions },
+      { type: ReportBlock.PAGE_BREAK, options: {} },
       { type: ReportBlock.TABLE, options: firstZoneTableOptions },
-      ...zoneTablesOptions.map(options => ({ type: ReportBlock.TABLE, options })),
+      ...Array.prototype.concat.apply([], zoneTablesOptions.map(options => [
+        { type: ReportBlock.PAGE_BREAK, options: {} },
+        ({ type: ReportBlock.TABLE, options }),
+      ])),
     ];
   }
 }

--- a/lib/reports/ReportPedDelaySummary.js
+++ b/lib/reports/ReportPedDelaySummary.js
@@ -1,0 +1,91 @@
+/* eslint-disable class-methods-use-this */
+import { ReportBlock, ReportType } from '@/lib/Constants';
+import ReportBaseFlow from '@/lib/reports/ReportBaseFlow';
+import TimeFormatters from '@/lib/time/TimeFormatters';
+
+/**
+ * Subclass of {@link ReportBaseFlow} for the Pedestrian Delay Summary Report.
+ *
+ * @see https://www.notion.so/bditto/Feature-Ped-Delays-781abf0b60c446b4a41e14d5e072dda9
+ * @see https://www.figma.com/file/j4jDx0GDT5OZ3udmOVHZmO/(DC)-Ped-Delay-Summary-Report
+ */
+class ReportPedDelaySummary extends ReportBaseFlow {
+  type() {
+    return ReportType.PED_DELAY_SUMMARY;
+  }
+
+  transformData(study, { counts, studyData }) {
+    if (counts.length === 0) {
+      return [];
+    }
+    const [count] = counts;
+    const {
+      date,
+      extraMetadata: { weather },
+      hours,
+      id,
+    } = count;
+    const countData = studyData.get(id);
+    // TODO: actually transform data
+
+    return {
+      date,
+      hours,
+      countData,
+      weather,
+    };
+  }
+
+  // CSV GENERATION
+
+  generateCsv(/* study, transformedData */) {
+    const columns = [
+      { key: 'zone', header: 'Zone' },
+      { key: 'start', header: 'Start' },
+      { key: 'end', header: 'End' },
+      { key: 'ac_d', header: 'Assisted Children <=10 sec' },
+      { key: 'ac_nd', header: 'Assisted Children >10 sec' },
+      { key: 'uc_d', header: 'Unassisted Children <=10 sec' },
+      { key: 'uc_nd', header: 'Unassisted Children >10 sec' },
+      { key: 'ya_d', header: 'Youth and Adults <=10 sec' },
+      { key: 'ya_nd', header: 'Youth and Adults >10 sec' },
+      { key: 'sc_d', header: 'Senior Citizens <=10 sec' },
+      { key: 'sc_nd', header: 'Senior Citizens >10 sec' },
+      { key: 'pwd_d', header: 'Persons with Disabilities <=10 sec' },
+      { key: 'pwd_nd', header: 'Persons with Disabilities >10 sec' },
+      { key: 'total', header: 'Total Pedestrians' },
+      { key: 'crossings', header: 'Number of Crossings' },
+    ];
+    // TODO: implement this
+    const rows = [];
+    return { columns, rows };
+  }
+
+  // PDF GENERATION
+
+  static getCountMetadataOptions({ date, hours, weather }) {
+    const dateStr = TimeFormatters.formatDefault(date);
+    const dayOfWeekStr = TimeFormatters.formatDayOfWeek(date);
+    const fullDateStr = `${dateStr} (${dayOfWeekStr})`;
+    const hoursStr = hours === null ? null : hours.description;
+    const entries = [
+      { cols: 3, name: 'Date', value: fullDateStr },
+      { cols: 3, name: 'Study Hours', value: hoursStr },
+      { cols: 6, name: 'Weather', value: weather },
+      { cols: 3, name: 'Zone A Total', value: 125 },
+      { cols: 3, name: 'Zone B Total', value: 71 },
+      { cols: 3, name: 'Zone C Total', value: 15 },
+      { cols: 3, name: 'All Zones Total', value: 211 },
+    ];
+    return { entries };
+  }
+
+  generateLayoutContent(study, reportData) {
+    const countMetadataOptions = ReportPedDelaySummary.getCountMetadataOptions(reportData);
+    return [
+      { type: ReportBlock.METADATA, options: countMetadataOptions },
+    ];
+  }
+}
+
+export default ReportPedDelaySummary;

--- a/lib/reports/ReportPedDelaySummary.js
+++ b/lib/reports/ReportPedDelaySummary.js
@@ -1,7 +1,50 @@
 /* eslint-disable class-methods-use-this */
+import ArrayUtils from '@/lib/ArrayUtils';
+import { Enum } from '@/lib/ClassUtils';
 import { ReportBlock, ReportType } from '@/lib/Constants';
 import ReportBaseFlow from '@/lib/reports/ReportBaseFlow';
 import TimeFormatters from '@/lib/time/TimeFormatters';
+
+class PedClass extends Enum {}
+PedClass.init({
+  ASSISTED_CHILDREN: {
+    description: 'Assisted Children',
+    factor: 2,
+    short: 'ac',
+  },
+  UNASSISTED_CHILDREN: {
+    description: 'Unassisted Children',
+    factor: 2,
+    short: 'uc',
+  },
+  YOUTH_ADULTS: {
+    description: 'Youth and Adults',
+    factor: 2,
+    short: 'ya',
+  },
+  SENIOR_CITIZENS: {
+    description: 'Senior Citizens',
+    factor: 2,
+    short: 'sc',
+  },
+  PERSONS_WITH_DISABILITIES: {
+    description: 'Persons with Disabilities',
+    factor: 2,
+    short: 'pwd',
+  },
+});
+
+class PedDelay extends Enum {}
+PedDelay.init({
+  NOT_DELAYED: {
+    description: '<=10sec',
+    short: 'nd',
+  },
+  DELAYED: {
+    description: '>10sec',
+    short: 'd',
+  },
+});
 
 /**
  * Subclass of {@link ReportBaseFlow} for the Pedestrian Delay Summary Report.
@@ -12,6 +55,41 @@ import TimeFormatters from '@/lib/time/TimeFormatters';
 class ReportPedDelaySummary extends ReportBaseFlow {
   type() {
     return ReportType.PED_DELAY_SUMMARY;
+  }
+
+  static computePedDelayTotals(rawData) {
+    const data = {};
+    let total = 0;
+    PedClass.enumValues.forEach((pedClass) => {
+      PedDelay.enumValues.forEach((pedDelay) => {
+        const key = `${pedClass.short}_${pedDelay.short}`;
+        const value = rawData[key];
+        data[key] = value;
+        total += value;
+      });
+    });
+    data.crossings = rawData.crossings;
+    data.total = total;
+    return data;
+  }
+
+  static computeAllPedDelayTotals(zoneData) {
+    return zoneData.map(({ t, data: rawData }) => {
+      const data = ReportPedDelaySummary.computePedDelayTotals(rawData);
+      return { t, data };
+    });
+  }
+
+  static transformCountData(countData) {
+    const countDataByZone = ArrayUtils.groupBySorted(countData, ({ data: { zone } }) => zone);
+    const zones = countDataByZone.map((zoneData) => {
+      const label = zoneData[0].data.zone;
+      const rows = ReportPedDelaySummary.computeAllPedDelayTotals(zoneData);
+      const totals = ArrayUtils.sumObjects(rows.map(row => row.data));
+      return { label, rows, totals };
+    });
+    const totals = ArrayUtils.sumObjects(zones.map(zone => zone.totals));
+    return { totals, zones };
   }
 
   transformData(study, { counts, studyData }) {
@@ -26,12 +104,12 @@ class ReportPedDelaySummary extends ReportBaseFlow {
       id,
     } = count;
     const countData = studyData.get(id);
-    // TODO: actually transform data
+    const stats = ReportPedDelaySummary.transformCountData(countData);
 
     return {
       date,
       hours,
-      countData,
+      stats,
       weather,
     };
   }
@@ -63,19 +141,29 @@ class ReportPedDelaySummary extends ReportBaseFlow {
 
   // PDF GENERATION
 
-  static getCountMetadataOptions({ date, hours, weather }) {
+  static getCountMetadataOptions({
+    date,
+    hours,
+    stats,
+    weather,
+  }) {
     const dateStr = TimeFormatters.formatDefault(date);
     const dayOfWeekStr = TimeFormatters.formatDayOfWeek(date);
     const fullDateStr = `${dateStr} (${dayOfWeekStr})`;
     const hoursStr = hours === null ? null : hours.description;
+
+    const { totals, zones } = stats;
+
     const entries = [
       { cols: 3, name: 'Date', value: fullDateStr },
       { cols: 3, name: 'Study Hours', value: hoursStr },
       { cols: 6, name: 'Weather', value: weather },
-      { cols: 3, name: 'Zone A Total', value: 125 },
-      { cols: 3, name: 'Zone B Total', value: 71 },
-      { cols: 3, name: 'Zone C Total', value: 15 },
-      { cols: 3, name: 'All Zones Total', value: 211 },
+      ...zones.map(zone => ({
+        cols: 3,
+        name: `Zone ${zone.label} Total`,
+        value: zone.totals.total,
+      })),
+      { cols: 3, name: 'All Zones Total', value: totals.total },
     ];
     return { entries };
   }

--- a/lib/reports/ReportSpeedPercentile.js
+++ b/lib/reports/ReportSpeedPercentile.js
@@ -187,23 +187,21 @@ class ReportSpeedPercentile extends ReportBaseFlow {
     };
   }
 
-  transformData(study, { arteries, counts, studyData }) {
+  transformData(study, { counts, studyData }) {
     if (counts.length === 0) {
       return [];
     }
 
     const countTuples = counts.map((count) => {
-      const { arteryCode, id } = count;
-      const artery = arteries.get(arteryCode);
-      const countData = studyData.get(id);
-      return { artery, count, countData };
+      const countData = studyData.get(count.id);
+      return { count, countData };
     });
 
     const reportData = [];
 
     let numDirections = 0;
     CardinalDirection.enumValues.forEach((direction) => {
-      const groupCounts = countTuples.filter(({ artery }) => artery.approachDir === direction);
+      const groupCounts = countTuples.filter(({ count }) => count.direction === direction);
       if (groupCounts.length > 0) {
         numDirections += 1;
       }

--- a/lib/reports/ReportWarrantTrafficSignalControl.js
+++ b/lib/reports/ReportWarrantTrafficSignalControl.js
@@ -414,7 +414,7 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
     );
 
     const { date, hours } = count;
-    const px = ReportCountSummaryTurningMovement.getTrafficSignalId(count);
+    const px = ReportCountSummaryTurningMovement.getTrafficSignalId(intersection);
     return {
       date,
       minVolume,

--- a/tests/jest/api/StudyController.spec.js
+++ b/tests/jest/api/StudyController.spec.js
@@ -27,7 +27,7 @@ afterAll(async () => {
 function expectNumPerCategoryStudy(actual, expected) {
   expect(actual).toHaveLength(expected.length);
   expected.forEach(([n0, value0], i) => {
-    const { category: { studyType: { name: value } }, n } = actual[i];
+    const { n, studyType: { name: value } } = actual[i];
     expect(n).toBe(n0);
     expect(value).toBe(value0);
   });
@@ -36,7 +36,7 @@ function expectNumPerCategoryStudy(actual, expected) {
 function expectNumPerCategoryAndLocationStudy(actual, expected) {
   expect(actual).toHaveLength(expected.length);
   expected.forEach(([ns0, value0], i) => {
-    const { category: { studyType: { name: value } }, perLocation } = actual[i];
+    const { perLocation, studyType: { name: value } } = actual[i];
     perLocation.forEach(({ n }, j) => {
       expect(n).toBe(ns0[j]);
     });
@@ -461,7 +461,7 @@ test('StudyController.getStudiesByCentrelineSummary', async () => {
   data = { s1 };
   response = await client.fetch('/studies/byCentreline/summary', { data });
   expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
-  expectNumPerCategoryStudy(response.result, [[1, 'ATR_VOLUME'], [2, 'ATR_SPEED_VOLUME']]);
+  expectNumPerCategoryStudy(response.result, [[2, 'ATR_SPEED_VOLUME'], [1, 'ATR_VOLUME']]);
 });
 
 test('StudyController.getStudiesByCentrelineSummaryPerLocation', async () => {
@@ -570,7 +570,7 @@ test('StudyController.getStudiesByCentrelineSummaryPerLocation', async () => {
   expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
   expectNumPerCategoryAndLocationStudy(
     response.result,
-    [[[1], 'ATR_VOLUME'], [[2], 'ATR_SPEED_VOLUME']],
+    [[[2], 'ATR_SPEED_VOLUME'], [[1], 'ATR_VOLUME']],
   );
 });
 

--- a/tests/jest/db/ArteryDAO.spec.js
+++ b/tests/jest/db/ArteryDAO.spec.js
@@ -80,7 +80,7 @@ test('ArteryDAO.byArteryCode', async () => {
 test('ArteryDAO.byStudy', async () => {
   // intersection
   let result = await ArteryDAO.byStudy({
-    arteryGroupId: 23945,
+    countLocationId: 23945,
   });
   expectArteriesMatch(result, [{
     approachDir: null,
@@ -100,7 +100,7 @@ test('ArteryDAO.byStudy', async () => {
 
   // segment
   result = await ArteryDAO.byStudy({
-    arteryGroupId: 32532,
+    countLocationId: 32532,
   });
   expectArteriesMatch(result, [{
     approachDir: CardinalDirection.EAST,
@@ -134,7 +134,7 @@ test('ArteryDAO.byStudy', async () => {
 
   // segment: other artery
   result = await ArteryDAO.byStudy({
-    arteryGroupId: 32533,
+    countLocationId: 32533,
   });
   expect(result).toEqual([]);
 });

--- a/tests/jest/db/CountDAO.spec.js
+++ b/tests/jest/db/CountDAO.spec.js
@@ -7,58 +7,68 @@ afterAll(() => {
   db.$pool.end();
 });
 
-test('CountDAO.byStudy', async () => {
-  // TMC: single-day, single-arterycode
-  let result = await CountDAO.byStudy({
-    arteryGroupId: 23945,
+test('CountDAO.byStudy [TMC]', async () => {
+  const result = await CountDAO.byStudy({
+    legacy: true,
+    countLocationId: 23945,
     endDate: DateTime.fromObject({ year: 2013, month: 5, day: 13 }),
     startDate: DateTime.fromObject({ year: 2013, month: 5, day: 13 }),
-    type: { id: 5, studyType: StudyType.TMC },
+    studyType: StudyType.TMC,
   });
   expect(result).toHaveLength(1);
+});
 
-  // RESCU: not aggregated across days
-  result = await CountDAO.byStudy({
-    arteryGroupId: 3184,
+test('CountDAO.byStudy [RESCU]', async () => {
+  const result = await CountDAO.byStudy({
+    legacy: true,
+    countLocationId: 3184,
     endDate: DateTime.fromObject({ year: 2009, month: 11, day: 20 }),
     startDate: DateTime.fromObject({ year: 2009, month: 11, day: 20 }),
-    type: { id: 2, studyType: StudyType.RESCU },
+    studyType: StudyType.RESCU,
   });
   expect(result).toHaveLength(1);
+});
 
-  // volume ATR: single-day, single-direction
-  result = await CountDAO.byStudy({
-    arteryGroupId: 32532,
+test('CountDAO.byStudy [volume ATR, single-day, single-direction]', async () => {
+  const result = await CountDAO.byStudy({
+    legacy: true,
+    countLocationId: 32532,
     endDate: DateTime.fromObject({ year: 2012, month: 12, day: 20 }),
     startDate: DateTime.fromObject({ year: 2012, month: 12, day: 20 }),
-    type: { id: 4, studyType: StudyType.ATR_SPEED_VOLUME },
+    studyType: StudyType.ATR_SPEED_VOLUME,
   });
   expect(result).toHaveLength(1);
+});
 
-  // volume ATR: multi-day, single-direction
-  result = await CountDAO.byStudy({
-    arteryGroupId: 38438,
+test('CountDAO.byStudy [volume ATR, multi-day, single-direction]', async () => {
+  const result = await CountDAO.byStudy({
+    legacy: true,
+    countLocationId: 38438,
     endDate: DateTime.fromObject({ year: 2017, month: 6, day: 15 }),
     startDate: DateTime.fromObject({ year: 2017, month: 6, day: 13 }),
-    type: { id: 4, studyType: StudyType.ATR_SPEED_VOLUME },
+    studyType: StudyType.ATR_SPEED_VOLUME,
   });
   expect(result).toHaveLength(3);
+});
 
-  // volume ATR: multi-day, multi-direction
-  result = await CountDAO.byStudy({
-    arteryGroupId: 32532,
+test('CountDAO.byStudy [volume ATR, multi-day, multi-direction]', async () => {
+  const result = await CountDAO.byStudy({
+    legacy: true,
+    countLocationId: 32532,
     endDate: DateTime.fromObject({ year: 2009, month: 9, day: 17 }),
     startDate: DateTime.fromObject({ year: 2009, month: 9, day: 15 }),
-    type: { id: 1, studyType: StudyType.ATR_VOLUME },
+    studyType: StudyType.ATR_VOLUME,
   });
   expect(result).toHaveLength(6);
+});
 
-  // study with notes
-  result = await CountDAO.byStudy({
-    arteryGroupId: 3184,
+test('CountDAO.byStudy [study with notes]', async () => {
+  const result = await CountDAO.byStudy({
+    legacy: true,
+    countLocationId: 3184,
     endDate: DateTime.fromObject({ year: 2009, month: 5, day: 10 }),
     startDate: DateTime.fromObject({ year: 2009, month: 5, day: 10 }),
-    type: { id: 2, studyType: StudyType.RESCU },
+    studyType: StudyType.RESCU,
   });
   expect(result).toHaveLength(1);
 });

--- a/tests/jest/db/LocationSearchDAO.spec.js
+++ b/tests/jest/db/LocationSearchDAO.spec.js
@@ -95,7 +95,7 @@ test('LocationSearchDAO.intersectionSuggestions', async () => {
   expectSuggestionsContain(result, CentrelineType.INTERSECTION, 13460034);
 
   // either term can be prefixed
-  result = await LocationSearchDAO.intersectionSuggestions('Dan and Main', 3);
+  result = await LocationSearchDAO.intersectionSuggestions('Danfo and Main', 3);
   expectSuggestionsContain(result, CentrelineType.INTERSECTION, 13460034);
 
   // full query with minor typo should match

--- a/tests/jest/db/StudyDAO.spec.js
+++ b/tests/jest/db/StudyDAO.spec.js
@@ -1,7 +1,6 @@
 import { CentrelineType, StudyType } from '@/lib/Constants';
 import db from '@/lib/db/db';
 import StudyDAO from '@/lib/db/StudyDAO';
-import Category from '@/lib/model/Category';
 import Joi from '@/lib/model/Joi';
 import Study from '@/lib/model/Study';
 import StudyFilters from '@/lib/model/StudyFilters';
@@ -114,7 +113,7 @@ test('StudyDAO.byCentreline()', async () => {
 function expectNumPerCategoryStudy(actual, expected) {
   expect(actual).toHaveLength(expected.length);
   expected.forEach(([n0, value0], i) => {
-    const { category: { studyType: { name: value } }, n } = actual[i];
+    const { n, studyType: { name: value } } = actual[i];
     expect(n).toBe(n0);
     expect(value).toBe(value0);
   });
@@ -163,9 +162,9 @@ test('StudyDAO.byCentrelineSummary()', async () => {
   studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);
   const studySummarySchema = Joi.array().items(
     Joi.object().keys({
-      category: Category.read,
       mostRecent: Study.read,
       n: Joi.number().integer().positive().required(),
+      studyType: Joi.enum().ofType(StudyType).required(),
     }),
   );
   expectNumPerCategoryStudy(studySummary, [[1, 'ATR_SPEED_VOLUME']]);
@@ -225,13 +224,13 @@ test('StudyDAO.byCentrelineSummary()', async () => {
   studyQuery = {};
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
   studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);
-  expectNumPerCategoryStudy(studySummary, [[1, 'ATR_VOLUME'], [2, 'ATR_SPEED_VOLUME']]);
+  expectNumPerCategoryStudy(studySummary, [[2, 'ATR_SPEED_VOLUME'], [1, 'ATR_VOLUME']]);
 });
 
 function expectNumPerCategoryAndLocationStudy(actual, expected) {
   expect(actual).toHaveLength(expected.length);
   expected.forEach(([ns0, value0], i) => {
-    const { category: { studyType: { name: value } }, perLocation } = actual[i];
+    const { perLocation, studyType: { name: value } } = actual[i];
     perLocation.forEach(({ n }, j) => {
       expect(n).toBe(ns0[j]);
     });
@@ -282,13 +281,13 @@ test('StudyDAO.byCentrelineSummaryPerLocation()', async () => {
   studySummary = await StudyDAO.byCentrelineSummaryPerLocation(features, studyQuery);
   const studySummaryPerLocationSchema = Joi.array().items(
     Joi.object().keys({
-      category: Category.read,
       perLocation: Joi.array().items(
         Joi.object().keys({
           mostRecent: Study.read.allow(null),
           n: Joi.number().integer().min(0).required(),
         }),
       ),
+      studyType: Joi.enum().ofType(StudyType).required(),
     }),
   );
   expectNumPerCategoryAndLocationStudy(
@@ -351,7 +350,7 @@ test('StudyDAO.byCentrelineSummaryPerLocation()', async () => {
   studyQuery = {};
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
   studySummary = await StudyDAO.byCentrelineSummaryPerLocation(features, studyQuery);
-  expectNumPerCategoryAndLocationStudy(studySummary, [[[1], 'ATR_VOLUME'], [[2], 'ATR_SPEED_VOLUME']]);
+  expectNumPerCategoryAndLocationStudy(studySummary, [[[2], 'ATR_SPEED_VOLUME'], [[1], 'ATR_VOLUME']]);
 });
 
 test('StudyDAO.byCentrelineTotal()', async () => {

--- a/tests/jest/db/StudyDataDAO.spec.js
+++ b/tests/jest/db/StudyDataDAO.spec.js
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 import path from 'path';
 
+import { StudyType } from '@/lib/Constants';
 import db from '@/lib/db/db';
 import StudyDAO from '@/lib/db/StudyDAO';
 import StudyDataDAO from '@/lib/db/StudyDataDAO';
@@ -19,7 +20,7 @@ afterAll(() => {
 
 test('StudyDataDAO [TMC]', async () => {
   // TMC
-  const study = await StudyDAO.byCategoryAndCountGroup(5, 26177);
+  const study = await StudyDAO.byStudyTypeAndCountGroup(StudyType.TMC, 26177);
   const result = await StudyDataDAO.byStudy(study);
   const countData = countData_5_26177.map(({ t, data }) => ({
     t: t.minus({ minutes: 15 }),
@@ -32,7 +33,7 @@ test('StudyDataDAO [TMC]', async () => {
 
 test('StudyDataDAO [ATR]', async () => {
   // non-TMC, speed-related
-  const study = await StudyDAO.byCategoryAndCountGroup(4, 1415698);
+  const study = await StudyDAO.byStudyTypeAndCountGroup(StudyType.ATR_SPEED_VOLUME, 1415698);
   const result = await StudyDataDAO.byStudy(study);
   const countData = countData_4_1415698.map(({ t, data }) => ({ t, data }));
   expect(result.studyData).toEqual(new Map([

--- a/tests/jest/unit/io/storage/StoragePath.spec.js
+++ b/tests/jest/unit/io/storage/StoragePath.spec.js
@@ -7,14 +7,12 @@ import {
   ReportType,
   StudyType,
 } from '@/lib/Constants';
-import ArteryDAO from '@/lib/db/ArteryDAO';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import CountDAO from '@/lib/db/CountDAO';
 import StudyDAO from '@/lib/db/StudyDAO';
 import StoragePath from '@/lib/io/storage/StoragePath';
 import DateTime from '@/lib/time/DateTime';
 
-jest.mock('@/lib/db/ArteryDAO');
 jest.mock('@/lib/db/CentrelineDAO');
 jest.mock('@/lib/db/CountDAO');
 jest.mock('@/lib/db/StudyDAO');
@@ -69,48 +67,45 @@ test('StoragePath.forReport [study, intersection]', async () => {
     centrelineType: CentrelineType.INTERSECTION,
     description: 'Caledonia Rd / Rogers Rd',
   });
-  StudyDAO.byCategoryAndCountGroup.mockResolvedValue({
+  StudyDAO.byStudyTypeAndCountGroup.mockResolvedValue({
     startDate: DateTime.fromObject({ year: 2018, month: 3, day: 24 }),
-    type: { studyType: StudyType.TMC },
+    studyType: StudyType.TMC,
   });
 
   const report = {
     type: ReportType.COUNT_SUMMARY_TURNING_MOVEMENT,
-    id: '5/36853',
+    id: 'TMC/36853',
     format: ReportFormat.CSV,
   };
   await expect(StoragePath.forReport(report)).resolves.toEqual({
     namespace: StoragePath.NAMESPACE_REPORTS_STUDY,
-    key: 'COUNT_SUMMARY_TURNING_MOVEMENT_CALEDONIA_RD_ROGERS_RD_2018-03-24_5_36853.csv',
+    key: 'COUNT_SUMMARY_TURNING_MOVEMENT_CALEDONIA_RD_ROGERS_RD_2018-03-24_TMC_36853.csv',
   });
 });
 
 test('StoragePath.forReport [study, midblock]', async () => {
   // /reporter/reports?type=SPEED_PERCENTILE&id=4%2F1349804&format=WEB
-  ArteryDAO.byStudy.mockResolvedValue([
-    { arteryCode: 11744, approachDir: CardinalDirection.SOUTH },
-    { arteryCode: 37691, approachDir: CardinalDirection.NORTH },
-  ]);
   CentrelineDAO.byFeature.mockResolvedValue({
     centrelineType: CentrelineType.SEGMENT,
     description: 'Silverthorn Ave: Rockwell Ave \u2013 Turnberry Ave',
   });
   CountDAO.byStudy.mockResolvedValue([
-    { arteryCode: 11744 },
+    { direction: CardinalDirection.SOUTH },
   ]);
-  StudyDAO.byCategoryAndCountGroup.mockResolvedValue({
+  StudyDAO.byStudyTypeAndCountGroup.mockResolvedValue({
     startDate: DateTime.fromObject({ year: 2011, month: 3, day: 1 }),
-    type: { studyType: StudyType.ATR_SPEED_VOLUME },
+    studyType: StudyType.ATR_SPEED_VOLUME,
   });
 
   const report = {
     type: ReportType.SPEED_PERCENTILE,
-    id: '4/1349804',
+    id: 'ATR_SPEED_VOLUME/1349804',
     format: ReportFormat.PDF,
   };
+  await StoragePath.forReport(report);
   await expect(StoragePath.forReport(report)).resolves.toEqual({
     namespace: StoragePath.NAMESPACE_REPORTS_STUDY,
-    key: 'SPEED_PERCENTILE_SILVERTHORN_AVE_ROCKWELL_AVE-TURNBERRY_AVE_SB_2011-03-01_4_1349804.pdf',
+    key: 'SPEED_PERCENTILE_SILVERTHORN_AVE_ROCKWELL_AVE-TURNBERRY_AVE_SB_2011-03-01_ATR_SPEED_VOLUME_1349804.pdf',
   });
 });
 

--- a/tests/jest/unit/reports/ReportBaseFlow.spec.js
+++ b/tests/jest/unit/reports/ReportBaseFlow.spec.js
@@ -3,6 +3,8 @@ import { StudyType } from '@/lib/Constants';
 import StudyDAO from '@/lib/db/StudyDAO';
 import { InvalidReportIdError } from '@/lib/error/MoveErrors';
 import ReportBaseFlow from '@/lib/reports/ReportBaseFlow';
+import ReportCountSummary24h from '@/lib/reports/ReportCountSummary24h';
+import ReportCountSummaryTurningMovement from '@/lib/reports/ReportCountSummaryTurningMovement';
 import ReportSpeedPercentile from '@/lib/reports/ReportSpeedPercentile';
 import { sumByTime } from '@/lib/reports/time/ReportTimeUtils';
 import DateTime from '@/lib/time/DateTime';
@@ -10,38 +12,116 @@ import { setup_4_2156283 } from '@/tests/jest/unit/reports/data/SetupTestData';
 
 jest.mock('@/lib/db/StudyDAO');
 
-test('ReportBaseFlow#parseId', async () => {
+test('ReportBaseFlow#parseId [invalid]', async () => {
   const reportInstance = new ReportSpeedPercentile();
   let rawId;
 
+  // expect non-empty
   rawId = '';
   await expect(reportInstance.parseId(rawId)).rejects.toThrow(InvalidReportIdError);
 
+  // expect `${studyType}/${countGroupId}`
   rawId = '42';
   await expect(reportInstance.parseId(rawId)).rejects.toThrow(InvalidReportIdError);
 
+  // expect valid studyType
   rawId = 'foo/bar';
   await expect(reportInstance.parseId(rawId)).rejects.toThrow(InvalidReportIdError);
 
-  rawId = '6/bar';
+  // expect numeric countGroupId
+  rawId = 'ATR_VOLUME/bar';
   await expect(reportInstance.parseId(rawId)).rejects.toThrow(InvalidReportIdError);
 
-  StudyDAO.byCategoryAndCountGroup.mockResolvedValue(null);
+  // expect studyType, not CATEGORY_ID
   rawId = '5/17';
   await expect(reportInstance.parseId(rawId)).rejects.toThrow(InvalidReportIdError);
+});
 
-  let study = {
-    type: { studyType: StudyType.TMC },
+test('ReportBaseFlow#parseId [study not found]', async () => {
+  const reportInstance = new ReportSpeedPercentile();
+
+  StudyDAO.byStudyTypeAndCountGroup.mockResolvedValue(null);
+  const rawId = 'ATR_SPEED_VOLUME/17';
+  await expect(reportInstance.parseId(rawId)).rejects.toThrow(InvalidReportIdError);
+});
+
+test('ReportBaseFlow#parseId [study type mismatch]', async () => {
+  const reportInstance = new ReportSpeedPercentile();
+
+  const study = {
+    studyType: StudyType.TMC,
   };
-  StudyDAO.byCategoryAndCountGroup.mockResolvedValue(study);
-  rawId = '5/17';
+  StudyDAO.byStudyTypeAndCountGroup.mockResolvedValue(study);
+  const rawId = 'ATR_SPEED_VOLUME/17';
+  await expect(reportInstance.parseId(rawId)).rejects.toThrow(InvalidReportIdError);
+});
+
+test('ReportBaseFlow#parseId [speed-related]', async () => {
+  const reportInstance = new ReportSpeedPercentile();
+  let rawId;
+
+  // speed percentile report requires speed / volume data!
+  let study = {
+    studyType: StudyType.TMC,
+  };
+  StudyDAO.byStudyTypeAndCountGroup.mockResolvedValue(study);
+  rawId = 'TMC/17';
   await expect(reportInstance.parseId(rawId)).rejects.toThrow(InvalidReportIdError);
 
   study = {
-    type: { studyType: StudyType.ATR_SPEED_VOLUME },
+    studyType: StudyType.ATR_SPEED_VOLUME,
   };
-  StudyDAO.byCategoryAndCountGroup.mockResolvedValue(study);
-  rawId = '4/17';
+  StudyDAO.byStudyTypeAndCountGroup.mockResolvedValue(study);
+  rawId = 'ATR_SPEED_VOLUME/17';
+  await expect(reportInstance.parseId(rawId)).resolves.toEqual(study);
+});
+
+test('ReportBaseFlow#parseId [TMC-related]', async () => {
+  const reportInstance = new ReportCountSummaryTurningMovement();
+  let rawId;
+
+  // TMC summary report requires TMC data!
+  let study = {
+    studyType: StudyType.RESCU,
+  };
+  StudyDAO.byStudyTypeAndCountGroup.mockResolvedValue(study);
+  rawId = 'RESCU/17';
+  await expect(reportInstance.parseId(rawId)).rejects.toThrow(InvalidReportIdError);
+
+  study = {
+    studyType: StudyType.TMC,
+  };
+  StudyDAO.byStudyTypeAndCountGroup.mockResolvedValue(study);
+  rawId = 'TMC/17';
+  await expect(reportInstance.parseId(rawId)).resolves.toEqual(study);
+});
+
+test('ReportBaseFlow#parseId [other]', async () => {
+  const reportInstance = new ReportCountSummary24h();
+  let rawId;
+
+  // non-TMC report cannot have TMC data!
+  let study = {
+    studyType: StudyType.TMC,
+  };
+  StudyDAO.byStudyTypeAndCountGroup.mockResolvedValue(study);
+  rawId = 'TMC/17';
+  await expect(reportInstance.parseId(rawId)).rejects.toThrow(InvalidReportIdError);
+
+  // non-TMC report can have speed / volume data
+  study = {
+    studyType: StudyType.ATR_SPEED_VOLUME,
+  };
+  StudyDAO.byStudyTypeAndCountGroup.mockResolvedValue(study);
+  rawId = 'ATR_SPEED_VOLUME/17';
+  await expect(reportInstance.parseId(rawId)).resolves.toEqual(study);
+
+  // non-TMC report can have volume data
+  study = {
+    studyType: StudyType.ATR_VOLUME,
+  };
+  StudyDAO.byStudyTypeAndCountGroup.mockResolvedValue(study);
+  rawId = 'ATR_VOLUME/17';
   await expect(reportInstance.parseId(rawId)).resolves.toEqual(study);
 });
 

--- a/tests/jest/unit/reports/ReportBaseFlow.spec.js
+++ b/tests/jest/unit/reports/ReportBaseFlow.spec.js
@@ -127,7 +127,7 @@ test('ReportBaseFlow#parseId [other]', async () => {
 
 test('ReportCountSummary24h.timeRange', () => {
   const { studyData } = setup_4_2156283();
-  const countData = studyData.get(17);
+  const countData = studyData.get(2156283);
   const totaledData = sumByTime(countData);
 
   expect(ReportBaseFlow.timeRange(totaledData, { lo: 0, hi: 4 })).toEqual({

--- a/tests/jest/unit/reports/ReportCountSummary24h.spec.js
+++ b/tests/jest/unit/reports/ReportCountSummary24h.spec.js
@@ -20,21 +20,21 @@ const transformedData_COUNT_SUMMARY_24H_4_2156283_empty = loadJsonSync(
 test('ReportCountSummary24h#transformData [empty dataset]', () => {
   const reportInstance = new ReportCountSummary24h();
 
-  const { arteries, counts, study } = setup_4_2156283();
-  const studyData = new Map([[17, []]]);
-  const transformedData = reportInstance.transformData(study, { arteries, counts, studyData });
+  const { countLocation, counts, study } = setup_4_2156283();
+  const studyData = new Map([[2156283, []]]);
+  const transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
   expect(transformedData).toEqual(transformedData_COUNT_SUMMARY_24H_4_2156283_empty);
 });
 
 test('ReportCountSummary24h#transformData [fuzz test, ATR speed / volume]', () => {
   const reportInstance = new ReportCountSummary24h();
 
-  const { arteries, counts, study } = setup_4_2156283();
+  const { countLocation, counts, study } = setup_4_2156283();
   for (let i = 0; i < 3; i++) {
     const countData = generateAtrSpeedVolume();
-    const studyData = new Map([[17, countData]]);
+    const studyData = new Map([[2156283, countData]]);
     expect(() => {
-      reportInstance.transformData(study, { arteries, counts, studyData });
+      reportInstance.transformData(study, { countLocation, counts, studyData });
     }).not.toThrow();
   }
 });
@@ -42,12 +42,12 @@ test('ReportCountSummary24h#transformData [fuzz test, ATR speed / volume]', () =
 test('ReportCountSummary24h#transformData [fuzz test, ATR volume]', () => {
   const reportInstance = new ReportCountSummary24h();
 
-  const { arteries, counts, study } = setup_4_2156283();
+  const { countLocation, counts, study } = setup_4_2156283();
   for (let i = 0; i < 3; i++) {
     const countData = generateAtrVolume();
-    const studyData = new Map([[17, countData]]);
+    const studyData = new Map([[2156283, countData]]);
     expect(() => {
-      reportInstance.transformData(study, { arteries, counts, studyData });
+      reportInstance.transformData(study, { countLocation, counts, studyData });
     }).not.toThrow();
   }
 });
@@ -55,37 +55,37 @@ test('ReportCountSummary24h#transformData [fuzz test, ATR volume]', () => {
 test('ReportCountSummary24h#transformData [fuzz test, ATR volume with missing]', () => {
   const reportInstance = new ReportCountSummary24h();
 
-  const { arteries, counts, study } = setup_4_2156283();
+  const { countLocation, counts, study } = setup_4_2156283();
   for (let i = 0; i < 3; i++) {
     const countData = generateWithMissing(generateAtrVolume());
-    const studyData = new Map([[17, countData]]);
+    const studyData = new Map([[2156283, countData]]);
     expect(() => {
-      reportInstance.transformData(study, { arteries, counts, studyData });
+      reportInstance.transformData(study, { countLocation, counts, studyData });
     }).not.toThrow();
   }
 });
 
-test('ReportCountSummary24h#transformData [Morningside S of Lawrence: 4/2156283]', () => {
+test('ReportCountSummary24h#transformData [Morningside S of Lawrence: ATR_SPEED_VOLUME/2156283]', () => {
   const reportInstance = new ReportCountSummary24h();
   const {
-    arteries,
+    countLocation,
     counts,
     study,
     studyData,
   } = setup_4_2156283();
-  const transformedData = reportInstance.transformData(study, { arteries, counts, studyData });
+  const transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
   expect(transformedData).toEqual(transformedData_COUNT_SUMMARY_24H_4_2156283);
 });
 
-test('ReportCountSummary24h#generateCsv [Morningside S of Lawrence: 4/2156283]', () => {
+test('ReportCountSummary24h#generateCsv [Morningside S of Lawrence: ATR_SPEED_VOLUME/2156283]', () => {
   const reportInstance = new ReportCountSummary24h();
   const {
-    arteries,
+    countLocation,
     counts,
     study,
     studyData,
   } = setup_4_2156283();
-  const transformedData = reportInstance.transformData(study, { arteries, counts, studyData });
+  const transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
   expect(() => {
     reportInstance.generateCsv(study, transformedData);
   }).not.toThrow();

--- a/tests/jest/unit/reports/ReportCountSummary24hDetailed.spec.js
+++ b/tests/jest/unit/reports/ReportCountSummary24hDetailed.spec.js
@@ -23,12 +23,12 @@ test('ReportCountSummary24hDetailed#transformData [empty dataset]', () => {
    * one data point per hour.  This allows us to test that the 24-hour detailed report
    * works in this case.
    */
-  const { arteries, counts, study } = setup_4_2156283();
-  const studyData = new Map([[17, []]]);
-  let transformedData = reportInstance.transformData(study, { arteries, counts, studyData });
+  const { countLocation, counts, study } = setup_4_2156283();
+  const studyData = new Map([[2156283, []]]);
+  let transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
   expect(transformedData).toHaveLength(1);
   const { date, direction, totaledData } = transformedData[0];
-  expect(date.equals(study.date)).toBe(true);
+  expect(date.equals(study.startDate)).toBe(true);
   expect(direction).toBe(CardinalDirection.NORTH);
   transformedData = totaledData;
   expect(transformedData).toEqual([]);
@@ -40,7 +40,7 @@ test('ReportCountSummary24hDetailed#transformData [fuzz test, ATR speed / volume
   const { arteries, counts, study } = setup_4_2156283();
   for (let i = 0; i < 3; i++) {
     const countData = generateAtrSpeedVolume();
-    const studyData = new Map([[17, countData]]);
+    const studyData = new Map([[2156283, countData]]);
     expect(() => {
       reportInstance.transformData(study, { arteries, counts, studyData });
     }).not.toThrow();
@@ -50,12 +50,12 @@ test('ReportCountSummary24hDetailed#transformData [fuzz test, ATR speed / volume
 test('ReportCountSummary24hDetailed#transformData [fuzz test, ATR volume]', () => {
   const reportInstance = new ReportCountSummary24hDetailed();
 
-  const { arteries, counts, study } = setup_4_2156283();
+  const { countLocation, counts, study } = setup_4_2156283();
   for (let i = 0; i < 3; i++) {
     const countData = generateAtrVolume();
-    const studyData = new Map([[17, countData]]);
+    const studyData = new Map([[2156283, countData]]);
     expect(() => {
-      reportInstance.transformData(study, { arteries, counts, studyData });
+      reportInstance.transformData(study, { countLocation, counts, studyData });
     }).not.toThrow();
   }
 });
@@ -63,12 +63,12 @@ test('ReportCountSummary24hDetailed#transformData [fuzz test, ATR volume]', () =
 test('ReportCountSummary24hDetailed#transformData [fuzz test, ATR volume with missing]', () => {
   const reportInstance = new ReportCountSummary24hDetailed();
 
-  const { arteries, counts, study } = setup_4_2156283();
+  const { countLocation, counts, study } = setup_4_2156283();
   for (let i = 0; i < 3; i++) {
     const countData = generateWithMissing(generateAtrVolume());
-    const studyData = new Map([[17, countData]]);
+    const studyData = new Map([[2156283, countData]]);
     expect(() => {
-      reportInstance.transformData(study, { arteries, counts, studyData });
+      reportInstance.transformData(study, { countLocation, counts, studyData });
     }).not.toThrow();
   }
 });
@@ -82,15 +82,15 @@ test('ReportCountSummary24hDetailed#transformData [Morningside S of Lawrence: 4/
    * works in this case.
    */
   const {
-    arteries,
+    countLocation,
     counts,
     study,
     studyData,
   } = setup_4_2156283();
-  let transformedData = reportInstance.transformData(study, { arteries, counts, studyData });
+  let transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
   expect(transformedData).toHaveLength(1);
   const { date, direction, totaledData } = transformedData[0];
-  expect(date.equals(study.date)).toBe(true);
+  expect(date.equals(study.startDate)).toBe(true);
   expect(direction).toBe(CardinalDirection.NORTH);
   transformedData = totaledData;
 
@@ -101,12 +101,12 @@ test('ReportCountSummary24hDetailed#generateCsv [Morningside S of Lawrence: 4/21
   const reportInstance = new ReportCountSummary24hDetailed();
 
   const {
-    arteries,
+    countLocation,
     counts,
     study,
     studyData,
   } = setup_4_2156283();
-  const transformedData = reportInstance.transformData(study, { arteries, counts, studyData });
+  const transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
   expect(() => {
     reportInstance.generateCsv(study, transformedData);
   }).not.toThrow();

--- a/tests/jest/unit/reports/ReportCountSummary24hDetailed.spec.js
+++ b/tests/jest/unit/reports/ReportCountSummary24hDetailed.spec.js
@@ -37,12 +37,12 @@ test('ReportCountSummary24hDetailed#transformData [empty dataset]', () => {
 test('ReportCountSummary24hDetailed#transformData [fuzz test, ATR speed / volume]', () => {
   const reportInstance = new ReportCountSummary24hDetailed();
 
-  const { arteries, counts, study } = setup_4_2156283();
+  const { countLocation, counts, study } = setup_4_2156283();
   for (let i = 0; i < 3; i++) {
     const countData = generateAtrSpeedVolume();
     const studyData = new Map([[2156283, countData]]);
     expect(() => {
-      reportInstance.transformData(study, { arteries, counts, studyData });
+      reportInstance.transformData(study, { countLocation, counts, studyData });
     }).not.toThrow();
   }
 });

--- a/tests/jest/unit/reports/ReportCountSummary24hGraphical.spec.js
+++ b/tests/jest/unit/reports/ReportCountSummary24hGraphical.spec.js
@@ -32,13 +32,13 @@ function dateTimeWithHour(hour) {
 test('ReportCountSummary24hGraphical#transformData [empty dataset]', () => {
   const reportInstance = new ReportCountSummary24hGraphical();
 
-  const { arteries, counts, study } = setup_4_2156283();
+  const { countLocation, counts, study } = setup_4_2156283();
   const countData = [];
-  const studyData = new Map([[17, countData]]);
-  const transformedData = reportInstance.transformData(study, { arteries, counts, studyData });
+  const studyData = new Map([[2156283, countData]]);
+  const transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
   const expected = new Array(24).fill(0);
   expect(transformedData).toEqual([{
-    date: study.date,
+    date: study.startDate,
     direction: CardinalDirection.NORTH,
     volumeByHour: expected,
   }]);
@@ -47,16 +47,16 @@ test('ReportCountSummary24hGraphical#transformData [empty dataset]', () => {
 test('ReportCountSummary24hGraphical#transformData [simple test cases]', () => {
   const reportInstance = new ReportCountSummary24hGraphical();
 
-  const { arteries, counts, study } = setup_4_2156283();
+  const { countLocation, counts, study } = setup_4_2156283();
   let countData = [
     { t: dateTimeWithHour(11), data: { COUNT: 42 } },
   ];
-  let studyData = new Map([[17, countData]]);
-  let transformedData = reportInstance.transformData(study, { arteries, counts, studyData });
+  let studyData = new Map([[2156283, countData]]);
+  let transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
   let expected = new Array(24).fill(0);
   expected[11] = 42;
   expect(transformedData).toEqual([{
-    date: study.date,
+    date: study.startDate,
     direction: CardinalDirection.NORTH,
     volumeByHour: expected,
   }]);
@@ -67,14 +67,14 @@ test('ReportCountSummary24hGraphical#transformData [simple test cases]', () => {
     { t: dateTimeWithHour(2), data: { COUNT: 2 } },
     { t: dateTimeWithHour(3), data: { COUNT: 73 } },
   ];
-  studyData = new Map([[17, countData]]);
-  transformedData = reportInstance.transformData(null, { arteries, counts, studyData });
+  studyData = new Map([[2156283, countData]]);
+  transformedData = reportInstance.transformData(null, { countLocation, counts, studyData });
   expected = new Array(24).fill(0);
   expected[1] = 6;
   expected[2] = 19;
   expected[3] = 73;
   expect(transformedData).toEqual([{
-    date: study.date,
+    date: study.startDate,
     direction: CardinalDirection.NORTH,
     volumeByHour: expected,
   }]);
@@ -83,12 +83,12 @@ test('ReportCountSummary24hGraphical#transformData [simple test cases]', () => {
 test('ReportCountSummary24hGraphical#transformData [fuzz test, ATR speed / volume]', () => {
   const reportInstance = new ReportCountSummary24hGraphical();
 
-  const { arteries, counts, study } = setup_4_2156283();
+  const { countLocation, counts, study } = setup_4_2156283();
   for (let i = 0; i < 3; i++) {
     const countData = generateAtrSpeedVolume();
-    const studyData = new Map([[17, countData]]);
+    const studyData = new Map([[2156283, countData]]);
     expect(() => {
-      reportInstance.transformData(study, { arteries, counts, studyData });
+      reportInstance.transformData(study, { countLocation, counts, studyData });
     }).not.toThrow();
   }
 });
@@ -96,12 +96,12 @@ test('ReportCountSummary24hGraphical#transformData [fuzz test, ATR speed / volum
 test('ReportCountSummary24hGraphical#transformData [fuzz test, ATR volume]', () => {
   const reportInstance = new ReportCountSummary24hGraphical();
 
-  const { arteries, counts, study } = setup_4_2156283();
+  const { countLocation, counts, study } = setup_4_2156283();
   for (let i = 0; i < 3; i++) {
     const countData = generateAtrVolume();
-    const studyData = new Map([[17, countData]]);
+    const studyData = new Map([[2156283, countData]]);
     expect(() => {
-      reportInstance.transformData(study, { arteries, counts, studyData });
+      reportInstance.transformData(study, { countLocation, counts, studyData });
     }).not.toThrow();
   }
 });
@@ -109,12 +109,12 @@ test('ReportCountSummary24hGraphical#transformData [fuzz test, ATR volume]', () 
 test('ReportCountSummary24hGraphical#transformData [fuzz test, ATR volume with missing]', () => {
   const reportInstance = new ReportCountSummary24hGraphical();
 
-  const { arteries, counts, study } = setup_4_2156283();
+  const { countLocation, counts, study } = setup_4_2156283();
   for (let i = 0; i < 3; i++) {
     const countData = generateWithMissing(generateAtrVolume());
-    const studyData = new Map([[17, countData]]);
+    const studyData = new Map([[2156283, countData]]);
     expect(() => {
-      reportInstance.transformData(study, { arteries, counts, studyData });
+      reportInstance.transformData(study, { countLocation, counts, studyData });
     }).not.toThrow();
   }
 });
@@ -128,15 +128,15 @@ test('ReportCountSummary24hGraphical#transformData [Morningside S of Lawrence: 4
    * works in this case.
    */
   const {
-    arteries,
+    countLocation,
     counts,
     study,
     studyData,
   } = setup_4_2156283();
-  let transformedData = reportInstance.transformData(study, { arteries, counts, studyData });
+  let transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
   expect(transformedData).toHaveLength(1);
   const { date, direction, volumeByHour } = transformedData[0];
-  expect(date.equals(study.date)).toBe(true);
+  expect(date.equals(study.startDate)).toBe(true);
   expect(direction).toBe(CardinalDirection.NORTH);
   transformedData = volumeByHour;
 
@@ -147,12 +147,12 @@ test('ReportCountSummary24hGraphical#generateCsv [Morningside S of Lawrence: 4/2
   const reportInstance = new ReportCountSummary24hGraphical();
 
   const {
-    arteries,
+    countLocation,
     counts,
     study,
     studyData,
   } = setup_4_2156283();
-  const transformedData = reportInstance.transformData(study, { arteries, counts, studyData });
+  const transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
   expect(() => {
     reportInstance.generateCsv(study, transformedData);
   }).not.toThrow();

--- a/tests/jest/unit/reports/ReportCountSummaryTurningMovement.spec.js
+++ b/tests/jest/unit/reports/ReportCountSummaryTurningMovement.spec.js
@@ -46,11 +46,11 @@ test('ReportCountSummaryTurningMovement.sumIndexRange', () => {
 test('ReportCountSummaryTurningMovement#transformData [empty dataset]', () => {
   const reportInstance = new ReportCountSummaryTurningMovement();
 
-  const { count, counts } = setup_5_36781();
-  const studyData = new Map([[1, []]]);
-  let transformedData = reportInstance.transformData(count, { counts, studyData });
+  const { countLocation, counts, study } = setup_5_36781();
+  const studyData = new Map([[36781, []]]);
+  let transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
   const { hours, px, stats } = transformedData;
-  expect(hours).toBe(StudyHours.SCHOOL);
+  expect(hours).toBe(StudyHours.ROUTINE);
   expect(px).toBe(1390);
   transformedData = stats;
 
@@ -60,12 +60,12 @@ test('ReportCountSummaryTurningMovement#transformData [empty dataset]', () => {
 test('ReportCountSummaryTurningMovement#transformData [fuzz test, TMC]', () => {
   const reportInstance = new ReportCountSummaryTurningMovement();
 
-  const { count, counts } = setup_5_36781();
+  const { countLocation, counts, study } = setup_5_36781();
   for (let i = 0; i < 3; i++) {
     const countData = generateTmc();
-    const studyData = new Map([[1, countData]]);
+    const studyData = new Map([[36781, countData]]);
     expect(() => {
-      reportInstance.transformData(count, { counts, studyData });
+      reportInstance.transformData(study, { countLocation, counts, studyData });
     }).not.toThrow();
   }
 });
@@ -73,12 +73,12 @@ test('ReportCountSummaryTurningMovement#transformData [fuzz test, TMC]', () => {
 test('ReportCountSummaryTurningMovement#transformData [fuzz test, 14-hour TMC]', () => {
   const reportInstance = new ReportCountSummaryTurningMovement();
 
-  const { count, counts } = setup_5_36781();
+  const { countLocation, counts, study } = setup_5_36781();
   for (let i = 0; i < 3; i++) {
     const countData = generateTmc14Hour();
-    const studyData = new Map([[1, countData]]);
+    const studyData = new Map([[36781, countData]]);
     expect(() => {
-      reportInstance.transformData(count, { counts, studyData });
+      reportInstance.transformData(study, { countLocation, counts, studyData });
     }).not.toThrow();
   }
 });
@@ -86,12 +86,12 @@ test('ReportCountSummaryTurningMovement#transformData [fuzz test, 14-hour TMC]',
 test('ReportCountSummaryTurningMovement#transformData [fuzz test, TMC with missing]', () => {
   const reportInstance = new ReportCountSummaryTurningMovement();
 
-  const { count, counts } = setup_5_36781();
+  const { countLocation, counts, study } = setup_5_36781();
   for (let i = 0; i < 3; i++) {
     const countData = generateWithMissing(generateTmc());
-    const studyData = new Map([[1, countData]]);
+    const studyData = new Map([[36781, countData]]);
     expect(() => {
-      reportInstance.transformData(count, { counts, studyData });
+      reportInstance.transformData(study, { countLocation, counts, studyData });
     }).not.toThrow();
   }
 });
@@ -109,10 +109,15 @@ test('ReportCountSummaryTurningMovement#transformData [Gerrard and Sumach: 5/367
    * (e.g. a "total" value is the sum of the values it includes), or c) the update is in one
    * of the base values, suggesting that it was in fact incorrect in the legacy report.
    */
-  const { count, counts, studyData } = setup_5_36781();
-  let transformedData = reportInstance.transformData(count, { counts, studyData });
+  const {
+    countLocation,
+    counts,
+    study,
+    studyData,
+  } = setup_5_36781();
+  let transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
   const { hours, px, stats } = transformedData;
-  expect(hours).toBe(StudyHours.SCHOOL);
+  expect(hours).toBe(StudyHours.ROUTINE);
   expect(px).toBe(1390);
   transformedData = stats;
 
@@ -121,9 +126,14 @@ test('ReportCountSummaryTurningMovement#transformData [Gerrard and Sumach: 5/367
 
 test('ReportCountSummaryTurningMovement#generateCsv [Gerrard and Sumach: 5/36781]', () => {
   const reportInstance = new ReportCountSummaryTurningMovement();
-  const { count, counts, studyData } = setup_5_36781();
-  const transformedData = reportInstance.transformData(count, { counts, studyData });
+  const {
+    countLocation,
+    counts,
+    study,
+    studyData,
+  } = setup_5_36781();
+  const transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
   expect(() => {
-    reportInstance.generateCsv(count, transformedData);
+    reportInstance.generateCsv(study, transformedData);
   }).not.toThrow();
 });

--- a/tests/jest/unit/reports/ReportCountSummaryTurningMovementDetailed.spec.js
+++ b/tests/jest/unit/reports/ReportCountSummaryTurningMovementDetailed.spec.js
@@ -22,11 +22,11 @@ const transformedData_COUNT_SUMMARY_TURNING_MOVEMENT_DETAILED_5_36781 = loadJson
 test('ReportCountSummaryTurningMovementDetailed#transformData [empty dataset]', () => {
   const reportInstance = new ReportCountSummaryTurningMovementDetailed();
 
-  const { count, counts } = setup_5_36781();
-  const studyData = new Map([[1, []]]);
-  let transformedData = reportInstance.transformData(count, { counts, studyData });
+  const { countLocation, counts, study } = setup_5_36781();
+  const studyData = new Map([[36781, []]]);
+  let transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
   const { hours, px, raw } = transformedData;
-  expect(hours).toBe(StudyHours.SCHOOL);
+  expect(hours).toBe(StudyHours.ROUTINE);
   expect(px).toBe(1390);
   transformedData = raw;
 
@@ -36,12 +36,12 @@ test('ReportCountSummaryTurningMovementDetailed#transformData [empty dataset]', 
 test('ReportCountSummaryTurningMovementDetailed#transformData [fuzz test, TMC]', () => {
   const reportInstance = new ReportCountSummaryTurningMovementDetailed();
 
-  const { count, counts } = setup_5_36781();
+  const { countLocation, counts, study } = setup_5_36781();
   for (let i = 0; i < 3; i++) {
     const countData = generateTmc();
-    const studyData = new Map([[1, countData]]);
+    const studyData = new Map([[36781, countData]]);
     expect(() => {
-      reportInstance.transformData(count, { counts, studyData });
+      reportInstance.transformData(study, { countLocation, counts, studyData });
     }).not.toThrow();
   }
 });
@@ -49,12 +49,12 @@ test('ReportCountSummaryTurningMovementDetailed#transformData [fuzz test, TMC]',
 test('ReportCountSummaryTurningMovementDetailed#transformData [fuzz test, 14-hour TMC]', () => {
   const reportInstance = new ReportCountSummaryTurningMovementDetailed();
 
-  const { count, counts } = setup_5_36781();
+  const { countLocation, counts, study } = setup_5_36781();
   for (let i = 0; i < 3; i++) {
     const countData = generateTmc14Hour();
-    const studyData = new Map([[1, countData]]);
+    const studyData = new Map([[36781, countData]]);
     expect(() => {
-      reportInstance.transformData(count, { counts, studyData });
+      reportInstance.transformData(study, { countLocation, counts, studyData });
     }).not.toThrow();
   }
 });
@@ -62,12 +62,12 @@ test('ReportCountSummaryTurningMovementDetailed#transformData [fuzz test, 14-hou
 test('ReportCountSummaryTurningMovementDetailed#transformData [fuzz test, TMC with missing]', () => {
   const reportInstance = new ReportCountSummaryTurningMovementDetailed();
 
-  const { count, counts } = setup_5_36781();
+  const { countLocation, counts, study } = setup_5_36781();
   for (let i = 0; i < 3; i++) {
     const countData = generateWithMissing(generateTmc());
-    const studyData = new Map([[1, countData]]);
+    const studyData = new Map([[36781, countData]]);
     expect(() => {
-      reportInstance.transformData(count, { counts, studyData });
+      reportInstance.transformData(study, { countLocation, counts, studyData });
     }).not.toThrow();
   }
 });
@@ -75,10 +75,15 @@ test('ReportCountSummaryTurningMovementDetailed#transformData [fuzz test, TMC wi
 test('ReportCountSummaryTurningMovementDetailed#transformData [Gerrard and Sumach: 5/36781]', () => {
   const reportInstance = new ReportCountSummaryTurningMovementDetailed();
 
-  const { count, counts, studyData } = setup_5_36781();
-  let transformedData = reportInstance.transformData(count, { counts, studyData });
+  const {
+    countLocation,
+    counts,
+    study,
+    studyData,
+  } = setup_5_36781();
+  let transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
   const { hours, px, raw } = transformedData;
-  expect(hours).toBe(StudyHours.SCHOOL);
+  expect(hours).toBe(StudyHours.ROUTINE);
   expect(px).toBe(1390);
   transformedData = raw;
 
@@ -88,9 +93,14 @@ test('ReportCountSummaryTurningMovementDetailed#transformData [Gerrard and Sumac
 test('ReportCountSummaryTurningMovementDetailed#generateCsv [Gerrard and Sumach: 5/36781]', () => {
   const reportInstance = new ReportCountSummaryTurningMovementDetailed();
 
-  const { count, counts, studyData } = setup_5_36781();
-  const transformedData = reportInstance.transformData(count, { counts, studyData });
+  const {
+    countLocation,
+    counts,
+    study,
+    studyData,
+  } = setup_5_36781();
+  const transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
   expect(() => {
-    reportInstance.generateCsv(count, transformedData);
+    reportInstance.generateCsv(study, transformedData);
   }).not.toThrow();
 });

--- a/tests/jest/unit/reports/ReportIdParser.spec.js
+++ b/tests/jest/unit/reports/ReportIdParser.spec.js
@@ -16,26 +16,26 @@ jest.mock('@/lib/db/CentrelineDAO');
 jest.mock('@/lib/db/StudyDAO');
 
 test('ReportIdParser.parseCollisionReportId [invalid]', async () => {
-  expect(parseCollisionReportId('')).rejects.toBeInstanceOf(InvalidReportIdError);
-  expect(parseCollisionReportId('/')).rejects.toBeInstanceOf(InvalidReportIdError);
-  expect(parseCollisionReportId('abc')).rejects.toBeInstanceOf(InvalidReportIdError);
-  expect(parseCollisionReportId('s1:AkttmBoXtmB')).rejects.toBeInstanceOf(InvalidReportIdError);
-  expect(parseCollisionReportId('s1:AkttmBoXtmB/')).rejects.toBeInstanceOf(InvalidReportIdError);
-  expect(parseCollisionReportId('/CORRIDOR')).rejects.toBeInstanceOf(InvalidReportIdError);
-  expect(
+  await expect(parseCollisionReportId('')).rejects.toBeInstanceOf(InvalidReportIdError);
+  await expect(parseCollisionReportId('/')).rejects.toBeInstanceOf(InvalidReportIdError);
+  await expect(parseCollisionReportId('abc')).rejects.toBeInstanceOf(InvalidReportIdError);
+  await expect(parseCollisionReportId('s1:AkttmBoXtmB')).rejects.toBeInstanceOf(InvalidReportIdError);
+  await expect(parseCollisionReportId('s1:AkttmBoXtmB/')).rejects.toBeInstanceOf(InvalidReportIdError);
+  await expect(parseCollisionReportId('/CORRIDOR')).rejects.toBeInstanceOf(InvalidReportIdError);
+  await expect(
     parseCollisionReportId('s1:AkttmBoXtmB/blargl'),
   ).rejects.toBeInstanceOf(InvalidReportIdError);
-  expect(parseCollisionReportId('s1:/POINTS')).rejects.toBeInstanceOf(InvalidReportIdError);
-  expect(parseCollisionReportId('5/36853')).rejects.toBeInstanceOf(InvalidReportIdError);
+  await expect(parseCollisionReportId('s1:/POINTS')).rejects.toBeInstanceOf(InvalidReportIdError);
+  await expect(parseCollisionReportId('5/36853')).rejects.toBeInstanceOf(InvalidReportIdError);
 });
 
 test('ReportIdParser.parseCollisionReportId', async () => {
   const resolvedValue = [{ a: 42 }, { b: 'foo' }];
   CentrelineDAO.byFeatures.mockResolvedValue(resolvedValue);
-  expect(parseCollisionReportId('s1:AkttmBoXtmB/POINTS')).resolves.toEqual({
+  await expect(parseCollisionReportId('s1:AkttmBoXtmB/POINTS')).resolves.toEqual({
     features: [
-      { centrelineId: 13462962, centrelineType: CentrelineType.SEGMENT },
-      { centrelineId: 13462260, centrelineType: CentrelineType.SEGMENT },
+      { centrelineId: 13462962, centrelineType: CentrelineType.INTERSECTION },
+      { centrelineId: 13462260, centrelineType: CentrelineType.INTERSECTION },
     ],
     locationsSelection: {
       locations: resolvedValue,
@@ -47,87 +47,87 @@ test('ReportIdParser.parseCollisionReportId', async () => {
 });
 
 test('ReportIdParser.parseStudyReportId [invalid]', async () => {
-  expect(
+  await expect(
     parseStudyReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, ''),
   ).rejects.toBeInstanceOf(InvalidReportIdError);
-  expect(
+  await expect(
     parseStudyReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, '/'),
   ).rejects.toBeInstanceOf(InvalidReportIdError);
-  expect(
+  await expect(
     parseStudyReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, 'abc'),
   ).rejects.toBeInstanceOf(InvalidReportIdError);
-  expect(
+  await expect(
     parseStudyReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, '5'),
   ).rejects.toBeInstanceOf(InvalidReportIdError);
-  expect(
+  await expect(
     parseStudyReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, '5/'),
   ).rejects.toBeInstanceOf(InvalidReportIdError);
-  expect(
+  await expect(
     parseStudyReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, '/36583'),
   ).rejects.toBeInstanceOf(InvalidReportIdError);
-  expect(
+  await expect(
     parseStudyReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, '5/blargl'),
   ).rejects.toBeInstanceOf(InvalidReportIdError);
-  expect(
+  await expect(
     parseStudyReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, 'foo/36583'),
   ).rejects.toBeInstanceOf(InvalidReportIdError);
-  expect(
+  await expect(
     parseStudyReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, 's1:AkttmBoXtmB/POINTS'),
   ).rejects.toBeInstanceOf(InvalidReportIdError);
 });
 
 test('ReportIdParser.parseStudyReportId [speed-related]', async () => {
   let resolvedValue = {
-    type: { studyType: StudyType.ATR_SPEED_VOLUME },
+    studyType: StudyType.ATR_SPEED_VOLUME,
   };
-  StudyDAO.byCategoryAndCountGroup.mockResolvedValue(resolvedValue);
-  expect(
-    parseCollisionReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, '5/36583'),
+  StudyDAO.byStudyTypeAndCountGroup.mockResolvedValue(resolvedValue);
+  await expect(
+    parseStudyReportId(ReportType.SPEED_PERCENTILE, 'TMC/36583'),
   ).rejects.toBeInstanceOf(InvalidReportIdError);
-  expect(
-    parseCollisionReportId(ReportType.SPEED_PERCENTILE, '4/1234'),
+  await expect(
+    parseStudyReportId(ReportType.SPEED_PERCENTILE, 'ATR_SPEED_VOLUME/1234'),
   ).resolves.toEqual({
-    categoryId: 4,
     countGroupId: 1234,
     study: resolvedValue,
+    studyType: StudyType.ATR_SPEED_VOLUME,
   });
 
   resolvedValue = {
-    type: { studyType: StudyType.ATR_VOLUME },
+    studyType: StudyType.ATR_VOLUME,
   };
-  StudyDAO.byCategoryAndCountGroup.mockResolvedValue(resolvedValue);
-  expect(
-    parseCollisionReportId(ReportType.SPEED_PERCENTILE, '4/1234'),
+  StudyDAO.byStudyTypeAndCountGroup.mockResolvedValue(resolvedValue);
+  await expect(
+    parseStudyReportId(ReportType.SPEED_PERCENTILE, 'ATR_SPEED_VOLUME/1234'),
   ).rejects.toBeInstanceOf(InvalidReportIdError);
 });
 
 test('ReportIdParser.parseStudyReportId [TMC-related]', async () => {
   const resolvedValue = {
-    type: { studyType: StudyType.TMC },
+    studyType: StudyType.TMC,
   };
-  StudyDAO.byCategoryAndCountGroup.mockResolvedValue(resolvedValue);
-  expect(
-    parseCollisionReportId(ReportType.SPEED_PERCENTILE, '4/1234'),
+  StudyDAO.byStudyTypeAndCountGroup.mockResolvedValue(resolvedValue);
+  await expect(
+    parseStudyReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, 'ATR_SPEED_VOLUME/1234'),
   ).rejects.toBeInstanceOf(InvalidReportIdError);
-  expect(
-    parseCollisionReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, '5/36583'),
+  await expect(
+    parseStudyReportId(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT, 'TMC/36583'),
   ).resolves.toEqual({
-    categoryId: 5,
-    countGroupId: 36853,
+    countGroupId: 36583,
     study: resolvedValue,
+    studyType: StudyType.TMC,
   });
 });
 
 test('ReportIdParser.parseStudyReportId [neither speed- nor TMC-related]', async () => {
   const resolvedValue = {
-    type: { studyType: StudyType.ATR_VOLUME },
+    studyType: StudyType.ATR_VOLUME,
   };
-  StudyDAO.byCategoryAndCountGroup.mockResolvedValue(resolvedValue);
-  expect(
-    parseCollisionReportId(ReportType.COUNT_SUMMARY_24H_GRAPHICAL, '1/5678'),
+  StudyDAO.byStudyTypeAndCountGroup.mockResolvedValue(resolvedValue);
+  await expect(
+    parseStudyReportId(ReportType.COUNT_SUMMARY_24H_GRAPHICAL, 'ATR_VOLUME/5678'),
   ).resolves.toEqual({
-    categoryId: 1,
     countGroupId: 5678,
     study: resolvedValue,
+    studyType: StudyType.ATR_VOLUME,
   });
 });

--- a/tests/jest/unit/reports/ReportPeakHourFactor.spec.js
+++ b/tests/jest/unit/reports/ReportPeakHourFactor.spec.js
@@ -42,12 +42,12 @@ function expectPeakHourFactorsMatch(actual, expected) {
 test('ReportPeakHourFactor#transformData [empty data]', () => {
   const reportInstance = new ReportPeakHourFactor();
 
-  const { count, counts } = setup_5_36781();
-  const studyData = new Map([[1, []]]);
-  const transformedData = reportInstance.transformData(count, { counts, studyData });
+  const { countLocation, counts, study } = setup_5_36781();
+  const studyData = new Map([[36781, []]]);
+  const transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
   const { date, hours, px } = transformedData;
-  expect(date.equals(count.date)).toBe(true);
-  expect(hours).toBe(StudyHours.SCHOOL);
+  expect(date.equals(study.startDate)).toBe(true);
+  expect(hours).toBe(StudyHours.ROUTINE);
   expect(px).toBe(1390);
 
   const { amPeak, pmPeak } = transformedData_PEAK_HOUR_FACTOR_5_36781_empty;
@@ -58,12 +58,12 @@ test('ReportPeakHourFactor#transformData [empty data]', () => {
 test('ReportPeakHourFactor#transformData [fuzz test, TMC]', () => {
   const reportInstance = new ReportPeakHourFactor();
 
-  const { count, counts } = setup_5_36781();
+  const { countLocation, counts, study } = setup_5_36781();
   for (let i = 0; i < 3; i++) {
     const countData = generateTmc();
-    const studyData = new Map([[1, countData]]);
+    const studyData = new Map([[36781, countData]]);
     expect(() => {
-      reportInstance.transformData(count, { counts, studyData });
+      reportInstance.transformData(study, { countLocation, counts, studyData });
     }).not.toThrow();
   }
 });
@@ -71,12 +71,12 @@ test('ReportPeakHourFactor#transformData [fuzz test, TMC]', () => {
 test('ReportPeakHourFactor#transformData [fuzz test, 14-hour TMC]', () => {
   const reportInstance = new ReportPeakHourFactor();
 
-  const { count, counts } = setup_5_36781();
+  const { countLocation, counts, study } = setup_5_36781();
   for (let i = 0; i < 3; i++) {
     const countData = generateTmc14Hour();
-    const studyData = new Map([[1, countData]]);
+    const studyData = new Map([[36781, countData]]);
     expect(() => {
-      reportInstance.transformData(count, { counts, studyData });
+      reportInstance.transformData(study, { countLocation, counts, studyData });
     }).not.toThrow();
   }
 });
@@ -84,12 +84,12 @@ test('ReportPeakHourFactor#transformData [fuzz test, 14-hour TMC]', () => {
 test('ReportPeakHourFactor#transformData [fuzz test, TMC with missing]', () => {
   const reportInstance = new ReportPeakHourFactor();
 
-  const { count, counts } = setup_5_36781();
+  const { countLocation, counts, study } = setup_5_36781();
   for (let i = 0; i < 3; i++) {
     const countData = generateWithMissing(generateTmc());
-    const studyData = new Map([[1, countData]]);
+    const studyData = new Map([[36781, countData]]);
     expect(() => {
-      reportInstance.transformData(count, { counts, studyData });
+      reportInstance.transformData(study, { countLocation, counts, studyData });
     }).not.toThrow();
   }
 });
@@ -97,11 +97,16 @@ test('ReportPeakHourFactor#transformData [fuzz test, TMC with missing]', () => {
 test('ReportPeakHourFactor#transformData [Gerrard and Sumach: 5/36781]', () => {
   const reportInstance = new ReportPeakHourFactor();
 
-  const { count, counts, studyData } = setup_5_36781();
-  const transformedData = reportInstance.transformData(count, { counts, studyData });
+  const {
+    countLocation,
+    counts,
+    study,
+    studyData,
+  } = setup_5_36781();
+  const transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
   const { date, hours, px } = transformedData;
-  expect(date.equals(count.date)).toBe(true);
-  expect(hours).toBe(StudyHours.SCHOOL);
+  expect(date.equals(study.startDate)).toBe(true);
+  expect(hours).toBe(StudyHours.ROUTINE);
   expect(px).toBe(1390);
 
   const { amPeak, pmPeak } = transformedData_PEAK_HOUR_FACTOR_5_36781;
@@ -112,9 +117,14 @@ test('ReportPeakHourFactor#transformData [Gerrard and Sumach: 5/36781]', () => {
 test('ReportPeakHourFactor#generateCsv [Gerrard and Sumach: 5/36781]', () => {
   const reportInstance = new ReportPeakHourFactor();
 
-  const { count, counts, studyData } = setup_5_36781();
-  const transformedData = reportInstance.transformData(count, { counts, studyData });
+  const {
+    countLocation,
+    counts,
+    study,
+    studyData,
+  } = setup_5_36781();
+  const transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
   expect(() => {
-    reportInstance.generateCsv(count, transformedData);
+    reportInstance.generateCsv(study, transformedData);
   }).not.toThrow();
 });

--- a/tests/jest/unit/reports/ReportSpeedPercentile.spec.js
+++ b/tests/jest/unit/reports/ReportSpeedPercentile.spec.js
@@ -53,18 +53,18 @@ test('ReportSpeedPercentile.getArrayStats', () => {
 test('ReportSpeedPercentile#transformData [empty dataset]', () => {
   const reportInstance = new ReportSpeedPercentile();
 
-  const { arteries, counts, study } = setup_4_2156283();
-  const studyData = new Map([[17, []]]);
-  let transformedData = reportInstance.transformData(study, { arteries, counts, studyData });
+  const { countLocation, counts, study } = setup_4_2156283();
+  const studyData = new Map([[2156283, []]]);
+  let transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
   expect(transformedData).toHaveLength(1);
   const { date, direction, stats } = transformedData[0];
-  expect(date.equals(study.date)).toBe(true);
+  expect(date.equals(study.startDate)).toBe(true);
   expect(direction).toBe(CardinalDirection.NORTH);
   transformedData = stats;
   expect(transformedData).toEqual(transformedData_SPEED_PERCENTILE_4_2156283_empty);
 });
 
-test('ReportSpeedPercentile#transformData [Morningside S of Lawrence: 4/2156283]', () => {
+test('ReportSpeedPercentile#transformData [Morningside S of Lawrence: ATR_SPEED_VOLUME/2156283]', () => {
   const reportInstance = new ReportSpeedPercentile();
 
   /*
@@ -72,15 +72,15 @@ test('ReportSpeedPercentile#transformData [Morningside S of Lawrence: 4/2156283]
    * tolerate some deviation from legacy report values.
    */
   const {
-    arteries,
+    countLocation,
     counts,
     study,
     studyData,
   } = setup_4_2156283();
-  let transformedData = reportInstance.transformData(study, { arteries, counts, studyData });
+  let transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
   expect(transformedData).toHaveLength(1);
   const { date, direction, stats } = transformedData[0];
-  expect(date.equals(study.date)).toBe(true);
+  expect(date.equals(study.startDate)).toBe(true);
   expect(direction).toBe(CardinalDirection.NORTH);
   transformedData = stats;
 
@@ -134,16 +134,16 @@ test('ReportSpeedPercentile#transformData [Morningside S of Lawrence: 4/2156283]
   });
 });
 
-test('ReportSpeedPercentile#generateCsv [Morningside S of Lawrence: 4/2156283]', () => {
+test('ReportSpeedPercentile#generateCsv [Morningside S of Lawrence: ATR_SPEED_VOLUME/2156283]', () => {
   const reportInstance = new ReportSpeedPercentile();
 
   const {
-    arteries,
+    countLocation,
     counts,
     study,
     studyData,
   } = setup_4_2156283();
-  const transformedData = reportInstance.transformData(study, { arteries, counts, studyData });
+  const transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
   expect(() => {
     reportInstance.generateCsv(study, transformedData);
   }).not.toThrow();

--- a/tests/jest/unit/reports/data/SetupTestData.js
+++ b/tests/jest/unit/reports/data/SetupTestData.js
@@ -71,17 +71,44 @@ function setup_5_34621_directional() {
   );
   const countData = mapTmcCountData(countData_5_34621);
 
-  const count = {
-    date: DateTime.fromSQL('2016-11-02 00:00:00'),
+  const study = {
+    legacy: true,
+    countLocationId: 14944,
+    studyType: StudyType.TMC,
+    countGroupId: 34621,
+    startDate: DateTime.fromSQL('2016-11-02 00:00:00'),
+    endDate: DateTime.fromSQL('2016-11-02 00:00:00'),
+    duration: null,
+    daysOfWeek: [3],
     hours: StudyHours.ROUTINE,
-    id: 34621,
-    locationDesc: 'CHAMPAGNE DR AT CHESSWOOD DR',
-  };
-  const intersection = {
+    centrelineId: 13448440,
+    centrelineType: CentrelineType.INTERSECTION,
     geom: {
       type: 'Point',
       coordinates: [-79.4765905, 43.76431897],
     },
+  };
+  const countLocation = {
+    id: 14944,
+    legacy: true,
+    description: 'CHAMPAGNE DR AT CHESSWOOD DR',
+    centrelineId: 13448440,
+    centrelineType: CentrelineType.INTERSECTION,
+    geom: {
+      type: 'Point',
+      coordinates: [-79.4765905, 43.76431897],
+    },
+  };
+  const count = {
+    id: 34621,
+    legacy: true,
+    studyType: StudyType.TMC,
+    hours: StudyHours.ROUTINE,
+    date: DateTime.fromSQL('2016-11-02 00:00:00'),
+    notes: null,
+    countLocationId: 14944,
+    direction: null,
+    extraMetadata: { arteryCode: 14944, stationCode: '0013448440' },
   };
   const segments = [
     {
@@ -163,8 +190,9 @@ function setup_5_34621_directional() {
   return {
     count,
     countData,
-    intersection,
+    intersection: countLocation,
     segments,
+    study,
   };
 }
 
@@ -174,18 +202,51 @@ function setup_5_36781() {
   );
   const countData = mapTmcCountData(countData_5_36781);
 
-  const count = {
-    date: DateTime.fromSQL('2018-02-27 00:00:00'),
-    hours: StudyHours.SCHOOL,
-    id: 1,
-    locationDesc: 'GERRARD ST AT SUMACH ST (PX 1390)',
-    type: { studyType: StudyType.TMC },
+  const study = {
+    legacy: true,
+    countLocationId: 5074,
+    studyType: StudyType.TMC,
+    countGroupId: 36781,
+    startDate: DateTime.fromSQL('2018-02-27 00:00:00'),
+    endDate: DateTime.fromSQL('2018-02-27 00:00:00'),
+    duration: null,
+    daysOfWeek: [2],
+    hours: StudyHours.ROUTINE,
+    centrelineId: 13464586,
+    centrelineType: CentrelineType.INTERSECTION,
+    geom: {
+      type: 'Point',
+      coordinates: [-79.3614980028034, 43.6631579996018],
+    },
   };
-  const studyData = new Map([[1, countData]]);
+  const countLocation = {
+    id: 5074,
+    legacy: true,
+    description: 'GERRARD ST AT SUMACH ST (PX 1390)',
+    centrelineId: 13464586,
+    centrelineType: CentrelineType.INTERSECTION,
+    geom: {
+      type: 'Point',
+      coordinates: [-79.3614980028034, 43.6631579996018],
+    },
+  };
+  const counts = [{
+    id: 36781,
+    legacy: true,
+    studyType: StudyType.TMC,
+    hours: StudyHours.ROUTINE,
+    date: DateTime.fromSQL('2018-02-27 00:00:00'),
+    notes: null,
+    countLocationId: 5074,
+    direction: null,
+    extraMetadata: { arteryCode: 5074, stationCode: '0013464586' },
+  }];
+  const studyData = new Map([[36781, countData]]);
 
   return {
-    count,
-    counts: [count],
+    countLocation,
+    counts,
+    study,
     studyData,
   };
 }
@@ -196,17 +257,44 @@ function setup_5_38661_directional() {
   );
   const countData = mapTmcCountData(countData_5_38661);
 
-  const count = {
-    date: DateTime.fromSQL('2019-04-13 00:00:00'),
+  const study = {
+    legacy: true,
+    countLocationId: 4117,
+    studyType: StudyType.TMC,
+    countGroupId: 38661,
+    startDate: DateTime.fromSQL('2019-04-13 00:00:00'),
+    endDate: DateTime.fromSQL('2019-04-13 00:00:00'),
+    duration: null,
+    daysOfWeek: [6],
     hours: StudyHours.ROUTINE,
-    id: 38661,
-    locationDesc: 'OVERLEA BLVD AT THORNCLIFFE PARK DR & E TCS (PX 679)',
-  };
-  const intersection = {
+    centrelineId: 13456854,
+    centrelineType: CentrelineType.INTERSECTION,
     geom: {
       type: 'Point',
-      coordinates: [-79.343625497, 43.70747321],
+      coordinates: [-79.3436250025741, 43.7074729970241],
     },
+  };
+  const countLocation = {
+    id: 4117,
+    legacy: true,
+    description: 'OVERLEA BLVD AT THORNCLIFFE PARK DR & E TCS (PX 679)',
+    centrelineId: 13456854,
+    centrelineType: CentrelineType.INTERSECTION,
+    geom: {
+      type: 'Point',
+      coordinates: [-79.3436250025741, 43.7074729970241],
+    },
+  };
+  const count = {
+    id: 38661,
+    legacy: true,
+    studyType: StudyType.TMC,
+    hours: StudyHours.ROUTINE,
+    date: DateTime.fromSQL('2019-04-13 00:00:00'),
+    notes: null,
+    countLocationId: 4117,
+    direction: null,
+    extraMetadata: { arteryCode: 4117, stationCode: '0013456854' },
   };
   const segments = [
     {
@@ -284,8 +372,9 @@ function setup_5_38661_directional() {
   return {
     count,
     countData,
-    intersection,
+    intersection: countLocation,
     segments,
+    study,
   };
 }
 

--- a/tests/jest/unit/reports/data/SetupTestData.js
+++ b/tests/jest/unit/reports/data/SetupTestData.js
@@ -3,6 +3,7 @@ import path from 'path';
 
 import {
   CardinalDirection,
+  CentrelineType,
   StudyHours,
   StudyType,
 } from '@/lib/Constants';
@@ -21,27 +22,45 @@ function setup_4_2156283() {
     path.resolve(__dirname, 'countData_4_2156283.json'),
   );
 
-  const artery = {
-    approachDir: CardinalDirection.NORTH,
-    arteryCode: 2946,
-    stationCode: 2946,
-    street1: 'MORNINGSIDE AVE',
+  const study = {
+    legacy: true,
+    countLocationId: 2946,
+    studyType: StudyType.ATR_SPEED_VOLUME,
+    countGroupId: 2156281,
+    startDate: DateTime.fromSQL('2019-03-07 00:00:00'),
+    endDate: DateTime.fromSQL('2019-03-07 00:00:00'),
+    duration: 24,
+    daysOfWeek: [4],
+    hours: null,
+    centrelineId: 108387,
+    centrelineType: CentrelineType.SEGMENT,
+    // TODO: geom as point location?
   };
-  const count = {
-    arteryCode: 2946,
+  const countLocation = {
+    id: 2946,
+    legacy: true,
+    description: 'MORNINGSIDE AVE S OF LAWRENCE AVE',
+    centrelineId: 108387,
+    centrelineType: CentrelineType.SEGMENT,
+    // TODO: geom as point location?
+  };
+  const counts = [{
+    id: 2156283,
+    legacy: true,
+    studyType: StudyType.ATR_SPEED_VOLUME,
+    hours: null,
     date: DateTime.fromSQL('2019-03-07 00:00:00'),
-    id: 17,
-    locationDesc: 'MORNINGSIDE AVE N/B S OF LAWRENCE AVE',
-    type: { studyType: StudyType.ATR_SPEED_VOLUME },
-  };
-  const counts = [count];
-  const arteries = new Map([[2946, artery]]);
-  const studyData = new Map([[17, countData_4_2156283]]);
+    notes: null,
+    countLocationId: 2946,
+    direction: CardinalDirection.NORTH,
+    extraMetadata: { arteryCode: 2946, stationCode: '2946' },
+  }];
+  const studyData = new Map([[2156283, countData_4_2156283]]);
 
   return {
-    arteries,
+    countLocation,
     counts,
-    study: count,
+    study,
     studyData,
   };
 }

--- a/tests/jest/unit/reports/data/transformedData_COUNT_SUMMARY_24H_4_2156283.json
+++ b/tests/jest/unit/reports/data/transformedData_COUNT_SUMMARY_24H_4_2156283.json
@@ -1,70 +1,78 @@
-[
-  {
-    "title": "MORNINGSIDE AVE",
-    "directionGroups": [
-      {
-        "title": "Northbound",
-        "counts": [
-          {
-            "location":"MORNINGSIDE AVE N/B S OF LAWRENCE AVE",
-            "category": "Speed / Volume ATR",
-            "stationCode": 2946,
-            "arteryCode": 2946,
-            "date": "2019-03-07 00:00:00.000",
-            "dayOfWeek": "Thu",
-            "amPeak": {
-              "sum": 488,
-              "timeRange": {
-                "start": "2019-03-07 08:00:00.000",
-                "end": "2019-03-07 09:00:00.000"
-              }
+{
+  "countLocation": {
+    "centrelineId": 108387,
+    "centrelineType": 1,
+    "description": "MORNINGSIDE AVE S OF LAWRENCE AVE",
+    "id": 2946,
+    "legacy": true
+  },
+  "sections": [
+    {
+      "title": "MORNINGSIDE AVE S OF LAWRENCE AVE",
+      "directionGroups": [
+        {
+          "title": "Northbound",
+          "counts": [
+            {
+              "studyType": "Speed / Volume ATR",
+              "stationCode": "2946",
+              "arteryCode": 2946,
+              "date": "2019-03-07 00:00:00.000",
+              "dayOfWeek": "Thu",
+              "amPeak": {
+                "sum": 488,
+                "timeRange": {
+                  "start": "2019-03-07 08:00:00.000",
+                  "end": "2019-03-07 09:00:00.000"
+                }
+              },
+              "pmPeak": {
+                "sum": 481,
+                "timeRange": {
+                  "start": "2019-03-07 15:30:00.000",
+                  "end": "2019-03-07 16:30:00.000"
+                }
+              },
+              "offPeak": {
+                "sum": 391,
+                "timeRange": {
+                  "start": "2019-03-07 14:30:00.000",
+                  "end": "2019-03-07 15:30:00.000"
+                }
+              },
+              "total": 6063
+            }
+          ],
+          "totals": {
+            "sum": {
+              "amPeak": 488,
+              "pmPeak": 481,
+              "offPeak": 391,
+              "total": 6063
             },
-            "pmPeak": {
-              "sum": 481,
-              "timeRange": {
-                "start": "2019-03-07 15:30:00.000",
-                "end": "2019-03-07 16:30:00.000"
-              }
-            },
-            "offPeak": {
-              "sum": 391,
-              "timeRange": {
-                "start": "2019-03-07 14:30:00.000",
-                "end": "2019-03-07 15:30:00.000"
-              }
-            },
-            "total": 6063
-          }
-        ],
-        "totals": {
-          "sum": {
-            "amPeak": 488,
-            "pmPeak": 481,
-            "offPeak": 391,
-            "total": 6063
-          },
-          "avg": {
-            "amPeak": 488,
-            "pmPeak": 481,
-            "offPeak": 391,
-            "total": 6063
+            "avg": {
+              "amPeak": 488,
+              "pmPeak": 481,
+              "offPeak": 391,
+              "total": 6063
+            }
           }
         }
-      }
-    ],
-    "totals": {
-      "sum": {
-        "amPeak": 488,
-        "pmPeak": 481,
-        "offPeak": 391,
-        "total": 6063
-      },
-      "avg": {
-        "amPeak": 488,
-        "pmPeak": 481,
-        "offPeak": 391,
-        "total": 6063
+      ],
+      "totals": {
+        "sum": {
+          "amPeak": 488,
+          "pmPeak": 481,
+          "offPeak": 391,
+          "total": 6063
+        },
+        "avg": {
+          "amPeak": 488,
+          "pmPeak": 481,
+          "offPeak": 391,
+          "total": 6063
+        }
       }
     }
-  }
-]
+  ]
+}

--- a/tests/jest/unit/reports/data/transformedData_COUNT_SUMMARY_24H_4_2156283_empty.json
+++ b/tests/jest/unit/reports/data/transformedData_COUNT_SUMMARY_24H_4_2156283_empty.json
@@ -1,61 +1,69 @@
-[
-  {
-    "title": "MORNINGSIDE AVE",
-    "directionGroups": [
-      {
-        "title": "Northbound",
-        "counts": [
-          {
-            "location":"MORNINGSIDE AVE N/B S OF LAWRENCE AVE",
-            "category": "Speed / Volume ATR",
-            "stationCode": 2946,
-            "arteryCode": 2946,
-            "date": "2019-03-07 00:00:00.000",
-            "dayOfWeek": "Thu",
-            "amPeak": {
-              "sum": 0,
-              "timeRange": null
+{
+  "countLocation": {
+    "centrelineId": 108387,
+    "centrelineType": 1,
+    "description": "MORNINGSIDE AVE S OF LAWRENCE AVE",
+    "id": 2946,
+    "legacy": true
+  },
+  "sections": [
+    {
+      "title": "MORNINGSIDE AVE S OF LAWRENCE AVE",
+      "directionGroups": [
+        {
+          "title": "Northbound",
+          "counts": [
+            {
+              "studyType": "Speed / Volume ATR",
+              "stationCode": "2946",
+              "arteryCode": 2946,
+              "date": "2019-03-07 00:00:00.000",
+              "dayOfWeek": "Thu",
+              "amPeak": {
+                "sum": 0,
+                "timeRange": null
+              },
+              "pmPeak": {
+                "sum": 0,
+                "timeRange": null
+              },
+              "offPeak": {
+                "sum": 0,
+                "timeRange": null
+              },
+              "total": 0
+            }
+          ],
+          "totals": {
+            "sum": {
+              "amPeak": 0,
+              "pmPeak": 0,
+              "offPeak": 0,
+              "total": 0
             },
-            "pmPeak": {
-              "sum": 0,
-              "timeRange": null
-            },
-            "offPeak": {
-              "sum": 0,
-              "timeRange": null
-            },
-            "total": 0
-          }
-        ],
-        "totals": {
-          "sum": {
-            "amPeak": 0,
-            "pmPeak": 0,
-            "offPeak": 0,
-            "total": 0
-          },
-          "avg": {
-            "amPeak": 0,
-            "pmPeak": 0,
-            "offPeak": 0,
-            "total": 0
+            "avg": {
+              "amPeak": 0,
+              "pmPeak": 0,
+              "offPeak": 0,
+              "total": 0
+            }
           }
         }
-      }
-    ],
-    "totals": {
-      "sum": {
-        "amPeak": 0,
-        "pmPeak": 0,
-        "offPeak": 0,
-        "total": 0
-      },
-      "avg": {
-        "amPeak": 0,
-        "pmPeak": 0,
-        "offPeak": 0,
-        "total": 0
+      ],
+      "totals": {
+        "sum": {
+          "amPeak": 0,
+          "pmPeak": 0,
+          "offPeak": 0,
+          "total": 0
+        },
+        "avg": {
+          "amPeak": 0,
+          "pmPeak": 0,
+          "offPeak": 0,
+          "total": 0
+        }
       }
     }
-  }
-]
+  ]
+}

--- a/tests/jest/unit/reports/format/MovePdfGenerator.spec.js
+++ b/tests/jest/unit/reports/format/MovePdfGenerator.spec.js
@@ -35,31 +35,43 @@ beforeAll(MovePdfGenerator.init);
 
 function setup_4_2156283_single() {
   const study = {
-    arteryGroupId: 2946,
+    legacy: true,
+    countLocationId: 2946,
+    studyType: StudyType.ATR_SPEED_VOLUME,
+    countGroupId: 2156281,
+    startDate: DateTime.fromSQL('2019-03-07 00:00:00'),
+    endDate: DateTime.fromSQL('2019-03-07 00:00:00'),
+    duration: 24,
+    daysOfWeek: [4],
+    hours: null,
     centrelineId: 108387,
     centrelineType: CentrelineType.SEGMENT,
-    countGroupId: 2156281,
-    endDate: DateTime.fromSQL('2019-03-07 00:00:00'),
-    startDate: DateTime.fromSQL('2019-03-07 00:00:00'),
-    type: { id: 4, studyType: StudyType.ATR_SPEED_VOLUME },
+    // TODO: geom as point location?
   };
-  StudyDAO.byCategoryAndCountGroup.mockResolvedValue(study);
+  StudyDAO.byStudyTypeAndCountGroup.mockResolvedValue(study);
 
+  const countLocation = {
+    id: 2946,
+    legacy: true,
+    description: 'MORNINGSIDE AVE S OF LAWRENCE AVE',
+    centrelineId: 108387,
+    centrelineType: CentrelineType.SEGMENT,
+    // TODO: geom as point location?
+  };
   const counts = [{
-    arteryCode: 2946,
-    date: DateTime.fromSQL('2019-03-07 00:00:00'),
     id: 2156283,
-    locationDesc: 'MORNINGSIDE AVE N/B S OF LAWRENCE AVE',
-    type: { studyType: StudyType.ATR_SPEED_VOLUME },
+    legacy: true,
+    studyType: StudyType.ATR_SPEED_VOLUME,
+    hours: null,
+    date: DateTime.fromSQL('2019-03-07 00:00:00'),
+    notes: null,
+    countLocationId: 2946,
+    direction: CardinalDirection.NORTH,
+    extraMetadata: { arteryCode: 2946, stationCode: '2946' },
   }];
-  const arteries = new Map([[2946, {
-    approachDir: CardinalDirection.NORTH,
-    arteryCode: 2946,
-    stationCode: 2946,
-    street1: 'MORNINGSIDE AVE',
-  }]]);
   const studyData = new Map([[2156283, countData_4_2156283]]);
-  StudyDataDAO.byStudy.mockResolvedValue({ arteries, counts, studyData });
+
+  StudyDataDAO.byStudy.mockResolvedValue({ countLocation, counts, studyData });
   CentrelineDAO.byFeature.mockResolvedValue({
     centrelineId: 108387,
     centrelineType: CentrelineType.SEGMENT,
@@ -83,23 +95,48 @@ function setup_4_2156283_single() {
 
 function setup_5_36781() {
   const study = {
+    legacy: true,
+    countLocationId: 5074,
+    studyType: StudyType.TMC,
+    countGroupId: 36781,
+    startDate: DateTime.fromSQL('2018-02-27 00:00:00'),
+    endDate: DateTime.fromSQL('2018-02-27 00:00:00'),
+    duration: null,
+    daysOfWeek: [2],
+    hours: StudyHours.SCHOOL,
     centrelineId: 13464586,
     centrelineType: CentrelineType.INTERSECTION,
-    countGroupId: 36781,
-    endDate: DateTime.fromSQL('2018-02-27 00:00:00'),
-    startDate: DateTime.fromSQL('2018-02-27 00:00:00'),
-    type: { id: 5, studyType: StudyType.TMC },
+    geom: {
+      type: 'Point',
+      coordinates: [-79.361498301, 43.663158537],
+    },
   };
-  StudyDAO.byCategoryAndCountGroup.mockResolvedValue(study);
+  StudyDAO.byStudyTypeAndCountGroup.mockResolvedValue(study);
 
+  const countLocation = {
+    id: 5074,
+    legacy: true,
+    description: 'GERRARD ST AT SUMACH ST (PX 1390)',
+    centrelineId: 13464586,
+    centrelineType: CentrelineType.INTERSECTION,
+    geom: {
+      type: 'Point',
+      coordinates: [-79.361498301, 43.663158537],
+    },
+  };
   const counts = [{
-    date: DateTime.fromSQL('2018-02-27 00:00:00'),
-    hours: StudyHours.SCHOOL,
     id: 36781,
-    locationDesc: 'GERRARD ST AT SUMACH ST (PX 1390)',
+    legacy: true,
+    studyType: StudyType.TMC,
+    hours: StudyHours.SCHOOL,
+    date: DateTime.fromSQL('2018-02-27 00:00:00'),
+    notes: null,
+    countLocationId: 5074,
+    direction: null,
+    extraMetadata: { arteryCode: 5074, stationCode: '0013464586' },
   }];
   const studyData = new Map([[36781, countData_5_36781]]);
-  StudyDataDAO.byStudy.mockResolvedValue({ counts, studyData });
+  StudyDataDAO.byStudy.mockResolvedValue({ countLocation, counts, studyData });
   CentrelineDAO.byFeature.mockResolvedValue({
     centrelineId: 13464586,
     centrelineType: CentrelineType.INTERSECTION,
@@ -113,23 +150,48 @@ function setup_5_36781() {
 
 function setup_5_38661() {
   const study = {
+    legacy: true,
+    countLocationId: 4117,
+    studyType: StudyType.TMC,
+    countGroupId: 38661,
+    startDate: DateTime.fromSQL('2019-04-13 00:00:00'),
+    endDate: DateTime.fromSQL('2019-04-13 00:00:00'),
+    duration: null,
+    daysOfWeek: [6],
+    hours: StudyHours.ROUTINE,
     centrelineId: 13456854,
     centrelineType: CentrelineType.INTERSECTION,
-    countGroupId: 38661,
-    endDate: DateTime.fromSQL('2019-04-13 00:00:00'),
-    startDate: DateTime.fromSQL('2019-04-13 00:00:00'),
-    type: { id: 5, studyType: StudyType.TMC },
+    geom: {
+      type: 'Point',
+      coordinates: [-79.343625497, 43.70747321],
+    },
   };
-  StudyDAO.byCategoryAndCountGroup.mockResolvedValue(study);
+  StudyDAO.byStudyTypeAndCountGroup.mockResolvedValue(study);
 
+  const countLocation = {
+    id: 4117,
+    legacy: true,
+    description: 'OVERLEA BLVD AT THORNCLIFFE PARK DR & E TCS (PX 679)',
+    centrelineId: 13456854,
+    centrelineType: CentrelineType.INTERSECTION,
+    geom: {
+      type: 'Point',
+      coordinates: [-79.343625497, 43.70747321],
+    },
+  };
   const counts = [{
-    date: DateTime.fromSQL('2019-04-13 00:00:00'),
-    hours: StudyHours.ROUTINE,
     id: 38661,
-    locationDesc: 'OVERLEA BLVD AT THORNCLIFFE PARK DR & E TCS (PX 679)',
+    legacy: true,
+    studyType: StudyType.TMC,
+    hours: StudyHours.ROUTINE,
+    date: DateTime.fromSQL('2019-04-13 00:00:00'),
+    notes: null,
+    countLocationId: 4117,
+    direction: null,
+    extraMetadata: { arteryCode: 4117, stationCode: '0013456854' },
   }];
   const studyData = new Map([[38661, countData_5_38661]]);
-  StudyDataDAO.byStudy.mockResolvedValue({ counts, studyData });
+  StudyDataDAO.byStudy.mockResolvedValue({ countLocation, counts, studyData });
   CentrelineDAO.byFeature.mockResolvedValue({
     centrelineId: 13456854,
     centrelineType: CentrelineType.INTERSECTION,
@@ -222,7 +284,7 @@ test('COUNT_SUMMARY_24H', async () => {
   setup_4_2156283_single();
 
   const reportInstance = ReportFactory.getInstance(ReportType.COUNT_SUMMARY_24H);
-  const doc = await reportInstance.generate('4/2156283', ReportFormat.PDF, {});
+  const doc = await reportInstance.generate('ATR_SPEED_VOLUME/2156283', ReportFormat.PDF, {});
   expect(getNumPages(doc)).toBe(1);
 });
 
@@ -230,7 +292,7 @@ test('COUNT_SUMMARY_24H_DETAILED', async () => {
   setup_4_2156283_single();
 
   const reportInstance = ReportFactory.getInstance(ReportType.COUNT_SUMMARY_24H_DETAILED);
-  const doc = await reportInstance.generate('4/2156283', ReportFormat.PDF, {});
+  const doc = await reportInstance.generate('ATR_SPEED_VOLUME/2156283', ReportFormat.PDF, {});
   expect(getNumPages(doc)).toBe(1);
 });
 
@@ -238,7 +300,7 @@ test('COUNT_SUMMARY_24H_GRAPHICAL', async () => {
   setup_4_2156283_single();
 
   const reportInstance = ReportFactory.getInstance(ReportType.COUNT_SUMMARY_24H_GRAPHICAL);
-  const doc = await reportInstance.generate('4/2156283', ReportFormat.PDF, {});
+  const doc = await reportInstance.generate('ATR_SPEED_VOLUME/2156283', ReportFormat.PDF, {});
   expect(getNumPages(doc)).toBe(1);
 });
 
@@ -246,7 +308,7 @@ test('COUNT_SUMMARY_TURNING_MOVEMENT', async () => {
   setup_5_36781();
 
   const reportInstance = ReportFactory.getInstance(ReportType.COUNT_SUMMARY_TURNING_MOVEMENT);
-  const doc = await reportInstance.generate('5/36781', ReportFormat.PDF, {});
+  const doc = await reportInstance.generate('TMC/36781', ReportFormat.PDF, {});
   expect(getNumPages(doc)).toBe(1);
 });
 
@@ -256,7 +318,7 @@ test('COUNT_SUMMARY_TURNING_MOVEMENT_DETAILED', async () => {
   const reportInstance = ReportFactory.getInstance(
     ReportType.COUNT_SUMMARY_TURNING_MOVEMENT_DETAILED,
   );
-  const doc = await reportInstance.generate('5/36781', ReportFormat.PDF, {});
+  const doc = await reportInstance.generate('TMC/36781', ReportFormat.PDF, {});
   expect(getNumPages(doc)).toBe(3);
 });
 
@@ -264,7 +326,7 @@ test('INTERSECTION_SUMMARY', async () => {
   setup_5_38661();
 
   const reportInstance = ReportFactory.getInstance(ReportType.INTERSECTION_SUMMARY);
-  const doc = await reportInstance.generate('5/38661', ReportFormat.PDF, {});
+  const doc = await reportInstance.generate('TMC/38661', ReportFormat.PDF, {});
   expect(getNumPages(doc)).toBe(1);
 });
 
@@ -272,7 +334,7 @@ test('SPEED_PERCENTILE', async () => {
   setup_4_2156283_single();
 
   const reportInstance = ReportFactory.getInstance(ReportType.SPEED_PERCENTILE);
-  const doc = await reportInstance.generate('4/2156283', ReportFormat.PDF, {});
+  const doc = await reportInstance.generate('ATR_SPEED_VOLUME/2156283', ReportFormat.PDF, {});
   expect(getNumPages(doc)).toBe(1);
 });
 
@@ -280,7 +342,7 @@ test('WARRANT_TRAFFIC_SIGNAL_CONTROL', async () => {
   setup_5_38661();
 
   const reportInstance = ReportFactory.getInstance(ReportType.WARRANT_TRAFFIC_SIGNAL_CONTROL);
-  const doc = await reportInstance.generate('5/38661', ReportFormat.PDF, {
+  const doc = await reportInstance.generate('TMC/38661', ReportFormat.PDF, {
     adequateTrial: true,
     isTwoLane: null,
     isXIntersection: null,

--- a/tests/jest/unit/reports/format/MovePdfGenerator.spec.js
+++ b/tests/jest/unit/reports/format/MovePdfGenerator.spec.js
@@ -10,6 +10,7 @@ import {
   StudyType,
 } from '@/lib/Constants';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import CountLocationDAO from '@/lib/db/CountLocationDAO';
 import StudyDAO from '@/lib/db/StudyDAO';
 import StudyDataDAO from '@/lib/db/StudyDataDAO';
 import ReportFactory from '@/lib/reports/ReportFactory';
@@ -18,6 +19,7 @@ import { loadJsonSync } from '@/lib/test/TestDataLoader';
 import DateTime from '@/lib/time/DateTime';
 
 jest.mock('@/lib/db/CentrelineDAO');
+jest.mock('@/lib/db/CountLocationDAO');
 jest.mock('@/lib/db/StudyDAO');
 jest.mock('@/lib/db/StudyDataDAO');
 
@@ -58,6 +60,8 @@ function setup_4_2156283_single() {
     centrelineType: CentrelineType.SEGMENT,
     // TODO: geom as point location?
   };
+  CountLocationDAO.byStudy.mockResolvedValue(countLocation);
+
   const counts = [{
     id: 2156283,
     legacy: true,
@@ -70,7 +74,6 @@ function setup_4_2156283_single() {
     extraMetadata: { arteryCode: 2946, stationCode: '2946' },
   }];
   const studyData = new Map([[2156283, countData_4_2156283]]);
-
   StudyDataDAO.byStudy.mockResolvedValue({ countLocation, counts, studyData });
   CentrelineDAO.byFeature.mockResolvedValue({
     centrelineId: 108387,

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -226,8 +226,8 @@ export default {
       if (this.activeStudy === null) {
         return null;
       }
-      const { countGroupId, type } = this.activeStudy;
-      return `${type.id}/${countGroupId}`;
+      const { countGroupId, studyType } = this.activeStudy;
+      return `${studyType.name}/${countGroupId}`;
     },
     activeReportType() {
       const { indexActiveReportType, reportTypes } = this;

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -23,12 +23,7 @@
           :disabled="item.n === 0">
           <v-expansion-panel-header class="pr-8">
             <div class="body-1">
-              <div v-if="item.category.studyType === null">
-                Unknown
-              </div>
-              <div v-else>
-                {{item.category.studyType.label}}
-              </div>
+              {{item.studyType.label}}
             </div>
             <v-spacer></v-spacer>
             <FcTextSummaryFraction
@@ -118,12 +113,12 @@ export default {
       );
     },
     items() {
-      return this.studySummaryUnfiltered.map(({ category, n }) => {
+      return this.studySummaryUnfiltered.map(({ n, studyType }) => {
         let item = this.studySummary.find(
-          itemFiltered => itemFiltered.category.id === category.id,
+          itemFiltered => itemFiltered.studyType === studyType,
         );
         if (item === undefined) {
-          item = { category, mostRecent: null, n: 0 };
+          item = { mostRecent: null, n: 0, studyType };
         }
         return {
           ...item,
@@ -132,9 +127,9 @@ export default {
       });
     },
     itemsPerLocation() {
-      return this.studySummaryPerLocationUnfiltered.map(({ category, perLocation }) => {
+      return this.studySummaryPerLocationUnfiltered.map(({ perLocation, studyType }) => {
         const itemPerLocation = this.studySummaryPerLocation.find(
-          itemPerLocationFiltered => itemPerLocationFiltered.category.id === category.id,
+          itemPerLocationFiltered => itemPerLocationFiltered.studyType === studyType,
         );
         return perLocation.map(({ n }, j) => {
           if (itemPerLocation === undefined) {

--- a/web/components/data/FcDetailStudies.vue
+++ b/web/components/data/FcDetailStudies.vue
@@ -12,19 +12,14 @@
     <template v-else>
       <div
         v-for="(item, i) in items"
-        :key="item.category.id"
+        :key="item.studyType.name"
         class="ml-5">
         <v-divider v-if="i > 0"></v-divider>
         <div
           class="align-center d-flex pr-5"
           :class="i === 0 ? 'mb-4' : 'my-4'">
           <div class="body-1 flex-grow-1 flex-shrink-1">
-            <div v-if="item.category.studyType === null">
-              Unknown
-            </div>
-            <div v-else>
-              {{item.category.studyType.label}}
-            </div>
+            <div>{{item.studyType.label}}</div>
             <div class="mt-1">
               <FcTextMostRecent
                 v-if="item.mostRecent !== null"
@@ -39,7 +34,7 @@
           </div>
           <FcButton
             class="flex-grow-0 flex-shrink-0"
-            :disabled="item.category.studyType === null || item.n === 0"
+            :disabled="!item.studyType.dataAvailable || item.n === 0"
             type="tertiary"
             @click="$emit('show-reports', item)">
             <span>View Reports</span>
@@ -76,12 +71,12 @@ export default {
   },
   computed: {
     items() {
-      return this.studySummaryUnfiltered.map(({ category, n }) => {
+      return this.studySummaryUnfiltered.map(({ n, studyType }) => {
         let item = this.studySummary.find(
-          itemFiltered => itemFiltered.category.id === category.id,
+          itemFiltered => itemFiltered.studyType === studyType,
         );
         if (item === undefined) {
-          item = { category, mostRecent: null, n: 0 };
+          item = { mostRecent: null, n: 0, studyType };
         }
         return {
           ...item,

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -289,7 +289,7 @@ export default {
       });
     },
     actionShowReportsStudy({
-      item: { category: { studyType } },
+      item: { studyType },
       locationsIndex,
     }) {
       this.setLocationsIndex(locationsIndex);

--- a/web/components/data/FcViewDataDetail.vue
+++ b/web/components/data/FcViewDataDetail.vue
@@ -164,7 +164,7 @@ export default {
         params,
       });
     },
-    actionShowReportsStudy({ category: { studyType } }) {
+    actionShowReportsStudy({ studyType }) {
       const params = {
         ...this.locationsRouteParams,
         studyTypeName: studyType.name,

--- a/web/components/geo/map/FcMap.vue
+++ b/web/components/geo/map/FcMap.vue
@@ -58,9 +58,7 @@
       :key="'h:' + featureKeyHovered"
       :feature="hoveredFeature"
       :hovered="true">
-      <template
-        v-if="hasActionPopupSlot"
-        v-slot:action="feature">
+      <template v-slot:action="feature">
         <slot name="action-popup" v-bind="feature" />
       </template>
     </FcMapPopup>
@@ -69,9 +67,7 @@
       :key="'s:' + featureKeySelected"
       :feature="selectedFeature"
       :hovered="false">
-      <template
-        v-if="hasActionPopupSlot"
-        v-slot:action="feature">
+      <template v-slot:action="feature">
         <slot name="action-popup" v-bind="feature" />
       </template>
     </FcMapPopup>
@@ -228,9 +224,6 @@ export default {
     },
     featureKeySelected() {
       return getFeatureKey(this.selectedFeature);
-    },
-    hasActionPopupSlot() {
-      return !!this.$scopedSlots['action-popup'];
     },
     internalLayers: {
       get() {

--- a/web/components/geo/map/FcMapPopup.vue
+++ b/web/components/geo/map/FcMapPopup.vue
@@ -17,12 +17,8 @@
           :feature-details="featureDetails" />
       </v-card-text>
 
-      <template v-if="hasActionSlot && featureSelectable && !loading">
-        <v-divider></v-divider>
-
-        <v-card-actions class="shading">
-          <slot name="action" v-bind="feature" />
-        </v-card-actions>
+      <template v-if="featureSelectable && !loading">
+        <slot name="action" v-bind="feature" />
       </template>
     </v-card>
   </div>
@@ -84,9 +80,6 @@ export default {
     },
     featureSelectable() {
       return SELECTABLE_LAYERS.includes(this.feature.layer.id);
-    },
-    hasActionSlot() {
-      return !!this.$scopedSlots.action;
     },
     layerId() {
       return this.feature.layer.id;

--- a/web/components/geo/map/FcPopupDetailsStudy.vue
+++ b/web/components/geo/map/FcPopupDetailsStudy.vue
@@ -45,11 +45,8 @@ export default {
       const { location, poiSummary, studySummary } = this.featureDetails;
       const description = [];
 
-      studySummary.forEach(({ category: { studyType }, mostRecent }) => {
-        let label = 'Unknown';
-        if (studyType !== null) {
-          label = studyType.label;
-        }
+      studySummary.forEach(({ mostRecent, studyType }) => {
+        const { label } = studyType;
         const { startDate } = mostRecent;
         const startDateStr = TimeFormatters.formatDefault(startDate);
         const dayOfWeek = TimeFormatters.formatDayOfWeek(startDate);

--- a/web/views/FcLayoutRequestEditor.vue
+++ b/web/views/FcLayoutRequestEditor.vue
@@ -29,8 +29,12 @@
           <template
             v-if="showActionPopup"
             v-slot:action-popup="feature">
-            <FcMapPopupActionRequestEditor
-              :feature="feature" />
+            <v-divider></v-divider>
+
+            <v-card-actions class="shading">
+              <FcMapPopupActionRequestEditor
+                :feature="feature" />
+            </v-card-actions>
           </template>
         </FcMap>
       </div>

--- a/web/views/FcLayoutViewData.vue
+++ b/web/views/FcLayoutViewData.vue
@@ -110,8 +110,12 @@
           <template
             v-if="showLocationSelection"
             v-slot:action-popup="feature">
-            <FcMapPopupActionViewData
-              :feature="feature" />
+            <v-divider></v-divider>
+
+            <v-card-actions class="shading">
+              <FcMapPopupActionViewData
+                :feature="feature" />
+            </v-card-actions>
           </template>
         </FcMap>
       </div>


### PR DESCRIPTION
# Issue Addressed
This PR closes #970 .

# Description
We implement `ReportPedDelaySummary`, and make several changes across the data-handling parts of the MOVE web application to accommodate the new `counts2.studies` schema.

# Tests
Updated tests to match changes, `npm run ci:jest-coverage` to ensure all tests still pass.  Tested report manually in frontend.  Downloaded PDF version to ensure that it fits within the page.
