### PR TITLE
MOVE-1098

### DIFF
--- a/lib/reports/ReportCollisionDirectory.js
+++ b/lib/reports/ReportCollisionDirectory.js
@@ -231,7 +231,7 @@ class ReportCollisionDirectory extends ReportBaseCrash {
       { value: pedestrians.length },
       { value: cyclists.length, style: { br: true } },
       ...injured.map((value, j) => ({ value, style: { br: j === 5 } })),
-      { value: verified },
+      { value: verified, style: { br: true } },
       { value: hasMvaImage },
     ];
     return row.map(({ style = {}, ...cellRest }) => {
@@ -262,8 +262,8 @@ class ReportCollisionDirectory extends ReportBaseCrash {
           { value: '#' },
           { value: '#', style: { br: true } },
           { value: 'Injury', colspan: 6, style: { br: true } },
-          { value: 'Veri' },
-          { value: 'MV' },
+          { value: 'Verified', style: { br: true } },
+          { value: 'MVCR' },
         ], [
           { value: 'Number', style: { br: true } },
           { value: 'Date' },
@@ -297,8 +297,8 @@ class ReportCollisionDirectory extends ReportBaseCrash {
           { value: 'FA' },
           { value: 'OT', style: { br: true } },
           // ---
-          { value: 'fied' },
-          { value: 'CR' },
+          { value: null, style: { br: true } },
+          { value: 'Img' },
         ],
       ],
       body: collisions.map(this.getTableCollisionRow.bind(this)),

--- a/lib/reports/ReportCollisionDirectory.js
+++ b/lib/reports/ReportCollisionDirectory.js
@@ -231,7 +231,7 @@ class ReportCollisionDirectory extends ReportBaseCrash {
       { value: pedestrians.length },
       { value: cyclists.length, style: { br: true } },
       ...injured.map((value, j) => ({ value, style: { br: j === 5 } })),
-      { value: verified, style: { br: true } },
+      { value: verified, style: { br: true, 'pr-4': true } },
       { value: hasMvaImage },
     ];
     return row.map(({ style = {}, ...cellRest }) => {

--- a/web/components/reports/FcReportTable.vue
+++ b/web/components/reports/FcReportTable.vue
@@ -34,9 +34,7 @@
             :key="'cell_header_' + r + '_' + c"
             :is="tag"
             v-bind="attrs">
-            <FcTextReportValue v-if="value ==='MV'" value="MVCR" />
-            <FcTextReportValue v-else-if="value === 'CR'" value="Img" />
-            <FcTextReportValue v-else :value="value" />
+            <FcTextReportValue :value="value" />
           </component>
         </tr>
       </thead>
@@ -269,7 +267,7 @@ export default {
       const secondHeaderRow = this.header[1];
       let colIndex = false;
       if (Array.isArray(secondHeaderRow)) {
-        colIndex = secondHeaderRow.findIndex(h => h.value === 'CR');
+        colIndex = secondHeaderRow.findIndex(h => h.value === 'Img');
         if (colIndex === -1) colIndex = false;
       }
       return colIndex;


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-1098](https://move-toronto.atlassian.net/browse/MOVE-1098)

# Description
The Collision Directory Report has an oddly formatted header
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/26462466/04e57620-d3ab-421f-b350-4dda60513896)

This header needed to be changed on the web layout, however the pdf layout needed to be consistent as well.
The new web format looks like this:

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/26462466/6f44a120-4651-448b-809b-731d2bae304a)

and the pdf looks like this:

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/26462466/4ecdb936-4596-43b7-9c2b-99b7c3ef3884)

CSV's remain unchanged.

# Tests
I have tested this on multiple collision directory reports (downloading both pdf and csv to make sure they look good as well).
