### PR TITLE
MOVE-488 - [Emails] Requestors should be notified when request needs clarification

### DIFF
--- a/lib/email/EmailStudyRequestBulkChangesNeeded.js
+++ b/lib/email/EmailStudyRequestBulkChangesNeeded.js
@@ -1,0 +1,36 @@
+import EmailBaseStudyRequestBulk from '@/lib/email/EmailBaseStudyRequestBulk';
+
+/**
+ * Notifies the requester that a bulk study request requires changes.  This is sent immediately
+ * when Data Collection marks the request as needs clairification.
+ */
+class EmailStudyRequestBulkChangesNeeded extends EmailBaseStudyRequestBulk {
+  getRecipients() {
+    const recipients = [];
+    if (this.requester !== null) {
+      recipients.push(this.requester.email);
+    }
+    return [
+      ...recipients,
+      ...this.studyRequestBulk.ccEmails,
+    ];
+  }
+
+  getSubject() {
+    const { name } = this.studyRequestBulk;
+    return `[MOVE] Changes Needed: ${name}`;
+  }
+
+  /* eslint-disable-next-line class-methods-use-this */
+  getBodyTemplate() {
+    return `
+    <div>
+        <p>Before we can send your request out for collection, we need more information, or we need you to make changes.</p>
+        ${EmailBaseStudyRequestBulk.TEMPLATE_LIST_STUDY_REQUESTS}
+        <p><a href="{{{hrefStudyRequest}}}">Update your request here</a></p>
+        <p>If you need additional clarification on what information is needed, please check the comment section in MOVE, or email the Data Collection team (<a href="mailto:TrafficData@toronto.ca>TrafficData@toronto.ca</a>).</p>
+    </div>`;
+  }
+}
+
+export default EmailStudyRequestBulkChangesNeeded;

--- a/lib/email/EmailStudyRequestChangesNeeded.js
+++ b/lib/email/EmailStudyRequestChangesNeeded.js
@@ -1,0 +1,40 @@
+import EmailBaseStudyRequest from '@/lib/email/EmailBaseStudyRequest';
+
+/**
+ * Notifies the requester that a study request needs clairification.  This is sent immediately when
+ * Data Collection marks the request as needs clairification.
+ */
+class EmailStudyRequestChangesNeeded extends EmailBaseStudyRequest {
+  getRecipients() {
+    const recipients = [];
+    if (this.requester !== null) {
+      recipients.push(this.requester.email);
+    }
+    return [
+      ...recipients,
+      ...this.studyRequest.ccEmails,
+    ];
+  }
+
+  getSubject() {
+    const { id } = this.studyRequest;
+    if (this.location === null) {
+      return `[MOVE] Changes Needed: #${id}`;
+    }
+    const { description } = this.location;
+    return `[MOVE] Changes Needed: #${id} - ${description}`;
+  }
+
+  /* eslint-disable-next-line class-methods-use-this */
+  getBodyTemplate() {
+    return `
+    <div>
+        <p>Before we can send your request out for collection, we need more information, or we need you to make changes.</p>
+        <p><strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}</p>
+        <p><a href="{{{hrefStudyRequest}}}">Update your request here</a></p>
+        <p>If you need additional clarification on what information is needed, please check the comment section in MOVE, or email the Data Collection team (<a href="mailto:TrafficData@toronto.ca>TrafficData@toronto.ca</a>).</p>
+    </div>`;
+  }
+}
+
+export default EmailStudyRequestChangesNeeded;

--- a/lib/email/MailUtils.js
+++ b/lib/email/MailUtils.js
@@ -2,8 +2,10 @@ import { StudyRequestStatus } from '@/lib/Constants';
 import StudyRequestBulkDAO from '@/lib/db/StudyRequestBulkDAO';
 import EmailStudyRequestBulkCancelled from '@/lib/email/EmailStudyRequestBulkCancelled';
 import EmailStudyRequestBulkCompleted from '@/lib/email/EmailStudyRequestBulkCompleted';
