### PR TITLE
MOVE-1146: Traffic Control Signal number is "None" in report headers

### DIFF
--- a/lib/reports/ReportBaseFlow.js
+++ b/lib/reports/ReportBaseFlow.js
@@ -4,6 +4,8 @@ import StudyDataDAO from '@/lib/db/StudyDataDAO';
 import ReportBase from '@/lib/reports/ReportBase';
 import { parseStudyReportId } from '@/lib/reports/ReportIdParser';
 import TimeFormatters from '@/lib/time/TimeFormatters';
+import PoiDAO from '@/lib/db/PoiDAO';
+import { POI_RADIUS } from '@/lib/Constants';
 
 /**
  * Base class for all FLOW-related reports, i.e. those reports that deal with traffic count
@@ -23,7 +25,26 @@ class ReportBaseFlow extends ReportBase {
   }
 
   async fetchRawData(study) {
-    return StudyDataDAO.byStudy(study);
+    const {
+      centrelineId,
+      centrelineType,
+    } = study;
+    const tasks = [
+      StudyDataDAO.byStudy(study),
+      PoiDAO.byCentrelineSummary(centrelineId, centrelineType, POI_RADIUS),
+    ];
+    const [data, { trafficSignals }] = await Promise.all(tasks);
+    if (trafficSignals === null) {
+      return { ...data };
+    }
+    const trafficSignalData = {
+      ...data.countLocation,
+      trafficSignalpx: trafficSignals[0].px,
+    };
+    return {
+      ...data,
+      countLocation: { ...trafficSignalData },
+    };
   }
 
   static async getCountLocation(study) {

--- a/lib/reports/ReportCountSummaryTurningMovement.js
+++ b/lib/reports/ReportCountSummaryTurningMovement.js
@@ -207,6 +207,9 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
     if (countLocation === null) {
       return null;
     }
+    if ('trafficSignalpx' in countLocation) {
+      return `PX ${countLocation.trafficSignalpx}`;
+    }
     const { description } = countLocation;
     const match = REGEX_PX.exec(description);
     if (match === null) {

--- a/tests/jest/unit/reports/format/MovePdfGenerator.spec.js
+++ b/tests/jest/unit/reports/format/MovePdfGenerator.spec.js
@@ -13,6 +13,7 @@ import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import CountLocationDAO from '@/lib/db/CountLocationDAO';
 import StudyDAO from '@/lib/db/StudyDAO';
 import StudyDataDAO from '@/lib/db/StudyDataDAO';
+import PoiDAO from '@/lib/db/PoiDAO';
 import ReportFactory from '@/lib/reports/ReportFactory';
 import MovePdfGenerator from '@/lib/reports/format/MovePdfGenerator';
 import { loadJsonSync } from '@/lib/test/TestDataLoader';
@@ -22,6 +23,7 @@ jest.mock('@/lib/db/CentrelineDAO');
 jest.mock('@/lib/db/CountLocationDAO');
 jest.mock('@/lib/db/StudyDAO');
 jest.mock('@/lib/db/StudyDataDAO');
+jest.mock('@/lib/db/PoiDAO');
 
 const countData_4_2156283 = loadJsonSync(
   path.resolve(__dirname, '../data/countData_4_2156283.json'),
@@ -59,6 +61,13 @@ function setup_4_2156283_single() {
     centrelineType: CentrelineType.SEGMENT,
   };
   CountLocationDAO.byStudy.mockResolvedValue(countLocation);
+
+  const poiResponse = {
+    hospital: null,
+    school: { id: 1134, geom_dist: 229.636281975754 },
+    trafficSignals: [{ px: 499 }],
+  };
+  PoiDAO.byCentrelineSummary.mockResolvedValue(poiResponse);
 
   const counts = [{
     id: 2156283,
@@ -125,6 +134,14 @@ function setup_5_36781() {
       coordinates: [-79.361498301, 43.663158537],
     },
   };
+
+  const poiResponse = {
+    hospital: null,
+    school: { id: 871, geom_dist: 239.31776433927 },
+    trafficSignals: [{ px: 1390 }],
+  };
+  PoiDAO.byCentrelineSummary.mockResolvedValue(poiResponse);
+
   const counts = [{
     id: 36781,
     legacy: true,
@@ -202,6 +219,12 @@ function setup_5_38661() {
       coordinates: [-79.343625497, 43.70747321],
     },
   });
+  const poiResponse = {
+    hospital: null,
+    school: { id: 741, geom_dist: 211.268629431655 },
+    trafficSignals: [{ px: 680 }],
+  };
+  PoiDAO.byCentrelineSummary.mockResolvedValue(poiResponse);
   CentrelineDAO.featuresIncidentTo.mockResolvedValue([
     {
       centrelineId: 649,


### PR DESCRIPTION
# Issue Addressed
"This PR closes [MOVE-1146](https://move-toronto.atlassian.net/browse/MOVE-1146)

# Description
It seems from looking at the test cases for reports, that we used to get PX as part of the location description (ex.: _OVERLEA BLVD AT THORNCLIFFE PARK DR & E TCS (PX 679)_). This doesn't appear to be the case anymore, so we need to get it from the PoiDao.

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/5003768/63bdb41e-1680-432b-a3e5-866f07622ef2)

# Tests
Updated the tests to mock the PoiDAO, all existing tests pass, and the PX value is appearing in the tests where 'None' was previously. Also, I left the old logic in as a fallback incase the PoiDAO doesn't return anything.
