### PR TITLE
MOVE-1000 - Peak Hour calculation not updated in the Peak Hour Factor Report

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -1249,6 +1249,27 @@ const StudyRequestChanges = {
   },
 };
 
+const REPORT_CONSTANTS = {
+  COUNT_INTERVAL_DURATION: { minutes: 15 },
+  PEAK_DURATION: { hours: 1 },
+  AM_PEAK_WINDOW: {
+    startTime: { hour: 7, minute: 30 },
+    endTime: { hour: 9, minute: 30 },
+  },
+  PM_PEAK_WINDOW: {
+    startTime: { hour: 14, minute: 15 },
+    endTime: { hour: 18, minute: 0 },
+  },
+  PM_2_HOUR_PERIOD: {
+    startTime: { hour: 16, minute: 0 },
+    endTime: { hour: 18, minute: 0 },
+  },
+  OFF_HOUR_PERIOD: {
+    startTime: { hour: 10, minute: 0 },
+    endTime: { hour: 15, minute: 0 },
+  },
+};
+
 const Constants = {
   AuthScope,
   CardinalDirection,
@@ -1272,6 +1293,7 @@ const Constants = {
   POI_RADIUS,
   ProjectMode,
   PT_PER_IN,
+  REPORT_CONSTANTS,
   ReportBlock,
   ReportExportMode,
   ReportFormat,
@@ -1314,6 +1336,7 @@ export {
   POI_RADIUS,
   ProjectMode,
   PT_PER_IN,
+  REPORT_CONSTANTS,
   ReportBlock,
   ReportExportMode,
   ReportFormat,

--- a/lib/reports/ReportCountSummary24h.js
+++ b/lib/reports/ReportCountSummary24h.js
@@ -1,6 +1,7 @@
 /* eslint-disable class-methods-use-this */
 import {
   CardinalDirection,
+  REPORT_CONSTANTS,
   ReportBlock,
   ReportType,
 } from '@/lib/Constants';
@@ -40,7 +41,7 @@ class ReportCountSummary24h extends ReportBaseFlow {
 
     const dayOfWeek = TimeFormatters.formatDayOfWeek(count.date);
 
-    const indicesAm = indexRangeHourOfDay(totaledData, 0, 12);
+    const indicesAm = indexRangeHourOfDay(totaledData, REPORT_CONSTANTS.AM_PEAK_WINDOW);
     const indicesAmPeak = indexRangePeakTime(
       totaledData,
       indicesAm,
@@ -49,7 +50,7 @@ class ReportCountSummary24h extends ReportBaseFlow {
     );
     const amPeak = ReportCountSummary24h.sumSection(count, totaledData, indicesAmPeak);
 
-    const indicesPm = indexRangeHourOfDay(totaledData, 12, 24);
+    const indicesPm = indexRangeHourOfDay(totaledData, REPORT_CONSTANTS.PM_PEAK_WINDOW);
     const indicesPmPeak = indexRangePeakTime(
       totaledData,
       indicesPm,

--- a/lib/reports/ReportCountSummaryTurningMovement.js
+++ b/lib/reports/ReportCountSummaryTurningMovement.js
@@ -1,6 +1,6 @@
 /* eslint-disable class-methods-use-this */
 import ArrayUtils from '@/lib/ArrayUtils';
-import { ReportBlock, ReportType } from '@/lib/Constants';
+import { REPORT_CONSTANTS, ReportBlock, ReportType } from '@/lib/Constants';
 import ReportBaseFlow from '@/lib/reports/ReportBaseFlow';
 import ReportBaseFlowDirectional from '@/lib/reports/ReportBaseFlowDirectional';
 import TimeFormatters from '@/lib/time/TimeFormatters';
@@ -18,31 +18,7 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
     return ReportType.COUNT_SUMMARY_TURNING_MOVEMENT;
   }
 
-  static COUNT_INTERVAL_DURATION = { minutes: 15 };
-
-  static PEAK_DURATION = { hours: 1 };
-
-  static AM_PEAK_WINDOW = {
-    startTime: { hour: 7, minute: 30 },
-    endTime: { hour: 9, minute: 30 },
-  }
-
-  static AM_2_HOUR_PERIOD = this.AM_PEAK_WINDOW;
-
-  static PM_PEAK_WINDOW = {
-    startTime: { hour: 14, minute: 15 },
-    endTime: { hour: 18, minute: 0 },
-  }
-
-  static PM_2_HOUR_PERIOD = {
-    startTime: { hour: 16, minute: 0 },
-    endTime: { hour: 18, minute: 0 },
-  }
-
-  static OFF_HOUR_PERIOD = {
-    startTime: { hour: 10, minute: 0 },
-    endTime: { hour: 15, minute: 0 },
-  }
+  static AM_2_HOUR_PERIOD = REPORT_CONSTANTS.AM_PEAK_WINDOW;
 
   static dateTimePeriodFromObject({ startTime, endTime }, dateTime) {
     const startTimeObject = { ...dateTime.toObject(), ...startTime };
@@ -77,7 +53,7 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
   static findLastIntervalIndexForPeriod(countIntervals, periodEndTime) {
     let periodEndIndex = -1;
     for (let n = 0; n < countIntervals.length; n++) {
-      const nIntervalEndTime = countIntervals[n].t.plus(this.COUNT_INTERVAL_DURATION);
+      const nIntervalEndTime = countIntervals[n].t.plus(REPORT_CONSTANTS.COUNT_INTERVAL_DURATION);
       if (nIntervalEndTime.valueOf() === periodEndTime.valueOf()) {
         periodEndIndex = n;
         break;
@@ -89,7 +65,9 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
     return periodEndIndex;
   }
 
-  static getCandidatesForPeak(countIntervals, peakWindow, peakDuration = this.PEAK_DURATION) {
+  static getCandidatesForPeak(countIntervals,
+    peakWindow,
+    peakDuration = REPORT_CONSTANTS.PEAK_DURATION) {
     const candidates = [];
 
     let candidateStartTime = peakWindow.startTime;
@@ -101,7 +79,7 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
       };
       const candidateTotals = this.totalsForPeriod(countIntervals, candidatePeriod);
       candidates.push(candidateTotals);
-      candidateStartTime = candidateStartTime.plus(this.COUNT_INTERVAL_DURATION);
+      candidateStartTime = candidateStartTime.plus(REPORT_CONSTANTS.COUNT_INTERVAL_DURATION);
     }
     return candidates;
   }
@@ -143,7 +121,9 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
       nIntervalsInPeriod = intervalTotals.length;
       validPeriod = {
         startTime: intervalTotals[0].t,
-        endTime: intervalTotals[nIntervalsInPeriod - 1].t.plus(this.COUNT_INTERVAL_DURATION),
+        endTime: intervalTotals[nIntervalsInPeriod - 1].t.plus(
+          REPORT_CONSTANTS.COUNT_INTERVAL_DURATION,
+        ),
       };
     } else {
       validPeriod = period;
@@ -193,19 +173,27 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
       const totaledData = RBFD.computeAllMovementAndVehicleTotals(countData);
       const studyDate = countData[0].t;
 
-      const amPeakWindow = this.dateTimePeriodFromObject(this.AM_PEAK_WINDOW, studyDate);
+      const amPeakWindow = this.dateTimePeriodFromObject(
+        REPORT_CONSTANTS.AM_PEAK_WINDOW, studyDate,
+      );
       statSummaries.amPeak = this.totalsForPeak(totaledData, amPeakWindow);
 
-      const pmPeakWindow = this.dateTimePeriodFromObject(this.PM_PEAK_WINDOW, studyDate);
+      const pmPeakWindow = this.dateTimePeriodFromObject(
+        REPORT_CONSTANTS.PM_PEAK_WINDOW, studyDate,
+      );
       statSummaries.pmPeak = this.totalsForPeak(totaledData, pmPeakWindow);
 
       const am2HourPeriod = this.dateTimePeriodFromObject(this.AM_2_HOUR_PERIOD, studyDate);
       statSummaries.am = this.totalsForPeriod(totaledData, am2HourPeriod);
 
-      const pm2HourPeriod = this.dateTimePeriodFromObject(this.PM_2_HOUR_PERIOD, studyDate);
+      const pm2HourPeriod = this.dateTimePeriodFromObject(
+        REPORT_CONSTANTS.PM_2_HOUR_PERIOD, studyDate,
+      );
       statSummaries.pm = this.totalsForPeriod(totaledData, pm2HourPeriod);
 
-      const offHoursPeriod = this.dateTimePeriodFromObject(this.OFF_HOUR_PERIOD, studyDate);
+      const offHoursPeriod = this.dateTimePeriodFromObject(
+        REPORT_CONSTANTS.OFF_HOUR_PERIOD, studyDate,
+      );
       const offHoursTotals = this.totalsForPeriod(totaledData, offHoursPeriod);
       statSummaries.offHours = this.averagesForPeriod(offHoursTotals);
 

--- a/lib/reports/ReportPeakHourFactor.js
+++ b/lib/reports/ReportPeakHourFactor.js
@@ -2,6 +2,7 @@
 import ArrayUtils from '@/lib/ArrayUtils';
 import {
   CardinalDirection,
+  REPORT_CONSTANTS,
   ReportBlock,
   ReportType,
   TurningMovement,
@@ -109,10 +110,10 @@ class ReportPeakHourFactor extends ReportBaseFlow {
       countData,
     );
 
-    const amIndices = indexRangeHourOfDay(totaledData, 0, 12);
+    const amIndices = indexRangeHourOfDay(totaledData, REPORT_CONSTANTS.AM_PEAK_WINDOW);
     const amPeak = ReportPeakHourFactor.getPeakData(totaledData, amIndices);
 
-    const pmIndices = indexRangeHourOfDay(totaledData, 12, 24);
+    const pmIndices = indexRangeHourOfDay(totaledData, REPORT_CONSTANTS.PM_PEAK_WINDOW);
     const pmPeak = ReportPeakHourFactor.getPeakData(totaledData, pmIndices);
 
     return {

--- a/lib/reports/time/ReportTimeUtils.js
+++ b/lib/reports/time/ReportTimeUtils.js
@@ -31,24 +31,40 @@ import ArrayUtils from '@/lib/ArrayUtils';
  */
 
 /**
- * @param {CountData} countData
- * @param {number} start - hour of day to start from (inclusive)
- * @param {number} end - hour of day to end at (exclusive)
- * @returns {IndexRange} index range where `t.hour >= start && t.hour < end`
+ * Defines a start DateTime values and an end Datetime value to represent a DateTime range
+ *
+ * @typedef {Object} TimeWindow
+ * @property {DateTime} startTime - DateTime value representing the start time of the TimeWindow
+ * @property {DateTime} endTime - DateTime value representing the end time of the TimeWindow
  */
-function indexRangeHourOfDay(countData, start, end) {
-  const n = countData.length;
-  let lo = 0;
-  while (lo < n && countData[lo].t.hour < start) {
-    lo += 1;
-  }
-  let hi = n;
-  while (hi > 0 && countData[hi - 1].t.hour >= end) {
-    hi -= 1;
-  }
-  return { lo, hi };
-}
 
+/**
+ * @param {CountData} countData
+ * @param {TimeWindow} timeWindow
+ * @returns {IndexRange} index range where `t >= timeWindow.startTime && t < timeWindow.endTime`
+ */
+function indexRangeHourOfDay(countData, timeWindow) {
+  const n = countData.length;
+  const range = {
+    lo: 0,
+    hi: n,
+  };
+  while (range.lo < n && countData[range.lo].t.hour <= timeWindow.startTime.hour) {
+    if (countData[range.lo].t.hour === timeWindow.startTime.hour
+      && countData[range.lo].t.minute >= timeWindow.startTime.minute) {
+      break;
+    }
+    range.lo += 1;
+  }
+  while (range.hi > 0 && countData[range.hi - 1].t.hour >= timeWindow.endTime.hour) {
+    if (countData[range.hi - 1].t.hour === timeWindow.endTime.hour
+      && countData[range.hi - 1].t.minute < timeWindow.endTime.minute) {
+      break;
+    }
+    range.hi -= 1;
+  }
+  return range;
+}
 /**
  * Returns a sequence of disjoint index ranges that identify consecutive counted hours
  * in `countData`.  Note that these may not align with clock hours, and that they may not

--- a/lib/test/random/CountDataGenerator.js
+++ b/lib/test/random/CountDataGenerator.js
@@ -33,6 +33,27 @@ function generateHourOfDayRange() {
   return { start: b, end: a };
 }
 
+function generateTimeOfDayRange() {
+  const a = DateTime.fromObject({
+    year: 2012,
+    month: 4,
+    day: 1,
+    hour: Random.range(0, 24),
+    minute: Random.range(0, 60),
+  });
+  const b = DateTime.fromObject({
+    year: 2012,
+    month: 4,
+    day: 1,
+    hour: Random.range(0, 24),
+    minute: Random.range(0, 60),
+  });
+  if (a < b) {
+    return { startTime: a, endTime: b };
+  }
+  return { startTime: b, endTime: a };
+}
+
 function generateWithMissing(countData) {
   const n = countData.length;
   const k = Random.choice([1, 1, 2, 3]);
@@ -189,6 +210,7 @@ const CountDataGenerator = {
   generateHourOfDayRange,
   generateIndexRange,
   generateRandomCountData,
+  generateTimeOfDayRange,
   generateTmcDataPoint,
   generateTmc,
   generateTmc14Hour,
@@ -202,6 +224,7 @@ export {
   generateHourOfDayRange,
   generateIndexRange,
   generateRandomCountData,
+  generateTimeOfDayRange,
   generateTmcDataPoint,
   generateTmc,
   generateTmc14Hour,

--- a/tests/jest/unit/reports/ReportCountSummaryTurningMovement.unit.spec.js
+++ b/tests/jest/unit/reports/ReportCountSummaryTurningMovement.unit.spec.js
@@ -1,9 +1,10 @@
 import ReportCountSummaryTurningMovement from '@/lib/reports/ReportCountSummaryTurningMovement';
+import { REPORT_CONSTANTS } from '@/lib/Constants';
 import DateTime from '@/lib/time/DateTime';
 
 describe('ReportCountSummaryTurningMovement', () => {
   const ReportTMC = ReportCountSummaryTurningMovement;
-  const INTERVAL_DURATION = ReportTMC.COUNT_INTERVAL_DURATION;
+  const INTERVAL_DURATION = REPORT_CONSTANTS.COUNT_INTERVAL_DURATION;
   const INTERVAL_MINS = INTERVAL_DURATION.minutes;
   const countStartTime = DateTime.now();
   const nullSummary = ReportTMC.statSummaryForNullCount();
@@ -127,7 +128,6 @@ describe('ReportCountSummaryTurningMovement', () => {
   });
 
   describe('totalsForPeak', () => {
-    const { PEAK_DURATION } = ReportTMC;
     let window;
     function getTotalsForPeak() {
       return ReportTMC.totalsForPeak(getFormattedCounts(), window);
@@ -155,7 +155,7 @@ describe('ReportCountSummaryTurningMovement', () => {
 
     test('returns the earliest peark period with highest count WITHIN the window', () => {
       const peakStartTime = countStartTime.plus({ minutes: INTERVAL_MINS * 10 });
-      const peakEndTime = peakStartTime.plus(PEAK_DURATION);
+      const peakEndTime = peakStartTime.plus(REPORT_CONSTANTS.PEAK_DURATION);
       expect(getTotalsForPeak().timeRange.start).toEqual(peakStartTime);
       expect(getTotalsForPeak().timeRange.end).toEqual(peakEndTime);
     });
@@ -177,7 +177,7 @@ describe('ReportCountSummaryTurningMovement', () => {
 
       test('the time range returned is the duration of a peak', () => {
         const peakStartTime = countStartTime.plus({ minutes: INTERVAL_MINS * 1 });
-        const peakEndTime = peakStartTime.plus(PEAK_DURATION);
+        const peakEndTime = peakStartTime.plus(REPORT_CONSTANTS.PEAK_DURATION);
         expect(getTotalsForPeak().timeRange.start).toEqual(peakStartTime);
         expect(getTotalsForPeak().timeRange.end).toEqual(peakEndTime);
       });
@@ -200,7 +200,7 @@ describe('ReportCountSummaryTurningMovement', () => {
 
       test('the time range returned is the duration of a peak', () => {
         const peakStartTime = countStartTime.plus({ minutes: INTERVAL_MINS * 6 });
-        const peakEndTime = peakStartTime.plus(PEAK_DURATION);
+        const peakEndTime = peakStartTime.plus(REPORT_CONSTANTS.PEAK_DURATION);
         expect(getTotalsForPeak().timeRange.start).toEqual(peakStartTime);
         expect(getTotalsForPeak().timeRange.end).toEqual(peakEndTime);
       });
@@ -225,7 +225,7 @@ describe('ReportCountSummaryTurningMovement', () => {
 
       test('the time range returned is the duration of a peak', () => {
         const peakStartTime = countStartTime.plus({ minutes: INTERVAL_MINS * 8 });
-        const peakEndTime = peakStartTime.plus(PEAK_DURATION);
+        const peakEndTime = peakStartTime.plus(REPORT_CONSTANTS.PEAK_DURATION);
         expect(getTotalsForPeak().timeRange.start).toEqual(peakStartTime);
         expect(getTotalsForPeak().timeRange.end).toEqual(peakEndTime);
       });

--- a/tests/jest/unit/reports/time/ReportTimeUtils.spec.js
+++ b/tests/jest/unit/reports/time/ReportTimeUtils.spec.js
@@ -12,7 +12,7 @@ import {
   generateAtrSpeedVolume,
   generateAtrVolume,
   generateRandomCountData,
-  generateHourOfDayRange,
+  generateTimeOfDayRange,
   generateIndexRange,
   generateTmc,
   generateWithMissing,
@@ -25,7 +25,8 @@ expect.extend({
 
 test('ReportTimeUtils.indexRangeHourOfDay [empty dataset]', () => {
   const countData = [];
-  const indexRange = indexRangeHourOfDay(countData, 9, 17);
+  const timeWindow = generateTimeOfDayRange();
+  const indexRange = indexRangeHourOfDay(countData, timeWindow);
   expect(indexRange).toEqual({ lo: 0, hi: 0 });
 });
 
@@ -34,10 +35,11 @@ test('ReportTimeUtils.indexRangeHourOfDay [fuzz test]', () => {
     const countData = generateRandomCountData({
       COUNT: [1000, 10000],
     });
-    const { start, end } = generateHourOfDayRange();
-    const { lo, hi } = indexRangeHourOfDay(countData, start, end);
+    const timeWindow = generateTimeOfDayRange();
+
+    const { lo, hi } = indexRangeHourOfDay(countData, timeWindow);
     countData.forEach(({ t }, j) => {
-      expect(t.hour >= start && t.hour < end).toEqual(j >= lo && j < hi);
+      expect(t >= timeWindow.startTime && t < timeWindow.endTime).toEqual(j >= lo && j < hi);
     });
   }
 });


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-1000](https://move-toronto.atlassian.net/browse/MOVE-1000)


**Before:**
![before](https://github.com/CityofToronto/bdit_flashcrow/assets/5003768/bc556557-823d-467e-9a80-6c5572ecbef9)

**After:**
![after](https://github.com/CityofToronto/bdit_flashcrow/assets/5003768/c85d1b80-5598-49fa-ab86-fdd18d8e1c4c)


# Description
Previously we were only looking at the hour value for finding and reporting on the peak hours. This updates the methods to use the minutes also since the AM and PM peak ranges include quarter-hour values (15min, 30min, 45min).

Also unified all of these ranges in the Constants, and updated the reports that use these values.

# Tests
Updated and passed all tests.
