### PR TITLE
Move-1113

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -204,6 +204,9 @@ HttpStatus.init({
   NOT_FOUND: {
     statusCode: 404,
   },
+  INTERNAL_SERVER_ERROR: {
+    statusCode: 500,
+  },
 });
 
 /**

--- a/lib/controller/CollisionController.js
+++ b/lib/controller/CollisionController.js
@@ -1,5 +1,7 @@
 import Boom from '@hapi/boom';
-
+import {
+  HttpStatus,
+} from '@/lib/Constants';
 import CollisionDAO from '@/lib/db/CollisionDAO';
 import CollisionFactorDAO from '@/lib/db/CollisionFactorDAO';
 import CompositeId from '@/lib/io/CompositeId';
@@ -53,7 +55,13 @@ CollisionController.push({
     tags: ['api'],
   },
   handler: async () => {
-    const collisionFactors = await CollisionFactorDAO.all();
+    let collisionFactors = null;
+    try {
+      collisionFactors = await CollisionFactorDAO.all();
+    } catch (err) {
+      const { statusCode } = HttpStatus.INTERNAL_SERVER_ERROR;
+      return Boom.boomify(err, { statusCode, override: false, message: 'unable to retrieve collision factors' });
+    }
     return Array.from(collisionFactors)
       .map(([field, fieldEntries]) => [field, Array.from(fieldEntries)]);
   },
@@ -86,9 +94,15 @@ CollisionController.push({
   },
   handler: async (request) => {
     const { collisionId } = request.params;
-    const collision = await CollisionDAO.byCollisionId(collisionId);
-    if (collision === null) {
-      return Boom.notFound(`no collision found with ID ${collisionId}`);
+    let collision = null;
+    try {
+      collision = await CollisionDAO.byCollisionId(collisionId);
+      if (collision === null) {
+        return Boom.notFound(`no collision found with ID ${collisionId}`);
+      }
+    } catch (err) {
+      const { statusCode } = HttpStatus.INTERNAL_SERVER_ERROR;
+      return Boom.boomify(err, { statusCode, override: false, message: 'bad data preventing collision retrieval' });
     }
     return collision;
   },

--- a/lib/controller/ReportController.js
+++ b/lib/controller/ReportController.js
@@ -126,7 +126,13 @@ ReportController.push({
     }
 
     const reportInstance = ReportFactory.getInstance(reportType);
-    const reportStream = await reportInstance.generate(id, reportFormat, reportOptions, user);
+    let reportStream = null;
+    try {
+      reportStream = await reportInstance.generate(id, reportFormat, reportOptions, user);
+    } catch (err) {
+      const { statusCode } = HttpStatus.INTERNAL_SERVER_ERROR;
+      return Boom.boomify(err, { statusCode, override: false, message: 'bad data preventing report generation' });
+    }
     const response = h.response(reportStream)
       .type(reportFormat.mimeType);
 

--- a/lib/log/Logger.js
+++ b/lib/log/Logger.js
@@ -1,9 +1,14 @@
 import db from '@/lib/db/db';
 
 class Logger {
-  static async createError(request, severity, response) {
+  static async createError(request, severity, error) {
     const userId = request.auth.credentials === null ? null : request.auth.credentials.id;
-    await db.none(`INSERT INTO app_logs(user_id, severity, log_message, log_details) VALUES(${userId}, '${severity}','${response.message}', '${JSON.stringify(response)}')`);
+    try {
+      await db.none(`INSERT INTO app_logs(user_id, severity, log_message, log_details) VALUES(${userId}, '${severity}','${error.message}', '${JSON.stringify(error)}')`);
+    } catch (err) {
+      request.log(err || err.message);
+    }
+    return true;
   }
 }
 

--- a/lib/log/Logger.js
+++ b/lib/log/Logger.js
@@ -1,0 +1,10 @@
+import db from '@/lib/db/db';
+
+class Logger {
+  static async createError(request, severity, response) {
+    const userId = request.auth.credentials === null ? null : request.auth.credentials.id;
+    await db.none(`INSERT INTO app_logs(user_id, severity, log_message, log_details) VALUES(${userId}, '${severity}','${response.message}', '${JSON.stringify(response)}')`);
+  }
+}
+
+export default Logger;

--- a/lib/log/Logger.js
+++ b/lib/log/Logger.js
@@ -6,7 +6,7 @@ class Logger {
     try {
       await db.none(`INSERT INTO app_logs(user_id, severity, log_message, log_details) VALUES(${userId}, '${severity}','${error.message}', '${JSON.stringify(error)}')`);
     } catch (err) {
-      request.log(err || err.message);
+      request.log(err);
     }
     return true;
   }

--- a/lib/server/MoveServer.js
+++ b/lib/server/MoveServer.js
@@ -17,6 +17,7 @@ import LogTag from '@/lib/log/LogTag';
 import Joi from '@/lib/model/Joi';
 import User from '@/lib/model/User';
 import vueConfig from '@/vue.config';
+import Logger from '@/lib/log/Logger';
 
 function replacer(key, value) {
   if (value instanceof Map || value instanceof Set) {
@@ -130,6 +131,14 @@ class MoveServer {
     this.initModules = [];
     this.name = name;
     this.server = Hapi.server(options);
+    this.server.ext('onPreResponse', (request, h) => {
+      const { response } = request;
+      if (!response.isBoom) {
+        return h.continue;
+      }
+      Logger.createError(request, LogTag.ERROR, response);
+      return h.continue;
+    });
   }
 
   addController(controller) {

--- a/lib/server/MoveServer.js
+++ b/lib/server/MoveServer.js
@@ -133,10 +133,14 @@ class MoveServer {
     this.server = Hapi.server(options);
     this.server.ext('onPreResponse', (request, h) => {
       const { response } = request;
-      if (!response.isBoom) {
-        return h.continue;
+      if (response.isBoom) {
+        try {
+          Logger.createError(request, LogTag.ERROR, response);
+        } catch (err) {
+          request.log(LogTag.ERROR, err);
+          return h.continue;
+        }
       }
-      Logger.createError(request, LogTag.ERROR, response);
       return h.continue;
     });
   }

--- a/scripts/db/schema-25.down.sql
+++ b/scripts/db/schema-25.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP TABLE app_logs;
+
+UPDATE "APP_META"."DB_UPDATE" SET "currentVersion" = 24;
+COMMIT;

--- a/scripts/db/schema-25.up.sql
+++ b/scripts/db/schema-25.up.sql
@@ -1,0 +1,20 @@
+BEGIN;
+
+
+CREATE TABLE IF NOT EXISTS public.app_logs
+(
+    id integer NOT NULL GENERATED ALWAYS AS IDENTITY ( INCREMENT 1 START 1 MINVALUE 1 MAXVALUE 2147483647 CACHE 1 ),
+    user_id integer,
+    severity text COLLATE pg_catalog."default",
+    log_message text,
+	  log_details jsonb,
+    created_at timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT app_logs_pkey PRIMARY KEY (id),
+    CONSTRAINT app_log_user_id_fkey FOREIGN KEY (user_id)
+        REFERENCES public.users (id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION
+);
+
+UPDATE "APP_META"."DB_UPDATE" SET "currentVersion" = 25;
+COMMIT;

--- a/tests/jest/api/CollisionController.spec.js
+++ b/tests/jest/api/CollisionController.spec.js
@@ -36,6 +36,9 @@ test('CollisionController.getCollisionByCollisionId', async () => {
   let response = await client.fetch('/collisions/999999999');
   expect(response.statusCode).toBe(HttpStatus.NOT_FOUND.statusCode);
 
+  response = await client.fetch('/collisions/2013:3001175197');
+  expect(response.statusCode).toBe(HttpStatus.INTERNAL_SERVER_ERROR.statusCode);
+
   response = await client.fetch('/collisions/2012:1288425');
   expect(response.statusCode).toBe(HttpStatus.OK.statusCode);
   expect(response.result.centrelineId).toBe(1142194);


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-1113](https://move-toronto.atlassian.net/browse/MOVE-1113)

# Description
This PR addresses two issues.

1. When a collision includes invalid data (for example, negative actual_speed on one or more involved parties), the app did not handle the error on the server side at all. A try/catch block was added in the collision controller (for both, the collision factor and collision endpoints) and a Boom error is generated if the retrieval fails. Similarly, the collision directory report depended on the successful retrieval of a collision, so the report controller also now has a try catch block added to the report endpoint to catch this and generate a Boom error.

2. Boom errors are now handled globally via the MoveServer. Using the 'onPreResponse' lifecycle hook, we can intercept a boom response, log the data to the new app_logs table, and then return the response to the user.

A new table called app_logs has been added to the DB and the migration scripts are included, devs will need to run the update-db script to update to version 25 of the database.

# Tests
The controller for collision controllers has been tested to ensure that a failed retrieval throws t he correct Boom error. The report controller is not so easy to test because every report request is different and so mocking the tests is not easy. I notice that no existing tests have been written for the report controller and this probably something we need to look into.

Next steps -> other controllers will need to be examined for appropriate error handling and if required, try/catches need to be added where a DAO is accessed and an appropriate Boom error fired in case of failure.