### PR TITLE
MOVE-1140: MVCR images not loading

### DIFF
--- a/web/components/reports/FcReportTable.vue
+++ b/web/components/reports/FcReportTable.vue
@@ -52,7 +52,7 @@
             <MvcrLink v-if="mvcrImgColumnIndex === c"
               :value="value"
               :collisionId="row[0].value"
-              :collisionIsoDateArray="row[1].value.split('-')"
+              :collisionIsoDateArray="row[2].value.split('-')"
               @showMvcrAccessDialog="showMvcrAccessDialog = !showMvcrAccessDialog"
               @showMvcrNotFoundAlert="showMvcrNotFoundAlert = !showMvcrNotFoundAlert"
             />


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-1140.

# Description
Changed which column in the Collision Directory Report is used to create parameters for fetching MVCR images. Previously, the second column was used, which is now the data source column. Now, the third column is used, which is the date column.

# Tests
Tested in MOVE local v.1.11.1 in Mozilla Firefox using dummy pdf.
