### PR TITLE
Move 515

### DIFF
--- a/lib/geo/GeoStyle.js
+++ b/lib/geo/GeoStyle.js
@@ -226,6 +226,9 @@ function addGeoJsonSource(style, id) {
   style.sources[id] = {
     type: 'geojson',
     data: CACHE_GEOJSON[id],
+    cluster: true,
+    clusterMaxZoom: 15, // Max zoom to cluster points on
+    clusterRadius: 50,
   };
 }
 
@@ -818,6 +821,50 @@ class GeoStyle {
     ];
   }
 
+  /*
+  * This method is used to add the cluster layers to the map
+  * I followed the maplibre documentation to get this up and running
+  * https://maplibre.org/maplibre-gl-js/docs/examples/cluster/
+  * Currently only applies to location markers in study requests.
+  * A corresponding change is made in the addGeoJsonSource function
+  * to add cluster options to the geoJson sources
+  */
+  static getClusterLayers() {
+    return [
+      {
+        id: 'clusters',
+        type: 'circle',
+        source: 'locations-markers',
+        filter: ['has', 'point_count'],
+        paint: {
+          // Use step expressions (https://maplibre.org/maplibre-style-spec/#expressions-step)
+          // with three steps to implement three types of circles:
+          //   * Blue, 20px circles when point count is less than 100
+          //   * Yellow, 30px circles when point count is between 100 and 750
+          //   * Pink, 40px circles when point count is greater than or equal to 750
+          'circle-color': [
+            'step',
+            ['get', 'point_count'],
+            '#51bbd6',
+            100,
+            '#f1f075',
+            750,
+            '#f28cb1',
+          ],
+          'circle-radius': [
+            'step',
+            ['get', 'point_count'],
+            20,
+            100,
+            30,
+            750,
+            40,
+          ],
+        },
+      },
+    ];
+  }
+
   static getStudiesFilter({ filtersCommon, filtersStudy }) {
     const {
       dateRangeStart,
@@ -882,6 +929,7 @@ class GeoStyle {
     const hospitalsLayers = GeoStyle.getHospitalsLayers(options, baseStyle);
     const schoolsLayers = GeoStyle.getSchoolsLayers(options, baseStyle);
     const studiesLayers = GeoStyle.getStudiesLayers(options, baseStyle);
+    const clusterLayers = GeoStyle.getClusterLayers(options, baseStyle);
 
     return [
       ...centrelineLayers,
@@ -889,6 +937,7 @@ class GeoStyle {
       ...hospitalsLayers,
       ...schoolsLayers,
       ...studiesLayers,
+      ...clusterLayers,
     ];
   }
 

--- a/lib/geo/GeoStyle.js
+++ b/lib/geo/GeoStyle.js
@@ -226,9 +226,6 @@ function addGeoJsonSource(style, id) {
   style.sources[id] = {
     type: 'geojson',
     data: CACHE_GEOJSON[id],
-    cluster: true,
-    clusterMaxZoom: 15, // Max zoom to cluster points on
-    clusterRadius: 50,
   };
 }
 
@@ -821,50 +818,6 @@ class GeoStyle {
     ];
   }
 
-  /*
-  * This method is used to add the cluster layers to the map
-  * I followed the maplibre documentation to get this up and running
-  * https://maplibre.org/maplibre-gl-js/docs/examples/cluster/
-  * Currently only applies to location markers in study requests.
-  * A corresponding change is made in the addGeoJsonSource function
-  * to add cluster options to the geoJson sources
-  */
-  static getClusterLayers() {
-    return [
-      {
-        id: 'clusters',
-        type: 'circle',
-        source: 'locations-markers',
-        filter: ['has', 'point_count'],
-        paint: {
-          // Use step expressions (https://maplibre.org/maplibre-style-spec/#expressions-step)
-          // with three steps to implement three types of circles:
-          //   * Blue, 20px circles when point count is less than 100
-          //   * Yellow, 30px circles when point count is between 100 and 750
-          //   * Pink, 40px circles when point count is greater than or equal to 750
-          'circle-color': [
-            'step',
-            ['get', 'point_count'],
-            '#51bbd6',
-            100,
-            '#f1f075',
-            750,
-            '#f28cb1',
-          ],
-          'circle-radius': [
-            'step',
-            ['get', 'point_count'],
-            20,
-            100,
-            30,
-            750,
-            40,
-          ],
-        },
-      },
-    ];
-  }
-
   static getStudiesFilter({ filtersCommon, filtersStudy }) {
     const {
       dateRangeStart,
@@ -929,7 +882,6 @@ class GeoStyle {
     const hospitalsLayers = GeoStyle.getHospitalsLayers(options, baseStyle);
     const schoolsLayers = GeoStyle.getSchoolsLayers(options, baseStyle);
     const studiesLayers = GeoStyle.getStudiesLayers(options, baseStyle);
-    const clusterLayers = GeoStyle.getClusterLayers(options, baseStyle);
 
     return [
       ...centrelineLayers,
@@ -937,7 +889,6 @@ class GeoStyle {
       ...hospitalsLayers,
       ...schoolsLayers,
       ...studiesLayers,
-      ...clusterLayers,
     ];
   }
 

--- a/lib/geo/map/MaplibreGlBase.js
+++ b/lib/geo/map/MaplibreGlBase.js
@@ -25,8 +25,8 @@ function makeMaplibreGlMap($el, mapStyle) {
   map.addControl(
     new maplibregl.AttributionControl({
       customAttribution: [
-        '<span role="listitem"><a href="https://docs.mapbox.com/mapbox-gl-js/overview/">Mapbox GL</a></span>',
-        '<span role="listitem">Powered by <a href="https://www.esri.com/">Esri</a></span>',
+        '<span role="listitem" style="user-select:none;"><a href="https://docs.mapbox.com/mapbox-gl-js/overview/">Mapbox GL</a></span>',
+        '<span role="listitem" style="user-select:none;">Powered by <a href="https://www.esri.com/">Esri</a></span>',
       ],
     }),
     'bottom-left',

--- a/web/components/filters/FcGlobalFilters.vue
+++ b/web/components/filters/FcGlobalFilters.vue
@@ -5,7 +5,7 @@
     <div class="align-center d-flex">
       <component
         :is="headerTag"
-        class="headline" :id="headingId">
+        class="headline mr-1 filter-title" :id="headingId">
         Filters
       </component>
       <v-spacer></v-spacer>
@@ -122,6 +122,9 @@ export default {
   .filter-name {
     align-self: flex-start;
     margin-right: 15px;
+  }
+  .filter-title {
+    user-select: none;
   }
 }
 </style>

--- a/web/components/geo/legend/FcMapLegend.vue
+++ b/web/components/geo/legend/FcMapLegend.vue
@@ -118,6 +118,7 @@ export default {
 .fc-map-legend {
   width: 250px;
   display: block;
+  user-select: none;
   & .fc-legend-icon {
     height: 24px;
     position: relative;

--- a/web/components/geo/legend/FcMapLegend.vue
+++ b/web/components/geo/legend/FcMapLegend.vue
@@ -134,4 +134,10 @@ export default {
     display: none;
   }
 }
+// hide when screen is too-short, too
+@media only screen and (max-height: 450px) {
+  .fc-map-legend {
+    display: none;
+  }
+}
 </style>

--- a/web/components/geo/legend/FcMapLegend.vue
+++ b/web/components/geo/legend/FcMapLegend.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card class="fc-map-legend" :class="{ shrink: isHidden }">
+  <v-card class="fc-map-legend" :class="{ shrink: isHidden, drawerOpen: drawerOpen }">
     <v-card-text class="default--text pa-0">
       <fieldset>
         <legend class="headline px-4 py-3 d-flex justify-content-between">
@@ -54,6 +54,7 @@ import FcLegendRowHospitals from '@/web/components/geo/legend/FcLegendRowHospita
 import FcLegendRowSchools from '@/web/components/geo/legend/FcLegendRowSchools.vue';
 import FcLegendRowStudies from '@/web/components/geo/legend/FcLegendRowStudies.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+import { mapState } from 'vuex';
 
 export default {
   name: 'FcMapLegend',
@@ -106,6 +107,9 @@ export default {
       });
       return layerLabels;
     },
+    ...mapState('viewData', [
+      'drawerOpen',
+    ]),
   },
 };
 </script>
@@ -127,6 +131,9 @@ export default {
 }
 .shrink {
   opacity: 0.9;
+}
+.drawerOpen {
+  display: none;
 }
 
 @media only screen and (max-width: 600px) {

--- a/web/components/geo/map/FcMap.vue
+++ b/web/components/geo/map/FcMap.vue
@@ -294,7 +294,7 @@ export default {
       return GeoStyle.get(this.mapOptions);
     },
     showHoveredPopup() {
-      if (this.hoveredFeature === null) {
+      if (this.hoveredFeature === null || this.selectedFeature !== null) {
         return false;
       }
       return this.featureKeyHovered !== this.featureKeySelected

--- a/web/components/geo/map/FcMap.vue
+++ b/web/components/geo/map/FcMap.vue
@@ -599,6 +599,7 @@ export default {
   & > .fc-map-legend-wrapper {
     right: 20px;
     top: 12px;
+    z-index: 1;
   }
   & > .fc-map-navigate {
     bottom: 77px;

--- a/web/components/nav/FcAppbar.vue
+++ b/web/components/nav/FcAppbar.vue
@@ -6,7 +6,7 @@
     clipped-left
     dense>
     <FcDashboardNavBrand />
-    <h1 class="headline ml-2">{{textH1}}</h1>
+    <h1 class="headline ml-2 no-select">{{textH1}}</h1>
     <v-chip
       class="ml-2"
       :color="frontendEnv.colorClass + ' darken-4'"
@@ -74,6 +74,9 @@ export default {
 .fc-appbar {
   & > .v-toolbar__content {
     border-bottom: 1px solid var(--v-border-base);
+  }
+  .no-select {
+    user-select: none;
   }
 }
 </style>

--- a/web/components/reports/FcReportHeader.vue
+++ b/web/components/reports/FcReportHeader.vue
@@ -22,11 +22,11 @@
         :study-type="studyType" />
     </div>
 
-    <div class="callout ma-3" v-if="this.studyType == 'TMC'">
+    <div class="callout ma-3" v-if="this.showCallOut">
       <div class="ma-3">
         <v-icon color="blue">mdi-information</v-icon>
       </div>
-      <div class="ml-1 mr-2">
+      <div class="ml-1 mr-2 pa-2">
         For an in-depth explanation of how to interpret this data,
         <a class="link" href="https://www.notion.so/bditto/How-to-interpret-a-TMC-Summary-Report-310c8b7e9ca74b18b99aadc50dc27196" target="_blank" rel="noopener noreferrer">
           see here
@@ -66,6 +66,11 @@ export default {
       ORG_NAME,
     };
   },
+  computed: {
+    showCallOut() {
+      return this.$parent.type && this.$parent.type.name === 'COUNT_SUMMARY_TURNING_MOVEMENT';
+    },
+  },
 };
 </script>
 
@@ -90,6 +95,12 @@ export default {
     text-decoration: none;
     color: #005695;
     font-weight: bold;
+  }
+}
+// only show callout button if there's room
+@media only screen and (max-width: 800px) {
+  .callout {
+    display: none !important;
   }
 }
 </style>

--- a/web/components/reports/FcReportHeader.vue
+++ b/web/components/reports/FcReportHeader.vue
@@ -22,6 +22,18 @@
         :study-type="studyType" />
     </div>
 
+    <div class="callout ma-3" v-if="this.studyType == 'TMC'">
+      <div class="ma-3">
+        <v-icon color="blue">mdi-information</v-icon>
+      </div>
+      <div class="ml-1 mr-2">
+        For an in-depth explanation of how to interpret this data,
+        <a class="link" href="https://www.notion.so/bditto/How-to-interpret-a-TMC-Summary-Report-310c8b7e9ca74b18b99aadc50dc27196" target="_blank" rel="noopener noreferrer">
+          see here
+        </a>
+      </div>
+    </div>
+
     <v-spacer></v-spacer>
 
     <div class="text-right">
@@ -64,6 +76,20 @@ export default {
   & .beta-wrapper {
     line-height: 16px;
     width: 363px;
+  }
+  .callout {
+    display: flex;
+    align-items: center;
+    background-color: #ebf6fe;
+    color: black;
+    border-radius: 5px;
+    min-height: 60px;
+    font-size: 14px;
+  }
+  .link {
+    text-decoration: none;
+    color: #005695;
+    font-weight: bold;
   }
 }
 </style>


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-515](https://move-toronto.atlassian.net/browse/MOVE-515) (new callout in reporter html) and [MOVE-1124](https://move-toronto.atlassian.net/browse/MOVE-1124) (show one tooltip at a time). It also makes some minor changes to the legend, from [MOVE-1109](https://move-toronto.atlassian.net/browse/MOVE-1109).

# Description
* hides legend when left sidebar opens
* hides legend on minimum height, not just min width
* puts map tooltip above legend (via  `z-index` )
* adds `user-select: none` to missing menu and button elements

here is the new callout button:
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/399657/49ec74cd-59bb-4d17-a0de-562c8ceab8e7)
it will only show when there is the width for it

Accidentally added Omar's clustering commit from https://github.com/CityofToronto/bdit_flashcrow/compare/master...MOVE-479
I reverted it, so the PR is clean, and I believe it will prevent any problems when that branch merges