### PR TITLE
Move 1128: UI Error states and miscellaneous fixes

### DIFF
--- a/lib/io/CompositeId.js
+++ b/lib/io/CompositeId.js
@@ -73,10 +73,12 @@ class CompositeId {
     const bitStream = new BitStream(bytes);
 
     for (let i = 0; i < n; i++) {
-      const { centrelineId, centrelineType } = features[i];
-      const featureType = centrelineType === CentrelineType.INTERSECTION ? 0 : 1;
-      bitStream.write(1, featureType);
-      bitStream.write(CompositeId.BITS_PER_FEATURE - 1, centrelineId);
+      if (features[i]) {
+        const { centrelineId, centrelineType } = features[i];
+        const featureType = centrelineType === CentrelineType.INTERSECTION ? 0 : 1;
+        bitStream.write(1, featureType);
+        bitStream.write(CompositeId.BITS_PER_FEATURE - 1, centrelineId);
+      }
     }
 
     const str = bitStream.toString();

--- a/lib/reports/ReportCountSummary24h.js
+++ b/lib/reports/ReportCountSummary24h.js
@@ -400,6 +400,7 @@ class ReportCountSummary24h extends ReportBaseFlow {
   }
 
   static getSectionLayout(countLocation, section) {
+    console.log(countLocation, section); // eslint-disable-line no-console
     const {
       title: sectionTitle,
       directionGroups,
@@ -413,6 +414,7 @@ class ReportCountSummary24h extends ReportBaseFlow {
         directionGroup,
       )),
     );
+    console.log(body); // eslint-disable-line no-console
     const footer = ReportCountSummary24h.getSectionFooter(sectionTitle, totals);
     return { header, body, footer };
   }

--- a/lib/reports/ReportCountSummary24h.js
+++ b/lib/reports/ReportCountSummary24h.js
@@ -400,7 +400,6 @@ class ReportCountSummary24h extends ReportBaseFlow {
   }
 
   static getSectionLayout(countLocation, section) {
-    console.log(countLocation, section); // eslint-disable-line no-console
     const {
       title: sectionTitle,
       directionGroups,
@@ -414,7 +413,6 @@ class ReportCountSummary24h extends ReportBaseFlow {
         directionGroup,
       )),
     );
-    console.log(body); // eslint-disable-line no-console
     const footer = ReportCountSummary24h.getSectionFooter(sectionTitle, totals);
     return { header, body, footer };
   }

--- a/web/App.vue
+++ b/web/App.vue
@@ -37,6 +37,7 @@ import FcDialogAlertStudyTypeUnactionable
 import FcDialogConfirmUnauthorized
   from '@/web/components/dialogs/FcDialogConfirmUnauthorized.vue';
 import FcToastBackendError from '@/web/components/dialogs/FcToastBackendError.vue';
+import FcToastEnrichedError from '@/web/components/dialogs/FcToastEnrichedError.vue';
 import FcToastError from '@/web/components/dialogs/FcToastError.vue';
 import FcToastInfo from '@/web/components/dialogs/FcToastInfo.vue';
 import FcToastJob from '@/web/components/dialogs/FcToastJob.vue';
