### PR TITLE
Add studyTypeOther export to RequestItemExport

### DIFF
--- a/lib/requests/RequestItemExport.js
+++ b/lib/requests/RequestItemExport.js
@@ -16,6 +16,7 @@ const CSV_COLUMNS = [
   'Location',
   'Site #',
   'Study Type',
+  'Study Type (Other)',
   'Hours',
   'Date Requested',
   'Date Required',
@@ -92,7 +93,12 @@ class RequestItemExport {
     const projectRequest = RequestItemExport.getItemProjectRequest(item, studyRequestsBulkById);
     const comments = item.studyRequest.notes;
 
-    const { id, urgent, urgentReason } = item.studyRequest;
+    const {
+      id,
+      studyTypeOther,
+      urgent,
+      urgentReason,
+    } = item.studyRequest;
     const assignedTo = item.studyRequest.assignedTo === null
       ? null
       : item.studyRequest.assignedTo.text;
@@ -107,6 +113,7 @@ class RequestItemExport {
       location,
       siteNo,
       studyType,
+      studyTypeOther,
       hours,
       dateRequested,
       dateRequired,

--- a/scripts/test/db/generate-study-requests.js
+++ b/scripts/test/db/generate-study-requests.js
@@ -5,7 +5,6 @@ import db from '@/lib/db/db';
 import StudyRequestDAO from '@/lib/db/StudyRequestDAO';
 import StudyRequestBulkDAO from '@/lib/db/StudyRequestBulkDAO';
 import UserDAO from '@/lib/db/UserDAO';
-import CompositeId from '@/lib/io/CompositeId';
 import StudyRequest from '@/lib/model/StudyRequest';
 import StudyRequestBulk from '@/lib/model/StudyRequestBulk';
 import {
@@ -56,10 +55,8 @@ function correctStudyRequestBulkLocation(transientStudyRequestBulk, centrelineAl
   const studyRequests = transientStudyRequestBulk.studyRequests.map(
     transientStudyRequest => correctStudyRequestLocation(transientStudyRequest, centrelineAll),
   );
-  const s1 = CompositeId.encode(studyRequests);
   return {
     ...transientStudyRequestBulk,
-    s1,
     studyRequests,
   };
 }


### PR DESCRIPTION
# Issue Addressed
This PR closes #1045 .

# Description
Add `studyTypeOther` to exported CSVs in Track Requests so that Data Collection can use this column in their spreadsheet-based workflows.

# Tests
Tested quickly in local dev.