### PR TITLE
Move 1103

### DIFF
--- a/web/App.vue
+++ b/web/App.vue
@@ -26,7 +26,7 @@
 <script>
 import { mapGetters, mapMutations, mapState } from 'vuex';
 
-import '@mdi/font/css/materialdesignicons.css';
+import '@mdi/font/css/materialdesignicons.min.css';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import '@/web/css/main.scss';
 

--- a/web/components/geo/map/FcMap.vue
+++ b/web/components/geo/map/FcMap.vue
@@ -9,7 +9,7 @@
         silent />
     </div>
 
-    <div class="fc-map-controls fc-map-top-left">
+    <div class="fc-map-controls fc-map-top-left fc-max-width">
       <slot name="top-left" />
     </div>
 
@@ -667,5 +667,8 @@ export default {
       }
     }
   }
+}
+.fc-max-width {
+  max-width: 50%;
 }
 </style>

--- a/web/components/geo/map/FcMap.vue
+++ b/web/components/geo/map/FcMap.vue
@@ -9,7 +9,7 @@
         silent />
     </div>
 
-    <div class="fc-map-controls fc-map-top-left fc-max-width">
+    <div class="fc-map-controls fc-map-top-left fc-half-width">
       <slot name="top-left" />
     </div>
 
@@ -611,6 +611,9 @@ export default {
       width: 30px;
     }
   }
