### PR TITLE
MOVE-538: MVCRs won't view, only download

### DIFF
--- a/lib/controller/StorageController.js
+++ b/lib/controller/StorageController.js
@@ -104,7 +104,7 @@ StorageController.push({
 
     const mimeType = 'application/pdf';
     return h.response(file).type(mimeType)
-      .header('Content-Disposition', `attachment; filename="${mvcrFilename}"`);
+      .header('Content-Disposition', `inline; filename="${mvcrFilename}"`);
   },
 });
 


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-538

# Description
The endpoint used to fetch the MVCR set its Content-Disposition header to "attachment", so even if the user wished to view the MVCR in the browser, it will only be downloaded. Changing the header to "inline" now opens the MVCR in a new tab when the user wishes to view it, and downloads the MVCR when the user wishes to download it.

# Tests
Tested in MOVE local by viewing and downloading an MVCR through Chrome, Edge and Firefox.
