### PR TITLE
Move 1118

### DIFF
--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -18,7 +18,7 @@
           v-model="internalLocationsSelection" />
         <FcHeaderSingleLocation
           :location="locationActive" />
-        <div class="d-flex mt-4 justify-end">
+        <div class="d-flex mt-1 justify-end">
           <FcSummaryPoi :location="locationActive" />
         </div>
       </div>

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -17,17 +17,9 @@
         <FcSelectorSingleLocation
           v-model="internalLocationsSelection" />
         <FcHeaderSingleLocation
-          class="mt-4"
           :location="locationActive" />
         <div class="d-flex mt-4">
           <FcSummaryPoi :location="locationActive" />
-          <v-spacer></v-spacer>
-          <FcButton
-            type="secondary"
-            @click="actionAddLocation">
-            <v-icon color="primary" left>mdi-map-marker-plus</v-icon>
-            Add Location
-          </FcButton>
         </div>
       </div>
     </header>
@@ -172,9 +164,6 @@ export default {
     },
   },
   methods: {
-    actionAddLocation() {
-      this.setLocationMode(LocationMode.MULTI_EDIT);
-    },
     actionToggleDetailView() {
       if (this.detailView) {
         this.setLocationsIndex(-1);
@@ -193,7 +182,6 @@ export default {
       await this.initLocations({ features, selectionType });
     },
     ...mapMutations([
-      'setLocationMode',
       'setLocationsIndex',
       'setToastInfo',
     ]),

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -18,7 +18,7 @@
           v-model="internalLocationsSelection" />
         <FcHeaderSingleLocation
           :location="locationActive" />
-        <div class="d-flex mt-4">
+        <div class="d-flex mt-4 justify-end">
           <FcSummaryPoi :location="locationActive" />
         </div>
       </div>

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -4,14 +4,6 @@
       <FcSelectorMultiLocation
         v-if="locationMode.multi"
         :detail-view="detailView">
-        <!-- <template v-slot:action>
-          <FcButton
-            type="secondary"
-            @click="actionToggleDetailView">
-            <span v-if="detailView">Aggregate View</span>
-            <span v-else>Detail View</span>
-          </FcButton>
-        </template> -->
       </FcSelectorMultiLocation>
       <div v-else class="px-5 py-3">
         <FcSelectorSingleLocation
@@ -71,7 +63,6 @@ import FcViewDataDetail from '@/web/components/data/FcViewDataDetail.vue';
 import FcViewDataMultiEdit from '@/web/components/data/FcViewDataMultiEdit.vue';
 import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcGlobalFilters from '@/web/components/filters/FcGlobalFilters.vue';
-// import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcSelectorSingleLocation from '@/web/components/inputs/FcSelectorSingleLocation.vue';
 import FcSelectorMultiLocation from '@/web/components/inputs/FcSelectorMultiLocation.vue';
 import FcHeaderSingleLocation from '@/web/components/location/FcHeaderSingleLocation.vue';
@@ -84,7 +75,6 @@ export default {
     FcMixinRouteAsync,
   ],
   components: {
-    // FcButton,
     FcGlobalFilters,
     FcHeaderSingleLocation,
     FcProgressLinear,

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -18,7 +18,7 @@
           v-model="internalLocationsSelection" />
         <FcHeaderSingleLocation
           :location="locationActive" />
-        <div class="d-flex mt-1 justify-end">
+        <div class="d-flex mt-1 justify-start">
           <FcSummaryPoi :location="locationActive" />
         </div>
       </div>

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -4,14 +4,14 @@
       <FcSelectorMultiLocation
         v-if="locationMode.multi"
         :detail-view="detailView">
-        <template v-slot:action>
+        <!-- <template v-slot:action>
           <FcButton
             type="secondary"
             @click="actionToggleDetailView">
             <span v-if="detailView">Aggregate View</span>
             <span v-else>Detail View</span>
           </FcButton>
-        </template>
+        </template> -->
       </FcSelectorMultiLocation>
       <div v-else class="px-5 py-3">
         <FcSelectorSingleLocation
@@ -71,7 +71,7 @@ import FcViewDataDetail from '@/web/components/data/FcViewDataDetail.vue';
 import FcViewDataMultiEdit from '@/web/components/data/FcViewDataMultiEdit.vue';
 import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcGlobalFilters from '@/web/components/filters/FcGlobalFilters.vue';
-import FcButton from '@/web/components/inputs/FcButton.vue';
+// import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcSelectorSingleLocation from '@/web/components/inputs/FcSelectorSingleLocation.vue';
 import FcSelectorMultiLocation from '@/web/components/inputs/FcSelectorMultiLocation.vue';
 import FcHeaderSingleLocation from '@/web/components/location/FcHeaderSingleLocation.vue';
@@ -84,7 +84,7 @@ export default {
     FcMixinRouteAsync,
   ],
   components: {
-    FcButton,
+    // FcButton,
     FcGlobalFilters,
     FcHeaderSingleLocation,
     FcProgressLinear,

--- a/web/components/data/FcDetailCollisions.vue
+++ b/web/components/data/FcDetailCollisions.vue
@@ -4,8 +4,8 @@
       v-if="loading"
       aria-label="Loading Detail View collisions data" />
     <template v-else>
-      <dl class="d-flex flex-grow-1 flex-shrink-1 text-center">
-        <div class="flex-grow-1 flex-shrink-1">
+      <dl class="d-flex flex-grow-1 flex-shrink-1 text-center justify-space-around">
+        <div class="flex-grow-1 collision-fact">
           <dt class="body-1">
             Total
           </dt>
@@ -17,7 +17,7 @@
               :show-b="hasFiltersCollision || hasFiltersCommon" />
           </dd>
         </div>
-        <div class="flex-grow-1 flex-shrink-1">
+        <div class="flex-grow-1 flex-shrink-1 collision-fact">
           <dt class="body-1">
             KSI
           </dt>
@@ -29,7 +29,7 @@
               :show-b="hasFiltersCollision || hasFiltersCommon" />
           </dd>
         </div>
-        <div class="fc-collisions-validated flex-grow-0 flex-shrink-0 mr-8">
+        <div class="fc-collisions-validated flex-grow-0 flex-shrink-0 collision-fact mr-4">
           <dt class="body-1">
             Verified
           </dt>
@@ -43,8 +43,8 @@
         </div>
       </dl>
       <FcButton
-        class="flex-grow-0 flex-shrink-0"
-        type="tertiary"
+        class="flex-grow-0 flex-shrink-0 mt-2"
+        type="secondary"
         :disabled="collisionSummary.amount === 0"
         @click="$emit('show-reports')">
         <span>View Reports</span>
@@ -80,8 +80,13 @@ export default {
 
 <style lang="scss">
 .fc-detail-collisions {
+  flex-wrap: wrap;
+  justify-content: flex-end;
   .fc-collisions-validated {
     width: 120px;
+  }
+  .collision-fact {
+    min-width: 50px;
   }
 }
 </style>

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -55,15 +55,12 @@
         :locations-index="locationsIndex"
         :locations-selection="locationsSelection" />
       <FcButton
-        class="ml-3 edit-location-btn"
+        class="ml-3 edit-location-btn mb-1"
         type="tertiary"
         @click="setLocationMode(LocationMode.MULTI_EDIT)">
         <v-icon color="primary" left>mdi-pencil</v-icon>
         Edit Locations
       </FcButton>
-      <v-messages
-        class="mt-2"
-        :value="[]"></v-messages>
     </div>
     <div class="flex-grow-0 flex-shrink-0">
       <div class="d-flex align-center">

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -49,11 +49,18 @@
     </div>
     <div
       v-else
-      class="flex-grow-1 flex-shrink-1">
+      class="flex-grow-1 flex-shrink-1 text-right">
       <FcDisplayLocationMulti
         :locations="locations"
         :locations-index="locationsIndex"
         :locations-selection="locationsSelection" />
+      <FcButton
+        class="ml-3 edit-location-btn"
+        type="tertiary"
+        @click="setLocationMode(LocationMode.MULTI_EDIT)">
+        <v-icon color="primary" left>mdi-pencil</v-icon>
+        Edit Locations
+      </FcButton>
       <v-messages
         class="mt-2"
         :value="[]"></v-messages>
@@ -131,13 +138,6 @@
             <v-spacer></v-spacer>
 
             <slot name="action" />
-            <FcButton
-              class="ml-2 column-space"
-              type="secondary"
-              @click="setLocationMode(LocationMode.MULTI_EDIT)">
-              <v-icon color="primary" left>mdi-circle-edit-outline</v-icon>
-              Edit Locations
-            </FcButton>
 
           </div>
         </template>
@@ -151,13 +151,7 @@
           <v-spacer></v-spacer>
 
           <slot name="action" />
-          <FcButton
-            class="ml-2"
-            type="secondary"
-            @click="setLocationMode(LocationMode.MULTI_EDIT)">
-            <v-icon color="primary" left>mdi-circle-edit-outline</v-icon>
-            Edit Locations
-          </FcButton>
+
         </template>
       </div>
     </div>
@@ -430,5 +424,8 @@ export default {
       padding-left: 0 !important;
     }
   }
+}
+.edit-location-btn {
+  text-transform: none !important;
 }
 </style>

--- a/web/components/location/FcHeaderSingleLocation.vue
+++ b/web/components/location/FcHeaderSingleLocation.vue
@@ -5,6 +5,13 @@
       aria-label="Loading location details"
       small />
     <template v-else>
+      <FcButton
+        type="tertiary"
+        class="add-location-btn"
+        @click="actionAddLocation">
+        <v-icon color="primary" left>mdi-plus</v-icon>
+        Add Location
+      </FcButton>
       <h2 class="display-3">{{location.description}}</h2>
       <div class="label mt-2">
         {{textLocationFeatureType}} &#x2022; {{textMostRecentStudy}}
@@ -19,11 +26,15 @@ import { getLocationFeatureType } from '@/lib/geo/CentrelineUtils';
 import DateTime from '@/lib/time/DateTime';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 import FcProgressCircular from '@/web/components/dialogs/FcProgressCircular.vue';
+import FcButton from '@/web/components/inputs/FcButton.vue';
+import { LocationMode } from '@/lib/Constants';
+import { mapMutations } from 'vuex';
 
 export default {
   name: 'FcHeaderSingleLocation',
   components: {
     FcProgressCircular,
+    FcButton,
   },
   props: {
     location: Object,
@@ -65,6 +76,10 @@ export default {
     this.syncLocation();
   },
   methods: {
+    actionAddLocation() {
+      console.log('setLocation-stub');//eslint-disable-line
+      this.setLocationMode(LocationMode.MULTI_EDIT);
+    },
     async syncLocation() {
       if (this.location === null) {
         return;
@@ -76,6 +91,15 @@ export default {
       this.studySummary = studySummary;
       this.loading = false;
     },
+    ...mapMutations([
+      'setLocationMode',
+    ]),
   },
 };
 </script>
+
+<style lang="scss">
+.add-location-btn {
+  text-transform: none !important;
+}
+</style>

--- a/web/components/location/FcHeaderSingleLocation.vue
+++ b/web/components/location/FcHeaderSingleLocation.vue
@@ -7,12 +7,12 @@
     <template v-else>
       <FcButton
         type="tertiary"
-        class="add-location-btn"
+        class="add-location-btn ml-3 mb-3"
         @click="actionAddLocation">
         <v-icon color="primary" left>mdi-plus</v-icon>
         Add Location
       </FcButton>
-      <h2 class="display-3">{{location.description}}</h2>
+      <h2 class="display-2">{{location.description}}</h2>
       <div class="label mt-2">
         {{textLocationFeatureType}} &#x2022; {{textMostRecentStudy}}
       </div>
@@ -77,7 +77,6 @@ export default {
   },
   methods: {
     actionAddLocation() {
-      console.log('setLocation-stub');//eslint-disable-line
       this.setLocationMode(LocationMode.MULTI_EDIT);
     },
     async syncLocation() {


### PR DESCRIPTION
# Issue Addressed
This PR closes [Move-118](https://move-toronto.atlassian.net/browse/MOVE-1118) (Improve placement of Multi-Location edit buttons)

# Description
Moves and restyles both **Add Location** and **Edit Location** buttons to be closer to the location selectors
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/399657/8b5c8c84-a782-4896-a9d4-61c50f5aad6c)

---

Also:
* comments-out the neighbour **Detail View** button, which was unloved and rather challenged.
* adds responsive breakpoint to Collision detail-view, for smaller screens:
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/399657/2f1430cc-ece4-4ff1-9e24-7f2dbff03141)
