### PR TITLE
Swagger config fixed for local development

### DIFF
--- a/lib/server/MoveServer.js
+++ b/lib/server/MoveServer.js
@@ -304,7 +304,12 @@ class MoveServer {
 
     return [
       /*
-       * REST API documentation, served at `/documentation`.
+       * REST API documentation, served at `/docs
+       * The below config accounts for production deployments being behind a reverse proxy
+       * while our local enviroments are not. jsonRoutePath and routesBasePath are necessary
+       * for when the app is deployed however they replace jsonPath and swaggerUIPath when included.
+       * The local environment needs the docsPath prefix at all times so we conditionally replace
+       * the value here.
        */
       Inert,
       Vision,
@@ -319,8 +324,8 @@ class MoveServer {
             version: packageJson.version,
           },
           jsonPath: `${docsPath}/swagger.json`,
-          jsonRoutePath: '/swagger.json',
-          routesBasePath: '/swaggerui/',
+          jsonRoutePath: config.ENV === 'production' ? '/swagger.json' : `${docsPath}/swagger.json`,
+          routesBasePath: config.ENV === 'production' ? '/swaggerui/' : `${docsPath}/swaggerui/`,
           swaggerUIPath: `${docsPath}/swaggerui/`,
           validatorUrl: null,
         },


### PR DESCRIPTION
# Issue Addressed
This address [MOVE-1096](https://move-toronto.atlassian.net/browse/MOVE-1096)

# Description
Swagger config fixed for local dev environment

# Tests
Ran the server and checked the swagger UI [path]( https://localhost:8100/docs) to see if it loads the page, the api endpoints, and model definitions.