### PR TITLE
MOVE-618 - Staff should have a consistent understanding of verified collisions

### DIFF
--- a/web/components/filters/FcCollisionFilters.vue
+++ b/web/components/filters/FcCollisionFilters.vue
@@ -39,7 +39,7 @@
         { label: 'Not Verified', value: false },
         { label: 'All', value: null },
       ]"
-      label="Validation">
+      label="Verification">
       <template v-slot:label-right>
         <FcTooltipCollisionFilter>
           <span>


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-618](https://move-toronto.atlassian.net/browse/MOVE-618)

# Description
I missed a change from Validation -> Verification. This makes that change!
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/5003768/66d68266-54ee-4db7-a11c-76bba2a17598)

Steps to view:
- Select an area from the map
- Open the 'View Data' view
- In the Filters section, select 'ADD' and then expand the 'Collisions' section.
- Observe the section header 

# Tests
- Copy update, so no tests beyond existing unit tests, and viewing change in local.
