### PR TITLE
Move 1117 - Collapse Filter button null-state

### DIFF
--- a/web/components/data/FcDetailCollisions.vue
+++ b/web/components/data/FcDetailCollisions.vue
@@ -4,7 +4,7 @@
       v-if="loading"
       aria-label="Loading Detail View collisions data" />
     <template v-else>
-      <dl class="d-flex flex-grow-1 flex-shrink-1">
+      <dl class="d-flex flex-grow-1 flex-shrink-1 text-center">
         <div class="flex-grow-1 flex-shrink-1">
           <dt class="body-1">
             Total

--- a/web/components/data/FcHeaderCollisions.vue
+++ b/web/components/data/FcHeaderCollisions.vue
@@ -1,6 +1,6 @@
 <template>
   <header class="pa-5">
-    <div class="align-center d-flex">
+    <div class="align-center d-flex flex-wrap justify-end">
       <h3 class="headline">
         <span>Collisions</span>
         <span class="body-1 secondary--text">

--- a/web/components/data/FcHeaderStudies.vue
+++ b/web/components/data/FcHeaderStudies.vue
@@ -1,6 +1,6 @@
 <template>
   <header class="px-5 py-3">
-    <div class="align-center d-flex">
+    <div class="align-center d-flex flex-wrap justify-end">
       <h3 class="headline">
         <span>Studies</span>
         <span class="body-1 secondary--text">

--- a/web/components/data/FcViewDataMultiEdit.vue
+++ b/web/components/data/FcViewDataMultiEdit.vue
@@ -11,7 +11,7 @@
     </p>
     <template v-else>
       <section
-        class="fc-multi-edit-inset mt-5">
+        class="fc-multi-edit-inset mt-5 text-center">
         <v-row
           class="my-6"
           no-gutters>
@@ -30,7 +30,7 @@
             <div class="display-1 font-weight-medium mt-1">
               {{studyTotal}}
             </div>
-            <div class="font-weight-regular mt-2 title">
+            <div class="font-weight-regular mt-2 title" v-if="studyTotal !== 0">
               <FcTextMostRecent :study="mostRecent" />
             </div>
           </v-col>

--- a/web/components/data/FcViewDataMultiEdit.vue
+++ b/web/components/data/FcViewDataMultiEdit.vue
@@ -11,13 +11,7 @@
     </p>
     <template v-else>
       <section
-        aria-labelledby="heading_multi_edit_totals"
         class="fc-multi-edit-inset mt-5">
-        <h3
-          class="display-2 pb-1"
-          id="heading_multi_edit_totals">
-          Totals Over Selection
-        </h3>
         <v-row
           class="my-6"
           no-gutters>

--- a/web/components/filters/FcGlobalFilterBox.vue
+++ b/web/components/filters/FcGlobalFilterBox.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-card width="448">
-    <v-card-text class="px-4 pa-3">
+  <v-card class="fc-filter-box">
+    <v-card-text class="pl-3 pa-1">
       <FcGlobalFilters :readonly="readonly" />
     </v-card-text>
   </v-card>
@@ -22,3 +22,11 @@ export default {
   },
 };
 </script>
+
+<style lang="scss">
+.fc-filter-box {
+  opacity: 0.9;
+  display: inline-block;
+  min-width: 125px;
+}
+</style>

--- a/web/components/filters/FcGlobalFilters.vue
+++ b/web/components/filters/FcGlobalFilters.vue
@@ -13,12 +13,8 @@
         v-if="!readonly"
         type="tertiary"
         @click="setFiltersOpen(true)">
-        <span v-if="hasFilters">Edit</span>
-        <span v-else>Add</span>
+        <v-icon>mdi-plus</v-icon>
       </FcButton>
-    </div>
-    <div v-if="!hasFilters" class="secondary--text">
-      No active filters
     </div>
     <div
       v-if="filterChipsCommon.length > 0"

--- a/web/components/filters/FcGlobalFilters.vue
+++ b/web/components/filters/FcGlobalFilters.vue
@@ -18,7 +18,7 @@
     </div>
     <div
       v-if="filterChipsCommon.length > 0"
-      class="align-center d-flex mt-2">
+      class="align-center d-flex mt-2 mb-2">
       <FcListFilterChips
         @click-filter="actionRemoveFilterCommon"
         :filter-chips="filterChipsCommon"
@@ -27,7 +27,7 @@
     </div>
     <div
       v-if="filterChipsCollision.length > 0"
-      class="align-center d-flex mt-6">
+      class="align-center d-flex mt-4 mb-2">
       <span class="body-1 flex-grow-0 flex-shrink-0 secondary--text filter-name">
         Collisions:
       </span>
@@ -40,7 +40,7 @@
     </div>
     <div
       v-if="filterChipsStudy.length > 0"
