### PR TITLE
Reduce steps in multi-location, Collapse Legend

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -112,7 +112,7 @@ CollisionDetail.init({
 <ul>
   <li>damage has occurred to fixed City-owned objects (guard rails, poles, fences,
 bridge supports, buildings, trees, etc.); or</li>
-  <li>damage to roadway or infrastructure (spill, fire, subversion into water, rollover, debris); or</li>
+  <li>damage to roadway or infrastructure (spill, fire, submersion into water, rollover, debris); or</li>
   <li>"property damage" is noted in the comment section of the collision report.</li>
 </ul>`,
   },

--- a/web/components/geo/legend/FcMapLegend.vue
+++ b/web/components/geo/legend/FcMapLegend.vue
@@ -1,37 +1,46 @@
 <template>
-  <v-card class="fc-map-legend" width="250">
+  <v-card class="fc-map-legend" :class="{ shrink: isHidden }">
     <v-card-text class="default--text pa-0">
       <fieldset>
         <legend class="headline px-4 py-3 d-flex justify-content-between">
           <div>Legend</div>
           <v-icon v-if="!isHidden" @click="toggleLegend">mdi-chevron-down</v-icon>
-          <v-icon v-if="isHidden" @click="toggleLegend">mdi-chevron-up</v-icon>
+          <v-icon v-else @click="toggleLegend">mdi-chevron-up</v-icon>
         </legend>
         <v-divider></v-divider>
 
-        <template v-for="(layerItem, i) in layerItems">
-          <v-divider
-            v-if="layerItem === null"
-            :key="i"
-            class="ml-4"></v-divider>
-          <component
-            v-else
-            v-model="internalValue[layerItem.value]"
-            :key="layerItem.value"
-            :is="'FcLegendRow' + layerItem.suffix"
-            class="mx-4 mt-2 mb-3" />
-        </template>
+        <div v-if="!isHidden" >
+          <template v-for="(layerItem, i) in layerItems" >
+            <v-divider
+              v-if="layerItem === null"
+              :key="i"
+              class="ml-4"></v-divider>
+            <component
+              v-else
+              v-model="internalValue[layerItem.value]"
+              :key="layerItem.value"
+              :is="'FcLegendRow' + layerItem.suffix"
+              class="mx-4 mt-2 mb-3" />
+          </template>
+        </div>
       </fieldset>
 
-      <v-divider></v-divider>
+      <div v-if="!isHidden">
+        <v-divider></v-divider>
 
-      <div class="text-center py-1">
-        <FcButton
-          type="tertiary"
-          @click="showMore = !showMore">
-          <span v-if="showMore">Less</span>
-          <span v-else>More</span>
-        </FcButton>
+        <div class="text-center py-1">
+          <FcButton
+            type="tertiary"
+            @click="showMore = !showMore">
+            <span v-if="showMore">
+              <v-icon>mdi-menu-up</v-icon>
+              Less
+            </span>
+            <span v-else>
+              More
+            </span>
+          </FcButton>
+        </div>
       </div>
     </v-card-text>
   </v-card>
@@ -103,6 +112,7 @@ export default {
 
 <style lang="scss">
 .fc-map-legend {
+  width: 250px;
   & .fc-legend-icon {
     height: 24px;
     position: relative;
@@ -111,6 +121,11 @@ export default {
   & .headline {
     width: 100%;
     justify-content: space-between;
+    align-items: center;
   }
+}
+.shrink {
+  width: 130px;
+  opacity: 0.9;
 }
 </style>

--- a/web/components/geo/legend/FcMapLegend.vue
+++ b/web/components/geo/legend/FcMapLegend.vue
@@ -113,6 +113,7 @@ export default {
 <style lang="scss">
 .fc-map-legend {
   width: 250px;
+  display: block;
   & .fc-legend-icon {
     height: 24px;
     position: relative;
@@ -127,5 +128,11 @@ export default {
 .shrink {
   width: 130px;
   opacity: 0.9;
+}
+
+@media only screen and (max-width: 600px) {
+  .fc-map-legend {
+    display: none;
+  }
 }
 </style>

--- a/web/components/geo/legend/FcMapLegend.vue
+++ b/web/components/geo/legend/FcMapLegend.vue
@@ -2,8 +2,11 @@
   <v-card class="fc-map-legend" width="250">
     <v-card-text class="default--text pa-0">
       <fieldset>
-        <legend class="headline px-4 py-3">Legend</legend>
-
+        <legend class="headline px-4 py-3 d-flex justify-content-between">
+          <div>Legend</div>
+          <v-icon v-if="!isHidden" @click="toggleLegend">mdi-chevron-down</v-icon>
+          <v-icon v-if="isHidden" @click="toggleLegend">mdi-chevron-up</v-icon>
+        </legend>
         <v-divider></v-divider>
 
         <template v-for="(layerItem, i) in layerItems">
@@ -67,10 +70,16 @@ export default {
       { suffix: 'Hospitals', value: 'hospitals' },
     ];
     return {
+      isHidden: false,
       showMore: false,
       layerItemsLess,
       layerItemsMore,
     };
+  },
+  methods: {
+    toggleLegend() {
+      this.isHidden = !this.isHidden;
+    },
   },
   computed: {
     layerItems() {
@@ -98,6 +107,10 @@ export default {
     height: 24px;
     position: relative;
     width: 24px;
+  }
+  & .headline {
+    width: 100%;
+    justify-content: space-between;
   }
 }
 </style>

--- a/web/components/geo/legend/FcMapLegend.vue
+++ b/web/components/geo/legend/FcMapLegend.vue
@@ -126,7 +126,6 @@ export default {
   }
 }
 .shrink {
-  width: 130px;
   opacity: 0.9;
 }
 

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -14,6 +14,7 @@
             v-model="query"
             :aria-label="query"
             autocomplete="off"
+            spellcheck="false"
             dense
             :flat="hasLocationIndex"
             hide-details

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -115,12 +115,20 @@
             @click="showConfirmMultiLocationLeave = true">
             Cancel
           </FcButton>
-          <FcButton
+          <!-- <FcButton
             :disabled="loading || hasError"
             :loading="loading"
             type="secondary"
             @click="saveLocationsEdit">
             Done
+          </FcButton> -->
+          <FcButton
+            :disabled="loading || hasError"
+            :loading="loading"
+            type="secondary"
+            color="blue"
+            @click="saveAndThenView">
+            View Data
           </FcButton>
         </template>
         <template v-else-if="detailView">
@@ -312,6 +320,7 @@ export default {
       'locationsEditDescription',
       'locationsEditFull',
       'locationsForModeEmpty',
+      'locationsRouteParams',
     ]),
   },
   watch: {
@@ -332,6 +341,18 @@ export default {
     },
   },
   methods: {
+    saveAndThenView() {
+      this.saveLocationsEdit();
+      const { s1, selectionTypeName } = this.$route.params;
+      const params = this.locationsRouteParams;
+      // guard-against redundant view-change
+      if (s1 !== params.s1 || selectionTypeName !== params.selectionTypeName) {
+        this.$router.push({
+          name: 'viewDataAtLocation',
+          params,
+        });
+      }
+    },
     actionAdd(location) {
       const { description } = location;
       this.setToastInfo(`Added ${description} to selected locations.`);

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -108,7 +108,7 @@
             hide-details
             label="Include intersections and midblocks between locations" />
 
-      <div class="d-flex justify-end mt-1">
+      <div class="d-flex mt-1">
         <template v-if="locationMode === LocationMode.MULTI_EDIT">
           <FcButton
             type="tertiary"
@@ -131,18 +131,22 @@
           </FcButton>
         </template>
         <template v-else-if="detailView">
-          <FcSummaryPoi :location="locationActive" />
+          <div class="d-flex shrink-column">
 
-          <v-spacer></v-spacer>
+            <FcSummaryPoi :location="locationActive" class="column-space"/>
 
-          <slot name="action" />
-          <FcButton
-            class="ml-2"
-            type="secondary"
-            @click="setLocationMode(LocationMode.MULTI_EDIT)">
-            <v-icon color="primary" left>mdi-circle-edit-outline</v-icon>
-            Edit Locations
-          </FcButton>
+            <v-spacer></v-spacer>
+
+            <slot name="action" />
+            <FcButton
+              class="ml-2 column-space"
+              type="secondary"
+              @click="setLocationMode(LocationMode.MULTI_EDIT)">
+              <v-icon color="primary" left>mdi-circle-edit-outline</v-icon>
+              Edit Locations
+            </FcButton>
+
+          </div>
         </template>
         <template v-else>
           <span
@@ -432,6 +436,17 @@ export default {
       font-size: 0.875rem;
       padding-left: 0 !important;
     }
+  }
+}
+
+@media only screen and (max-width: 1000px) {
+  .shrink-column {
+    flex-direction: column;
+    align-items: baseline;
+  }
+  .column-space {
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
   }
 }
 </style>

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -131,9 +131,9 @@
           </FcButton>
         </template>
         <template v-else-if="detailView">
-          <div class="d-flex shrink-column">
+          <div class="d-flex">
 
-            <FcSummaryPoi :location="locationActive" class="column-space"/>
+            <FcSummaryPoi :location="locationActive"/>
 
             <v-spacer></v-spacer>
 
@@ -436,18 +436,6 @@ export default {
       font-size: 0.875rem;
       padding-left: 0 !important;
     }
-  }
-}
-
-@media only screen and (max-width: 1000px) {
-  .shrink-column {
-    flex-direction: column;
-    align-items: baseline;
-    width: 100%;
-  }
-  .column-space {
-    margin-top: 0.5rem;
-    margin-bottom: 0.5rem;
   }
 }
 </style>

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -112,7 +112,7 @@
         <template v-if="locationMode === LocationMode.MULTI_EDIT">
           <FcButton
             type="tertiary"
-            @click="showConfirmMultiLocationLeave = true">
+            @click="leaveLocationMode">
             Cancel
           </FcButton>
           <!-- <FcButton
@@ -354,6 +354,9 @@ export default {
           params,
         });
       }
+    },
+    leaveLocationMode() {
+      this.cancelLocationsEdit();
     },
     actionAdd(location) {
       const { description } = location;

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -108,7 +108,7 @@
             hide-details
             label="Include intersections and midblocks between locations" />
 
-      <div class="d-flex mt-1">
+      <div class="d-flex mt-1 justify-end">
         <template v-if="locationMode === LocationMode.MULTI_EDIT">
           <FcButton
             type="tertiary"
@@ -443,6 +443,7 @@ export default {
   .shrink-column {
     flex-direction: column;
     align-items: baseline;
+    width: 100%;
   }
   .column-space {
     margin-top: 0.5rem;

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -123,10 +123,9 @@
             Done
           </FcButton> -->
           <FcButton
-            :disabled="loading || hasError"
+            :disabled="loading || hasError || hasZeroLocations"
             :loading="loading"
-            type="secondary"
-            color="blue"
+            type="primary"
             @click="saveAndThenView">
             View Data
           </FcButton>
@@ -250,6 +249,9 @@ export default {
         keyCounter.set(key, counter);
         return `${key}_${counter}`;
       });
+    },
+    hasZeroLocations() {
+      return !this.locationsEditKeys || this.locationsEditKeys.length === 0;
     },
     hasManyLocations() {
       const mode = this.locationMode;

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -115,13 +115,6 @@
             @click="leaveLocationMode">
             Cancel
           </FcButton>
-          <!-- <FcButton
-            :disabled="loading || hasError"
-            :loading="loading"
-            type="secondary"
-            @click="saveLocationsEdit">
-            Done
-          </FcButton> -->
           <FcButton
             :disabled="loading || hasError || hasZeroLocations"
             :loading="loading"

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -259,7 +259,7 @@ export default {
     },
     hasManyLocations() {
       const mode = this.locationMode;
-      if (mode !== LocationMode.MULTI_EDIT && mode !== LocationMode.MULTI) {
+      if (mode !== LocationMode.MULTI_EDIT) {
         return false;
       }
       return this.locationsEditKeys.length > 1;

--- a/web/components/inputs/FcSelectorSingleLocation.vue
+++ b/web/components/inputs/FcSelectorSingleLocation.vue
@@ -58,7 +58,7 @@ export default {
 <style lang="scss">
 .fc-selector-single-location {
   & > .fc-input-location-search {
-    width: 448px;
+    max-width: 448px;
   }
 }
 </style>

--- a/web/views/FcLayoutViewData.vue
+++ b/web/views/FcLayoutViewData.vue
@@ -70,15 +70,7 @@
               class="mt-3 ml-5" />
             <FcSelectorMultiLocation
               v-else-if="locationMode.multi"
-              class="elevation-2">
-              <template v-slot:action>
-                <!-- <FcButton
-                  type="secondary"
-                  @click="actionViewData">
-                  View Data
-                </FcButton> -->
-              </template>
-            </FcSelectorMultiLocation>
+              class="elevation-2"/>
             <FcSelectorSingleLocation
               v-else
               v-model="internalLocationsSelection"

--- a/web/views/FcLayoutViewData.vue
+++ b/web/views/FcLayoutViewData.vue
@@ -72,11 +72,11 @@
               v-else-if="locationMode.multi"
               class="elevation-2">
               <template v-slot:action>
-                <FcButton
+                <!-- <FcButton
                   type="secondary"
                   @click="actionViewData">
                   View Data
-                </FcButton>
+                </FcButton> -->
               </template>
             </FcSelectorMultiLocation>
             <FcSelectorSingleLocation


### PR DESCRIPTION
# Issue Addressed

This closes [MOVE-1114](https://move-toronto.atlassian.net/browse/MOVE-1114) (Reduce steps in multi-location), and [MOVE-1109](https://move-toronto.atlassian.net/browse/MOVE-1109) (Collapse Legend).

# Description
Former Multi-location flow required a redundant 'Done' step, that is now skipped-over.
Additionally, the 'Cancel' has now skipped the scary confirmation dialogue.

The Legend now has a collapse button, and will now auto-hide when screen width is too small to support it.

Also:
* Fix typo for  [MOVE-1002](https://move-toronto.atlassian.net/browse/MOVE-1002)
* Remove spellcheck from location search box
* change class of 'View Data' button

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/399657/e6c3ef5d-ff77-4b79-8921-ff645d33d29a)

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/399657/1ea6c324-5324-4d08-85b6-5c7a8961e4e7)
