### PR TITLE
amendment to MOVE-1148 + fixes for tooltips and error state UI

### DIFF
--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -118,8 +118,7 @@
         textColor="white"
         type="error-callout"
         >There was a problem loading this report.
-            If you need this data urgently,
-            email&nbsp;<a href='mailto:move-team@toronto.ca'>us</a>.
+        Email the <a href='mailto:move-team@toronto.ca'>MOVE Team</a> for assistance.
         </FcCallout>
         <div
           v-else

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -130,13 +130,13 @@
             This page is loading, please wait.
           </div>
         </div>
-        <div
-          v-else-if="studies.length === 0"
-          class="ma-3 text-center">
-          <div class="font-weight-regular headline secondary--text">
-            Report not available, try a different location.
-          </div>
-        </div>
+        <FcCallout v-else-if="studies.length === 0"
+          icon="mdi-alert-circle"
+          iconColor="white"
+          textColor="white"
+          type="error-callout"
+          >Report not available, try a different location.
+        </FcCallout>
         <FcCallout v-else-if="studyRetrievalError || reportBodyEmpty"
         icon="mdi-alert-circle"
         iconColor="white"

--- a/web/components/dialogs/FcCallout.vue
+++ b/web/components/dialogs/FcCallout.vue
@@ -35,6 +35,8 @@ export default {
     border-radius: 5px;
     min-height: 60px;
     font-size: 18px;
+    width: max-content;
+    padding: 0 1rem;
     & > a {
       font-weight: bold;
     }

--- a/web/components/geo/map/FcMapPopup.vue
+++ b/web/components/geo/map/FcMapPopup.vue
@@ -21,6 +21,10 @@
           />
         </p>
         <component
+          v-else-if="title.includes('Study Request')"
+          :is="'FcPopupDetails' + detailsSuffix"
+          :feature-details="this.feature.properties"/>
+        <component
           v-else
           :is="'FcPopupDetails' + detailsSuffix"
           :feature-details="featureDetails"/>
@@ -145,7 +149,6 @@ export default {
   },
   watch: {
     coordinates() {
-      this.loadAsyncForFeature();
       this.popup.setLngLat(this.coordinates);
     },
     featureKey: {
@@ -185,7 +188,7 @@ export default {
         this.featureDetails = await getFeatureDetails(this.layerId, this.feature);
       } catch (err) {
         this.error = true;
-        this.setToastEnrichedError('<span>Tooltip failed to load. If you have questions, email <a style="color:white; font-weight:bold" href="mailto:move-team@toronto.ca">the MOVE team</a></span>');
+        this.setToastEnrichedError('<span>Tooltip failed to load. Email the<a style="color:white; font-weight:bold" href="mailto:move-team@toronto.ca"> MOVE team</a> for assistance.</span>');
       }
       this.loading = false;
     },

--- a/web/components/geo/map/FcPopupDetailsError.vue
+++ b/web/components/geo/map/FcPopupDetailsError.vue
@@ -2,7 +2,7 @@
   <div>
     <p class="pa-1">
       There was a problem loading this information.
-      Contact the MOVE team for assistance.
+      Contact the <a href='mailto:move-team@toronto.ca'>MOVE Team</a> for assistance.
     </p>
   </div>
 </template>


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-1113

# Description
- Messaging on error toasts fixed and standardized
- Callout width reduced on study and collision reports
- Messaging added to backlinked reports that have no data, like RESCU for example (with callout)
- Fixed an unrelated issue where api calls were being made multiple times on map events (hover on features)

# Tests
Clarified against @mkewins's requirements in JIRA
