### PR TITLE
MOVE-239 - Track more metadata about granting/revoking permissions to MVCR_READ role

### DIFF
--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -742,8 +742,6 @@ async function putUser(auth, newUserData) {
       const deltas = {
         mvcrRemovedAt: DateTime.local(),
         mvcrRemovedBy: adminUser.id,
-        mvcrAddedAt: null,
-        mvcrAddedBy: null,
       };
       updatedUserData = { ...newUserData, ...deltas };
     } else if (!currentUserData.scope.includes(AuthScope.MVCR_READ)

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -6,6 +6,7 @@ import {
   ReportFormat,
   ReportType,
   StudyType,
+  AuthScope,
 } from '@/lib/Constants';
 import { mapBy } from '@/lib/MapUtils';
 import AxiosBackendClient from '@/lib/api/AxiosBackendClient';
@@ -728,15 +729,39 @@ async function putStudyRequestItems(csrf) {
   return response;
 }
 
-async function putUser(csrf, user) {
-  const { id: userId } = user;
+async function putUser(auth, newUserData) {
+  const { csrf, user: adminUser } = auth;
+  const { id: userId } = newUserData;
+  const currentUserMap = await getUsersByIds([userId]);
   const url = `/users/${userId}`;
+  let updatedUserData = newUserData;
+  const currentUserData = currentUserMap.entries().next().value[1];
+  if (currentUserData.scope.length !== newUserData.scope.length) {
+    if (currentUserData.scope.includes(AuthScope.MVCR_READ)
+      && !newUserData.scope.includes(AuthScope.MVCR_READ)) {
+      const deltas = {
+        mvcrRemovedAt: DateTime.local(),
+        mvcrRemovedBy: adminUser.id,
+        mvcrAddedAt: null,
+        mvcrAddedBy: null,
+      };
+      updatedUserData = { ...newUserData, ...deltas };
+    } else if (!currentUserData.scope.includes(AuthScope.MVCR_READ)
+      && newUserData.scope.includes(AuthScope.MVCR_READ)) {
+      const deltas = {
+        mvcrRemovedAt: null,
+        mvcrRemovedBy: null,
+        mvcrAddedAt: DateTime.local(),
+        mvcrAddedBy: adminUser.id,
+      };
+      updatedUserData = { ...newUserData, ...deltas };
+    }
+  }
   const options = {
     method: 'PUT',
     csrf,
-    data: user,
+    data: updatedUserData,
   };
-
   const persistedUser = await apiClient.fetch(url, options);
   return User.read.validateAsync(persistedUser);
 }

--- a/lib/db/UserDAO.js
+++ b/lib/db/UserDAO.js
@@ -115,7 +115,11 @@ UPDATE "users"
   SET
     "email" = $(email),
     "scope" = $(scope),
-    "uniqueName" = $(uniqueName)
+    "uniqueName" = $(uniqueName),
+    "mvcrAddedAt" = $(mvcrAddedAt),
+    "mvcrRemovedAt" = $(mvcrRemovedAt),
+    "mvcrAddedBy" = $(mvcrAddedBy),
+    "mvcrRemovedBy" = $(mvcrRemovedBy)
   WHERE "id" = $(id)`;
     await db.query(sql, user);
     return normalizeUser(user);

--- a/lib/model/User.js
+++ b/lib/model/User.js
@@ -11,5 +11,11 @@ export default {
     ).required(),
     sub: Joi.string().required(),
     uniqueName: Joi.string().required(),
+    mvcrAddedAt: Joi.dateTime().allow(null).default(null),
+    mvcrRemovedAt: Joi.dateTime().allow(null).default(null),
+    mvcrAddedBy: Joi.number().integer().positive().allow(null)
+      .default(null),
+    mvcrRemovedBy: Joi.number().integer().positive().allow(null)
+      .default(null),
   }),
 };

--- a/scripts/db/schema-26.down.sql
+++ b/scripts/db/schema-26.down.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+ALTER TABLE public.users
+DROP COLUMN "mvcrAddedAt",
+DROP COLUMN "mvcrRemovedAt",
+DROP COLUMN "mvcrAddedBy",
+DROP COLUMN "mvcrRemovedBy";
+
+UPDATE "APP_META"."DB_UPDATE" SET "currentVersion" = 25;
+COMMIT;

--- a/scripts/db/schema-26.up.sql
+++ b/scripts/db/schema-26.up.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+ALTER TABLE public.users
+ADD "mvcrAddedAt" TIMESTAMP,
+ADD "mvcrRemovedAt" TIMESTAMP,
+ADD "mvcrAddedBy" BIGINT,
+ADD "mvcrRemovedBy" BIGINT;
+
+UPDATE "APP_META"."DB_UPDATE" SET "currentVersion" = 26;
+COMMIT;

--- a/web/components/admin/FcAdminPermissions.vue
+++ b/web/components/admin/FcAdminPermissions.vue
@@ -18,7 +18,7 @@
             sort-by="UNIQUE_NAME"
             :sort-desc="false"
             :sort-keys="sortKeys">
-            <template v-slot:item.UNIQUE_NAME="{ item }">
+            <template v-slot:[`item.UNIQUE_NAME`]="{ item }">
               <span>{{item | username}}</span>
             </template>
             <template
@@ -136,7 +136,7 @@ export default {
   methods: {
     async actionChangeUserScope(user) {
       this.loadingChangeUserScope = true;
-      await putUser(this.auth.csrf, user);
+      await putUser(this.auth, user);
       this.loadingChangeUserScope = false;
     },
     async getPage(page) {

--- a/web/components/admin/FcAdminPermissions.vue
+++ b/web/components/admin/FcAdminPermissions.vue
@@ -98,9 +98,9 @@ export default {
         value: 'UNIQUE_NAME',
         text: 'User',
       },
-      ...AuthScope.enumValues.map(({ name }) => ({
+      ...AuthScope.enumValues.map(({ name, description }) => ({
         value: name,
-        text: name,
+        text: description,
       })),
     ];
     const sortKeys = {


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-239](https://move-toronto.atlassian.net/browse/MOVE-239)

# Description
This adds four columns to the users table, and populates it when an admin gives or revokes a user's MVCR_READ permissions.

I’ve added:

- `mvcrAddedAt`: When (DateTime) the role is granted
- `mvcrRemovedAt`: When (DateTime) the role is revoked
- `mvcrAddedBy`: Who (user id) granted the role
- `mvcrRemovedB`: Who (user id) revoked the role

For clarity of the data, adding permissions to a user who had them revoked previously will clear out the previous revocation information. Ex:

- userA has the MVCR_READ permission. It was given by adminA on DateA. The JSON representation of the database entry for userA will look like:

```
{
  "id":3,
  "createdAt":"2024-04-11 16:56:45.120",
  "email":"tops01@o365.sandbox-toronto.ca",
  "sub":"23iZ6yetpZiubK7IbaD0+TATyLJL3RDLJ6CsjvdXUho=",
  "uniqueName":"CHILD\\tops01",
  "scope":["STUDY_REQUESTS","MVCR_READ"],
  "mvcrAddedAt":"2022-04-12 13:13:51.152",
  "mvcrRemovedAt":null,
  "mvcrAddedBy":2,
  "mvcrRemovedBy":null
}
```

- On DateB, adminB revokes the MVCR_READ permission of userA. The JSON representation of the database entry for userA will look like:

```
{
  "id":3,
  "createdAt":"2024-04-11 16:56:45.120",
  "email":"tops01@o365.sandbox-toronto.ca",
  "sub":"23iZ6yetpZiubK7IbaD0+TATyLJL3RDLJ6CsjvdXUho=",
  "uniqueName":"CHILD\\tops01",
  "scope":["STUDY_REQUESTS"],
  "mvcrAddedAt":"2022-04-12 13:13:51.152",
  "mvcrRemovedAt":"2023-05-12 09:15:57.340",
  "mvcrAddedBy":2,
  "mvcrRemovedBy":4
}
```
- On DateC, adminC adds the MVCR_READ permission of userA. The JSON representation of the database entry for userA will look like:
```
{
  "id":3,
  "createdAt":"2024-04-11 16:56:45.120",
  "email":"tops01@o365.sandbox-toronto.ca",
  "sub":"23iZ6yetpZiubK7IbaD0+TATyLJL3RDLJ6CsjvdXUho=",
  "uniqueName":"CHILD\\tops01",
  "scope":["STUDY_REQUESTS"],
  "mvcrAddedAt":"2024-04-12 09:13:51.152",
  "mvcrRemovedAt":null,
  "mvcrAddedBy":2,
  "mvcrRemovedBy":null
}
```
# Tests
All existing test are passing, and I have successfully added and revoked the MVCR_READ permissions of users with various other permissions. I have also added new users, and tested that one admin can add the permission, and another can remove it...
