### PR TITLE
adding new directory creation to start script.

### DIFF
--- a/deploy_scripts/start.sh
+++ b/deploy_scripts/start.sh
@@ -13,8 +13,9 @@ cp -r /home/ec2-user/flashcrow.config.js /var/app/flashcrow/lib/config/private.j
 
 # make move-storage directory
 sudo mkdir -p /data/move-storage
-sudo mkdir -p /data/log/web
 sudo chown -R appsvc:appsvc /data/move-storage
+sudo mkdir -p /data/log/web
+sudo chown -R appsvc:appsvc /data/log/web
 
 # install node dependencies
 cd /var/app/flashcrow


### PR DESCRIPTION
# Issue Addressed
Deployment was failing because /data/log/web directory hadn't been created in QA

# Description
added a mkdir in the start script.