-      class="align-center d-flex mt-6">
+      class="align-center d-flex mt-4 mb-2">
       <span class="body-1 flex-grow-0 flex-shrink-0 secondary--text filter-name">
         Studies:
       </span>

--- a/web/components/filters/FcGlobalFilters.vue
+++ b/web/components/filters/FcGlobalFilters.vue
@@ -22,33 +22,33 @@
       <FcListFilterChips
         @click-filter="actionRemoveFilterCommon"
         :filter-chips="filterChipsCommon"
-        :max-width="320"
+        :max-width="250"
         :readonly="readonly" />
     </div>
     <div
       v-if="filterChipsCollision.length > 0"
-      class="align-center d-flex mt-2">
-      <span class="body-1 flex-grow-0 flex-shrink-0 secondary--text">
-        Collisions &#x2022;
+      class="align-center d-flex mt-6">
+      <span class="body-1 flex-grow-0 flex-shrink-0 secondary--text filter-name">
+        Collisions:
       </span>
       <FcListFilterChips
         class="ml-1"
         @click-filter="actionRemoveFilterCollision"
         :filter-chips="filterChipsCollision"
-        :max-width="320"
+        :max-width="250"
         :readonly="readonly" />
     </div>
     <div
       v-if="filterChipsStudy.length > 0"
-      class="align-center d-flex mt-2">
-      <span class="body-1 flex-grow-0 flex-shrink-0 secondary--text">
-        Studies &#x2022;
+      class="align-center d-flex mt-6">
+      <span class="body-1 flex-grow-0 flex-shrink-0 secondary--text filter-name">
+        Studies:
       </span>
       <FcListFilterChips
         class="ml-1"
         @click-filter="actionRemoveFilterStudy"
         :filter-chips="filterChipsStudy"
-        :max-width="320"
+        :max-width="250"
         :readonly="readonly" />
     </div>
   </section>
@@ -116,3 +116,12 @@ export default {
   },
 };
 </script>
+
+<style lang="scss">
+.fc-global-filters {
+  .filter-name {
+    align-self: flex-start;
+    margin-right: 15px;
+  }
+}
+</style>

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -61,7 +61,7 @@
     <div class="flex-grow-0 flex-shrink-0">
       <div class="d-flex align-center">
         <template v-if="locationMode === LocationMode.MULTI_EDIT">
-          <h2 class="display-3 mb-4 mt-4">{{locationsEditDescription}}</h2>
+          <!-- <h2 class="display-3 mb-4 mt-4">{{locationsEditDescription}}</h2> -->
         </template>
         <template v-else-if="detailView">
           <FcHeaderSingleLocation

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -61,7 +61,7 @@
     <div class="flex-grow-0 flex-shrink-0">
       <div class="d-flex align-center">
         <template v-if="locationMode === LocationMode.MULTI_EDIT">
-          <!-- <h2 class="display-3 mb-4 mt-4">{{locationsEditDescription}}</h2> -->
+          <!-- <h2 class="display-2 mb-4 mt-4">{{locationsEditDescription}}</h2> -->
         </template>
         <template v-else-if="detailView">
           <FcHeaderSingleLocation
@@ -97,7 +97,7 @@
           </FcTooltip>
         </template>
         <template v-else>
-          <h2 class="display-3 mb-4">{{locationsDescription}}</h2>
+          <h2 class="display-2 mb-4">{{locationsDescription}}</h2>
         </template>
       </div>
 

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -104,7 +104,7 @@
         <v-checkbox
             v-if="hasManyLocations"
             v-model="internalCorridor"
-            class="fc-multi-location-corridor mt-0"
+            class="fc-multi-location-corridor mt-0 mb-1"
             hide-details
             label="Include corridor between locations" />
 

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -106,7 +106,7 @@
             v-model="internalCorridor"
             class="fc-multi-location-corridor mt-0"
             hide-details
-            label="Include intersections and midblocks between locations" />
+            label="Include corridor between locations" />
 
       <div class="d-flex mt-1 justify-end">
         <template v-if="locationMode === LocationMode.MULTI_EDIT">

--- a/web/components/location/FcSummaryPoiChip.vue
+++ b/web/components/location/FcSummaryPoiChip.vue
@@ -39,5 +39,6 @@ export default {
 <style lang="scss">
 .fc-summary-poi-chip {
   display: inline-block;
+  margin-top: 5px;
 }
 </style>


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-1117](https://move-toronto.atlassian.net/browse/MOVE-1117) which shrinks the screen-space of the empty filter box.

It also makes some small cleanup of sidebar elements, per a discussion with maddy.

# Description

* changes 'ADD' to a + icon
* removes 'Totals Over Section' heading
* only show the MultiLocation title header when _not_ in edit-mode
* small layout tweaks to filter presentation
* add flex-wrap breakpoints for sidebar x-overflows