@@ -57,6 +58,7 @@ export default {
     FcNavbar,
     FcToastBackendError,
     FcToastError,
+    FcToastEnrichedError,
     FcToastInfo,
     FcToastJob,
     FcToastMvcrJob,

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -112,16 +112,13 @@
             This page is loading, please wait.
           </div>
         </div>
-         <div class="callout ma-3" v-if="reportRetrievalError">
-          <div class="ma-3">
-            <v-icon color="blue">mdi-information</v-icon>
-          </div>
-          <div class="ml-1 mr-2 pa-2">
-            There was a problem loading this report.
+        <FcCallout v-if="reportRetrievalError"
+        type="error-callout"
+        iconColor="black"
+        >There was a problem loading this report.
             If you need this data urgently,
-            email <a href="mailto:move-team@toronto.ca">us</a>.
-          </div>
-        </div>
+            email&nbsp;<a href='mailto:move-team@toronto.ca'>us</a>.
+        </FcCallout>
         <div
           v-else
           class="fc-report-wrapper pa-3">
@@ -167,12 +164,14 @@ import FcListLocationMulti from '@/web/components/location/FcListLocationMulti.v
 import FcReport from '@/web/components/reports/FcReport.vue';
 import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
 import DateTime from '@/lib/time/DateTime';
+import FcCallout from '@/web/components/dialogs/FcCallout.vue';
 
 export default {
   name: 'FcDrawerViewCollisionReports',
   mixins: [FcMixinRouteAsync, FcMixinAuthScope],
   components: {
     FcButton,
+    FcCallout,
     FcDialogConfirm,
     FcIconLocationMulti,
     FcListLocationMulti,

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -66,6 +66,7 @@
             <v-tabs v-model="indexActiveReportType">
               <v-tab
                 v-for="reportType in reportTypes"
+                :disabled="reportRetrievalError"
                 :key="reportType.name">
                 {{reportType.label}}
               </v-tab>
@@ -88,6 +89,7 @@
 
           <div class="mr-3">
             <FcMenuDownloadReportFormat
+              :disabled="reportRetrievalError"
               :loading="loadingDownload"
               :report-type="activeReportType"
               text-screen-reader="Collision Report"
@@ -108,6 +110,15 @@
             class="ma-3" />
           <div class="font-weight-regular headline secondary--text">
             This page is loading, please wait.
+          </div>
+        </div>
+        <div
+          v-else-if="reportRetrievalError"
+          class="ma-3 text-center">
+          <div class="font-weight-regular headline secondary--text mt-12">
+            There was a problem loading this report.
+            Email the <a href="mailto:move-team@toronto.ca">MOVE team</a> if you need
+            this data urgently.
           </div>
         </div>
         <div
@@ -179,6 +190,7 @@ export default {
       loadingReportLayout: false,
       nextRoute: null,
       reportLayout: null,
+      reportRetrievalError: false,
       reportTypes: [
         ReportType.COLLISION_DIRECTORY,
         ReportType.COLLISION_TABULATION,
@@ -375,6 +387,11 @@ export default {
 
       return true;
     },
+    handleError(err) {
+      this.reportRetrievalError = true;
+      this.loadingReportLayout = false;
+      this.setToastError(`${err}`);
+    },
     async loadAsyncForRoute(to) {
       const { s1, selectionTypeName } = to.params;
       const features = CompositeId.decode(s1);
@@ -403,7 +420,7 @@ export default {
         this.activeReportType,
         this.activeReportId,
         this.filterParamsCollision,
-      );
+      ).catch(err => this.handleError(err));
       this.reportLayout = reportLayout;
 
       this.loadingReportLayout = false;
@@ -452,7 +469,7 @@ export default {
       if (Array.isArray(headerRows)) row = headerRows[index];
       return row;
     },
-    ...mapMutations(['setLocationsIndex', 'setToast']),
+    ...mapMutations(['setLocationsIndex', 'setToast', 'setToastError']),
     ...mapMutations('viewData', ['setFiltersCollision', 'setFiltersCommon']),
     ...mapActions(['initLocations']),
   },

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -208,7 +208,7 @@ export default {
       return this.hasAuthScope(AuthScope.MVCR_READ);
     },
     activeReportId() {
-      if (this.locationMode === LocationMode.SINGLE || this.detailView) {
+      if ((this.locationMode === LocationMode.SINGLE || this.detailView)) {
         const s1 = CompositeId.encode(this.locationsActive);
         const selectionType = LocationSelectionType.POINTS;
         return `${s1}/${selectionType.name}`;
@@ -423,9 +423,9 @@ export default {
         this.activeReportId,
         this.filterParamsCollision,
       ).catch(err => this.handleError(err));
-      this.reportLayout = reportLayout;
-
       this.loadingReportLayout = false;
+
+      this.reportLayout = reportLayout;
     },
     parseFiltersFromRouteParams() {
       const routeParams = this.$route.params;

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -113,8 +113,10 @@
           </div>
         </div>
         <FcCallout v-if="reportRetrievalError"
+        icon="mdi-alert-circle"
+        iconColor="white"
+        textColor="white"
         type="error-callout"
-        iconColor="black"
         >There was a problem loading this report.
             If you need this data urgently,
             email&nbsp;<a href='mailto:move-team@toronto.ca'>us</a>.
@@ -390,7 +392,7 @@ export default {
     handleError(err) {
       this.reportRetrievalError = true;
       this.loadingReportLayout = false;
-      this.setToastError(`${err}`);
+      this.setToastError(err);
     },
     async loadAsyncForRoute(to) {
       const { s1, selectionTypeName } = to.params;

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -208,7 +208,7 @@ export default {
       return this.hasAuthScope(AuthScope.MVCR_READ);
     },
     activeReportId() {
-      if ((this.locationMode === LocationMode.SINGLE || this.detailView)) {
+      if (this.locationMode === LocationMode.SINGLE || this.detailView) {
         const s1 = CompositeId.encode(this.locationsActive);
         const selectionType = LocationSelectionType.POINTS;
         return `${s1}/${selectionType.name}`;

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -112,13 +112,14 @@
             This page is loading, please wait.
           </div>
         </div>
-        <div
-          v-else-if="reportRetrievalError"
-          class="ma-3 text-center">
-          <div class="font-weight-regular headline secondary--text mt-12">
+         <div class="callout ma-3" v-if="reportRetrievalError">
+          <div class="ma-3">
+            <v-icon color="blue">mdi-information</v-icon>
+          </div>
+          <div class="ml-1 mr-2 pa-2">
             There was a problem loading this report.
-            Email the <a href="mailto:move-team@toronto.ca">MOVE team</a> if you need
-            this data urgently.
+            If you need this data urgently,
+            email <a href="mailto:move-team@toronto.ca">us</a>.
           </div>
         </div>
         <div

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -75,7 +75,7 @@
 
           <v-spacer></v-spacer>
 
-          <template v-if="!loadingReportLayout">
+          <template v-if="!loadingReportLayout && !reportRetrievalError">
             <div v-if="isDirectoryReport && userLoggedIn
               && userHasMvcrReadPermission && mvcrCount > 0">
               <FcButton
@@ -392,7 +392,7 @@ export default {
     handleError(err) {
       this.reportRetrievalError = true;
       this.loadingReportLayout = false;
-      this.setToastError(err);
+      this.setToastError(err.message);
     },
     async loadAsyncForRoute(to) {
       const { s1, selectionTypeName } = to.params;

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -137,17 +137,14 @@
             Report not available, try a different location.
           </div>
         </div>
-        <div class="callout ma-3" v-else-if="studyRetrievalError ||
-        (this.reportLayout !== null && this.reportLayout.content[0].options?.body?.length === 0)">
-          <div class="ma-3">
-            <v-icon color="blue">mdi-information</v-icon>
-          </div>
-          <div class="ml-1 mr-2 pa-2">
-            There was a problem loading this report.
+        <FcCallout v-else-if="studyRetrievalError ||
+        (this.reportLayout !== null && this.reportLayout.content[0].options?.body?.length === 0)"
+        type="error-callout"
+        iconColor="black"
+        >There was a problem loading this report.
             If you need this data urgently,
-            email <a href="mailto:move-team@toronto.ca">us</a>.
-          </div>
-        </div>
+            email&nbsp;<a href='mailto:move-team@toronto.ca'>us</a>.
+        </FcCallout>
         <div
           v-else
           class="fc-report-wrapper pa-3">
@@ -194,12 +191,14 @@ import FcListLocationMulti from '@/web/components/location/FcListLocationMulti.v
 import FcReport from '@/web/components/reports/FcReport.vue';
 import FcReportParameters from '@/web/components/reports/FcReportParameters.vue';
 import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
+import FcCallout from '@/web/components/dialogs/FcCallout.vue';
 
 export default {
   name: 'FcDrawerViewStudyReports',
   mixins: [FcMixinRouteAsync],
   components: {
     FcButton,
+    FcCallout,
     FcDialogConfirm,
     FcIconLocationMulti,
     FcListLocationMulti,

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -137,13 +137,15 @@
             Report not available, try a different location.
           </div>
         </div>
-        <div
-          v-else-if="studyRetrievalError || reportBodyEmpty"
-          class="ma-3 text-center">
-          <div class="font-weight-regular headline secondary--text mt-12">
+        <div class="callout ma-3" v-else-if="studyRetrievalError ||
+        (this.reportLayout !== null && this.reportLayout.content[0].options?.body?.length === 0)">
+          <div class="ma-3">
+            <v-icon color="blue">mdi-information</v-icon>
+          </div>
+          <div class="ml-1 mr-2 pa-2">
             There was a problem loading this report.
-            Email the <a href="mailto:move-team@toronto.ca">MOVE team</a> if you need
-            this data urgently.
+            If you need this data urgently,
+            email <a href="mailto:move-team@toronto.ca">us</a>.
           </div>
         </div>
         <div

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -137,10 +137,10 @@
             Report not available, try a different location.
           </div>
         </div>
-        <FcCallout v-else-if="studyRetrievalError ||
-        (this.reportLayout !== null && this.reportLayout.content[0].options?.body?.length === 0)"
+        <FcCallout v-else-if="studyRetrievalError || reportBodyEmpty"
+        icon="mdi-alert-circle"
+        iconColor="white"
         type="error-callout"
-        iconColor="black"
         >There was a problem loading this report.
             If you need this data urgently,
             email&nbsp;<a href='mailto:move-team@toronto.ca'>us</a>.

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -82,7 +82,7 @@
 
         <div class="align-center d-flex">
           <nav>
-            <v-tabs v-model="indexActiveReportType">
+            <v-tabs v-if="!error" v-model="indexActiveReportType">
               <v-tab
                 v-for="reportType in reportTypes"
                 :key="reportType.name"
@@ -103,6 +103,7 @@
           </FcButton>
           <div class="mr-3">
             <FcMenuDownloadReportFormat
+              :disabled="error"
               :loading="loadingDownload"
               :report-type="activeReportType"
               text-screen-reader="Study Report"
@@ -135,6 +136,9 @@
           <div class="font-weight-regular headline secondary--text">
             Report not available, try a different location.
           </div>
+        </div>
+        <div v-else-if="error">
+          Report broken, please contact the move team.
         </div>
         <div
           v-else
@@ -208,6 +212,7 @@ export default {
       reportUserParameters[name] = defaultParameters;
     });
     return {
+      error: false,
       indexActiveReportType: 0,
       indexActiveStudy: 0,
       leaveConfirmed: false,
@@ -455,6 +460,11 @@ export default {
         activeReportId,
         reportParameters,
       );
+      if (1 < 2) {
+        this.error = true;
+        this.loadingReportLayout = false;
+        throw new Error();
+      }
       this.reportLayout = reportLayout;
 
       this.loadingReportLayout = false;

--- a/web/components/dialogs/FcCallout.vue
+++ b/web/components/dialogs/FcCallout.vue
@@ -30,13 +30,13 @@ export default {
 .error-callout {
     display: flex;
     align-items: center;
-    background-color: #ff0606c0;
+    background-color: #e7000077;
     color: #ffff;
     border-radius: 5px;
     min-height: 60px;
     font-size: 18px;
     & > a {
-      color: black;
+      font-weight: bold;
     }
   }
 </style>

--- a/web/components/dialogs/FcCallout.vue
+++ b/web/components/dialogs/FcCallout.vue
@@ -1,7 +1,7 @@
 <template>
   <div :class="type">
           <div class="ma-3">
-            <v-icon :color="iconColor">mdi-information</v-icon>
+            <v-icon :color="iconColor">{{ icon }}</v-icon>
           </div>
           <slot class="ml-1 mr-2 pa-2">
            Error getting data
@@ -18,9 +18,10 @@
 export default {
   name: 'FcCallout',
   props: {
-    type: String,
-    iconColor: String,
     calloutMessage: String,
+    icon: String,
+    iconColor: String,
+    type: String,
   },
 };
 </script>
@@ -29,10 +30,13 @@ export default {
 .error-callout {
     display: flex;
     align-items: center;
-    background-color: #ff06064f;
-    color: black;
+    background-color: #ff0606e7;
+    color: #ffff;
     border-radius: 5px;
     min-height: 60px;
-    font-size: 16px;
+    font-size: 18px;
+    & > a {
+      color: black;
+    }
   }
 </style>

--- a/web/components/dialogs/FcCallout.vue
+++ b/web/components/dialogs/FcCallout.vue
@@ -1,0 +1,38 @@
+<template>
+  <div :class="type">
+          <div class="ma-3">
+            <v-icon :color="iconColor">mdi-information</v-icon>
+          </div>
+          <slot class="ml-1 mr-2 pa-2">
+           Error getting data
+          </slot>
+        </div>
+</template>
+
+<script>
+
+/* This is a generic 'callout' component. We can set our
+ * class, callout icon color, and callout message via props
+*/
+
+export default {
+  name: 'FcCallout',
+  props: {
+    type: String,
+    iconColor: String,
+    calloutMessage: String,
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.error-callout {
+    display: flex;
+    align-items: center;
+    background-color: #ff06064f;
+    color: black;
+    border-radius: 5px;
+    min-height: 60px;
+    font-size: 16px;
+  }
+</style>

--- a/web/components/dialogs/FcCallout.vue
+++ b/web/components/dialogs/FcCallout.vue
@@ -30,7 +30,7 @@ export default {
 .error-callout {
     display: flex;
     align-items: center;
-    background-color: #ff0606e7;
+    background-color: #ff0606c0;
     color: #ffff;
     border-radius: 5px;
     min-height: 60px;

--- a/web/components/dialogs/FcToast.vue
+++ b/web/components/dialogs/FcToast.vue
@@ -8,6 +8,7 @@
     :timeout="timeout">
     <slot name="icon"></slot>
     <span class="body-1">{{text}}</span>
+    <span class="body-1" v-html="html"></span>
     <template v-slot:action="{ attrs }">
       <FcButton
         v-if="action !== null"
@@ -57,6 +58,7 @@ export default {
       type: String,
       default: 'black',
     },
+    html: String,
     loading: {
       type: Boolean,
       default: false,

--- a/web/components/dialogs/FcToastEnrichedError.vue
+++ b/web/components/dialogs/FcToastEnrichedError.vue
@@ -1,0 +1,27 @@
+<template>
+  <FcToast
+    v-model="internalValue"
+    color="error"
+    :html="html"
+    >
+    <template v-slot:icon>
+      <v-icon left>mdi-alert-circle</v-icon>
+    </template>
+  </FcToast>
+</template>
+
+<script>
+import FcToast from '@/web/components/dialogs/FcToast.vue';
+import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+
+export default {
+  name: 'FcToastEnrichedError',
+  mixins: [FcMixinVModelProxy(Boolean)],
+  components: {
+    FcToast,
+  },
+  props: {
+    html: String,
+  },
+};
+</script>

--- a/web/components/geo/map/FcMapPopup.vue
+++ b/web/components/geo/map/FcMapPopup.vue
@@ -170,11 +170,11 @@ export default {
         this.featureDetails = await getFeatureDetails(this.layerId, this.feature);
       } catch (err) {
         this.error = true;
-        this.setToastBackendError(err);
+        this.setToastEnrichedError('<span>Tooltip failed to load. If you have questions, email <a href="mailto:move-team@toronto.ca">the MOVE team</a></span>');
       }
       this.loading = false;
     },
-    ...mapMutations(['setToastBackendError']),
+    ...mapMutations(['setToastEnrichedError']),
   },
 };
 </script>

--- a/web/components/geo/map/FcMapPopup.vue
+++ b/web/components/geo/map/FcMapPopup.vue
@@ -170,7 +170,7 @@ export default {
         this.featureDetails = await getFeatureDetails(this.layerId, this.feature);
       } catch (err) {
         this.error = true;
-        this.setToastEnrichedError('<span>Tooltip failed to load. If you have questions, email <a href="mailto:move-team@toronto.ca">the MOVE team</a></span>');
+        this.setToastEnrichedError('<span>Tooltip failed to load. If you have questions, email <a style="color:white; font-weight:bold" href="mailto:move-team@toronto.ca">the MOVE team</a></span>');
       }
       this.loading = false;
     },

--- a/web/components/geo/map/FcMapPopup.vue
+++ b/web/components/geo/map/FcMapPopup.vue
@@ -11,6 +11,11 @@
         <FcProgressLinear
           v-if="loading"
           aria-label="Loading feature details" />
+        <p v-else-if="error">
+          <component
+          :is="'FcPopupDetails' + 'Error'"
+          />
+        </p>
         <component
           v-else
           :is="'FcPopupDetails' + detailsSuffix"
@@ -26,6 +31,7 @@
 
 <script>
 import maplibregl from 'maplibre-gl/dist/maplibre-gl';
+import { mapMutations } from 'vuex';
 
 import { getGeometryMidpoint } from '@/lib/geo/GeometryUtils';
 import { getFeatureDetails, getFeatureDetailsSuffix } from '@/lib/geo/map/PopupDetails';
@@ -35,6 +41,7 @@ import FcPopupDetailsHospital from '@/web/components/geo/map/FcPopupDetailsHospi
 import FcPopupDetailsLocation from '@/web/components/geo/map/FcPopupDetailsLocation.vue';
 import FcPopupDetailsSchool from '@/web/components/geo/map/FcPopupDetailsSchool.vue';
 import FcPopupDetailsStudy from '@/web/components/geo/map/FcPopupDetailsStudy.vue';
+import FcPopupDetailsError from '@/web/components/geo/map/FcPopupDetailsError.vue';
 
 const SELECTABLE_LAYERS = [
   'studies',
@@ -51,6 +58,7 @@ export default {
     FcPopupDetailsSchool,
     FcPopupDetailsStudy,
     FcProgressLinear,
+    FcPopupDetailsError,
   },
   props: {
     feature: Object,
@@ -65,6 +73,7 @@ export default {
     return {
       featureDetails: null,
       loading: true,
+      error: false,
     };
   },
   computed: {
@@ -155,10 +164,17 @@ export default {
       });
     },
     async loadAsyncForFeature() {
+      this.error = false;
       this.loading = true;
-      this.featureDetails = await getFeatureDetails(this.layerId, this.feature);
+      try {
+        this.featureDetails = await getFeatureDetails(this.layerId, this.feature);
+      } catch (err) {
+        this.error = true;
+        this.setToastBackendError(err);
+      }
       this.loading = false;
     },
+    ...mapMutations(['setToastBackendError']),
   },
 };
 </script>

--- a/web/components/geo/map/FcPopupDetailsError.vue
+++ b/web/components/geo/map/FcPopupDetailsError.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    <p>
+      There was a problem loading this information.
+      The MOVE Team has been notified. Email
+      <a href="mailto:move-team@toronto.ca">move-team@toronto.ca</a> if you have questions.
+    </p>
+  </div>
+</template>
+
+<script>
+
+export default {
+  name: 'FcPopupDetailsError',
+};
+</script>

--- a/web/components/geo/map/FcPopupDetailsError.vue
+++ b/web/components/geo/map/FcPopupDetailsError.vue
@@ -1,9 +1,8 @@
 <template>
   <div>
-    <p>
+    <p class="pa-1">
       There was a problem loading this information.
-      The MOVE Team has been notified. Email
-      <a href="mailto:move-team@toronto.ca">move-team@toronto.ca</a> if you have questions.
+      Contact the MOVE team for assistance.
     </p>
   </div>
 </template>

--- a/web/components/inputs/FcMenuDownloadReportFormat.vue
+++ b/web/components/inputs/FcMenuDownloadReportFormat.vue
@@ -5,6 +5,7 @@
         v-bind="attrs"
         v-on="on"
         class="ml-2"
+        :disabled="disabled"
         :loading="loading"
         :scope="requireAuth ? [] : null"
         :type="type">
@@ -50,6 +51,10 @@ export default {
     FcButton,
   },
   props: {
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
     loading: {
       type: Boolean,
       default: false,

--- a/web/components/reports/FcReportHeader.vue
+++ b/web/components/reports/FcReportHeader.vue
@@ -9,7 +9,7 @@
     <div class="ml-3">
       <div class="title">{{ORG_NAME}}</div>
       <h3 class="display-1">
-        <span>{{type.label}}</span>
+        <span v-if="type">{{type.label}}</span>
         <span class="sr-only">{{info}}</span>
         <span class="sr-only">{{subinfo}}</span>
       </h3>

--- a/web/components/reports/FcReportHeader.vue
+++ b/web/components/reports/FcReportHeader.vue
@@ -1,15 +1,15 @@
 <template>
-  <header class="fc-report-header align-center d-flex">
+  <header v-if="type" class="fc-report-header align-center d-flex">
     <div>
       <img
         alt="City of Toronto"
         src="/cot_logo.png"
         width="175" />
     </div>
-    <div class="ml-3">
-      <div class="title">{{ORG_NAME}}</div>
+    <div v-if="type" class="ml-3">
+      <div  class="title">{{ORG_NAME}}</div>
       <h3 class="display-1">
-        <span v-if="type">{{type.label}}</span>
+        <span>{{type.label}}</span>
         <span class="sr-only">{{info}}</span>
         <span class="sr-only">{{subinfo}}</span>
       </h3>

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -222,6 +222,11 @@ export default new Vuex.Store({
       Vue.set(state, 'toastData', { text });
       Vue.set(state, 'toastKey', state.toastKey + 1);
     },
+    setToastEnrichedError(state, html) {
+      Vue.set(state, 'toast', 'EnrichedError');
+      Vue.set(state, 'toastData', { html });
+      Vue.set(state, 'toastKey', state.toastKey + 1);
+    },
     setToastInfo(state, text) {
       Vue.set(state, 'toast', 'Info');
       Vue.set(state, 'toastData', { text });


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-1113](https://move-toronto.atlassian.net/browse/MOVE-1113) and [MOVE-1128](https://move-toronto.atlassian.net/browse/MOVE-1128)

# Description
With some basic error handling on collisions and reports added at the server level, we need to handle corresponding errors on the front. This PR adds the following:

- A new 'enriched' error toast component that allows devs to add HTML to a toast message
- Enriched toasts being rendered when a report fails to load (collision director / counts)
- Regular error toasts being rendered on a failed popup on the main map UI
- Popups rendering an error message on a failed load
- An error callout being rendered on a failed report
- Report tabs and buttons being disabled on failed report load
- Console errors thrown in CompositeId class are now gone
- A new FcCallout component that abstracts the callouts out of other  components

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/26462466/c4a245b2-fc8d-4193-bc7d-4dd3396c1d53)

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/26462466/0b24bbf7-9803-4922-a1dc-f1316f6d0263)

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/26462466/edf6f21f-9d5f-4bae-9b0c-c2962b5d3110)

# Tests
Tested by breaking some data and trying to load those reports
Tested a location with multiple ATR's to see that those multiple report options are still presented to the user.
