### PR TITLE
(Update) MOVE-1100 - Export comments with request queue CSV export

### DIFF
--- a/lib/reports/ReportBaseTrackRequests.js
+++ b/lib/reports/ReportBaseTrackRequests.js
@@ -40,15 +40,30 @@ class ReportBaseTrackRequests extends ReportBase {
 
   async getStudyRequestComments(studyRequests) {
     const studyRequestComments = new Map();
-    studyRequests.forEach(async (studyRequest) => {
-      const commentList = [];
+    const distinctStudyRequests = [];
+    const studyIds = new Set();
+    studyRequests.forEach((studyRequest) => {
       const studyId = studyRequest.id;
-      const comments = await StudyRequestCommentDAO.byStudyRequest(studyRequest);
-      comments.forEach((commentObject) => {
-        commentList.push(commentObject.comment);
+      if (!studyIds.has(studyId)) {
+        studyIds.add(studyId);
+        distinctStudyRequests.push(studyRequest);
+      }
+    });
+
+    for (let i = 0; i < distinctStudyRequests.length; i++) {
+      const distinctStudyRequest = distinctStudyRequests[i];
+      const studyId = distinctStudyRequest.id;
+      const commentList = [];
+      /* eslint-disable-next-line no-await-in-loop */
+      const comments = await StudyRequestCommentDAO.byStudyRequest(distinctStudyRequest);
+      comments.forEach(({ comment }) => {
+        if (comment === null) {
+          return;
+        }
+        commentList.push(comment);
       });
       studyRequestComments.set(studyId, commentList);
-    });
+    }
     return studyRequestComments;
   }
 


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-1100](https://move-toronto.atlassian.net/browse/MOVE-1100)

# Description
Previous PR had a race collision that I got stuck trying to work around... so I rewrote this function, and mirrored it on the existing get functions... and it works!

# Tests
I tested in local with reports that had 1 comment, no comments, huge comments, deleted comments and verified that the project requests view is still functional.