+  & > .fc-half-width {
+    width: 50%;
+  }
 
   /*
    * MapboxGL style overrides.
@@ -667,8 +670,5 @@ export default {
       }
     }
   }
-}
-.fc-max-width {
-  max-width: 50%;
 }
 </style>

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -18,7 +18,7 @@
     <div
       v-if="locationMode === LocationMode.MULTI_EDIT"
       class="align-start d-flex flex-grow-1 flex-shrink-1">
-      <div>
+      <div class="fc-input-grow">
         <div class="fc-input-location-search-wrapper elevation-2">
           <FcInputLocationSearch
             v-for="(_, i) in locationsEditSelection.locations"
@@ -37,7 +37,7 @@
             @location-add="actionAdd" />
         </div>
         <v-messages
-          class="mt-2"
+          class="mt-2 mb-2"
           :value="messagesMaxLocations"></v-messages>
       </div>
       <div class="ml-2">
@@ -105,7 +105,7 @@
           </FcTooltip>
         </template>
         <template v-else>
-          <h2 class="display-2 mb-4">{{locationsDescription}}</h2>
+          <h2 class="display-3 mb-4">{{locationsDescription}}</h2>
         </template>
       </div>
 
@@ -394,12 +394,15 @@ export default {
   }
 
   & .fc-input-location-search-wrapper {
-    width: 448px;
+    width: 100%;
     & > .fc-input-location-search {
       &:not(:first-child) {
         border-top: 1px solid var(--v-border-base);
       }
     }
+  }
+  & .fc-input-grow {
+    width: 100%;
   }
   & .fc-input-location-search-remove {
     height: 39px;

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -408,6 +408,7 @@ export default {
   & .fc-multi-location-corridor {
     & .v-label {
       font-size: 0.875rem;
+      padding-left: 0 !important;
     }
   }
 }

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -108,16 +108,16 @@
           <h2 class="display-2 mb-4">{{locationsDescription}}</h2>
         </template>
       </div>
-      <div class="d-flex align-center">
-        <template v-if="locationMode === LocationMode.MULTI_EDIT">
-          <v-checkbox
+
+        <v-checkbox
+            v-if="locationMode === LocationMode.MULTI_EDIT"
             v-model="internalCorridor"
             class="fc-multi-location-corridor mt-0"
             hide-details
             label="Include intersections and midblocks between locations" />
 
-          <v-spacer></v-spacer>
-          <br/>
+      <div class="d-flex justify-end mt-1">
+        <template v-if="locationMode === LocationMode.MULTI_EDIT">
           <FcButton
             type="tertiary"
             @click="showConfirmMultiLocationLeave = true">

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -7,12 +7,14 @@
       v-model="showConfirmMultiLocationLeave" />
 
     <FcButton
-      v-if="locationMode === LocationMode.MULTI"
-      class="btn-clear-all mr-5 mt-3"
-      type="secondary"
+      v-if="hasManyLocations"
+      class="btn btn-clear-all"
+      width="10"
+      title="Clear All"
+      type="tertiary"
       @click="actionClear">
-      <v-icon color="primary" left>mdi-map-marker-remove-variant</v-icon>
-      Clear
+      <v-icon color="error">mdi-close-box-multiple</v-icon>
+
     </FcButton>
 
     <div
@@ -38,6 +40,7 @@
         </div>
         <v-messages
           class="mt-2 mb-2"
+          v-if="locationsEditFull"
           :value="messagesMaxLocations"></v-messages>
       </div>
       <div class="ml-2">
@@ -69,7 +72,7 @@
     <div class="flex-grow-0 flex-shrink-0">
       <div class="d-flex align-center">
         <template v-if="locationMode === LocationMode.MULTI_EDIT">
-          <h2 class="display-3 mb-4">{{locationsEditDescription}}</h2>
+          <h2 class="display-3 mb-4 mt-4">{{locationsEditDescription}}</h2>
         </template>
         <template v-else-if="detailView">
           <FcHeaderSingleLocation
@@ -110,7 +113,7 @@
       </div>
 
         <v-checkbox
-            v-if="locationMode === LocationMode.MULTI_EDIT"
+            v-if="hasManyLocations"
             v-model="internalCorridor"
             class="fc-multi-location-corridor mt-0"
             hide-details
@@ -251,6 +254,13 @@ export default {
         return `${key}_${counter}`;
       });
     },
+    hasManyLocations() {
+      const mode = this.locationMode;
+      if (mode !== LocationMode.MULTI_EDIT && mode !== LocationMode.MULTI) {
+        return false;
+      }
+      return this.locationsEditKeys.length > 1;
+    },
     messagesMaxLocations() {
       if (this.locationMode !== LocationMode.MULTI_EDIT || !this.locationsEditFull) {
         return [];
@@ -388,9 +398,10 @@ export default {
   position: relative;
 
   & > .btn-clear-all {
-    position: absolute;
-    right: 0;
-    top: 0;
+    align-self: end;
+    padding: 0;
+    min-width: 30px !important;
+    opacity: 0.8;
   }
 
   & .fc-input-location-search-wrapper {

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -6,17 +6,6 @@
     <FcDialogConfirmMultiLocationLeave
       v-model="showConfirmMultiLocationLeave" />
 
-    <FcButton
-      v-if="hasManyLocations"
-      class="btn btn-clear-all"
-      width="10"
-      title="Clear All"
-      type="tertiary"
-      @click="actionClear">
-      <v-icon color="error">mdi-close-box-multiple</v-icon>
-
-    </FcButton>
-
     <div
       v-if="locationMode === LocationMode.MULTI_EDIT"
       class="align-start d-flex flex-grow-1 flex-shrink-1">
@@ -396,13 +385,6 @@ export default {
 <style lang="scss">
 .fc-selector-multi-location {
   position: relative;
-
-  & > .btn-clear-all {
-    align-self: end;
-    padding: 0;
-    min-width: 30px !important;
-    opacity: 0.8;
-  }
 
   & .fc-input-location-search-wrapper {
     width: 100%;

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -105,10 +105,10 @@
           </FcTooltip>
         </template>
         <template v-else>
-          <h2 class="display-3 mb-4">{{locationsDescription}}</h2>
+          <h2 class="display-2 mb-4">{{locationsDescription}}</h2>
         </template>
       </div>
-      <div class="d-flex align-center mt-4">
+      <div class="d-flex align-center">
         <template v-if="locationMode === LocationMode.MULTI_EDIT">
           <v-checkbox
             v-model="internalCorridor"
@@ -117,7 +117,7 @@
             label="Include intersections and midblocks between locations" />
 
           <v-spacer></v-spacer>
-
+          <br/>
           <FcButton
             type="tertiary"
             @click="showConfirmMultiLocationLeave = true">

--- a/web/views/FcLayoutViewData.vue
+++ b/web/views/FcLayoutViewData.vue
@@ -360,8 +360,6 @@ export default {
   & .fc-map .fc-selector-multi-location {
     background-color: var(--v-shading-base);
     border-radius: 8px;
-    height: 387px;
-    width: 640px;
   }
 
   &.vertical {


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-1103](https://move-toronto.atlassian.net/browse/MOVE-1103) - multiple location selection responsive fixes.

# Description
some CSS tweaks for the multi-select sidebar.
Bringing visual parity between multi-select sidebar and the single-select sidebar. 
Prevents stretching of width for long location names, and removes some hardcoded widths/heights.

A 'Clear all' button is removed, as it was already hidden behind the sidebar during many interactions. 

Other:
* use *.min* file of material Design icons (320kb vs 380kb)
* shows 'include intersections ...' toggle only if multi-locations selected

Feedback and questions welcome!
