### PR TITLE
MOVE-1002 Update Vision Zero descriptions

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -112,18 +112,14 @@ CollisionDetail.init({
 <ul>
   <li>damage has occurred to fixed City-owned objects (guard rails, poles, fences,
 bridge supports, buildings, trees, etc.); or</li>
+  <li>damage to roadway or infrastructure (spill, fire, subversion into water, rollover, debris); or</li>
   <li>"property damage" is noted in the comment section of the collision report.</li>
 </ul>`,
   },
   RED_LIGHT: {
     field: 'red_light',
     text: 'Running Red Light',
-    tooltip: `
-<span>Collisions at a signalized intersection where:</span>
-<ul>
-  <li>one or more drivers disobeyed the traffic control; or</li>
-  <li>the initial impact type was angled.</li>
-</ul>`,
+    tooltip: '<span>Collisions at a signalized intersection where one or more drivers disobeyed the traffic control.</span>',
   },
 });
 
@@ -177,12 +173,7 @@ CollisionEmphasisArea.init({
   SCHOOL_CHILDREN: {
     field: 'school_child',
     text: 'School Children',
-    tooltip: `
-<span>Collisions where:</span>
-<ul>
-  <li>at least one child of school age (4-19) was involved; and</li>
-  <li>that child was using an active mode of transportation or personal mobility device.</li>
-</ul>`,
+    tooltip: '<span>Collisions where at least one person aged 4-19 was involved.</span>',
   },
 });
 

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -172,7 +172,7 @@ CollisionEmphasisArea.init({
   OLDER_ADULTS: {
     field: 'older_adult',
     text: 'Older Adults',
-    tooltip: '<span>Collisions where at least one person 55 or over was involved.</span>',
+    tooltip: '<span>Collisions where at least one person 65 or over was involved.</span>',
   },
   SCHOOL_CHILDREN: {
     field: 'school_child',


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-1002](https://move-toronto.atlassian.net/browse/MOVE-1002)

# Description
The SQL queries for these filters got subtly changed, sometime in the 19th century, but the tooltip descriptions were not updated at the time.

# Tests
These guys are all in the `(i)` hovers, over in Filters > Collisions
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/399657/85f12c1f-954a-43ff-aec3-8300bb2548ef)
✌️ 