### PR TITLE
PR for MOVE-1090 and MOVE-640

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -1222,6 +1222,8 @@ TurningMovement.init({
   },
 });
 
+const StudyRequestChanges = ['centrelineId', 'studyType', 'hours', 'duration', 'notes'];
+
 const Constants = {
   AuthScope,
   CardinalDirection,
@@ -1256,6 +1258,7 @@ const Constants = {
   SPEED_CLASSES,
   StudyHours,
   StudyRequestAssignee,
+  StudyRequestChanges,
   StudyRequestStatus,
   StudyType,
   TMC_MODES_NON_VEHICLE,
@@ -1297,6 +1300,7 @@ export {
   SPEED_CLASSES,
   StudyHours,
   StudyRequestAssignee,
+  StudyRequestChanges,
   StudyRequestStatus,
   StudyType,
   TMC_MODES_NON_VEHICLE,

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -1222,7 +1222,28 @@ TurningMovement.init({
   },
 });
 
-const StudyRequestChanges = ['centrelineId', 'studyType', 'hours', 'duration', 'notes'];
+const StudyRequestChanges = {
+  geom: {
+    label: 'Location',
+    subKey: 'coordinates',
+  },
+  studyType: {
+    label: 'Study Type',
+    subKey: 'label',
+  },
+  hours: {
+    label: 'Hours',
+    subKey: 'times',
+  },
+  duration: {
+    label: 'Duration',
+    subKey: '',
+  },
+  notes: {
+    label: 'Notes',
+    subKey: '',
+  },
+};
 
 const Constants = {
   AuthScope,

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -1223,9 +1223,9 @@ TurningMovement.init({
 });
 
 const StudyRequestChanges = {
-  geom: {
+  centrelineId: {
     label: 'Location',
-    subKey: 'coordinates',
+    subKey: '',
   },
   studyType: {
     label: 'Study Type',
@@ -1241,6 +1241,10 @@ const StudyRequestChanges = {
   },
   notes: {
     label: 'Notes',
+    subKey: '',
+  },
+  daysOfWeek: {
+    label: 'Days of Week',
     subKey: '',
   },
 };

--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -318,10 +318,7 @@ StudyRequestController.push({
     const studyRequestNew = request.payload;
 
     const studyRequestOld = await StudyRequestDAO.byId(id);
-    // eslint-disable-next-line no-console
-    console.log('studyRequestNew:', studyRequestNew);
-    // eslint-disable-next-line no-console
-    console.log('studyRequestOld:', studyRequestOld);
+
     if (studyRequestOld === null) {
       return Boom.notFound(`no study request found with ID ${id}`);
     }

--- a/lib/controller/StudyRequestController.js
+++ b/lib/controller/StudyRequestController.js
@@ -318,6 +318,10 @@ StudyRequestController.push({
     const studyRequestNew = request.payload;
 
     const studyRequestOld = await StudyRequestDAO.byId(id);
+    // eslint-disable-next-line no-console
+    console.log('studyRequestNew:', studyRequestNew);
+    // eslint-disable-next-line no-console
+    console.log('studyRequestOld:', studyRequestOld);
     if (studyRequestOld === null) {
       return Boom.notFound(`no study request found with ID ${id}`);
     }

--- a/lib/email/EmailBaseStudyRequestChanged.js
+++ b/lib/email/EmailBaseStudyRequestChanged.js
@@ -1,0 +1,52 @@
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import UserDAO from '@/lib/db/UserDAO';
+import EmailBase from '@/lib/email/EmailBase';
+
+class EmailBaseStudyRequestChanged extends EmailBase {
+  constructor(requestChanges) {
+    super();
+    this.requestChanges = requestChanges;
+    this.location = null;
+    this.requester = null;
+  }
+
+  async init() {
+    const { centrelineId, centrelineType } = this.requestChanges;
+    const feature = { centrelineId, centrelineType };
+    const [location, requester] = await Promise.all([
+      CentrelineDAO.byFeature(feature),
+      UserDAO.byId(this.studyRequest.userId),
+    ]);
+    this.location = location;
+    this.requester = requester;
+  }
+
+  getBodyParams() {
+    const { id } = this.requestChanges;
+    const hrefStudyRequest = EmailBase.getUrl(`requests/study/${id}`);
+
+    let location = null;
+    if (this.location !== null) {
+      location = this.location.description;
+    }
+
+    const studyChanges = this.requestChanges.studyRequestChanges;
+
+    return {
+      hrefStudyRequest,
+      location,
+      studyChanges,
+    };
+  }
+}
+
+EmailBaseStudyRequestChanged.TEMPLATE_CHANGES_LIST = `
+<div>
+{{#studyChanges}}
+  <div>
+    &mdash; <strong>{{changeType}}</strong> changed from: {{from}} to: {{to}}
+  </div>
+{{/studyChanges}}
+</div>`;
+
+export default EmailBaseStudyRequestChanged;

--- a/lib/email/EmailBaseStudyRequestChanged.js
+++ b/lib/email/EmailBaseStudyRequestChanged.js
@@ -11,11 +11,10 @@ class EmailBaseStudyRequestChanged extends EmailBase {
   }
 
   async init() {
-    const { centrelineId, centrelineType } = this.requestChanges;
-    const feature = { centrelineId, centrelineType };
+    const { feature } = this.requestChanges;
     const [location, requester] = await Promise.all([
       CentrelineDAO.byFeature(feature),
-      UserDAO.byId(this.studyRequest.userId),
+      UserDAO.byId(this.requestChanges.userId),
     ]);
     this.location = location;
     this.requester = requester;

--- a/lib/email/EmailBaseStudyRequestChanged.js
+++ b/lib/email/EmailBaseStudyRequestChanged.js
@@ -6,34 +6,60 @@ class EmailBaseStudyRequestChanged extends EmailBase {
   constructor(requestChanges) {
     super();
     this.requestChanges = requestChanges;
-    this.location = null;
+    this.locationOld = null;
+    this.locationNew = null;
     this.requester = null;
   }
 
   async init() {
-    const { feature } = this.requestChanges;
-    const [location, requester] = await Promise.all([
-      CentrelineDAO.byFeature(feature),
+    const { featureOld, featureNew } = this.requestChanges;
+    const [locationOld, locationNew, requester] = await Promise.all([
+      CentrelineDAO.byFeature(featureOld),
+      CentrelineDAO.byFeature(featureNew),
       UserDAO.byId(this.requestChanges.userId),
     ]);
-    this.location = location;
+    this.locationOld = locationOld;
+    this.locationNew = locationNew;
     this.requester = requester;
+  }
+
+  /* eslint-disable-next-line class-methods-use-this */
+  parseStudyChanges(studyChanges, locationOld, locationNew) {
+    return studyChanges.map((studyChange) => {
+      if (studyChange.changeType === 'Location') {
+        return {
+          changeType: studyChange.changeType,
+          from: locationOld,
+          to: locationNew,
+        };
+      }
+      return studyChange;
+    });
   }
 
   getBodyParams() {
     const { id } = this.requestChanges;
     const hrefStudyRequest = EmailBase.getUrl(`requests/study/${id}`);
 
-    let location = null;
-    if (this.location !== null) {
-      location = this.location.description;
+    let locationOld = null;
+    if (this.locationOld !== null) {
+      locationOld = this.locationOld.description;
     }
 
-    const studyChanges = this.requestChanges.studyRequestChanges;
+    let locationNew = null;
+    if (this.locationNew !== null) {
+      locationNew = this.locationNew.description;
+    }
+
+    const studyChanges = this.parseStudyChanges(
+      this.requestChanges.studyRequestChanges,
+      locationOld,
+      locationNew,
+    );
 
     return {
       hrefStudyRequest,
-      location,
+      locationOld,
       studyChanges,
     };
   }
@@ -42,9 +68,9 @@ class EmailBaseStudyRequestChanged extends EmailBase {
 EmailBaseStudyRequestChanged.TEMPLATE_CHANGES_LIST = `
 <div>
 {{#studyChanges}}
-  <div>
-    &mdash; <strong>{{changeType}}</strong> changed from: {{from}} to: {{to}}
-  </div>
+  <p>
+    <strong>{{changeType}}</strong> changed from: <i>{{from}}</i> to: <i>{{to}}</i>
+  </p>
 {{/studyChanges}}
 </div>`;
 

--- a/lib/email/EmailStudyRequestBulkCancelledAdmin.js
+++ b/lib/email/EmailStudyRequestBulkCancelledAdmin.js
@@ -1,0 +1,37 @@
+import EmailBase from '@/lib/email/EmailBase';
+import EmailBaseStudyRequestBulk from '@/lib/email/EmailBaseStudyRequestBulk';
+
+/**
+ * Notifies the Data supervisors that a bulk study request has been cancelled. This is sent
+ * immediately when the request is marked as cancelled, either by Data Collection or by the
+ * requester.
+ */
+class EmailStudyRequestBulkCancelledAdmin extends EmailBaseStudyRequestBulk {
+  /* eslint-disable-next-line class-methods-use-this */
+  getRecipients() {
+    return [
+      EmailBase.getRecipientStudyRequestAdmin('EmailStudyRequestBulkCancelledAdmin'),
+    ];
+  }
+
+  getSubject() {
+    const { name } = this.studyRequestBulk;
+    return `[MOVE] Project request cancelled: ${name}`;
+  }
+
+  /* eslint-disable-next-line class-methods-use-this */
+  getBodyTemplate() {
+    return `
+    <div>
+      <p>
+        The project for the following studies has been cancelled:
+      </p>
+      ${EmailBaseStudyRequestBulk.TEMPLATE_LIST_STUDY_REQUESTS}
+      <p>
+        <a href="{{{hrefStudyRequestBulk}}}">View cancelled project</a>
+      </p>
+    </div>`;
+  }
+}
+
+export default EmailStudyRequestBulkCancelledAdmin;

--- a/lib/email/EmailStudyRequestCancelledAdmin.js
+++ b/lib/email/EmailStudyRequestCancelledAdmin.js
@@ -1,0 +1,38 @@
+import EmailBase from '@/lib/email/EmailBase';
+import EmailBaseStudyRequest from '@/lib/email/EmailBaseStudyRequest';
+
+/**
+ * Notifies the Data supervisors that a study request has been canceled. This is sent
+ * immediately upon study cancelation user flow in the frontend.
+ */
+class EmailStudyRequestCancelledAdmin extends EmailBaseStudyRequest {
+  /* eslint-disable-next-line class-methods-use-this */
+  getRecipients() {
+    return [
+      EmailBase.getRecipientStudyRequestAdmin(
+        'EmailStudyRequestCancelledAdmin',
+      ),
+    ];
+  }
+
+  getSubject() {
+    const { id } = this.studyRequest;
+    if (this.location === null) {
+      return `[MOVE] Request cancelled: #${id}`;
+    }
+    const { description } = this.location;
+    return `[MOVE] Request cancelled: #${id} - ${description}`;
+  }
+
+  /* eslint-disable-next-line class-methods-use-this */
+  getBodyTemplate() {
+    return `
+    <div>
+        <p>The following study at {location} was cancelled:</p>
+        <p><strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}</p>
+        <p><a href="{{{hrefStudyRequest}}}">View request</a></p>
+    </div>`;
+  }
+}
+
+export default EmailStudyRequestCancelledAdmin;

--- a/lib/email/EmailStudyRequestChanged.js
+++ b/lib/email/EmailStudyRequestChanged.js
@@ -1,0 +1,46 @@
+import EmailBase from '@/lib/email/EmailBase';
+import EmailBaseStudyRequestChanged from '@/lib/email/EmailBaseStudyRequestChanged';
+
+/**
+ * Notifies the requester that a study request has been completed.  This is sent immediately when
+ * Data Collection marks the request as completed.
+ */
+class EmailStudyRequestChanged extends EmailBaseStudyRequestChanged {
+  /* eslint-disable-next-line class-methods-use-this */
+  getRecipients() {
+    return [
+      EmailBase.getRecipientStudyRequestAdmin(
+        'EmailStudyRequestChanged',
+      ),
+    ];
+  }
+
+  getSubject() {
+    const { id } = this.requestChanges;
+    if (this.location === null) {
+      return `[MOVE] Request changed: #${id}`;
+    }
+    const { description } = this.location;
+    return `[MOVE] Request changed: #${id} - ${description}`;
+  }
+
+  /* eslint-disable-next-line class-methods-use-this */
+  getBodyTemplate() {
+    return `
+    <div>
+      <p>
+        Your request for the following study
+        {{#location}}
+          at {{location}}
+        {{/location}}
+        has had the following changes:
+      </p>
+      ${EmailBaseStudyRequestChanged.TEMPLATE_CHANGES_LIST}
+      <p>
+        <a href="{{{hrefStudyRequest}}}">View changed request</a>
+      </p>
+    </div>`;
+  }
+}
+
+export default EmailStudyRequestChanged;

--- a/lib/email/EmailStudyRequestChanged.js
+++ b/lib/email/EmailStudyRequestChanged.js
@@ -17,10 +17,10 @@ class EmailStudyRequestChanged extends EmailBaseStudyRequestChanged {
 
   getSubject() {
     const { id } = this.requestChanges;
-    if (this.location === null) {
+    if (this.locationOld === null) {
       return `[MOVE] Request changed: #${id}`;
     }
-    const { description } = this.location;
+    const { description } = this.locationOld;
     return `[MOVE] Request changed: #${id} - ${description}`;
   }
 
@@ -29,10 +29,10 @@ class EmailStudyRequestChanged extends EmailBaseStudyRequestChanged {
     return `
     <div>
       <p>
-        Your request for the following study
-        {{#location}}
-          at {{location}}
-        {{/location}}
+      Your study
+        {{#locationOld}}
+          at <strong>{{locationOld}}</strong>
+        {{/locationOld}}
         has had the following changes:
       </p>
       ${EmailBaseStudyRequestChanged.TEMPLATE_CHANGES_LIST}

--- a/lib/email/EmailStudyRequestChanged.js
+++ b/lib/email/EmailStudyRequestChanged.js
@@ -29,7 +29,7 @@ class EmailStudyRequestChanged extends EmailBaseStudyRequestChanged {
     return `
     <div>
       <p>
-      Your study
+      The study
         {{#locationOld}}
           at <strong>{{locationOld}}</strong>
         {{/locationOld}}

--- a/lib/email/EmailStudyRequestUtils.js
+++ b/lib/email/EmailStudyRequestUtils.js
@@ -18,18 +18,6 @@ class EmailStudyRequestUtils {
     hours = hours.description.toLowerCase();
     return `${hours} hours`;
   }
-
-  static renderHoursString(studyHours) {
-    if (studyHours === null) return 'None';
-
-    const hoursString = `${studyHours.description}`;
-    const ranges = studyHours.times.map(timeRange => ` ${timeRange[0]} - ${timeRange[1]}`);
-    return `${hoursString}:${ranges}`;
-  }
-
-  static renderCoordinates(coords) {
-    return `(${coords[0]}, ${coords[1]})`;
-  }
 }
 
 export default EmailStudyRequestUtils;

--- a/lib/email/EmailStudyRequestUtils.js
+++ b/lib/email/EmailStudyRequestUtils.js
@@ -18,6 +18,18 @@ class EmailStudyRequestUtils {
     hours = hours.description.toLowerCase();
     return `${hours} hours`;
   }
+
+  static renderHoursString(studyHours) {
+    if (studyHours === null) return 'None';
+
+    const hoursString = `${studyHours.description}`;
+    const ranges = studyHours.times.map(timeRange => ` ${timeRange[0]} - ${timeRange[1]}`);
+    return `${hoursString}:${ranges}`;
+  }
+
+  static renderCoordinates(coords) {
+    return `(${coords[0]}, ${coords[1]})`;
+  }
 }
 
 export default EmailStudyRequestUtils;

--- a/lib/email/MailUtils.js
+++ b/lib/email/MailUtils.js
@@ -1,3 +1,4 @@
+// import { StudyRequestStatus, StudyRequestChanges } from '@/lib/Constants';
 import { StudyRequestStatus } from '@/lib/Constants';
 import StudyRequestBulkDAO from '@/lib/db/StudyRequestBulkDAO';
 import EmailStudyRequestBulkCancelled from '@/lib/email/EmailStudyRequestBulkCancelled';
@@ -13,9 +14,49 @@ import Mailer from '@/lib/email/Mailer';
 import LogTag from '@/lib/log/LogTag';
 import { bulkStatus } from '@/lib/requests/RequestStudyBulkUtils';
 
+// function parseHours(studyHours) {
+//   return studyHours.map((timeRange) => {
+//     return `${timeRange[0]} - ${timeRange[1]}`
+//   })
+// }
+
+function defineChanges(studyRequestNew, studyRequestOld) {
+  if (studyRequestNew.studyType !== studyRequestOld.studyType) {
+    return `Study Type Changed - From: ${studyRequestOld.studyType.label} to: ${studyRequestNew.studyType.label}`;
+  }
+  const changeList = [];
+  if (studyRequestNew.centrelineId !== studyRequestOld.centrelineId) {
+    const oldCoordinates = studyRequestOld.geom.coordinates;
+    const newCoordinates = studyRequestNew.geom.coordinates;
+    changeList.push(
+      `Study Location Changed - From: (${oldCoordinates[0]}, ${oldCoordinates[1]}) 
+        to: (${newCoordinates[0]}, ${newCoordinates[1]})`,
+    );
+  }
+  return changeList;
+
+  // StudyRequestChanges.forEach((change) => {
+  //   if (studyRequestNew[change] !== studyRequestOld[change]){
+  //     if (change === 'studyType') {
+  //       return `Study Type Changed: '${studyRequestOld['studyType']['label']}'
+  // -> '${studyRequestNew['studyType']['label']}'`
+  //     } else if (change === 'hours') {
+  //       console.log('============================================================')
+  //       // console.log(studyRequestNew['hours']['name'])
+  //       // console.log(parseHours(studyRequestNew['hours']['times']))
+  //       console.log(studyRequestNew['hours'])
+  //       console.log('============================================================')
+  //     }
+  //     changeList.push(studyRequestNew[change])
+  //   }
+  // });
+  // // console.log(changeList)
+}
+
 function getStudyRequestUpdateEmails(studyRequestNew, studyRequestOld) {
   const emails = [];
-
+  // eslint-disable-next-line no-console
+  console.log(defineChanges(studyRequestNew, studyRequestOld));
   if (studyRequestNew.status !== studyRequestOld.status) {
     if (studyRequestNew.status === StudyRequestStatus.CANCELLED) {
       const emailCancelled = new EmailStudyRequestCancelled(studyRequestNew);

--- a/lib/email/MailUtils.js
+++ b/lib/email/MailUtils.js
@@ -229,6 +229,7 @@ const MailUtils = {
   getStudyRequestUpdateEmailsDeep,
   sendEmailSafe,
   sendEmailsSafe,
+  getRequestChanges,
 };
 
 export {
@@ -239,4 +240,5 @@ export {
   getStudyRequestUpdateEmailsDeep,
   sendEmailSafe,
   sendEmailsSafe,
+  getRequestChanges,
 };

--- a/lib/email/MailUtils.js
+++ b/lib/email/MailUtils.js
@@ -77,8 +77,11 @@ function getStudyRequestUpdateEmails(studyRequestNew, studyRequestOld) {
 
   if (studyRequestChanges.length > 0) {
     const { centrelineId, centrelineType, id } = studyRequestOld;
+    const { userId } = studyRequestNew;
     const feature = { centrelineId, centrelineType };
-    const requestChanges = { studyRequestChanges, feature, id };
+    const requestChanges = {
+      studyRequestChanges, feature, id, userId,
+    };
     const emailRequestChanged = new EmailStudyRequestChanged(requestChanges);
     emails.push(emailRequestChanged);
   }

--- a/lib/email/MailUtils.js
+++ b/lib/email/MailUtils.js
@@ -3,9 +3,12 @@ import StudyRequestBulkDAO from '@/lib/db/StudyRequestBulkDAO';
 import EmailStudyRequestBulkCancelled from '@/lib/email/EmailStudyRequestBulkCancelled';
 import EmailStudyRequestBulkCompleted from '@/lib/email/EmailStudyRequestBulkCompleted';
 import EmailStudyRequestBulkChangesNeeded from '@/lib/email/EmailStudyRequestBulkChangesNeeded';
+import EmailStudyRequestBulkCancelledAdmin from '@/lib/email/EmailStudyRequestBulkCancelledAdmin';
 import EmailStudyRequestCancelled from '@/lib/email/EmailStudyRequestCancelled';
 import EmailStudyRequestCompleted from '@/lib/email/EmailStudyRequestCompleted';
 import EmailStudyRequestChangesNeeded from '@/lib/email/EmailStudyRequestChangesNeeded';
+import EmailStudyRequestCancelledAdmin from '@/lib/email/EmailStudyRequestCancelledAdmin';
+
 import Mailer from '@/lib/email/Mailer';
 import LogTag from '@/lib/log/LogTag';
 import { bulkStatus } from '@/lib/requests/RequestStudyBulkUtils';
@@ -17,6 +20,8 @@ function getStudyRequestUpdateEmails(studyRequestNew, studyRequestOld) {
     if (studyRequestNew.status === StudyRequestStatus.CANCELLED) {
       const emailCancelled = new EmailStudyRequestCancelled(studyRequestNew);
       emails.push(emailCancelled);
+      const emailCancelledAdmin = new EmailStudyRequestCancelledAdmin(studyRequestNew);
+      emails.push(emailCancelledAdmin);
     } else if (studyRequestNew.status === StudyRequestStatus.COMPLETED) {
       const emailCompleted = new EmailStudyRequestCompleted(studyRequestNew);
       emails.push(emailCompleted);
@@ -38,6 +43,8 @@ function getStudyRequestBulkUpdateEmails(studyRequestBulkNew, studyRequestBulkOl
     if (bulkStatusNew === StudyRequestStatus.CANCELLED) {
       const emailCancelled = new EmailStudyRequestBulkCancelled(studyRequestBulkNew);
       emails.push(emailCancelled);
+      const emailCancelledAdmin = new EmailStudyRequestBulkCancelledAdmin(studyRequestBulkNew);
+      emails.push(emailCancelledAdmin);
     } else if (bulkStatusNew === StudyRequestStatus.COMPLETED) {
       const emailCompleted = new EmailStudyRequestBulkCompleted(studyRequestBulkNew);
       emails.push(emailCompleted);

--- a/lib/email/MailUtils.js
+++ b/lib/email/MailUtils.js
@@ -1,5 +1,4 @@
-// import { StudyRequestStatus, StudyRequestChanges } from '@/lib/Constants';
-import { StudyRequestStatus } from '@/lib/Constants';
+import { StudyRequestStatus, StudyRequestChanges } from '@/lib/Constants';
 import StudyRequestBulkDAO from '@/lib/db/StudyRequestBulkDAO';
 import EmailStudyRequestBulkCancelled from '@/lib/email/EmailStudyRequestBulkCancelled';
 import EmailStudyRequestBulkCompleted from '@/lib/email/EmailStudyRequestBulkCompleted';
@@ -9,54 +8,58 @@ import EmailStudyRequestCancelled from '@/lib/email/EmailStudyRequestCancelled';
 import EmailStudyRequestCompleted from '@/lib/email/EmailStudyRequestCompleted';
 import EmailStudyRequestChangesNeeded from '@/lib/email/EmailStudyRequestChangesNeeded';
 import EmailStudyRequestCancelledAdmin from '@/lib/email/EmailStudyRequestCancelledAdmin';
+import EmailStudyRequestChanged from '@/lib/email/EmailStudyRequestChanged';
+import EmailStudyRequestUtils from '@/lib/email/EmailStudyRequestUtils';
 
 import Mailer from '@/lib/email/Mailer';
 import LogTag from '@/lib/log/LogTag';
 import { bulkStatus } from '@/lib/requests/RequestStudyBulkUtils';
 
-// function parseHours(studyHours) {
-//   return studyHours.map((timeRange) => {
-//     return `${timeRange[0]} - ${timeRange[1]}`
-//   })
-// }
-
-function defineChanges(studyRequestNew, studyRequestOld) {
-  if (studyRequestNew.studyType !== studyRequestOld.studyType) {
-    return `Study Type Changed - From: ${studyRequestOld.studyType.label} to: ${studyRequestNew.studyType.label}`;
-  }
+function getRequestChanges(studyRequestNew, studyRequestOld) {
   const changeList = [];
-  if (studyRequestNew.centrelineId !== studyRequestOld.centrelineId) {
-    const oldCoordinates = studyRequestOld.geom.coordinates;
-    const newCoordinates = studyRequestNew.geom.coordinates;
-    changeList.push(
-      `Study Location Changed - From: (${oldCoordinates[0]}, ${oldCoordinates[1]}) 
-        to: (${newCoordinates[0]}, ${newCoordinates[1]})`,
-    );
-  }
+  Object.keys(StudyRequestChanges).forEach((change) => {
+    if (JSON.stringify(studyRequestNew[change]) !== JSON.stringify(studyRequestOld[change])) {
+      const changeItem = {};
+      switch (change) {
+        case 'studyType':
+          changeItem.changeType = StudyRequestChanges[change].label;
+          changeItem.from = studyRequestOld[change][StudyRequestChanges[change].subKey];
+          changeItem.to = studyRequestNew[change][StudyRequestChanges[change].subKey];
+          changeList.push(changeItem);
+          break;
+        case 'geom':
+          changeItem.changeType = StudyRequestChanges[change].label;
+          changeItem.from = EmailStudyRequestUtils.renderCoordinates(
+            studyRequestOld[change][StudyRequestChanges[change].subKey],
+          );
+          changeItem.to = EmailStudyRequestUtils.renderCoordinates(
+            studyRequestNew[change][StudyRequestChanges[change].subKey],
+          );
+          changeList.push(changeItem);
+          break;
+        case 'hours':
+          changeItem.changeType = StudyRequestChanges[change].label;
+          changeItem.from = EmailStudyRequestUtils.renderHoursString(studyRequestOld[change]);
+          changeItem.to = EmailStudyRequestUtils.renderHoursString(studyRequestNew[change]);
+          changeList.push(changeItem);
+          break;
+        default:
+          changeItem.changeType = StudyRequestChanges[change].label;
+          changeItem.from = studyRequestOld[change];
+          changeItem.to = studyRequestNew[change];
+          changeList.push(changeItem);
+          break;
+      }
+    }
+  });
   return changeList;
-
-  // StudyRequestChanges.forEach((change) => {
-  //   if (studyRequestNew[change] !== studyRequestOld[change]){
-  //     if (change === 'studyType') {
-  //       return `Study Type Changed: '${studyRequestOld['studyType']['label']}'
-  // -> '${studyRequestNew['studyType']['label']}'`
-  //     } else if (change === 'hours') {
-  //       console.log('============================================================')
-  //       // console.log(studyRequestNew['hours']['name'])
-  //       // console.log(parseHours(studyRequestNew['hours']['times']))
-  //       console.log(studyRequestNew['hours'])
-  //       console.log('============================================================')
-  //     }
-  //     changeList.push(studyRequestNew[change])
-  //   }
-  // });
-  // // console.log(changeList)
 }
 
 function getStudyRequestUpdateEmails(studyRequestNew, studyRequestOld) {
   const emails = [];
-  // eslint-disable-next-line no-console
-  console.log(defineChanges(studyRequestNew, studyRequestOld));
+
+  const studyRequestChanges = getRequestChanges(studyRequestNew, studyRequestOld);
+
   if (studyRequestNew.status !== studyRequestOld.status) {
     if (studyRequestNew.status === StudyRequestStatus.CANCELLED) {
       const emailCancelled = new EmailStudyRequestCancelled(studyRequestNew);
@@ -70,6 +73,14 @@ function getStudyRequestUpdateEmails(studyRequestNew, studyRequestOld) {
       const emailChangesNeeded = new EmailStudyRequestChangesNeeded(studyRequestNew);
       emails.push(emailChangesNeeded);
     }
+  }
+
+  if (studyRequestChanges.length > 0) {
+    const { centrelineId, centrelineType, id } = studyRequestOld;
+    const feature = { centrelineId, centrelineType };
+    const requestChanges = { studyRequestChanges, feature, id };
+    const emailRequestChanged = new EmailStudyRequestChanged(requestChanges);
+    emails.push(emailRequestChanged);
   }
 
   return emails;

--- a/lib/email/MailUtils.js
+++ b/lib/email/MailUtils.js
@@ -27,20 +27,28 @@ function getRequestChanges(studyRequestNew, studyRequestOld) {
           changeItem.to = studyRequestNew[change][StudyRequestChanges[change].subKey];
           changeList.push(changeItem);
           break;
-        case 'geom':
+        case 'centrelineId':
           changeItem.changeType = StudyRequestChanges[change].label;
-          changeItem.from = EmailStudyRequestUtils.renderCoordinates(
-            studyRequestOld[change][StudyRequestChanges[change].subKey],
-          );
-          changeItem.to = EmailStudyRequestUtils.renderCoordinates(
-            studyRequestNew[change][StudyRequestChanges[change].subKey],
-          );
+          changeItem.from = 'new';
+          changeItem.to = 'old';
           changeList.push(changeItem);
           break;
         case 'hours':
           changeItem.changeType = StudyRequestChanges[change].label;
-          changeItem.from = EmailStudyRequestUtils.renderHoursString(studyRequestOld[change]);
-          changeItem.to = EmailStudyRequestUtils.renderHoursString(studyRequestNew[change]);
+          changeItem.from = EmailStudyRequestUtils.renderHours(studyRequestOld);
+          changeItem.to = EmailStudyRequestUtils.renderHours(studyRequestNew);
+          changeList.push(changeItem);
+          break;
+        case 'duration':
+          changeItem.changeType = StudyRequestChanges[change].label;
+          changeItem.from = `${studyRequestOld[change]} hours`;
+          changeItem.to = `${studyRequestNew[change]} hours`;
+          changeList.push(changeItem);
+          break;
+        case 'daysOfWeek':
+          changeItem.changeType = StudyRequestChanges[change].label;
+          changeItem.from = EmailStudyRequestUtils.renderDays(studyRequestOld);
+          changeItem.to = EmailStudyRequestUtils.renderDays(studyRequestNew);
           changeList.push(changeItem);
           break;
         default:
@@ -76,11 +84,18 @@ function getStudyRequestUpdateEmails(studyRequestNew, studyRequestOld) {
   }
 
   if (studyRequestChanges.length > 0) {
-    const { centrelineId, centrelineType, id } = studyRequestOld;
-    const { userId } = studyRequestNew;
-    const feature = { centrelineId, centrelineType };
+    const {
+      centrelineId: centrelineIdOld,
+      centrelineType: centrelineTypeOld, id,
+    } = studyRequestOld;
+    const {
+      centrelineId: centrelineIdNew,
+      centrelineType: centrelineTypeNew, userId,
+    } = studyRequestNew;
+    const featureOld = { centrelineId: centrelineIdOld, centrelineType: centrelineTypeOld };
+    const featureNew = { centrelineId: centrelineIdNew, centrelineType: centrelineTypeNew };
     const requestChanges = {
-      studyRequestChanges, feature, id, userId,
+      studyRequestChanges, featureOld, featureNew, id, userId,
     };
     const emailRequestChanged = new EmailStudyRequestChanged(requestChanges);
     emails.push(emailRequestChanged);

--- a/lib/test/random/StudyRequestGenerator.js
+++ b/lib/test/random/StudyRequestGenerator.js
@@ -213,16 +213,24 @@ function generateStudyRequestBulk() {
   };
 }
 
+function generateStudyTypeChange(studyRequest) {
+  const newStudyType = generateStudyType();
+  const studyChanged = { ...studyRequest, ...newStudyType };
+  return studyChanged;
+}
+
 /**
  * @namespace
  */
 const StudyRequestGenerator = {
   generateStudyRequest,
   generateStudyRequestBulk,
+  generateStudyTypeChange,
 };
 
 export {
   StudyRequestGenerator as default,
   generateStudyRequest,
   generateStudyRequestBulk,
+  generateStudyTypeChange,
 };

--- a/tests/jest/unit/email/EmailStudyRequestChanged.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestChanged.spec.js
@@ -1,0 +1,58 @@
+import CentrelineDAO from '@/lib/db/CentrelineDAO';
+import UserDAO from '@/lib/db/UserDAO';
+import EmailBase from '@/lib/email/EmailBase';
+import EmailStudyRequestChanged from '@/lib/email/EmailStudyRequestChanged';
+import { getRequestChanges } from '@/lib/email/MailUtils';
+import { generateStudyRequest, generateStudyTypeChange } from '@/lib/test/random/StudyRequestGenerator';
+import { generateUser } from '@/lib/test/random/UserGenerator';
+
+jest.mock('@/lib/db/CentrelineDAO');
+jest.mock('@/lib/db/UserDAO');
+
+test('EmailStudyRequestChanged', async () => {
+  const requester = generateUser();
+  const studyRequestOld = generateStudyRequest();
+  studyRequestOld.id = 42;
+  const studyRequestNew = generateStudyTypeChange(studyRequestOld);
+  const studyRequestChanges = getRequestChanges(studyRequestNew, studyRequestOld);
+
+  const { centrelineId, centrelineType } = studyRequestOld;
+  CentrelineDAO.byFeature.mockResolvedValue({
+    centrelineId,
+    centrelineType,
+    description: 'Test location',
+  });
+  UserDAO.byId.mockResolvedValue(requester);
+
+  const {
+    centrelineId: centrelineIdOld,
+    centrelineType: centrelineTypeOld, id,
+  } = studyRequestOld;
+  const {
+    centrelineId: centrelineIdNew,
+    centrelineType: centrelineTypeNew, userId,
+  } = studyRequestNew;
+  const featureOld = { centrelineId: centrelineIdOld, centrelineType: centrelineTypeOld };
+  const featureNew = { centrelineId: centrelineIdNew, centrelineType: centrelineTypeNew };
+  const requestChanges = {
+    studyRequestChanges, featureOld, featureNew, id, userId,
+  };
+  const email = new EmailStudyRequestChanged(requestChanges);
+
+  await email.init();
+
+  const recipients = email.getRecipients();
+  expect(recipients).toEqual([EmailBase.getRecipientStudyRequestAdmin('EmailStudyRequestChanged')]);
+
+  const subject = email.getSubject();
+  expect(subject).toEqual('[MOVE] Request changed: #42 - Test location');
+
+  const params = email.getBodyParams();
+  expect(params.hrefStudyRequest).toEqual('https://localhost:8080/requests/study/42');
+  expect(params.locationOld).toEqual('Test location');
+  expect(params.studyChanges.length).toBeGreaterThanOrEqual(1);
+
+  expect(() => {
+    email.render();
+  }).not.toThrow();
+});

--- a/tests/jest/unit/email/MailUtils.spec.js
+++ b/tests/jest/unit/email/MailUtils.spec.js
@@ -2,6 +2,7 @@ import { StudyRequestStatus } from '@/lib/Constants';
 import StudyRequestBulkDAO from '@/lib/db/StudyRequestBulkDAO';
 import EmailStudyRequestBulkCancelled from '@/lib/email/EmailStudyRequestBulkCancelled';
 import EmailStudyRequestBulkCompleted from '@/lib/email/EmailStudyRequestBulkCompleted';
+import EmailStudyRequestCancelledAdmin from '@/lib/email/EmailStudyRequestCancelledAdmin';
 import EmailStudyRequestCancelled from '@/lib/email/EmailStudyRequestCancelled';
 import EmailStudyRequestCompleted from '@/lib/email/EmailStudyRequestCompleted';
 import {
@@ -45,7 +46,7 @@ test('MailUtils.getStudyRequestBulkUpdateEmails', () => {
     StudyRequestStatus.CANCELLED,
   );
   emails = getStudyRequestBulkUpdateEmails(studyRequestBulkNew, studyRequestBulkOld);
-  expect(emails).toHaveLength(1);
+  expect(emails).toHaveLength(2);
   expect(emails[0]).toBeInstanceOf(EmailStudyRequestBulkCancelled);
 
   studyRequestBulkOld = studyRequestBulkWithStatus(
@@ -79,7 +80,7 @@ test('MailUtils.getStudyRequestUpdateEmails', () => {
     status: StudyRequestStatus.CANCELLED,
   };
   emails = getStudyRequestUpdateEmails(studyRequestNew, studyRequestOld);
-  expect(emails).toHaveLength(1);
+  expect(emails).toHaveLength(2);
   expect(emails[0]).toBeInstanceOf(EmailStudyRequestCancelled);
 
   studyRequestOld = {
@@ -112,7 +113,7 @@ test('MailUtils.getStudyRequestUpdateEmailsDeep [cancelling single request]', as
   };
   const studyRequestOld = studyRequestBulk.studyRequests[0];
   const emails = await getStudyRequestUpdateEmailsDeep(studyRequestNew, studyRequestOld);
-  expect(emails).toHaveLength(1);
+  expect(emails).toHaveLength(2);
   expect(emails[0]).toBeInstanceOf(EmailStudyRequestCancelled);
 });
 
@@ -174,9 +175,10 @@ test('MailUtils.getStudyRequestUpdateEmailsDeep [cancelling last request]', asyn
   };
   const studyRequestOld = studyRequestBulk.studyRequests[0];
   const emails = await getStudyRequestUpdateEmailsDeep(studyRequestNew, studyRequestOld);
-  expect(emails).toHaveLength(2);
+  expect(emails).toHaveLength(3);
   expect(emails[0]).toBeInstanceOf(EmailStudyRequestCancelled);
-  expect(emails[1]).toBeInstanceOf(EmailStudyRequestBulkCompleted);
+  expect(emails[1]).toBeInstanceOf(EmailStudyRequestCancelledAdmin);
+  expect(emails[2]).toBeInstanceOf(EmailStudyRequestBulkCompleted);
 });
 
 test('MailUtils.getStudyRequestBulkUpdateEmailsDeep [cancelling single request]', async () => {
@@ -198,7 +200,7 @@ test('MailUtils.getStudyRequestBulkUpdateEmailsDeep [cancelling single request]'
     studyRequestBulkNew,
     studyRequestBulkOld,
   );
-  expect(emails).toHaveLength(1);
+  expect(emails).toHaveLength(2);
   expect(emails[0]).toBeInstanceOf(EmailStudyRequestCancelled);
 });
 
@@ -266,7 +268,8 @@ test('MailUtils.getStudyRequestBulkUpdateEmailsDeep [cancelling last request]', 
     studyRequestBulkNew,
     studyRequestBulkOld,
   );
-  expect(emails).toHaveLength(2);
+  expect(emails).toHaveLength(3);
   expect(emails[0]).toBeInstanceOf(EmailStudyRequestCancelled);
-  expect(emails[1]).toBeInstanceOf(EmailStudyRequestBulkCompleted);
+  expect(emails[1]).toBeInstanceOf(EmailStudyRequestCancelledAdmin);
+  expect(emails[2]).toBeInstanceOf(EmailStudyRequestBulkCompleted);
 });

--- a/tests/jest/unit/email/MailUtils.spec.js
+++ b/tests/jest/unit/email/MailUtils.spec.js
@@ -1,6 +1,7 @@
 import { StudyRequestStatus } from '@/lib/Constants';
 import StudyRequestBulkDAO from '@/lib/db/StudyRequestBulkDAO';
 import EmailStudyRequestBulkCancelled from '@/lib/email/EmailStudyRequestBulkCancelled';
+import EmailStudyRequestBulkCancelledAdmin from '@/lib/email/EmailStudyRequestBulkCancelledAdmin';
 import EmailStudyRequestBulkCompleted from '@/lib/email/EmailStudyRequestBulkCompleted';
 import EmailStudyRequestCancelledAdmin from '@/lib/email/EmailStudyRequestCancelledAdmin';
 import EmailStudyRequestCancelled from '@/lib/email/EmailStudyRequestCancelled';
@@ -48,6 +49,7 @@ test('MailUtils.getStudyRequestBulkUpdateEmails', () => {
   emails = getStudyRequestBulkUpdateEmails(studyRequestBulkNew, studyRequestBulkOld);
   expect(emails).toHaveLength(2);
   expect(emails[0]).toBeInstanceOf(EmailStudyRequestBulkCancelled);
+  expect(emails[1]).toBeInstanceOf(EmailStudyRequestBulkCancelledAdmin);
 
   studyRequestBulkOld = studyRequestBulkWithStatus(
     studyRequestBulk,
@@ -82,6 +84,7 @@ test('MailUtils.getStudyRequestUpdateEmails', () => {
   emails = getStudyRequestUpdateEmails(studyRequestNew, studyRequestOld);
   expect(emails).toHaveLength(2);
   expect(emails[0]).toBeInstanceOf(EmailStudyRequestCancelled);
+  expect(emails[1]).toBeInstanceOf(EmailStudyRequestCancelledAdmin);
 
   studyRequestOld = {
     ...studyRequest,
@@ -115,6 +118,7 @@ test('MailUtils.getStudyRequestUpdateEmailsDeep [cancelling single request]', as
   const emails = await getStudyRequestUpdateEmailsDeep(studyRequestNew, studyRequestOld);
   expect(emails).toHaveLength(2);
   expect(emails[0]).toBeInstanceOf(EmailStudyRequestCancelled);
+  expect(emails[1]).toBeInstanceOf(EmailStudyRequestCancelledAdmin);
 });
 
 test('MailUtils.getStudyRequestUpdateEmailsDeep [completing single request]', async () => {
@@ -202,6 +206,7 @@ test('MailUtils.getStudyRequestBulkUpdateEmailsDeep [cancelling single request]'
   );
   expect(emails).toHaveLength(2);
   expect(emails[0]).toBeInstanceOf(EmailStudyRequestCancelled);
+  expect(emails[1]).toBeInstanceOf(EmailStudyRequestCancelledAdmin);
 });
 
 test('MailUtils.getStudyRequestBulkUpdateEmailsDeep [completing single request]', async () => {


### PR DESCRIPTION
# Issue Addressed
This closes [MOVE-1090](https://move-toronto.atlassian.net/browse/MOVE-1090) and closes [MOVE-640](https://move-toronto.atlassian.net/browse/MOVE-640).

# Description
- MOVE-1090: Sends an email to the Data supervisors when a study request is changed. The fields that trigger the notification are: 
  - Location
  - Study type
  - Study hours
  - Study duration
  - Days or day options
  - Collection notes
- MOVE-640: Sends an email to the Data supervisors when a study request is cancelled.

# Tests
This needs to be deployed to dev to fully test it, but I have created tests, and they are passing.
