### PR TITLE
MOVE-108 - Analysts need to see multi-day, multi-direction speed studies so they can plug this data into their modelling software

### DIFF
--- a/lib/reports/ReportSpeedPercentile.js
+++ b/lib/reports/ReportSpeedPercentile.js
@@ -214,7 +214,14 @@ class ReportSpeedPercentile extends ReportBaseFlow {
         reportData.push({ date, direction: null, stats });
       }
     }
-
+    if (counts.length > 1) {
+      const groupCountData = Array.prototype.concat.apply(
+        [],
+        countTuples.map(({ countData }) => countData),
+      );
+      const stats = ReportSpeedPercentile.transformCountData(groupCountData);
+      reportData.push({ date: null, direction: null, stats });
+    }
     return reportData;
   }
 
@@ -340,9 +347,13 @@ class ReportSpeedPercentile extends ReportBaseFlow {
   }
 
   static getCountMetadataOptions({ date, direction, stats }) {
-    const dateStr = TimeFormatters.formatDefault(date);
-    const dayOfWeekStr = TimeFormatters.formatDayOfWeek(date);
-    const fullDateStr = `${dateStr} (${dayOfWeekStr})`;
+    let fullDateStr = 'All Dates';
+    if (date) {
+      const dateStr = TimeFormatters.formatDefault(date);
+      const dayOfWeekStr = TimeFormatters.formatDayOfWeek(date);
+      fullDateStr = `${dateStr} (${dayOfWeekStr})`;
+    }
+
     const directionStr = direction === null ? 'All Directions' : direction.bound;
     const { totalStats } = stats;
     return {

--- a/lib/reports/ReportSpeedPercentile.js
+++ b/lib/reports/ReportSpeedPercentile.js
@@ -203,11 +203,11 @@ class ReportSpeedPercentile extends ReportBaseFlow {
       groupCounts.forEach(({ count, countData }) => {
         const { date } = count;
         const stats = ReportSpeedPercentile.transformCountData(countData);
-        reportData.push({ date, direction: parsedDirection, stats });
+        reportData.push({ date, direction: direction.bound, stats });
       });
     });
 
-    const reportDirections = [...reportDirectionsSet].join(' | ');
+    const reportDirections = `All Directions (${[...reportDirectionsSet].join(', ')})`;
 
     if (numDirections > 1) {
       for (let date = study.startDate; date <= study.endDate; date = date.plus({ days: 1 })) {
@@ -303,7 +303,7 @@ class ReportSpeedPercentile extends ReportBaseFlow {
     pct85,
     pct95,
   }, h) {
-    const dateStr = date === null ? ' ' : TimeFormatters.formatDefault(date);
+    const dateStr = date === null ? '00:00' : TimeFormatters.formatDefault(date);
     const hourHuman = h === 0 ? dateStr : hoursHuman[h];
     const shade = h % 2 === 1;
     return [

--- a/lib/reports/ReportSpeedPercentile.js
+++ b/lib/reports/ReportSpeedPercentile.js
@@ -240,7 +240,6 @@ class ReportSpeedPercentile extends ReportBaseFlow {
 
     const rows = [];
     reportData.forEach(({ date, direction, stats }) => {
-      const { year, month, day } = date;
       const { countDataByHour } = stats;
       countDataByHour.forEach(({
         volume,
@@ -251,12 +250,12 @@ class ReportSpeedPercentile extends ReportBaseFlow {
         pct95,
         mu,
       }, hour) => {
-        const time = DateTime.fromObject({
-          year,
-          month,
-          day,
+        const time = date ? DateTime.fromObject({
+          year: date.year,
+          month: date.month,
+          day: date.day,
           hour,
-        });
+        }) : `All Study Days ${hour}:00`;
         const fields = {
           time,
           direction,

--- a/lib/reports/ReportSpeedPercentile.js
+++ b/lib/reports/ReportSpeedPercentile.js
@@ -189,19 +189,25 @@ class ReportSpeedPercentile extends ReportBaseFlow {
     });
 
     const reportData = [];
+    const reportDirectionsSet = new Set();
 
     let numDirections = 0;
     CardinalDirection.enumValues.forEach((direction) => {
+      let parsedDirection = null;
       const groupCounts = countTuples.filter(({ count }) => count.direction === direction);
       if (groupCounts.length > 0) {
         numDirections += 1;
+        parsedDirection = `${direction.short}B`;
+        reportDirectionsSet.add(parsedDirection);
       }
       groupCounts.forEach(({ count, countData }) => {
         const { date } = count;
         const stats = ReportSpeedPercentile.transformCountData(countData);
-        reportData.push({ date, direction, stats });
+        reportData.push({ date, direction: parsedDirection, stats });
       });
     });
+
+    const reportDirections = [...reportDirectionsSet].join(' | ');
 
     if (numDirections > 1) {
       for (let date = study.startDate; date <= study.endDate; date = date.plus({ days: 1 })) {
@@ -211,7 +217,7 @@ class ReportSpeedPercentile extends ReportBaseFlow {
           groupCounts.map(({ countData }) => countData),
         );
         const stats = ReportSpeedPercentile.transformCountData(groupCountData);
-        reportData.push({ date, direction: null, stats });
+        reportData.push({ date, direction: reportDirections, stats });
       }
     }
     if (counts.length > 1) {
@@ -220,7 +226,7 @@ class ReportSpeedPercentile extends ReportBaseFlow {
         countTuples.map(({ countData }) => countData),
       );
       const stats = ReportSpeedPercentile.transformCountData(groupCountData);
-      reportData.push({ date: null, direction: null, stats });
+      reportData.push({ date: null, direction: reportDirections, stats });
     }
     return { study, reportData };
   }
@@ -346,7 +352,7 @@ class ReportSpeedPercentile extends ReportBaseFlow {
     ];
   }
 
-  static getCountMetadataOptions(study, { date, direction, stats }) {
+  static getCountMetadataOptions(study, { date, direction: directionStr, stats }) {
     let fullDateStr = 'All Dates';
     if (date) {
       const dateStr = TimeFormatters.formatDefault(date);
@@ -354,13 +360,14 @@ class ReportSpeedPercentile extends ReportBaseFlow {
       fullDateStr = `${dateStr} (${dayOfWeekStr})`;
     } else {
       const dateStrStart = TimeFormatters.formatDefault(study.startDate);
-      const dayOfWeekStrStart = TimeFormatters.formatDayOfWeek(study.startDate);
+      // const dayOfWeekStrStart = TimeFormatters.formatDayOfWeek(study.startDate);
       const dateStrEnd = TimeFormatters.formatDefault(study.endDate);
-      const dayOfWeekStrEnd = TimeFormatters.formatDayOfWeek(study.endDate);
-      fullDateStr = `${dateStrStart} (${dayOfWeekStrStart}) - ${dateStrEnd} (${dayOfWeekStrEnd})`;
+      // const dayOfWeekStrEnd = TimeFormatters.formatDayOfWeek(study.endDate);
+      // fullDateStr =
+      // `${dateStrStart} (${dayOfWeekStrStart}) - ${dateStrEnd} (${dayOfWeekStrEnd})`;
+      fullDateStr = `${dateStrStart} to ${dateStrEnd}`;
     }
 
-    const directionStr = direction === null ? 'All Directions' : direction.bound;
     const { totalStats } = stats;
     return {
       entries: [

--- a/lib/reports/ReportSpeedPercentile.js
+++ b/lib/reports/ReportSpeedPercentile.js
@@ -222,10 +222,10 @@ class ReportSpeedPercentile extends ReportBaseFlow {
       const stats = ReportSpeedPercentile.transformCountData(groupCountData);
       reportData.push({ date: null, direction: null, stats });
     }
-    return reportData;
+    return { study, reportData };
   }
 
-  generateCsv(count, reportData) {
+  generateCsv(count, { reportData }) {
     const speedClassColumns = SPEED_CLASSES.map(([lo, hi]) => {
       const key = `speed_${lo}_${hi}`;
       const header = `${lo}-${hi} kph`;
@@ -291,13 +291,13 @@ class ReportSpeedPercentile extends ReportBaseFlow {
     return hoursHuman;
   }
 
-  static getRowOptions(reportData, date, hoursHuman, {
+  static getRowOptions({ reportData }, date, hoursHuman, {
     volume,
     total,
     pct85,
     pct95,
   }, h) {
-    const dateStr = TimeFormatters.formatDefault(date);
+    const dateStr = date === null ? ' ' : TimeFormatters.formatDefault(date);
     const hourHuman = h === 0 ? dateStr : hoursHuman[h];
     const shade = h % 2 === 1;
     return [
@@ -346,12 +346,18 @@ class ReportSpeedPercentile extends ReportBaseFlow {
     ];
   }
 
-  static getCountMetadataOptions({ date, direction, stats }) {
+  static getCountMetadataOptions(study, { date, direction, stats }) {
     let fullDateStr = 'All Dates';
     if (date) {
       const dateStr = TimeFormatters.formatDefault(date);
       const dayOfWeekStr = TimeFormatters.formatDayOfWeek(date);
       fullDateStr = `${dateStr} (${dayOfWeekStr})`;
+    } else {
+      const dateStrStart = TimeFormatters.formatDefault(study.startDate);
+      const dayOfWeekStrStart = TimeFormatters.formatDayOfWeek(study.startDate);
+      const dateStrEnd = TimeFormatters.formatDefault(study.endDate);
+      const dayOfWeekStrEnd = TimeFormatters.formatDayOfWeek(study.endDate);
+      fullDateStr = `${dateStrStart} (${dayOfWeekStrStart}) - ${dateStrEnd} (${dayOfWeekStrEnd})`;
     }
 
     const directionStr = direction === null ? 'All Directions' : direction.bound;
@@ -394,7 +400,7 @@ class ReportSpeedPercentile extends ReportBaseFlow {
       ],
       body: [
         ...reportData.countDataByHour.map((section, h) => ReportSpeedPercentile.getRowOptions(
-          reportData,
+          { reportData },
           date,
           hoursHuman,
           section,
@@ -483,10 +489,12 @@ class ReportSpeedPercentile extends ReportBaseFlow {
     };
   }
 
-  generateLayoutContent(count, reportData) {
+  generateLayoutContent(count, { study, reportData }) {
     const layout = [];
     reportData.forEach((reportBlock) => {
-      const countMetadataOptions = ReportSpeedPercentile.getCountMetadataOptions(reportBlock);
+      const countMetadataOptions = ReportSpeedPercentile.getCountMetadataOptions(
+        study, reportBlock,
+      );
       const tableOptions = ReportSpeedPercentile.getTableOptions(reportBlock);
       layout.push({ type: ReportBlock.METADATA, options: countMetadataOptions });
       layout.push({ type: ReportBlock.TABLE, options: tableOptions });

--- a/tests/jest/unit/reports/ReportSpeedPercentile.spec.js
+++ b/tests/jest/unit/reports/ReportSpeedPercentile.spec.js
@@ -70,7 +70,7 @@ test('ReportSpeedPercentile#transformData [empty dataset]', () => {
   expect(transformedData).toHaveLength(1);
   const { date, direction, stats } = transformedData[0];
   expect(date.equals(study.startDate)).toBe(true);
-  expect(direction).toBe('NB');
+  expect(direction).toBe('Northbound');
   transformedData = stats;
   expect(transformedData).toEqual(transformedData_SPEED_PERCENTILE_4_2156283_empty);
 });
@@ -93,7 +93,7 @@ test('ReportSpeedPercentile#transformData [Morningside S of Lawrence: ATR_SPEED_
   expect(transformedData).toHaveLength(1);
   const { date, direction, stats } = transformedData[0];
   expect(date.equals(study.startDate)).toBe(true);
-  expect(direction).toBe('NB');
+  expect(direction).toBe('Northbound');
   transformedData = stats;
 
   const {

--- a/tests/jest/unit/reports/ReportSpeedPercentile.spec.js
+++ b/tests/jest/unit/reports/ReportSpeedPercentile.spec.js
@@ -65,7 +65,8 @@ test('ReportSpeedPercentile#transformData [empty dataset]', () => {
 
   const { countLocation, counts, study } = setup_4_2156283();
   const studyData = new Map([[2156283, []]]);
-  let transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
+  let { reportData: transformedData } = reportInstance.transformData(study,
+    { countLocation, counts, studyData });
   expect(transformedData).toHaveLength(1);
   const { date, direction, stats } = transformedData[0];
   expect(date.equals(study.startDate)).toBe(true);
@@ -87,7 +88,8 @@ test('ReportSpeedPercentile#transformData [Morningside S of Lawrence: ATR_SPEED_
     study,
     studyData,
   } = setup_4_2156283();
-  let transformedData = reportInstance.transformData(study, { countLocation, counts, studyData });
+  let { reportData: transformedData } = reportInstance.transformData(study,
+    { countLocation, counts, studyData });
   expect(transformedData).toHaveLength(1);
   const { date, direction, stats } = transformedData[0];
   expect(date.equals(study.startDate)).toBe(true);

--- a/tests/jest/unit/reports/ReportSpeedPercentile.spec.js
+++ b/tests/jest/unit/reports/ReportSpeedPercentile.spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import path from 'path';
 
-import { CardinalDirection, SPEED_CLASSES } from '@/lib/Constants';
+import { SPEED_CLASSES } from '@/lib/Constants';
 import ReportSpeedPercentile from '@/lib/reports/ReportSpeedPercentile';
 import { toBeWithinTolerance } from '@/lib/test/ExpectMatchers';
 import { loadJsonSync } from '@/lib/test/TestDataLoader';
@@ -70,7 +70,7 @@ test('ReportSpeedPercentile#transformData [empty dataset]', () => {
   expect(transformedData).toHaveLength(1);
   const { date, direction, stats } = transformedData[0];
   expect(date.equals(study.startDate)).toBe(true);
-  expect(direction).toBe(CardinalDirection.NORTH);
+  expect(direction).toBe('NB');
   transformedData = stats;
   expect(transformedData).toEqual(transformedData_SPEED_PERCENTILE_4_2156283_empty);
 });
@@ -93,7 +93,7 @@ test('ReportSpeedPercentile#transformData [Morningside S of Lawrence: ATR_SPEED_
   expect(transformedData).toHaveLength(1);
   const { date, direction, stats } = transformedData[0];
   expect(date.equals(study.startDate)).toBe(true);
-  expect(direction).toBe(CardinalDirection.NORTH);
+  expect(direction).toBe('NB');
   transformedData = stats;
 
   const {


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-108](https://move-toronto.atlassian.net/browse/MOVE-108)

# Description
This adds a summary report as the last report in the Speed Percentile report. It combines all the days and directions into a single view.

There were some other changes:
- 'All Directions' in the metadata header now shows what those directions are as short + bound directions. Ex. 'All Directions (NB, SB)'
- The summary date is listed as '{start date} to {end date}' where the dates are in the YYYY-MM-DD format.
- The first row is set to `00:00` for the all days
- Added the data to the CSV, and unbroke the CSV

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/5003768/958512bc-95dd-4005-b4b4-c6f04f063cdf)


[SPEED_PERCENTILE_EIREANN_QUAY_LITTLE_NORWAY_PARK_TRL-BATHURST_ST_NB_SB_2010-04-06_ATR_SPEED_VOLUME_1231720.pdf](https://github.com/CityofToronto/bdit_flashcrow/files/15016462/SPEED_PERCENTILE_EIREANN_QUAY_LITTLE_NORWAY_PARK_TRL-BATHURST_ST_NB_SB_2010-04-06_ATR_SPEED_VOLUME_1231720.pdf)
[SPEED_PERCENTILE_EIREANN_QUAY_LITTLE_NORWAY_PARK_TRL-BATHURST_ST_NB_SB_2010-04-06_ATR_SPEED_VOLUME_1231720.csv](https://github.com/CityofToronto/bdit_flashcrow/files/15016463/SPEED_PERCENTILE_EIREANN_QUAY_LITTLE_NORWAY_PARK_TRL-BATHURST_ST_NB_SB_2010-04-06_ATR_SPEED_VOLUME_1231720.csv)


# Tests
All relevant tests were updated and are passing.