+import EmailStudyRequestBulkChangesNeeded from '@/lib/email/EmailStudyRequestBulkChangesNeeded';
 import EmailStudyRequestCancelled from '@/lib/email/EmailStudyRequestCancelled';
 import EmailStudyRequestCompleted from '@/lib/email/EmailStudyRequestCompleted';
+import EmailStudyRequestChangesNeeded from '@/lib/email/EmailStudyRequestChangesNeeded';
 import Mailer from '@/lib/email/Mailer';
 import LogTag from '@/lib/log/LogTag';
 import { bulkStatus } from '@/lib/requests/RequestStudyBulkUtils';
@@ -18,6 +20,9 @@ function getStudyRequestUpdateEmails(studyRequestNew, studyRequestOld) {
     } else if (studyRequestNew.status === StudyRequestStatus.COMPLETED) {
       const emailCompleted = new EmailStudyRequestCompleted(studyRequestNew);
       emails.push(emailCompleted);
+    } else if (studyRequestNew.status === StudyRequestStatus.CHANGES_NEEDED) {
+      const emailChangesNeeded = new EmailStudyRequestChangesNeeded(studyRequestNew);
+      emails.push(emailChangesNeeded);
     }
   }
 
@@ -36,6 +41,9 @@ function getStudyRequestBulkUpdateEmails(studyRequestBulkNew, studyRequestBulkOl
     } else if (bulkStatusNew === StudyRequestStatus.COMPLETED) {
       const emailCompleted = new EmailStudyRequestBulkCompleted(studyRequestBulkNew);
       emails.push(emailCompleted);
+    } else if (bulkStatusNew === StudyRequestStatus.CHANGES_NEEDED) {
+      const emailChangesNeeded = new EmailStudyRequestBulkChangesNeeded(studyRequestBulkNew);
+      emails.push(emailChangesNeeded);
     }
   }
 

--- a/tests/jest/unit/email/MailUtils.spec.js
+++ b/tests/jest/unit/email/MailUtils.spec.js
@@ -37,7 +37,7 @@ test('MailUtils.getStudyRequestBulkUpdateEmails', () => {
   );
   let studyRequestBulkOld = studyRequestBulk;
   let emails = getStudyRequestBulkUpdateEmails(studyRequestBulkNew, studyRequestBulkOld);
-  expect(emails).toHaveLength(0);
+  expect(emails).toHaveLength(1);
 
   studyRequestBulkOld = studyRequestBulkNew;
   studyRequestBulkNew = studyRequestBulkWithStatus(
@@ -71,7 +71,7 @@ test('MailUtils.getStudyRequestUpdateEmails', () => {
   };
   let studyRequestOld = studyRequest;
   let emails = getStudyRequestUpdateEmails(studyRequestNew, studyRequestOld);
-  expect(emails).toHaveLength(0);
+  expect(emails).toHaveLength(1);
 
   studyRequestOld = studyRequestNew;
   studyRequestNew = {

--- a/web/components/requests/status/SetStatusDropdown.vue
+++ b/web/components/requests/status/SetStatusDropdown.vue
@@ -116,7 +116,7 @@ export default {
     },
     statusTriggersEmails(status) {
       const srs = StudyRequestStatus;
-      return status === srs.COMPLETED || status === srs.CANCELLED;
+      return status === srs.COMPLETED || status === srs.CANCELLED || status === srs.CHANGES_NEEDED;
     },
   },
 };


### PR DESCRIPTION
# Issue Addressed
This PR closes #[MOVE-488](https://move-toronto.atlassian.net/browse/MOVE-488)
# Description
Currently the requestor of a study does not receive an email when the request status is changed to `Needs Clarification`. This ticket changes this by sending an email to the requestor for both bulk study requests, and single requests on status change to `Needs Clarification`

# Tests
I've updated and passed all tests. I think we'll need to verify the functionality in dev - I can see the frontend changes, but I can't validate the emails being sent / received from local.
