### PR TITLE
MOVE-754: Add pagination for admin console

### DIFF
--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -530,6 +530,17 @@ async function getUsers() {
   return usersSchema.validateAsync(users);
 }
 
+async function getUsersPagination(limit, offset) {
+  const users = await apiClient.fetch(`/users?limit=${limit}&offset=${offset}`);
+  const usersSchema = Joi.array.items(User.read);
+  return usersSchema.validateAsync(users);
+}
+
+async function getUsersTotal() {
+  const total = await apiClient.fetch('/users/total');
+  return total;
+}
+
 async function postJobGenerateCollisionReports(csrf, locationsSelection, filters, reportFormat) {
   const { locations, selectionType } = locationsSelection;
   const s1 = CompositeId.encode(locations);
@@ -767,6 +778,8 @@ const WebApi = {
   getStudyRequestItems,
   getStudyRequestItemsTotal,
   getUsers,
+  getUsersPagination,
+  getUsersTotal,
   getUsersByIds,
   postJobGenerateCollisionReports,
   postJobCompressMvcrs,
@@ -824,6 +837,8 @@ export {
   getStudyRequestItemsTotal,
   getUsers,
   getUsersByIds,
+  getUsersPagination,
+  getUsersTotal,
   postJobGenerateCollisionReports,
   postJobCompressMvcrs,
   postJobGenerateStudyReports,

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -532,12 +532,12 @@ async function getUsers() {
 
 async function getUsersPagination(limit, offset) {
   const users = await apiClient.fetch(`/users?limit=${limit}&offset=${offset}`);
-  const usersSchema = Joi.array.items(User.read);
+  const usersSchema = Joi.array().items(User.read);
   return usersSchema.validateAsync(users);
 }
 
 async function getUsersTotal() {
-  const total = await apiClient.fetch('/users/total');
+  const { total } = await apiClient.fetch('/users/total');
   return total;
 }
 

--- a/lib/controller/UserController.js
+++ b/lib/controller/UserController.js
@@ -21,18 +21,18 @@ const UserController = [];
  * @name getUsers
  * @type {Hapi.ServerRoute}
  */
-UserController.push({
-  method: 'GET',
-  path: '/users',
-  options: {
-    description: 'Get all users',
-    response: {
-      schema: Joi.array().items(User.read),
-    },
-    tags: ['api'],
-  },
-  handler: async () => UserDAO.all(),
-});
+// UserController.push({
+//   method: 'GET',
+//   path: '/users',
+//   options: {
+//     description: 'Get all users',
+//     response: {
+//       schema: Joi.array().items(User.read),
+//     },
+//     tags: ['api'],
+//   },
+//   handler: async () => UserDAO.all(),
+// });
 
 UserController.push({
   method: 'GET',
@@ -69,7 +69,10 @@ UserController.push({
     },
     tags: ['api'],
   },
-  handler: async () => UserDAO.getUsersTotal(),
+  handler: async () => {
+    const total = await UserDAO.getUsersTotal();
+    return { total };
+  },
 });
 
 /**

--- a/lib/controller/UserController.js
+++ b/lib/controller/UserController.js
@@ -34,6 +34,44 @@ UserController.push({
   handler: async () => UserDAO.all(),
 });
 
+UserController.push({
+  method: 'GET',
+  path: '/users',
+  options: {
+    description: 'Paginate users',
+    response: {
+      schema: Joi.array().items(User.read),
+    },
+    tags: ['api'],
+    validate: {
+      query: {
+        limit: Joi.number().integer().min(0).required(),
+        offset: Joi.number().integer().min(0).required(),
+      },
+    },
+  },
+  handler: async (request) => {
+    const { limit: pageLimit, offset: pageOffset } = request.query;
+    const users = await UserDAO.getUsersPagination(pageLimit, pageOffset);
+    return users;
+  },
+});
+
+UserController.push({
+  method: 'GET',
+  path: '/users/total',
+  options: {
+    description: 'Get total number of users',
+    response: {
+      schema: {
+        total: Joi.number().integer().min(0).required(),
+      },
+    },
+    tags: ['api'],
+  },
+  handler: async () => UserDAO.getUsersTotal(),
+});
+
 /**
  * Get user names and emails for the given user IDs.
  *

--- a/lib/db/UserDAO.js
+++ b/lib/db/UserDAO.js
@@ -61,6 +61,18 @@ class UserDAO {
     return normalizeUsers(users);
   }
 
+  static async getUsersPagination(limit, offset) {
+    const sql = `SELECT * FROM "users" ORDER BY "id" ASC LIMIT ${limit} OFFSET ${offset}`;
+    const users = await db.manyOrNone(sql, { limit, offset });
+    return normalizeUsers(users);
+  }
+
+  static async getUsersTotal() {
+    const sql = 'SELECT COUNT(*) as total from "users"';
+    const { total } = await db.one(sql);
+    return total;
+  }
+
   static async bySub(sub) {
     const sql = 'SELECT * FROM "users" WHERE "sub" = $(sub)';
     const user = await db.oneOrNone(sql, { sub });

--- a/web/components/admin/FcAdminPermissions.vue
+++ b/web/components/admin/FcAdminPermissions.vue
@@ -2,60 +2,64 @@
   <section class="fc-requests-track d-flex flex-column fill-height">
     <section class="flex-grow-1 flex-shrink-1 mt-4 mb-6 px-5">
       <v-card class= "fc-requests-track-card d-flex flex-column fill-height">
-        <div class="fc-admin-permissions">
-          <v-card-text class="fc-data-table-requests-wrapper flex-grow-1 flex-shrink-1 pa-0">
-            <FcDataTable
-              class="fc-data-table-users"
-              :columns="columns"
-              :page.sync="page"
-              :items="users"
-              :loading="loading"
-              must-sort
-              sort-by="UNIQUE_NAME"
-              :sort-desc="false"
-              :sort-keys="sortKeys">
-              <template v-slot:item.UNIQUE_NAME="{ item }">
-                <span>{{item | username}}</span>
-              </template>
-              <template
-                v-for="{ authScope, itemSlot } of authScopeSlots"
-                v-slot:[itemSlot]="{ item }">
-                <div
-                  :key="'u:' + item.id + ':' + authScope.name"
-                  class="d-flex">
-                  <FcTooltip right>
-                    <template v-slot:activator="{ on }">
-                      <v-checkbox
-                        v-model="item.scope"
-                        class="mt-0 pt-0"
-                        :disabled="loadingChangeUserScope"
-                        hide-details
-                        :value="authScope"
-                        @change="actionChangeUserScope(item)"
-                        v-on="on"></v-checkbox>
-                    </template>
-                    <span>
-                      <span v-if="item.scope.includes(authScope)">
-                        Deny {{authScope.name}}
-                      </span>
-                      <span v-else>
-                        Grant {{authScope.name}}
-                      </span>
+        <v-divider></v-divider>
+
+        <v-card-text class="fc-data-table-requests-wrapper flex-grow-1 flex-shrink-1 pa-0">
+          <FcDataTable
+            class="fc-data-table-users"
+            :columns="columns"
+            :page.sync="page"
+            :items="users"
+            :loading="loading"
+            must-sort
+            sort-by="UNIQUE_NAME"
+            :sort-desc="false"
+            :sort-keys="sortKeys">
+            <template v-slot:item.UNIQUE_NAME="{ item }">
+              <span>{{item | username}}</span>
+            </template>
+            <template
+              v-for="{ authScope, itemSlot } of authScopeSlots"
+              v-slot:[itemSlot]="{ item }">
+              <div
+                :key="'u:' + item.id + ':' + authScope.name"
+                class="d-flex">
+                <FcTooltip right>
+                  <template v-slot:activator="{ on }">
+                    <v-checkbox
+                      v-model="item.scope"
+                      class="mt-0 pt-0"
+                      :disabled="loadingChangeUserScope"
+                      hide-details
+                      :value="authScope"
+                      @change="actionChangeUserScope(item)"
+                      v-on="on"></v-checkbox>
+                  </template>
+                  <span>
+                    <span v-if="item.scope.includes(authScope)">
+                      Deny {{authScope.name}}
                     </span>
-                  </FcTooltip>
-                </div>
-              </template>
-            </FcDataTable>
-          </v-card-text>
-          <v-divider></v-divider>
-          <v-card-actions class="flex-grow-0 flex-shrink-0">
-            <v-spacer></v-spacer>
-            <div>
-              {{pageFrom}}&ndash;{{pageTo}} of {{total}}
-            </div>
-            <v-pagination v-model="page" :length="numPages" :total-visible="7" @input="getPage"/>
-          </v-card-actions>
-        </div>
+                    <span v-else>
+                      Grant {{authScope.name}}
+                    </span>
+                  </span>
+                </FcTooltip>
+              </div>
+            </template>
+          </FcDataTable>
+        </v-card-text>
+
+        <v-divider></v-divider>
+
+        <v-card-actions class="flex-grow-0 flex-shrink-0">
+          <v-spacer></v-spacer>
+
+          <div>
+            {{pageFrom}}&ndash;{{pageTo}} of {{total}}
+          </div>
+
+          <v-pagination v-model="page" :length="numPages" :total-visible="7" @input="getPage"/>
+        </v-card-actions>
       </v-card>
     </section>
   </section>
@@ -107,7 +111,7 @@ export default {
       users: [],
       page: 1,
       total: 0,
-      itemsPerPage: 1,
+      itemsPerPage: 8,
     };
   },
   computed: {

--- a/web/components/admin/FcAdminPermissions.vue
+++ b/web/components/admin/FcAdminPermissions.vue
@@ -3,7 +3,8 @@
     <FcDataTable
       class="fc-data-table-users"
       :columns="columns"
-      disable-pagination
+      :items-per-page.sync="itemsPerPage"
+      :page.sync="page"
       :items="users"
       :loading="loading"
       must-sort
@@ -42,6 +43,7 @@
         </div>
       </template>
     </FcDataTable>
+    <v-pagination v-model="page" :length="numPages" :total-visible="7"/>
   </div>
 </template>
 
@@ -89,10 +91,25 @@ export default {
       loadingChangeUserScope: false,
       sortKeys,
       users: [],
+      page: 1,
+      total: 2,
+      itemsPerPage: 1,
     };
   },
   computed: {
     ...mapState(['auth']),
+    numPages() {
+      return Math.ceil(this.total / this.itemsPerPage);
+    },
+    pageFrom() {
+      if (this.total === 0) {
+        return 0;
+      }
+      return (this.page - 1) * this.itemsPerPage + 1;
+    },
+    pageTo() {
+      return Math.min(this.total, this.page * this.itemsPerPage);
+    },
   },
   methods: {
     async actionChangeUserScope(user) {

--- a/web/components/admin/FcAdminPermissions.vue
+++ b/web/components/admin/FcAdminPermissions.vue
@@ -3,7 +3,6 @@
     <FcDataTable
       class="fc-data-table-users"
       :columns="columns"
-      :items-per-page.sync="itemsPerPage"
       :page.sync="page"
       :items="users"
       :loading="loading"
@@ -43,7 +42,7 @@
         </div>
       </template>
     </FcDataTable>
-    <v-pagination v-model="page" :length="numPages" :total-visible="7"/>
+    <v-pagination v-model="page" :length="numPages" :total-visible="7" @input="getPage"/>
   </div>
 </template>
 
@@ -52,7 +51,7 @@ import { mapState } from 'vuex';
 
 import { AuthScope } from '@/lib/Constants';
 import { formatUsername } from '@/lib/StringFormatters';
-import { getUsers, putUser } from '@/lib/api/WebApi';
+import { getUsersPagination, getUsersTotal, putUser } from '@/lib/api/WebApi';
 import FcDataTable from '@/web/components/FcDataTable.vue';
 import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
 import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
@@ -92,7 +91,7 @@ export default {
       sortKeys,
       users: [],
       page: 1,
-      total: 2,
+      total: 0,
       itemsPerPage: 1,
     };
   },
@@ -117,9 +116,18 @@ export default {
       await putUser(this.auth.csrf, user);
       this.loadingChangeUserScope = false;
     },
-    async loadAsyncForRoute() {
-      const users = await getUsers();
+    async getPage(page) {
+      const offset = this.itemsPerPage * (page - 1);
+      const users = await getUsersPagination(this.itemsPerPage, offset);
       this.users = users;
+    },
+    async loadAsyncForRoute() {
+      const offset = this.itemsPerPage * (this.page - 1);
+      const users = await getUsersPagination(this.itemsPerPage, offset);
+      this.users = users;
+
+      const total = await getUsersTotal();
+      this.total = total;
     },
   },
 };

--- a/web/components/admin/FcAdminPermissions.vue
+++ b/web/components/admin/FcAdminPermissions.vue
@@ -4,12 +4,15 @@
       <v-card class= "fc-requests-track-card d-flex flex-column fill-height">
         <v-divider></v-divider>
 
-        <v-card-text class="fc-data-table-requests-wrapper flex-grow-1 flex-shrink-1 pa-0">
+        <v-card-text class="flex-grow-1 pa-0">
           <FcDataTable
             class="fc-data-table-users"
             :columns="columns"
             :page.sync="page"
             :items="users"
+            :items-per-page.sync="itemsPerPage"
+            fixed-header
+            height="calc(100vh - 250px)"
             :loading="loading"
             must-sort
             sort-by="UNIQUE_NAME"
@@ -107,11 +110,12 @@ export default {
       authScopeSlots,
       columns,
       loadingChangeUserScope: false,
+      loading: true,
       sortKeys,
       users: [],
       page: 1,
       total: 0,
-      itemsPerPage: 8,
+      itemsPerPage: 10,
     };
   },
   computed: {
@@ -137,13 +141,13 @@ export default {
     },
     async getPage(page) {
       const offset = this.itemsPerPage * (page - 1);
+      this.loading = true;
       const users = await getUsersPagination(this.itemsPerPage, offset);
       this.users = users;
+      this.loading = false;
     },
     async loadAsyncForRoute() {
-      const offset = this.itemsPerPage * (this.page - 1);
-      const users = await getUsersPagination(this.itemsPerPage, offset);
-      this.users = users;
+      this.getPage(this.page);
 
       const total = await getUsersTotal();
       this.total = total;

--- a/web/components/admin/FcAdminPermissions.vue
+++ b/web/components/admin/FcAdminPermissions.vue
@@ -115,7 +115,7 @@ export default {
       users: [],
       page: 1,
       total: 0,
-      itemsPerPage: 10,
+      itemsPerPage: 50,
     };
   },
   computed: {

--- a/web/components/admin/FcAdminPermissions.vue
+++ b/web/components/admin/FcAdminPermissions.vue
@@ -1,49 +1,64 @@
 <template>
-  <div class="fc-admin-permissions">
-    <FcDataTable
-      class="fc-data-table-users"
-      :columns="columns"
-      :page.sync="page"
-      :items="users"
-      :loading="loading"
-      must-sort
-      sort-by="UNIQUE_NAME"
-      :sort-desc="false"
-      :sort-keys="sortKeys">
-      <template v-slot:item.UNIQUE_NAME="{ item }">
-        <span>{{item | username}}</span>
-      </template>
-      <template
-        v-for="{ authScope, itemSlot } of authScopeSlots"
-        v-slot:[itemSlot]="{ item }">
-        <div
-          :key="'u:' + item.id + ':' + authScope.name"
-          class="d-flex">
-          <FcTooltip right>
-            <template v-slot:activator="{ on }">
-              <v-checkbox
-                v-model="item.scope"
-                class="mt-0 pt-0"
-                :disabled="loadingChangeUserScope"
-                hide-details
-                :value="authScope"
-                @change="actionChangeUserScope(item)"
-                v-on="on"></v-checkbox>
-            </template>
-            <span>
-              <span v-if="item.scope.includes(authScope)">
-                Deny {{authScope.name}}
-              </span>
-              <span v-else>
-                Grant {{authScope.name}}
-              </span>
-            </span>
-          </FcTooltip>
+  <section class="fc-requests-track d-flex flex-column fill-height">
+    <section class="flex-grow-1 flex-shrink-1 mt-4 mb-6 px-5">
+      <v-card class= "fc-requests-track-card d-flex flex-column fill-height">
+        <div class="fc-admin-permissions">
+          <v-card-text class="fc-data-table-requests-wrapper flex-grow-1 flex-shrink-1 pa-0">
+            <FcDataTable
+              class="fc-data-table-users"
+              :columns="columns"
+              :page.sync="page"
+              :items="users"
+              :loading="loading"
+              must-sort
+              sort-by="UNIQUE_NAME"
+              :sort-desc="false"
+              :sort-keys="sortKeys">
+              <template v-slot:item.UNIQUE_NAME="{ item }">
+                <span>{{item | username}}</span>
+              </template>
+              <template
+                v-for="{ authScope, itemSlot } of authScopeSlots"
+                v-slot:[itemSlot]="{ item }">
+                <div
+                  :key="'u:' + item.id + ':' + authScope.name"
+                  class="d-flex">
+                  <FcTooltip right>
+                    <template v-slot:activator="{ on }">
+                      <v-checkbox
+                        v-model="item.scope"
+                        class="mt-0 pt-0"
+                        :disabled="loadingChangeUserScope"
+                        hide-details
+                        :value="authScope"
+                        @change="actionChangeUserScope(item)"
+                        v-on="on"></v-checkbox>
+                    </template>
+                    <span>
+                      <span v-if="item.scope.includes(authScope)">
+                        Deny {{authScope.name}}
+                      </span>
+                      <span v-else>
+                        Grant {{authScope.name}}
+                      </span>
+                    </span>
+                  </FcTooltip>
+                </div>
+              </template>
+            </FcDataTable>
+          </v-card-text>
+          <v-divider></v-divider>
+          <v-card-actions class="flex-grow-0 flex-shrink-0">
+            <v-spacer></v-spacer>
+            <div>
+              {{pageFrom}}&ndash;{{pageTo}} of {{total}}
+            </div>
+            <v-pagination v-model="page" :length="numPages" :total-visible="7" @input="getPage"/>
+          </v-card-actions>
         </div>
-      </template>
-    </FcDataTable>
-    <v-pagination v-model="page" :length="numPages" :total-visible="7" @input="getPage"/>
-  </div>
+      </v-card>
+    </section>
+  </section>
 </template>
 
 <script>

--- a/web/views/FcAdmin.vue
+++ b/web/views/FcAdmin.vue
@@ -53,5 +53,6 @@ export default {
 .fc-admin {
   max-height: var(--full-height);
   width: 100%;
+  background-color: var(--v-shading-base);
 }
 </style>

--- a/web/views/FcAdmin.vue
+++ b/web/views/FcAdmin.vue
@@ -17,7 +17,7 @@
         <h2 class="display-3 mt-5">{{title}}</h2>
       </div>
     </nav>
-    <section class="flex-grow-1 flex-shrink-1 overflow-y-auto px-5">
+    <section class="flex-grow-1 flex-shrink-1 overflow-y-auto px-0">
       <router-view></router-view>
     </section>
   </section>


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-754

# Description
Added pagination to the User Permissions tab of the Admin Console, with a limit of 50 users per page, and stylized to resemble the Track Requests page.

Before:
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/64811136/59e71742-5446-49eb-bbaa-6cf971451096)

After:
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/64811136/c099e090-6ce5-429e-bef8-8ed7619f58e5)

# Tests
Tested in MOVE local using Google Chrome and Microsoft Edge, by switching between pages with various page limits, and tested on various window sizes.
