### PR TITLE
logging made asynchronous

### DIFF
--- a/lib/server/MoveServer.js
+++ b/lib/server/MoveServer.js
@@ -131,11 +131,11 @@ class MoveServer {
     this.initModules = [];
     this.name = name;
     this.server = Hapi.server(options);
-    this.server.ext('onPreResponse', (request, h) => {
+    this.server.ext('onPreResponse', async (request, h) => {
       const { response } = request;
       if (response.isBoom) {
         try {
-          Logger.createError(request, LogTag.ERROR, response);
+          await Logger.createError(request, LogTag.ERROR, response);
         } catch (err) {
           request.log(LogTag.ERROR, err);
           return h.continue;


### PR DESCRIPTION
# Issue Addressed
This PR addresses [MOVE-1127](https://move-toronto.atlassian.net/browse/MOVE-1127)

# Description
I implemented logging without awaiting the actual logging action. Had to change that.

# Tests
Tested multiple logging events (corrupt collisions, corrupt reports, missing collisions)
