### PR TITLE
MOVE-419 - Add data source to Collision Directory Report

### DIFF
--- a/lib/db/CollisionDAO.js
+++ b/lib/db/CollisionDAO.js
@@ -44,7 +44,8 @@ const COLLISION_EVENTS_FIELDS = `
   e.pedestrian,
   e.red_light AS "redLight",
   e.school_child AS "schoolChild",
-  e.speeding
+  e.speeding,
+  e.src
   FROM collisions.events e
   JOIN collisions.events_centreline ec ON e.collision_id = ec.collision_id`;
 

--- a/lib/model/CollisionEvent.js
+++ b/lib/model/CollisionEvent.js
@@ -48,6 +48,7 @@ const PERSISTED_COLUMNS = {
   schoolChild: Joi.boolean(),
   speeding: Joi.boolean(),
   involved: new ModelRelation(CollisionInvolved, ModelRelationType.TO_MANY, false),
+  src: Joi.string().allow(null),
 };
 
 const CollisionEvent = new Model(ModelField.persisted(PERSISTED_COLUMNS));

--- a/lib/reports/ReportCollisionDirectory.js
+++ b/lib/reports/ReportCollisionDirectory.js
@@ -23,9 +23,12 @@ class ReportCollisionDirectory extends ReportBaseCrash {
       changed,
       mvaimg,
       involved,
+      src,
     } = collision;
     const verified = changed === -1;
     const hasMvaImage = mvaimg !== null;
+
+    const dataSrc = src != null ? src.toUpperCase() : ' ';
 
     let drivers = involved.filter(
       ({ invtype }) => invtype === 1 || invtype === 6 || invtype === 18,
@@ -65,6 +68,7 @@ class ReportCollisionDirectory extends ReportBaseCrash {
       injured,
       verified,
       hasMvaImage,
+      dataSrc,
     };
   }
 
@@ -108,12 +112,14 @@ class ReportCollisionDirectory extends ReportBaseCrash {
     injured,
     verified,
     hasMvaImage,
+    dataSrc,
   }) {
     const [driver1 = {}, driver2 = {}] = drivers;
     const driver1Cells = this.getCsvDriverCells(driver1);
     const driver2Cells = this.getCsvDriverCells(driver2);
     return {
       accnb,
+      dataSrc,
       accdate: TimeFormatters.formatCsv(accdate),
       acclass: this.getCollisionFactorCode('acclass', acclass),
       traffictl: this.getCollisionFactorCode('traffictl', traffictl),
@@ -149,6 +155,7 @@ class ReportCollisionDirectory extends ReportBaseCrash {
   generateCsv(location, { collisions }) {
     const columns = [
       { key: 'accnb', header: 'MVA Number' },
+      { key: 'dataSrc', header: 'Source' },
       { key: 'accdate', header: 'Date Time' },
       { key: 'acclass', header: 'Acc Cla' },
       { key: 'traffictl', header: 'Traffic Control' },
@@ -201,6 +208,7 @@ class ReportCollisionDirectory extends ReportBaseCrash {
 
   getTableCollisionRow({
     accnb,
+    dataSrc,
     accdate,
     acclass,
     traffictl,
@@ -218,6 +226,7 @@ class ReportCollisionDirectory extends ReportBaseCrash {
     const shade = i % 2 === 1;
     const row = [
       { value: accnb, style: { br: true } },
+      { value: dataSrc, style: { br: true } },
       { value: TimeFormatters.formatDefault(accdate) },
       { value: TimeFormatters.formatTimeOfDay(accdate) },
       { value: this.getCollisionFactorCode('acclass', acclass) },
@@ -249,6 +258,7 @@ class ReportCollisionDirectory extends ReportBaseCrash {
       header: [
         [
           { value: 'MVCR', style: { br: true } },
+          { value: 'Data', style: { br: true } },
           { value: null },
           { value: null },
           { value: 'Acc' },
@@ -266,6 +276,7 @@ class ReportCollisionDirectory extends ReportBaseCrash {
           { value: 'MV' },
         ], [
           { value: 'Number', style: { br: true } },
+          { value: 'Src', style: { br: true } },
           { value: 'Date' },
           { value: 'Time' },
           { value: 'Cla' },


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-419](https://move-toronto.atlassian.net/browse/MOVE-419)

# Description
**Note: this feature requires the latest db** - [see info](https://www.notion.so/bditto/MOVE-Developer-Handbook-182de05ad8a94888b52ccc68093a497a?pvs=4#7742122d620f4b688191cccb882fdb68)
Added the collision data source (src) to the Collision Directory Report. I added it between the MVCR Number and the Collision details (its easy to move, if this is not the best place for it):

![Capture](https://github.com/CityofToronto/bdit_flashcrow/assets/5003768/bb699433-1bf9-49ad-9651-87e44a7b559d)

[COLLISION_DIRECTORY_BATHURST_ST_LAKE_SHORE_BLVD_W_s1_AQdwmB_POINTS_a771de83 (2).pdf](https://github.com/CityofToronto/bdit_flashcrow/files/14876983/COLLISION_DIRECTORY_BATHURST_ST_LAKE_SHORE_BLVD_W_s1_AQdwmB_POINTS_a771de83.2.pdf)
[COLLISION_DIRECTORY_BATHURST_ST_LAKE_SHORE_BLVD_W_s1_AQdwmB_POINTS_a771de83.csv](https://github.com/CityofToronto/bdit_flashcrow/files/14876984/COLLISION_DIRECTORY_BATHURST_ST_LAKE_SHORE_BLVD_W_s1_AQdwmB_POINTS_a771de83.csv)

# Tests
All existing unit tests pass, and I've validated that the data works when the data exists, and when it doesn't (see screenshots / files)
