### PR TITLE
Move 1105: Speed percentile report headers not matching (csv vs pdf)

### DIFF
--- a/lib/reports/ReportSpeedPercentile.js
+++ b/lib/reports/ReportSpeedPercentile.js
@@ -221,7 +221,7 @@ class ReportSpeedPercentile extends ReportBaseFlow {
   generateCsv(count, reportData) {
     const speedClassColumns = SPEED_CLASSES.map(([lo, hi]) => {
       const key = `speed_${lo}_${hi}`;
-      const header = `${lo + 1}-${hi} kph`;
+      const header = `${lo}-${hi} kph`;
       return { key, header };
     });
 

--- a/tests/jest/unit/reports/ReportSpeedPercentile.spec.js
+++ b/tests/jest/unit/reports/ReportSpeedPercentile.spec.js
@@ -170,28 +170,22 @@ test('ReportSpeedPercentile#generateCsv Column Names are as expected', () => {
   } = setup_4_2156283();
   const transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
   const { columns } = reportInstance.generateCsv(study, transformedData);
-  expect(columns).toEqual([
+
+  const speedClassColumns = SPEED_CLASSES.map(([lo, hi]) => {
+    const key = `speed_${lo}_${hi}`;
+    const header = `${lo}-${hi} kph`;
+    return { key, header };
+  });
+  const expectedColumns = [
     { key: 'time', header: 'Time' },
     { key: 'direction', header: 'Direction' },
-    { key: 'speed_1_19', header: '1-19 kph' },
-    { key: 'speed_20_25', header: '20-25 kph' },
-    { key: 'speed_26_30', header: '26-30 kph' },
-    { key: 'speed_31_35', header: '31-35 kph' },
-    { key: 'speed_36_40', header: '36-40 kph' },
-    { key: 'speed_41_45', header: '41-45 kph' },
-    { key: 'speed_46_50', header: '46-50 kph' },
-    { key: 'speed_51_55', header: '51-55 kph' },
-    { key: 'speed_56_60', header: '56-60 kph' },
-    { key: 'speed_61_65', header: '61-65 kph' },
-    { key: 'speed_66_70', header: '66-70 kph' },
-    { key: 'speed_71_75', header: '71-75 kph' },
-    { key: 'speed_76_80', header: '76-80 kph' },
-    { key: 'speed_81_160', header: '81-160 kph' },
+    ...speedClassColumns,
     { key: 'count', header: 'Count' },
     { key: 'pct15', header: 'p15' },
     { key: 'pct50', header: 'p50' },
     { key: 'pct85', header: 'p85' },
     { key: 'pct95', header: 'p95' },
     { key: 'mu', header: 'Mean' },
-  ]);
+  ];
+  expect(expectedColumns).toEqual(columns);
 });

--- a/tests/jest/unit/reports/ReportSpeedPercentile.spec.js
+++ b/tests/jest/unit/reports/ReportSpeedPercentile.spec.js
@@ -158,3 +158,40 @@ test('ReportSpeedPercentile#generateCsv [Morningside S of Lawrence: ATR_SPEED_VO
     reportInstance.generateCsv(study, transformedData);
   }).not.toThrow();
 });
+
+test('ReportSpeedPercentile#generateCsv Column Names are as expected', () => {
+  const reportInstance = new ReportSpeedPercentile();
+
+  const {
+    countLocation,
+    counts,
+    study,
+    studyData,
+  } = setup_4_2156283();
+  const transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
+  const { columns } = reportInstance.generateCsv(study, transformedData);
+  expect(columns).toEqual([
+    { key: 'time', header: 'Time' },
+    { key: 'direction', header: 'Direction' },
+    { key: 'speed_1_19', header: '1-19 kph' },
+    { key: 'speed_20_25', header: '20-25 kph' },
+    { key: 'speed_26_30', header: '26-30 kph' },
+    { key: 'speed_31_35', header: '31-35 kph' },
+    { key: 'speed_36_40', header: '36-40 kph' },
+    { key: 'speed_41_45', header: '41-45 kph' },
+    { key: 'speed_46_50', header: '46-50 kph' },
+    { key: 'speed_51_55', header: '51-55 kph' },
+    { key: 'speed_56_60', header: '56-60 kph' },
+    { key: 'speed_61_65', header: '61-65 kph' },
+    { key: 'speed_66_70', header: '66-70 kph' },
+    { key: 'speed_71_75', header: '71-75 kph' },
+    { key: 'speed_76_80', header: '76-80 kph' },
+    { key: 'speed_81_160', header: '81-160 kph' },
+    { key: 'count', header: 'Count' },
+    { key: 'pct15', header: 'p15' },
+    { key: 'pct50', header: 'p50' },
+    { key: 'pct85', header: 'p85' },
+    { key: 'pct95', header: 'p95' },
+    { key: 'mu', header: 'Mean' },
+  ]);
+});


### PR DESCRIPTION
# Issue Addressed
This PR addresses [MOVE-1105](https://move-toronto.atlassian.net/browse/MOVE-1105)

# Description
Speed percentile reports were generating different headers for the csv and pdf downloads. The issue was that the csv generator method was adding 1 to the low end of the range for each percentile (due to a change in the constants file not being propagated down to this method).

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/26462466/e3f1b398-36a0-4283-ad24-2139fc9f595a)

This has been changed and a corresponding test to see if the generated columns correspond to the expected values has been added as well.

# Tests
Tested locally on multiple speed percentile reports to see if csv and pdf download headers match, no changes to other parts of the files.
Test added to the test suite.
