### PR TITLE
Show percentiles, mean to one decimal place in Speed Percentile report

### DIFF
--- a/lib/reports/ReportSpeedPercentile.js
+++ b/lib/reports/ReportSpeedPercentile.js
@@ -23,6 +23,11 @@ class ReportSpeedPercentile extends ReportBaseFlow {
     return ReportType.SPEED_PERCENTILE;
   }
 
+  static getArrayPercentile(xs, p) {
+    const x = ArrayStats.histogramPercentile(SPEED_CLASSES, xs, p);
+    return NumberFormatters.formatDecimal(x, 1);
+  }
+
   static getArrayStats(xs) {
     const total = ArrayStats.sum(xs);
     let pct15 = null;
@@ -31,30 +36,16 @@ class ReportSpeedPercentile extends ReportBaseFlow {
     let pct95 = null;
     let mu = null;
     if (total > 0) {
-      pct15 = Math.floor(ArrayStats.histogramPercentile(
+      pct15 = ReportSpeedPercentile.getArrayPercentile(xs, 0.15);
+      pct50 = ReportSpeedPercentile.getArrayPercentile(xs, 0.5);
+      pct85 = ReportSpeedPercentile.getArrayPercentile(xs, 0.85);
+      pct95 = ReportSpeedPercentile.getArrayPercentile(xs, 0.95);
+
+      mu = ArrayStats.histogramMean(
         SPEED_CLASSES,
         xs,
-        0.15,
-      ));
-      pct50 = Math.floor(ArrayStats.histogramPercentile(
-        SPEED_CLASSES,
-        xs,
-        0.5,
-      ));
-      pct85 = Math.floor(ArrayStats.histogramPercentile(
-        SPEED_CLASSES,
-        xs,
-        0.85,
-      ));
-      pct95 = Math.floor(ArrayStats.histogramPercentile(
-        SPEED_CLASSES,
-        xs,
-        0.95,
-      ));
-      mu = Math.floor(ArrayStats.histogramMean(
-        SPEED_CLASSES,
-        xs,
-      ));
+      );
+      mu = NumberFormatters.formatDecimal(mu, 1);
     }
     return {
       total,

--- a/tests/jest/unit/reports/ReportSpeedPercentile.spec.js
+++ b/tests/jest/unit/reports/ReportSpeedPercentile.spec.js
@@ -18,6 +18,16 @@ expect.extend({
   toBeWithinTolerance,
 });
 
+test('ReportSpeedPercentile.getArrayPercentile', () => {
+  const xs = SPEED_CLASSES.map(() => 0);
+
+  xs[3] = 1;
+  expect(ReportSpeedPercentile.getArrayPercentile(xs, 0.15)).toEqual('30.8');
+
+  xs[4] = 1;
+  expect(ReportSpeedPercentile.getArrayPercentile(xs, 0.15)).toEqual('31.5');
+});
+
 test('ReportSpeedPercentile.getArrayStats', () => {
   const xs = SPEED_CLASSES.map(() => 0);
   expect(ReportSpeedPercentile.getArrayStats(xs)).toEqual({
@@ -32,21 +42,21 @@ test('ReportSpeedPercentile.getArrayStats', () => {
   xs[3] = 1;
   expect(ReportSpeedPercentile.getArrayStats(xs)).toEqual({
     total: 1,
-    pct15: 30,
-    pct50: 32,
-    pct85: 34,
-    pct95: 34,
-    mu: 32,
+    pct15: '30.8',
+    pct50: '32.5',
+    pct85: '34.3',
+    pct95: '34.8',
+    mu: '32.5',
   });
 
   xs[4] = 1;
   expect(ReportSpeedPercentile.getArrayStats(xs)).toEqual({
     total: 2,
-    pct15: 31,
-    pct50: 35,
-    pct85: 38,
-    pct95: 39,
-    mu: 35,
+    pct15: '31.5',
+    pct50: '35.0',
+    pct85: '38.5',
+    pct95: '39.5',
+    mu: '35.0',
   });
 });
 
@@ -117,14 +127,14 @@ test('ReportSpeedPercentile#transformData [Morningside S of Lawrence: ATR_SPEED_
      * The TraxPro reports only give hourly 85th and 95th percentile, so we have no
      * values to test against for the other hourly percentiles.
      */
-    expect(transformedData.countDataByHour[h].pct85).toBeWithinTolerance(pct85, 1);
-    expect(transformedData.countDataByHour[h].pct95).toBeWithinTolerance(pct95, 1);
+    expect(transformedData.countDataByHour[h].pct85).toBeWithinTolerance(pct85, 2);
+    expect(transformedData.countDataByHour[h].pct95).toBeWithinTolerance(pct95, 2);
   });
-  expect(transformedData.totalStats.pct15).toBeWithinTolerance(totalStats.pct15, 1);
-  expect(transformedData.totalStats.pct50).toBeWithinTolerance(totalStats.pct50, 1);
-  expect(transformedData.totalStats.pct85).toBeWithinTolerance(totalStats.pct85, 1);
-  expect(transformedData.totalStats.pct95).toBeWithinTolerance(totalStats.pct95, 1);
-  expect(transformedData.totalStats.mu).toBeWithinTolerance(totalStats.mu, 1);
+  expect(transformedData.totalStats.pct15).toBeWithinTolerance(totalStats.pct15, 2);
+  expect(transformedData.totalStats.pct50).toBeWithinTolerance(totalStats.pct50, 2);
+  expect(transformedData.totalStats.pct85).toBeWithinTolerance(totalStats.pct85, 2);
+  expect(transformedData.totalStats.pct95).toBeWithinTolerance(totalStats.pct95, 2);
+  expect(transformedData.totalStats.mu).toBeWithinTolerance(totalStats.mu, 2);
 
   /*
    * Speed class percentages should match to 3 decimal digits.


### PR DESCRIPTION
# Issue Addressed
This PR closes #974 .

# Description
Adding a bit more precision here, as per user feedback.

# Tests
Updated `ReportSpeedPercentile.spec.js` and ran this.  Tested in local development using frontend, backend, and reporter.
