### PR TITLE
Ped Delay: "beta" copy, info line

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -1071,6 +1071,9 @@ StudyRequestStatus.init({
  * @param {string} label - human-readable description of study type
  * @param {boolean} automatic - whether data for this study type is collected automatically
  * (or, if `false`, manually)
+ * @param {Object?} beta - whether this study type is in beta; if so, an `Object` that includes
+ * a medium-length `description` and a longer `descriptionLarge` for use with
+ * `<FcTextStudyTypeBeta>`
  * @param {boolean} dataAvailable - whether data for this study type is available in MOVE
  * @param {StudyDataType} dataType - what type of data this study produces
  * @param {boolean} other - whether this study type is an "other" type

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -1095,6 +1095,7 @@ StudyType.init({
   ATR_SPEED_VOLUME: {
     label: 'Speed / Volume ATR',
     automatic: true,
+    beta: null,
     dataAvailable: true,
     dataType: ReportDataType.ATR_SPEED_VOLUME,
     other: false,
@@ -1102,6 +1103,7 @@ StudyType.init({
   ATR_VOLUME: {
     label: 'Volume ATR',
     automatic: true,
+    beta: null,
     dataAvailable: true,
     dataType: ReportDataType.ATR_VOLUME,
     other: false,
@@ -1109,6 +1111,7 @@ StudyType.init({
   ATR_VOLUME_BICYCLE: {
     label: 'Bicycle Volume ATR',
     automatic: true,
+    beta: null,
     dataAvailable: true,
     dataType: ReportDataType.ATR_VOLUME,
     other: false,
@@ -1116,6 +1119,7 @@ StudyType.init({
   OTHER_AUTOMATIC: {
     label: 'Other',
     automatic: true,
+    beta: null,
     dataAvailable: false,
     dataType: ReportDataType.OTHER,
     other: true,
@@ -1123,6 +1127,7 @@ StudyType.init({
   OTHER_MANUAL: {
     label: 'Other',
     automatic: false,
+    beta: null,
     dataAvailable: false,
     dataType: ReportDataType.OTHER,
     other: true,
@@ -1130,6 +1135,13 @@ StudyType.init({
   PED_DELAY: {
     label: 'Ped Delay and Classification',
     automatic: false,
+    beta: {
+      description: '2015 to 2020 data only',
+      descriptionLarge:
+        `This is a new feature that is actively in development.
+        The accuracy and presentation of the data may change.
+        Ped Delay data is available for 2015 to 2020 only.`,
+    },
     dataAvailable: true,
     dataType: ReportDataType.PED_DELAY,
     other: false,
@@ -1137,6 +1149,7 @@ StudyType.init({
   PXO_OBSERVE: {
     label: 'Ped Crossover Observation',
     automatic: false,
+    beta: null,
     dataAvailable: false,
     dataType: ReportDataType.PXO_OBSERVE,
     other: false,
@@ -1144,6 +1157,7 @@ StudyType.init({
   RESCU: {
     label: 'RESCU (Highway / Ramp)',
     automatic: true,
+    beta: null,
     dataAvailable: true,
     dataType: ReportDataType.ATR_VOLUME,
     other: false,
@@ -1151,6 +1165,7 @@ StudyType.init({
   TMC: {
     label: 'Turning Movement Count',
     automatic: false,
+    beta: null,
     dataAvailable: true,
     dataType: ReportDataType.TMC,
     other: false,
@@ -1158,6 +1173,7 @@ StudyType.init({
   VEHICLE_CLASS: {
     label: 'Vehicle Classification',
     automatic: false,
+    beta: null,
     dataAvailable: false,
     dataType: ReportDataType.VEHICLE_CLASS,
     other: false,

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -405,6 +405,9 @@ ReportBlock.init({
   BAR_CHART: {
     suffix: 'BarChart',
   },
+  INFO: {
+    suffix: 'Info',
+  },
   METADATA: {
     suffix: 'Metadata',
   },

--- a/lib/controller/StudyController.js
+++ b/lib/controller/StudyController.js
@@ -77,12 +77,12 @@ StudyController.push({
 /**
  * Fetch summary statistics on traffic studies matching the given query.
  *
- * This returns an array by category.  Only categories for which there is at least one matching
+ * This returns an array by study type.  Only categories for which there is at least one matching
  * study are represented in this array.  These entries contain three fields:
  *
- * - `category`: the category of traffic study represented by this entry;
- * - `mostRecent`: the most recent matching traffic study of that category;
- * - `n`: the number of matching traffic studies of that category.
+ * - `studyType`: the type of traffic study represented by this entry;
+ * - `mostRecent`: the most recent matching traffic study of that study type;
+ * - `n`: the number of matching traffic studies of that study type.
  *
  * @memberof StudyController
  * @name getStudiesByCentrelineSummary
@@ -125,15 +125,15 @@ StudyController.push({
 /**
  * Fetch summary statistics on traffic studies matching the given query, broken down per location.
  *
- * This returns an array of arrays, first by category and then by location.  Only categories for
+ * This returns an array of arrays, first by study type and then by location.  Only categories for
  * which there is at least one matching study are represented in this first-level array.
  *
  * These second-level arrays contain one element per feature in the given `CentrelineSelection`,
- * regardless of whether they have matching studies of the first-level category, in the same order
+ * regardless of whether they have matching studies of the first-level study type, in the same order
  * as they appear in that selection.  Since selections can contain duplicate features (e.g. if a
  * selected corridor loops back on itself), the sum of `n` values in the response may exceed:
  *
- * - the total per category as determined using
+ * - the total per study type as determined using
  *   {@link CollisionController.getCollisionsByCentrelineSummary};
  * - the overall total as determined using
  *   {@link CollisionController.getCollisionsByCentrelineTotal}.
@@ -192,7 +192,7 @@ StudyController.push({
  * Fetch total number of traffic studies at the given centreline features, regardless
  * of active filters.
  *
- * This value should match the sum of `n` values from the per-category entries of
+ * This value should match the sum of `n` values from the per-study-type entries of
  * {@link StudyController.getStudiesByCentrelineSummary} when called with the same
  * `CentrelineSelection` and no filters.
  *

--- a/lib/db/StudyDAO.js
+++ b/lib/db/StudyDAO.js
@@ -88,7 +88,8 @@ SELECT * FROM (
     ${STUDIES_FIELDS}
   WHERE ${studyFilters}
 ) x
-WHERE x.__row = 1`;
+WHERE x.__row = 1
+ORDER BY "studyType" ASC`;
     const sqlNumPerStudyType = `
 SELECT COUNT(*) AS n, "studyType"
 FROM counts2.studies
@@ -125,7 +126,8 @@ SELECT * FROM (
     ${STUDIES_FIELDS}
   WHERE ${studyFilters}
 ) x
-WHERE x.__row = 1`;
+WHERE x.__row = 1
+ORDER BY "studyType" ASC`;
     const sqlNumPerStudyType = `
 SELECT COUNT(*) AS n,
 "studyType",

--- a/lib/db/StudyDAO.js
+++ b/lib/db/StudyDAO.js
@@ -52,19 +52,6 @@ async function validateStudies(studies) {
  * counts.
  */
 class StudyDAO {
-  /**
-   * @deprecated
-   */
-  static async byCategoryAndCountGroup(categoryId, countGroupId) {
-    const sql = `
-SELECT ${STUDIES_FIELDS}
-JOIN counts2.category_study_type cst USING ("studyType")
-WHERE cst."CATEGORY_ID" = $(categoryId)
-AND "countGroupId" = $(countGroupId)`;
-    const study = await db.oneOrNone(sql, { categoryId, countGroupId });
-    return validateStudy(study);
-  }
-
   static async byStudyTypeAndCountGroup(studyType, countGroupId) {
     const sql = `
 SELECT ${STUDIES_FIELDS}

--- a/lib/reports/ReportPedDelaySummary.js
+++ b/lib/reports/ReportPedDelaySummary.js
@@ -433,6 +433,10 @@ class ReportPedDelaySummary extends ReportBaseFlow {
   }
 
   generateLayoutContent(study, reportData) {
+    const infoOptions = {
+      text:
+        'Note: Factored Totals and Factored Summary are factored by 2 for all Pedestrian Types.',
+    };
     const countMetadataOptions = ReportPedDelaySummary.getCountMetadataOptions(reportData);
     const { stats } = reportData;
     const factoredSummaryTableOptions = ReportPedDelaySummary
@@ -440,6 +444,7 @@ class ReportPedDelaySummary extends ReportBaseFlow {
     const firstZoneTableOptions = ReportPedDelaySummary.getFirstZoneTableOptions(stats);
     const zoneTablesOptions = stats.zones.slice(1).map(ReportPedDelaySummary.getZoneTableOptions);
     return [
+      { type: ReportBlock.INFO, options: infoOptions },
       { type: ReportBlock.METADATA, options: countMetadataOptions },
       { type: ReportBlock.TABLE, options: factoredSummaryTableOptions },
       { type: ReportBlock.PAGE_BREAK, options: {} },

--- a/lib/reports/format/MovePdfGenerator.js
+++ b/lib/reports/format/MovePdfGenerator.js
@@ -177,6 +177,19 @@ class MovePdfGenerator {
     }];
   }
 
+  // ReportBlock.INFO
+
+  generateInfo({ text }) {
+    const fontSizeS = FormatCss.var('--font-size-s');
+    return [
+      {
+        color: '#696969',
+        fontSize: fontSizeS,
+        text,
+      },
+    ];
+  }
+
   // ReportBlock.METADATA
 
   static getMetadataBlock({ cols, name, value }) {

--- a/tests/jest/db/StudyDAO.spec.js
+++ b/tests/jest/db/StudyDAO.spec.js
@@ -10,40 +10,41 @@ afterAll(() => {
   db.$pool.end();
 });
 
-test('StudyDAO.byCentreline()', async () => {
-  // invalid feature
-  let features = [
+test('StudyDAO.byCentreline [invalid feature]', async () => {
+  const features = [
     { centrelineId: 0, centrelineType: CentrelineType.INTERSECTION },
   ];
   let studyQuery = {
     studyTypes: [StudyType.TMC],
   };
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  let studies = await StudyDAO.byCentreline(features, studyQuery, { limit: 10, offset: 0 });
+  const studies = await StudyDAO.byCentreline(features, studyQuery, { limit: 10, offset: 0 });
   expect(studies).toHaveLength(0);
+});
 
-  // invalid date range (start > end)
-  features = [
+test('StudyDAO.byCentreline [invalid date range]', async () => {
+  const features = [
     { centrelineId: 30000549, centrelineType: CentrelineType.INTERSECTION },
   ];
-  studyQuery = {
+  let studyQuery = {
     dateRangeEnd: DateTime.fromObject({ year: 2017, month: 12, day: 31 }),
     dateRangeStart: DateTime.fromObject({ year: 2018, month: 1, day: 1 }),
     studyTypes: [StudyType.TMC],
   };
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  studies = await StudyDAO.byCentreline(features, studyQuery, { limit: 10, offset: 0 });
+  const studies = await StudyDAO.byCentreline(features, studyQuery, { limit: 10, offset: 0 });
   expect(studies).toHaveLength(0);
+});
 
-  // valid feature with less than 10 counts
-  features = [
+test('StudyDAO.byCentreline [valid feature, fewer than limit]', async () => {
+  const features = [
     { centrelineId: 14659630, centrelineType: CentrelineType.SEGMENT },
   ];
-  studyQuery = {
+  let studyQuery = {
     studyTypes: [StudyType.ATR_SPEED_VOLUME],
   };
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  studies = await StudyDAO.byCentreline(features, studyQuery, { limit: 10, offset: 0 });
+  const studies = await StudyDAO.byCentreline(features, studyQuery, { limit: 10, offset: 0 });
   await expect(
     Joi.array().items(Study.read).validateAsync(studies),
   ).resolves.toEqual(studies);
@@ -52,49 +53,53 @@ test('StudyDAO.byCentreline()', async () => {
     expect(study.duration % 24).toEqual(0);
     expect(study.hours).toBeNull();
   });
+});
 
-  // valid feature with less than 10 counts, date range filters to empty
-  features = [
+test('StudyDAO.byCentreline [valid feature, date range filters to empty]', async () => {
+  const features = [
     { centrelineId: 14659630, centrelineType: CentrelineType.SEGMENT },
   ];
-  studyQuery = {
+  let studyQuery = {
     dateRangeEnd: DateTime.fromObject({ year: 2019, month: 1, day: 1 }),
     dateRangeStart: DateTime.fromObject({ year: 2018, month: 1, day: 1 }),
     studyTypes: [StudyType.ATR_SPEED_VOLUME],
   };
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  studies = await StudyDAO.byCentreline(features, studyQuery, { limit: 10, offset: 0 });
+  const studies = await StudyDAO.byCentreline(features, studyQuery, { limit: 10, offset: 0 });
   expect(studies).toHaveLength(0);
+});
 
-  // valid feature with more than 10 counts
-  features = [
+test('StudyDAO.byCentreline [valid feature, more than limit]', async () => {
+  const features = [
     { centrelineId: 1145768, centrelineType: CentrelineType.SEGMENT },
   ];
-  studyQuery = {
+  let studyQuery = {
     studyTypes: [StudyType.RESCU],
   };
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  studies = await StudyDAO.byCentreline(features, studyQuery, { limit: 10, offset: 0 });
+  const studies = await StudyDAO.byCentreline(features, studyQuery, { limit: 10, offset: 0 });
   expect(studies).toHaveLength(10);
+});
 
-  // valid feature with more than 10 counts, date range filters to less
-  features = [
+test('StudyDAO.byCentreline [valid feature, date range filters to less]', async () => {
+  const features = [
     { centrelineId: 1145768, centrelineType: CentrelineType.SEGMENT },
   ];
-  studyQuery = {
+  let studyQuery = {
     dateRangeEnd: DateTime.fromObject({ year: 2015, month: 4, day: 15 }),
     dateRangeStart: DateTime.fromObject({ year: 2015, month: 4, day: 1 }),
     studyTypes: [StudyType.RESCU],
   };
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  studies = await StudyDAO.byCentreline(features, studyQuery, { limit: 10, offset: 0 });
+  const studies = await StudyDAO.byCentreline(features, studyQuery, { limit: 10, offset: 0 });
   expect(studies).toHaveLength(8);
+});
 
-  // pagination works
-  features = [
+test('StudyDAO.byCentreline [pagination]', async () => {
+  const features = [
     { centrelineId: 1145768, centrelineType: CentrelineType.SEGMENT },
   ];
-  studyQuery = {
+  let studyQuery = {
     dateRangeEnd: DateTime.fromObject({ year: 2017, month: 1, day: 1 }),
     dateRangeStart: DateTime.fromObject({ year: 2015, month: 1, day: 1 }),
     studyTypes: [StudyType.RESCU],
@@ -104,13 +109,13 @@ test('StudyDAO.byCentreline()', async () => {
   const { n } = studySummary[0];
   for (let offset = 0; offset < n; offset += 100) {
     /* eslint-disable-next-line no-await-in-loop */
-    studies = await StudyDAO.byCentreline(features, studyQuery, { limit: 100, offset });
+    const studies = await StudyDAO.byCentreline(features, studyQuery, { limit: 100, offset });
     const expectedLength = Math.min(100, n - offset);
     expect(studies).toHaveLength(expectedLength);
   }
 });
 
-function expectNumPerCategoryStudy(actual, expected) {
+function expectNumPerStudyTypeStudy(actual, expected) {
   expect(actual).toHaveLength(expected.length);
   expected.forEach(([n0, value0], i) => {
     const { n, studyType: { name: value } } = actual[i];
@@ -119,47 +124,49 @@ function expectNumPerCategoryStudy(actual, expected) {
   });
 }
 
-test('StudyDAO.byCentrelineSummary()', async () => {
-  // invalid feature
-  let features = [
+test('StudyDAO.byCentrelineSummary [invalid feature]', async () => {
+  const features = [
     { centrelineId: 0, centrelineType: CentrelineType.INTERSECTION },
   ];
   let studyQuery = {
     studyTypes: [StudyType.TMC],
   };
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  let studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);
-  expectNumPerCategoryStudy(studySummary, []);
+  const studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);
+  expectNumPerStudyTypeStudy(studySummary, []);
+});
 
-  // invalid date range (start > end)
-  features = [
+test('StudyDAO.byCentrelineSummary [invalid date range]', async () => {
+  const features = [
     { centrelineId: 30000549, centrelineType: CentrelineType.INTERSECTION },
   ];
-  studyQuery = {
+  let studyQuery = {
     dateRangeEnd: DateTime.fromObject({ year: 2017, month: 12, day: 31 }),
     dateRangeStart: DateTime.fromObject({ year: 2018, month: 1, day: 1 }),
     studyTypes: [StudyType.TMC],
   };
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);
-  expectNumPerCategoryStudy(studySummary, []);
+  const studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);
+  expectNumPerStudyTypeStudy(studySummary, []);
+});
 
-  // centreline feature with no counts
-  features = [
+test('StudyDAO.byCentrelineSummary [valid feature, no studies]', async () => {
+  const features = [
     { centrelineId: 30062737, centrelineType: CentrelineType.SEGMENT },
   ];
-  studyQuery = {};
+  let studyQuery = {};
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);
-  expectNumPerCategoryStudy(studySummary, []);
+  const studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);
+  expectNumPerStudyTypeStudy(studySummary, []);
+});
 
-  // centreline feature with some counts
-  features = [
+test('StudyDAO.byCentrelineSummary [valid feature, some studies]', async () => {
+  const features = [
     { centrelineId: 14659630, centrelineType: CentrelineType.SEGMENT },
   ];
-  studyQuery = {};
+  let studyQuery = {};
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);
+  const studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);
   const studySummarySchema = Joi.array().items(
     Joi.object().keys({
       mostRecent: Study.read,
@@ -167,67 +174,72 @@ test('StudyDAO.byCentrelineSummary()', async () => {
       studyType: Joi.enum().ofType(StudyType).required(),
     }),
   );
-  expectNumPerCategoryStudy(studySummary, [[1, 'ATR_SPEED_VOLUME']]);
+  expectNumPerStudyTypeStudy(studySummary, [[2, 'ATR_SPEED_VOLUME'], [4, 'ATR_VOLUME']]);
   await expect(
     studySummarySchema.validateAsync(studySummary),
   ).resolves.toEqual(studySummary);
+});
 
-  // valid feature with some counts, date range filters to empty
-  features = [
+test('StudyDAO.byCentrelineSummary [valid feature, date range filters to empty]', async () => {
+  const features = [
     { centrelineId: 14659630, centrelineType: CentrelineType.SEGMENT },
   ];
-  studyQuery = {
+  let studyQuery = {
     dateRangeEnd: DateTime.fromObject({ year: 2019, month: 1, day: 1 }),
     dateRangeStart: DateTime.fromObject({ year: 2018, month: 1, day: 1 }),
   };
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);
-  expectNumPerCategoryStudy(studySummary, []);
+  const studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);
+  expectNumPerStudyTypeStudy(studySummary, []);
+});
 
-  // centreline feature with lots of counts
-  features = [
+test('StudyDAO.byCentrelineSummary [valid feature, lots of studies]', async () => {
+  const features = [
     { centrelineId: 1145768, centrelineType: CentrelineType.SEGMENT },
   ];
-  studyQuery = {};
+  let studyQuery = {};
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);
-  expectNumPerCategoryStudy(studySummary, [[3, 'ATR_VOLUME'], [3633, 'RESCU'], [2, 'TMC']]);
+  const studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);
+  expectNumPerStudyTypeStudy(studySummary, [[3, 'ATR_VOLUME'], [3633, 'RESCU'], [2, 'TMC']]);
+});
 
-  // centreline feature with lots of counts, date range filters to empty
-  features = [
+test('StudyDAO.byCentrelineSummary [valid feature, lots of studies, date range filters to empty]', async () => {
+  const features = [
     { centrelineId: 1145768, centrelineType: CentrelineType.SEGMENT },
   ];
-  studyQuery = {
+  let studyQuery = {
     dateRangeEnd: DateTime.fromObject({ year: 1980, month: 1, day: 2 }),
     dateRangeStart: DateTime.fromObject({ year: 1980, month: 1, day: 1 }),
   };
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);
-  expectNumPerCategoryStudy(studySummary, []);
+  const studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);
+  expectNumPerStudyTypeStudy(studySummary, []);
+});
 
-  // centreline feature with lots of counts, date range filters down
-  features = [
+test('StudyDAO.byCentrelineSummary [valid feature, lots of studies, date range filters to less]', async () => {
+  const features = [
     { centrelineId: 1145768, centrelineType: CentrelineType.SEGMENT },
   ];
-  studyQuery = {
+  let studyQuery = {
     dateRangeEnd: DateTime.fromObject({ year: 2016, month: 1, day: 1 }),
     dateRangeStart: DateTime.fromObject({ year: 2015, month: 1, day: 1 }),
   };
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);
-  expectNumPerCategoryStudy(studySummary, [[187, 'RESCU']]);
-
-  // centreline feature with more than one kind of count
-  features = [
-    { centrelineId: 9278884, centrelineType: CentrelineType.SEGMENT },
-  ];
-  studyQuery = {};
-  studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);
-  expectNumPerCategoryStudy(studySummary, [[2, 'ATR_SPEED_VOLUME'], [1, 'ATR_VOLUME']]);
+  const studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);
+  expectNumPerStudyTypeStudy(studySummary, [[187, 'RESCU']]);
 });
 
-function expectNumPerCategoryAndLocationStudy(actual, expected) {
+test('StudyDAO.byCentrelineSummary [valid feature, multiple study types]', async () => {
+  const features = [
+    { centrelineId: 9278884, centrelineType: CentrelineType.SEGMENT },
+  ];
+  let studyQuery = {};
+  studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
+  const studySummary = await StudyDAO.byCentrelineSummary(features, studyQuery);
+  expectNumPerStudyTypeStudy(studySummary, [[2, 'ATR_SPEED_VOLUME'], [1, 'ATR_VOLUME']]);
+});
+
+function expectNumPerStudyTypeAndLocationStudy(actual, expected) {
   expect(actual).toHaveLength(expected.length);
   expected.forEach(([ns0, value0], i) => {
     const { perLocation, studyType: { name: value } } = actual[i];
@@ -238,47 +250,51 @@ function expectNumPerCategoryAndLocationStudy(actual, expected) {
   });
 }
 
-test('StudyDAO.byCentrelineSummaryPerLocation()', async () => {
+test('StudyDAO.byCentrelineSummaryPerLocation [invalid feature]', async () => {
   // invalid feature
-  let features = [
+  const features = [
     { centrelineId: 0, centrelineType: CentrelineType.INTERSECTION },
   ];
   let studyQuery = {
     studyTypes: [StudyType.TMC],
   };
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  let studySummary = await StudyDAO.byCentrelineSummaryPerLocation(features, studyQuery);
-  expectNumPerCategoryAndLocationStudy(studySummary, []);
+  const studySummary = await StudyDAO.byCentrelineSummaryPerLocation(features, studyQuery);
+  expectNumPerStudyTypeAndLocationStudy(studySummary, []);
+});
 
+test('StudyDAO.byCentrelineSummaryPerLocation [invalid date range]', async () => {
   // invalid date range (start > end)
-  features = [
+  const features = [
     { centrelineId: 30000549, centrelineType: CentrelineType.INTERSECTION },
   ];
-  studyQuery = {
+  let studyQuery = {
     dateRangeEnd: DateTime.fromObject({ year: 2017, month: 12, day: 31 }),
     dateRangeStart: DateTime.fromObject({ year: 2018, month: 1, day: 1 }),
     studyTypes: [StudyType.TMC],
   };
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  studySummary = await StudyDAO.byCentrelineSummaryPerLocation(features, studyQuery);
-  expectNumPerCategoryAndLocationStudy(studySummary, []);
+  const studySummary = await StudyDAO.byCentrelineSummaryPerLocation(features, studyQuery);
+  expectNumPerStudyTypeAndLocationStudy(studySummary, []);
+});
 
-  // centreline feature with no counts
-  features = [
+test('StudyDAO.byCentrelineSummaryPerLocation [valid feature, no studies]', async () => {
+  const features = [
     { centrelineId: 30062737, centrelineType: CentrelineType.SEGMENT },
   ];
-  studyQuery = {};
+  let studyQuery = {};
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  studySummary = await StudyDAO.byCentrelineSummaryPerLocation(features, studyQuery);
-  expectNumPerCategoryAndLocationStudy(studySummary, []);
+  const studySummary = await StudyDAO.byCentrelineSummaryPerLocation(features, studyQuery);
+  expectNumPerStudyTypeAndLocationStudy(studySummary, []);
+});
 
-  // centreline feature with some counts
-  features = [
+test('StudyDAO.byCentrelineSummaryPerLocation [valid feature, some studies]', async () => {
+  const features = [
     { centrelineId: 14659630, centrelineType: CentrelineType.SEGMENT },
   ];
-  studyQuery = {};
+  let studyQuery = {};
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  studySummary = await StudyDAO.byCentrelineSummaryPerLocation(features, studyQuery);
+  const studySummary = await StudyDAO.byCentrelineSummaryPerLocation(features, studyQuery);
   const studySummaryPerLocationSchema = Joi.array().items(
     Joi.object().keys({
       perLocation: Joi.array().items(
@@ -290,102 +306,110 @@ test('StudyDAO.byCentrelineSummaryPerLocation()', async () => {
       studyType: Joi.enum().ofType(StudyType).required(),
     }),
   );
-  expectNumPerCategoryAndLocationStudy(
+  expectNumPerStudyTypeAndLocationStudy(
     studySummary,
-    [[[1], 'ATR_SPEED_VOLUME']],
+    [[[2], 'ATR_SPEED_VOLUME'], [[4], 'ATR_VOLUME']],
   );
   await expect(
     studySummaryPerLocationSchema.validateAsync(studySummary),
   ).resolves.toEqual(studySummary);
+});
 
-  // valid feature with some counts, date range filters to empty
-  features = [
+test('StudyDAO.byCentrelineSummaryPerLocation [valid feature, some studies, date range filters to empty]', async () => {
+  const features = [
     { centrelineId: 14659630, centrelineType: CentrelineType.SEGMENT },
   ];
-  studyQuery = {
+  let studyQuery = {
     dateRangeEnd: DateTime.fromObject({ year: 2019, month: 1, day: 1 }),
     dateRangeStart: DateTime.fromObject({ year: 2018, month: 1, day: 1 }),
   };
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  studySummary = await StudyDAO.byCentrelineSummaryPerLocation(features, studyQuery);
-  expectNumPerCategoryAndLocationStudy(studySummary, []);
+  const studySummary = await StudyDAO.byCentrelineSummaryPerLocation(features, studyQuery);
+  expectNumPerStudyTypeAndLocationStudy(studySummary, []);
+});
 
-  // centreline feature with lots of counts
-  features = [
+test('StudyDAO.byCentrelineSummaryPerLocation [valid feature, lots of studies]', async () => {
+  const features = [
     { centrelineId: 1145768, centrelineType: CentrelineType.SEGMENT },
   ];
-  studyQuery = {};
+  let studyQuery = {};
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  studySummary = await StudyDAO.byCentrelineSummaryPerLocation(features, studyQuery);
-  expectNumPerCategoryAndLocationStudy(studySummary, [[[3], 'ATR_VOLUME'], [[3633], 'RESCU'], [[2], 'TMC']]);
+  const studySummary = await StudyDAO.byCentrelineSummaryPerLocation(features, studyQuery);
+  expectNumPerStudyTypeAndLocationStudy(studySummary, [[[3], 'ATR_VOLUME'], [[3633], 'RESCU'], [[2], 'TMC']]);
+});
 
-  // centreline feature with lots of counts, date range filters to empty
-  features = [
+test('StudyDAO.byCentrelineSummaryPerLocation [valid feature, lots of studies, date range filters to empty]', async () => {
+  const features = [
     { centrelineId: 1145768, centrelineType: CentrelineType.SEGMENT },
   ];
-  studyQuery = {
+  let studyQuery = {
     dateRangeEnd: DateTime.fromObject({ year: 1980, month: 1, day: 2 }),
     dateRangeStart: DateTime.fromObject({ year: 1980, month: 1, day: 1 }),
   };
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  studySummary = await StudyDAO.byCentrelineSummaryPerLocation(features, studyQuery);
-  expectNumPerCategoryAndLocationStudy(studySummary, []);
+  const studySummary = await StudyDAO.byCentrelineSummaryPerLocation(features, studyQuery);
+  expectNumPerStudyTypeAndLocationStudy(studySummary, []);
+});
 
-  // centreline feature with lots of counts, date range filters down
-  features = [
+test('StudyDAO.byCentrelineSummaryPerLocation [valid feature, lots of studies, date range filters to less]', async () => {
+  const features = [
     { centrelineId: 1145768, centrelineType: CentrelineType.SEGMENT },
   ];
-  studyQuery = {
+  let studyQuery = {
     dateRangeEnd: DateTime.fromObject({ year: 2016, month: 1, day: 1 }),
     dateRangeStart: DateTime.fromObject({ year: 2015, month: 1, day: 1 }),
   };
   studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  studySummary = await StudyDAO.byCentrelineSummaryPerLocation(features, studyQuery);
-  expectNumPerCategoryAndLocationStudy(studySummary, [[[187], 'RESCU']]);
-
-  // centreline feature with more than one kind of count
-  features = [
-    { centrelineId: 9278884, centrelineType: CentrelineType.SEGMENT },
-  ];
-  studyQuery = {};
-  studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
-  studySummary = await StudyDAO.byCentrelineSummaryPerLocation(features, studyQuery);
-  expectNumPerCategoryAndLocationStudy(studySummary, [[[2], 'ATR_SPEED_VOLUME'], [[1], 'ATR_VOLUME']]);
+  const studySummary = await StudyDAO.byCentrelineSummaryPerLocation(features, studyQuery);
+  expectNumPerStudyTypeAndLocationStudy(studySummary, [[[187], 'RESCU']]);
 });
 
-test('StudyDAO.byCentrelineTotal()', async () => {
-  // invalid feature
-  let features = [
-    { centrelineId: 0, centrelineType: CentrelineType.INTERSECTION },
-  ];
-  let total = await StudyDAO.byCentrelineTotal(features);
-  expect(total).toBe(0);
-
-  // centreline feature with no counts
-  features = [
-    { centrelineId: 30062737, centrelineType: CentrelineType.SEGMENT },
-  ];
-  total = await StudyDAO.byCentrelineTotal(features);
-  expect(total).toBe(0);
-
-  // centreline feature with some counts
-  features = [
-    { centrelineId: 14659630, centrelineType: CentrelineType.SEGMENT },
-  ];
-  total = await StudyDAO.byCentrelineTotal(features);
-  expect(total).toBe(1);
-
-  // centreline feature with lots of counts
-  features = [
-    { centrelineId: 1145768, centrelineType: CentrelineType.SEGMENT },
-  ];
-  total = await StudyDAO.byCentrelineTotal(features);
-  expect(total).toBeGreaterThanOrEqual(3635);
-
-  // centreline feature with more than one kind of count
-  features = [
+test('StudyDAO.byCentrelineSummaryPerLocation [valid feature, multiple study types]', async () => {
+  const features = [
     { centrelineId: 9278884, centrelineType: CentrelineType.SEGMENT },
   ];
-  total = await StudyDAO.byCentrelineTotal(features);
+  let studyQuery = {};
+  studyQuery = await Joi.object().keys(StudyFilters).validateAsync(studyQuery);
+  const studySummary = await StudyDAO.byCentrelineSummaryPerLocation(features, studyQuery);
+  expectNumPerStudyTypeAndLocationStudy(studySummary, [[[2], 'ATR_SPEED_VOLUME'], [[1], 'ATR_VOLUME']]);
+});
+
+test('StudyDAO.byCentrelineTotal [invalid feature]', async () => {
+  const features = [
+    { centrelineId: 0, centrelineType: CentrelineType.INTERSECTION },
+  ];
+  const total = await StudyDAO.byCentrelineTotal(features);
+  expect(total).toBe(0);
+});
+
+test('StudyDAO.byCentrelineTotal [valid feature, no studies]', async () => {
+  const features = [
+    { centrelineId: 30062737, centrelineType: CentrelineType.SEGMENT },
+  ];
+  const total = await StudyDAO.byCentrelineTotal(features);
+  expect(total).toBe(0);
+});
+
+test('StudyDAO.byCentrelineTotal [valid feature, some studies]', async () => {
+  const features = [
+    { centrelineId: 14659630, centrelineType: CentrelineType.SEGMENT },
+  ];
+  const total = await StudyDAO.byCentrelineTotal(features);
+  expect(total).toBe(6);
+});
+
+test('StudyDAO.byCentrelineTotal [valid feature, lots of studies]', async () => {
+  const features = [
+    { centrelineId: 1145768, centrelineType: CentrelineType.SEGMENT },
+  ];
+  const total = await StudyDAO.byCentrelineTotal(features);
+  expect(total).toBeGreaterThanOrEqual(3635);
+});
+
+test('StudyDAO.byCentrelineTotal [valid feature, multiple study types]', async () => {
+  const features = [
+    { centrelineId: 9278884, centrelineType: CentrelineType.SEGMENT },
+  ];
+  const total = await StudyDAO.byCentrelineTotal(features);
   expect(total).toBe(3);
 });

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -139,7 +139,9 @@
         <div
           v-else
           class="fc-report-wrapper pa-3">
-          <FcReport v-bind="reportLayout" />
+          <FcReport
+            :study-type="studyType"
+            v-bind="reportLayout" />
         </div>
       </section>
     </template>

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -24,6 +24,10 @@
           <v-expansion-panel-header class="pr-8">
             <div class="body-1">
               {{item.studyType.label}}
+              <FcTextStudyTypeBeta
+                class="ml-2"
+                small
+                :study-type="item.studyType" />
             </div>
             <v-spacer></v-spacer>
             <FcTextSummaryFraction
@@ -78,6 +82,7 @@ import { mapGetters } from 'vuex';
 
 import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
 import FcTextMostRecent from '@/web/components/data/FcTextMostRecent.vue';
+import FcTextStudyTypeBeta from '@/web/components/data/FcTextStudyTypeBeta.vue';
 import FcTextSummaryFraction from '@/web/components/data/FcTextSummaryFraction.vue';
 import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
@@ -90,6 +95,7 @@ export default {
     FcListLocationMulti,
     FcProgressLinear,
     FcTextMostRecent,
+    FcTextStudyTypeBeta,
     FcTextSummaryFraction,
   },
   props: {

--- a/web/components/data/FcDetailStudies.vue
+++ b/web/components/data/FcDetailStudies.vue
@@ -19,7 +19,13 @@
           class="align-center d-flex pr-5"
           :class="i === 0 ? 'mb-4' : 'my-4'">
           <div class="body-1 flex-grow-1 flex-shrink-1">
-            <div>{{item.studyType.label}}</div>
+            <div>
+              {{item.studyType.label}}
+              <FcTextStudyTypeBeta
+                class="ml-2"
+                small
+                :study-type="item.studyType" />
+            </div>
             <div class="mt-1">
               <FcTextMostRecent
                 v-if="item.mostRecent !== null"
@@ -49,6 +55,7 @@
 import { mapGetters } from 'vuex';
 
 import FcTextMostRecent from '@/web/components/data/FcTextMostRecent.vue';
+import FcTextStudyTypeBeta from '@/web/components/data/FcTextStudyTypeBeta.vue';
 import FcTextSummaryFraction from '@/web/components/data/FcTextSummaryFraction.vue';
 import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
@@ -59,6 +66,7 @@ export default {
     FcButton,
     FcProgressLinear,
     FcTextMostRecent,
+    FcTextStudyTypeBeta,
     FcTextSummaryFraction,
   },
   props: {

--- a/web/components/data/FcTextStudyTypeBeta.vue
+++ b/web/components/data/FcTextStudyTypeBeta.vue
@@ -1,0 +1,49 @@
+<template>
+  <span class="fc-text-study-type-beta">{{text}}</span>
+</template>
+
+<script>
+import { StudyType } from '@/lib/Constants';
+
+const BETA = 'Beta';
+
+export default {
+  name: 'FcTextStudyTypeBeta',
+  props: {
+    large: {
+      type: Boolean,
+      default: false,
+    },
+    small: {
+      type: Boolean,
+      default: false,
+    },
+    studyType: StudyType,
+  },
+  computed: {
+    hasBeta() {
+      return this.studyType.beta !== null;
+    },
+    text() {
+      if (!this.hasBeta) {
+        return null;
+      }
+      if (this.small) {
+        return BETA;
+      }
+      const { beta } = this.studyType;
+      if (this.large) {
+        return `${BETA} - ${beta.descriptionLarge}`;
+      }
+      return `${BETA} - ${beta.description}`;
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+.fc-text-study-type-beta {
+  background-color: #fff9d3;
+  color: #9b6e0c;
+}
+</style>

--- a/web/components/filters/FcStudyFilters.vue
+++ b/web/components/filters/FcStudyFilters.vue
@@ -4,14 +4,23 @@
       <legend class="headline">Study Types</legend>
 
       <template v-for="studyType in StudyType.enumValues">
-        <v-checkbox
-          v-if="studyType.dataAvailable"
-          :key="studyType.name"
-          v-model="internalValue.studyTypes"
-          class="mt-2"
-          hide-details
-          :label="studyType.label"
-          :value="studyType"></v-checkbox>
+        <template v-if="studyType.dataAvailable">
+          <v-checkbox
+            :key="studyType.name"
+            v-model="internalValue.studyTypes"
+            class="mt-2"
+            hide-details
+            :label="studyType.label"
+            :value="studyType" />
+          <div
+            v-if="studyType.beta !== null"
+            :key="studyType.name + '_beta'"
+            class="ml-2">
+            <FcTextStudyTypeBeta
+              class="ml-12"
+              :study-type="studyType" />
+          </div>
+        </template>
       </template>
     </fieldset>
 
@@ -35,11 +44,15 @@ import {
   StudyHours,
   StudyType,
 } from '@/lib/Constants';
+import FcTextStudyTypeBeta from '@/web/components/data/FcTextStudyTypeBeta.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
 
 export default {
   name: 'FcStudyFilters',
   mixins: [FcMixinVModelProxy(Object)],
+  components: {
+    FcTextStudyTypeBeta,
+  },
   data() {
     return {
       StudyHours,

--- a/web/components/reports/FcReport.vue
+++ b/web/components/reports/FcReport.vue
@@ -36,6 +36,8 @@ import FcReportBarChart
   from '@/web/components/reports/FcReportBarChart.vue';
 import FcReportHeader
   from '@/web/components/reports/FcReportHeader.vue';
+import FcReportInfo
+  from '@/web/components/reports/FcReportInfo.vue';
 import FcReportMetadata
   from '@/web/components/reports/FcReportMetadata.vue';
 import FcReportPageBreak
@@ -48,6 +50,7 @@ export default {
   components: {
     FcReportBarChart,
     FcReportHeader,
+    FcReportInfo,
     FcReportMetadata,
     FcReportPageBreak,
     FcReportTable,

--- a/web/components/reports/FcReport.vue
+++ b/web/components/reports/FcReport.vue
@@ -1,6 +1,7 @@
 <template>
   <article class="fc-report">
     <FcReportHeader
+      :study-type="studyType"
       :type="type"
       v-bind="header" />
     <div>
@@ -29,7 +30,7 @@
 </template>
 
 <script>
-import { ReportType } from '@/lib/Constants';
+import { ReportType, StudyType } from '@/lib/Constants';
 import DateTime from '@/lib/time/DateTime';
 import FcReportBarChart
   from '@/web/components/reports/FcReportBarChart.vue';
@@ -55,6 +56,10 @@ export default {
     content: Array,
     generatedAt: DateTime,
     header: Object,
+    studyType: {
+      type: StudyType,
+      default: null,
+    },
     type: ReportType,
   },
 };

--- a/web/components/reports/FcReportHeader.vue
+++ b/web/components/reports/FcReportHeader.vue
@@ -14,6 +14,13 @@
         <span class="sr-only">{{subinfo}}</span>
       </h3>
     </div>
+    <div
+      v-if="studyType !== null && studyType.beta !== null"
+      class="beta-wrapper ml-4">
+      <FcTextStudyTypeBeta
+        large
+        :study-type="studyType" />
+    </div>
 
     <v-spacer></v-spacer>
 
@@ -25,13 +32,21 @@
 </template>
 
 <script>
-import { ORG_NAME, ReportType } from '@/lib/Constants';
+import { ORG_NAME, ReportType, StudyType } from '@/lib/Constants';
+import FcTextStudyTypeBeta from '@/web/components/data/FcTextStudyTypeBeta.vue';
 
 export default {
   name: 'FcReportHeader',
+  components: {
+    FcTextStudyTypeBeta,
+  },
   props: {
     info: String,
     subinfo: String,
+    studyType: {
+      type: StudyType,
+      default: null,
+    },
     type: ReportType,
   },
   data() {
@@ -45,5 +60,10 @@ export default {
 <style lang="scss">
 .fc-report-header {
   color: var(--v-primary-base);
+
+  & .beta-wrapper {
+    line-height: 16px;
+    width: 363px;
+  }
 }
 </style>

--- a/web/components/reports/FcReportInfo.vue
+++ b/web/components/reports/FcReportInfo.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    <span class="font-weight-regular secondary--text subtitle-2">
+      {{text}}
+    </span>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'FcReportInfo',
+  props: {
+    text: String,
+  },
+};
+</script>

--- a/web/components/reports/FcReportMetadata.vue
+++ b/web/components/reports/FcReportMetadata.vue
@@ -4,7 +4,7 @@
       v-for="({ cols, name, value }, i) in entries"
       :key="i"
       :cols="cols">
-      <dt class="subtitle-1">{{name}}</dt>
+      <dt class="subtitle-1 font-weight-medium">{{name}}</dt>
       <dd class="mt-1 display-1 font-weight-medium">
         <FcTextReportValue
           text-null="None"

--- a/web/store/modules/editRequests.js
+++ b/web/store/modules/editRequests.js
@@ -31,8 +31,7 @@ function getMostRecentByStudyType(studySummaryPerLocation, i) {
   const mostRecentByStudyType = new Map(
     StudyType.enumValues.map(studyType => [studyType, null]),
   );
-  studySummaryPerLocation.forEach(({ category, perLocation }) => {
-    const { studyType } = category;
+  studySummaryPerLocation.forEach(({ perLocation, studyType }) => {
     const { mostRecent } = perLocation[i];
     mostRecentByStudyType.set(studyType, mostRecent);
   });


### PR DESCRIPTION
# Issue Addressed
This PR closes #989 , and closes #986.

# Description
We add `FcTextStudyTypeBeta` and the new `beta` parameter on `StudyType` enum values, to show contextual "beta" copy in various places (View Data, View Reports, global filters drawer).

We also add the new `ReportBlock.INFO` block type, and implement it in `MovePdfGenerator` and `FcReportInfo`.

Finally, we fix a release-blocking bug in Request New, caused by an errant `category` reference.

# Tests
Tested quickly in frontend, using both web and PDF formats, and using both in-beta and not-in-beta study types.
