### PR TITLE
Pin sass to 1.32.x to reduce DEPRECATION WARNING log spam

### DIFF
--- a/.ncurc.json
+++ b/.ncurc.json
@@ -5,6 +5,7 @@
     "d3-axis",
     "d3-scale",
     "d3-selection",
+    "sass",
     "sass-loader"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25946,9 +25946,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.38.1.tgz",
-      "integrity": "sha512-Lj8nPaSYOuRhgqdyShV50fY5jKnvaRmikUNalMPmbH+tKMGgEKVkltI/lP30PEfO2T1t6R9yc2QIBLgOc3uaFw==",
+      "version": "1.32.13",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.13.tgz",
+      "integrity": "sha512-dEgI9nShraqP7cXQH+lEXVf73WOPCse0QlFzSD8k+1TcOxCMwVXfQlr0jtoluZysQOyJGnfr21dLvYKDJq8HkA==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0"

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "npm-audit-resolver": "^2.3.1",
     "npm-check-updates": "^11.8.3",
     "npm-run-all": "^4.1.5",
-    "sass": "^1.38.1",
+    "sass": "~1.32.12",
     "sass-loader": "^10.1.1",
     "stylelint": "^13.13.1",
     "stylelint-config-standard": "^22.0.0",


### PR DESCRIPTION
# Issue Addressed
This PR closes #991 .

# Description
The longer-term fix is to upgrade Vuetify to a version that fixes this, but since we're waiting on the Vuetify 3 release to do that...this is an OK fix for now.  (See #968 for the Vuetify / Vue upgrade task.)

# Tests
Ran `ci:npm-outdated`, ensured that `sass` did not show up as an outdated package.  Ran frontend / backend, checked that site still loads in local dev, and that the frontend log output does not include loads of DEPRECATION WARNING messages.