### PR TITLE
MOVE-1100: Export comments with request queue CSV export

### DIFF
--- a/lib/reports/ReportBaseTrackRequests.js
+++ b/lib/reports/ReportBaseTrackRequests.js
@@ -11,6 +11,7 @@ import {
   getStudyRequestBulkItem,
 } from '@/lib/requests/RequestItems';
 import RequestItemExport from '@/lib/requests/RequestItemExport';
+import StudyRequestCommentDAO from '@/lib/db/StudyRequestCommentDAO';
 
 /**
  * Base class for all study-request-related reports, i.e. those reports that export study
@@ -35,6 +36,20 @@ class ReportBaseTrackRequests extends ReportBase {
       }
     });
     return studyRequests;
+  }
+
+  async getStudyRequestComments(studyRequests) {
+    const studyRequestComments = new Map();
+    studyRequests.forEach(async (studyRequest) => {
+      const commentList = [];
+      const studyId = studyRequest.id;
+      const comments = await StudyRequestCommentDAO.byStudyRequest(studyRequest);
+      comments.forEach((commentObject) => {
+        commentList.push(commentObject.comment);
+      });
+      studyRequestComments.set(studyId, commentList);
+    });
+    return studyRequestComments;
   }
 
   async getStudyRequestLocations(studyRequests) {
@@ -102,15 +117,18 @@ class ReportBaseTrackRequests extends ReportBase {
     const [
       studyRequestLocations,
       studyRequestUsers,
+      studyRequestComments,
     ] = await Promise.all([
       this.getStudyRequestLocations(studyRequests),
       this.getStudyRequestUsers(studyRequests),
+      this.getStudyRequestComments(studyRequests),
     ]);
 
     return {
       studyRequestItems,
       studyRequestLocations,
       studyRequestUsers,
+      studyRequestComments,
       studyRequestsBulk,
     };
   }
@@ -119,6 +137,7 @@ class ReportBaseTrackRequests extends ReportBase {
     studyRequestItems,
     studyRequestLocations,
     studyRequestUsers,
+    studyRequestComments,
     studyRequestsBulk,
   }) {
     const items = [];
@@ -128,6 +147,7 @@ class ReportBaseTrackRequests extends ReportBase {
           studyRequestLocations,
           studyRequestUsers,
           request,
+          studyRequestComments,
         );
         items.push(...itemBulk.studyRequestBulk.studyRequests);
       } else {
@@ -135,6 +155,7 @@ class ReportBaseTrackRequests extends ReportBase {
           studyRequestLocations,
           studyRequestUsers,
           request,
+          studyRequestComments,
         );
         items.push(item);
       }

--- a/lib/requests/RequestItemExport.js
+++ b/lib/requests/RequestItemExport.js
@@ -21,6 +21,7 @@ const CSV_COLUMNS = [
   'Days of Week',
   'Hours',
   'Collection Notes',
+  'Comments',
   'MOVE ID',
   'Date Requested',
   'Client',
@@ -70,6 +71,8 @@ class RequestItemExport {
       siteNo = item.location.centrelineId;
     }
 
+    const comments = item.comments === null ? '' : item.comments;
+
     const {
       id,
       urgent,
@@ -103,6 +106,7 @@ class RequestItemExport {
       daysOfWeek,
       hours,
       notes,
+      comments,
       id,
       dateRequested,
       client,

--- a/lib/requests/RequestItems.js
+++ b/lib/requests/RequestItems.js
@@ -12,6 +12,7 @@ function getStudyRequestItem(
   studyRequestLocations,
   studyRequestUsers,
   studyRequest,
+  studyRequestComments,
 ) {
   const {
     assignedTo,
@@ -41,6 +42,11 @@ function getStudyRequestItem(
 
   const assignedToStr = assignedTo === null ? 'Unassigned' : assignedTo.text;
 
+  let comments = null;
+  if (studyRequestComments.has(id) && studyRequestComments.get(id).length > 0) {
+    comments = studyRequestComments.get(id).join(' | ');
+  }
+
   return {
     type: ItemType.STUDY_REQUEST,
     ariaLabel,
@@ -53,6 +59,7 @@ function getStudyRequestItem(
     status,
     studyRequest,
     urgent,
+    comments,
   };
 }
 
@@ -60,6 +67,7 @@ function getStudyRequestBulkItem(
   studyRequestLocations,
   studyRequestUsers,
   studyRequestBulk,
+  studyRequestComments,
 ) {
   const {
     id,
@@ -72,6 +80,7 @@ function getStudyRequestBulkItem(
       studyRequestLocations,
       studyRequestUsers,
       studyRequest,
+      studyRequestComments,
     ),
   );
 

--- a/web/views/FcRequestsTrack.vue
+++ b/web/views/FcRequestsTrack.vue
@@ -189,6 +189,7 @@ export default {
       studyRequestItems: [],
       studyRequestLocations: new Map(),
       studyRequestUsers: new Map(),
+      studyRequestComments: new Map(),
       total: 0,
     };
   },
@@ -209,12 +210,14 @@ export default {
             this.studyRequestLocations,
             this.studyRequestUsers,
             request,
+            this.studyRequestComments,
           );
         }
         return getStudyRequestItem(
           this.studyRequestLocations,
           this.studyRequestUsers,
           request,
+          this.studyRequestComments,
         );
       });
     },


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-1100](https://move-toronto.atlassian.net/browse/MOVE-1100)

# Description
This PR gets the comments that have been made on a study request, and includes these comments when a study request is exported / downloaded. I have added only the comments (separated by a '|' if there is more than one), but we can easily extend this to include the metadata surrounding the comments (username of commenter, date, etc.)

Sample of what the output looks like:
[TRACK_REQUESTS_SELECTED_202404031613_690e4a12.csv](https://github.com/CityofToronto/bdit_flashcrow/files/14858148/TRACK_REQUESTS_SELECTED_202404031613_690e4a12.csv)


where:

- id 11 has one comment: 'test'
- id 12 has two comments: 'Test!' and 'test'
- id 13 has no comments

# Tests
I tried a variety of requests and requests with no comments, many comments, one comment.... no issues seen.
