### PR TITLE
MOVE-1141: Add "Bicycle Volume ATR" to available study request options for midblocks

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -1098,7 +1098,7 @@ StudyType.init({
     isMultiDay: true,
     beta: null,
     dataAvailable: true,
-    maskStudy: true,
+    maskStudy: false,
     dataType: ReportDataType.ATR_VOLUME,
     other: false,
     hourOptions: null,

--- a/lib/geo/CentrelineUtils.js
+++ b/lib/geo/CentrelineUtils.js
@@ -50,6 +50,7 @@ function getLocationStudyTypes(location) {
     || locationFeatureType === RoadSegmentType.MAJOR_ARTERIAL_RAMP) {
     return [
       StudyType.ATR_SPEED_VOLUME,
+      StudyType.ATR_VOLUME_BICYCLE,
       StudyType.VEHICLE_CLASS,
       StudyType.PED_DELAY,
       StudyType.PXO_OBSERVE,
@@ -62,6 +63,7 @@ function getLocationStudyTypes(location) {
   }
   return [
     StudyType.ATR_SPEED_VOLUME,
+    StudyType.ATR_VOLUME_BICYCLE,
     StudyType.VEHICLE_CLASS,
     StudyType.PED_DELAY,
     StudyType.PXO_OBSERVE,

--- a/web/components/requests/fields/FcStudyRequestDuration.vue
+++ b/web/components/requests/fields/FcStudyRequestDuration.vue
@@ -11,22 +11,12 @@
 </template>
 
 <script>
+import { StudyType } from '@/lib/Constants';
+
 export default {
   name: 'FcStudyRequestDuration',
   props: {
     v: Object,
-  },
-  data() {
-    const itemsDuration = [
-      { text: '1 day', value: 24 },
-      { text: '2 days', value: 48 },
-      { text: '3 days', value: 72 },
-      { text: '4 days', value: 96 },
-      { text: '5 days', value: 120 },
-      { text: '1 week', value: 168 },
-      { text: '2 weeks', value: 336 },
-    ];
-    return { itemsDuration };
   },
   computed: {
     studyType() {
@@ -52,6 +42,26 @@ export default {
         caption = `${mainClause} across ${nDays} consecutive days (${nHours} hours)`;
       }
       return caption;
+    },
+    itemsDuration() {
+      if (this.studyType === StudyType.ATR_VOLUME_BICYCLE) {
+        const itemsDuration = [
+          { text: '1 day', value: 24 },
+          { text: '3 days', value: 72 },
+          { text: '1 week', value: 168 },
+        ];
+        return itemsDuration;
+      }
+      const itemsDuration = [
+        { text: '1 day', value: 24 },
+        { text: '2 days', value: 48 },
+        { text: '3 days', value: 72 },
+        { text: '4 days', value: 96 },
+        { text: '5 days', value: 120 },
+        { text: '1 week', value: 168 },
+        { text: '2 weeks', value: 336 },
+      ];
+      return itemsDuration;
     },
   },
 };


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-1141

# Description
Added "Bicycle Volume ATR" to available study request options at midblocks. Also made duration options dynamically generated, so they will be different depending on the study request type selected.

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/64811136/625fa063-1edb-4821-ad14-cad4020ffbcf)


# Tests
Tested in MOVE local v1.11.1 in Firefox