### PR TITLE
Move 1122 2

### DIFF
--- a/web/components/data/FcAggregateCollisions.vue
+++ b/web/components/data/FcAggregateCollisions.vue
@@ -3,7 +3,7 @@
     <FcProgressLinear
       v-if="loading"
       aria-label="Loading Aggregate View collisions data" />
-    <template v-else>
+    <template v-else-if="collisionSummary.amount > 0">
       <v-expansion-panels
         v-model="indexOpen"
         accordion

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -3,13 +3,7 @@
     <FcProgressLinear
       v-if="loading"
       aria-label="Loading Aggregate View studies data" />
-    <p
-      v-else-if="studySummaryUnfiltered.length === 0"
-      class="my-8 py-12 secondary--text text-center">
-      There are no studies for these locations,<br>
-      please request studies if necessary
-    </p>
-    <template v-else>
+    <template v-else-if="studySummaryUnfiltered.length > 0">
       <v-expansion-panels
         v-model="indexOpen"
         accordion

--- a/web/components/data/FcDetailCollisions.vue
+++ b/web/components/data/FcDetailCollisions.vue
@@ -3,7 +3,7 @@
     <FcProgressLinear
       v-if="loading"
       aria-label="Loading Detail View collisions data" />
-    <template v-else>
+    <template v-else-if="collisionSummary.amount > 0">
       <dl class="d-flex flex-grow-1 flex-shrink-1 justify-space-around">
         <div class="flex-grow-1 collision-fact">
           <dt class="body-1">
@@ -46,6 +46,7 @@
         class="flex-grow-0 flex-shrink-0 mt-2"
         type="secondary"
         :disabled="collisionSummary.amount === 0"
+        v-if="collisionSummary.amount > 0"
         @click="$emit('show-reports')">
         <span>View Reports</span>
       </FcButton>

--- a/web/components/data/FcDetailStudies.vue
+++ b/web/components/data/FcDetailStudies.vue
@@ -3,12 +3,7 @@
     <FcProgressLinear
       v-if="loading"
       aria-label="Loading Detail View studies data" />
-    <p
-      v-else-if="studySummaryUnfiltered.length === 0"
-      class="my-8 py-12 secondary--text text-center">
-      There are no studies for this location,<br>
-      please request a study if necessary
-    </p>
+    <p v-else-if="studySummaryUnfiltered.length === 0"></p>
     <template v-else>
       <div
         v-for="(item, i) in items"

--- a/web/components/data/FcHeaderCollisions.vue
+++ b/web/components/data/FcHeaderCollisions.vue
@@ -1,5 +1,5 @@
 <template>
-  <header class="pa-5">
+  <header class="pa-3 pl-5">
     <div class="align-center d-flex flex-wrap justify-end">
       <h3 class="headline">
         <span>Collisions</span>

--- a/web/components/data/FcSectionStudyRequestsPending.vue
+++ b/web/components/data/FcSectionStudyRequestsPending.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="pa-5">
+  <section class="pa-3 pl-5">
     <p
       v-for="studyRequest in studyRequestsPending"
       :key="studyRequest.id"

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -8,9 +8,9 @@
         <FcHeaderCollisions
           :collision-total="collisionTotal"
           :disabled="reportExportMode === ReportExportMode.STUDIES">
-          <template v-slot:action>
+          <template v-slot:action v-if="collisionSummary.amount > 0">
             <FcButton
-              class="ml-2"
+              class="ml-2 mb-1"
               :disabled="
                 collisionSummary.amount === 0
                 || reportExportMode === ReportExportMode.STUDIES"

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -64,6 +64,7 @@
           <template v-slot:action>
             <FcButton
               class="ml-2"
+              v-if="studySummary.length > 0"
               :disabled="
                 studySummary.length === 0
                 || reportExportMode === ReportExportMode.COLLISIONS"

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -106,7 +106,6 @@
           :locations-selection="locationsSelection"
           @show-reports="actionShowReportsStudy" />
 
-        <v-divider></v-divider>
       </section>
     </template>
   </div>

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -10,7 +10,7 @@
           :disabled="reportExportMode === ReportExportMode.STUDIES">
           <template v-slot:action v-if="collisionSummary.amount > 0">
             <FcButton
-              class="ml-2 mb-1"
+              class="ma-1"
               :disabled="
                 collisionSummary.amount === 0
                 || reportExportMode === ReportExportMode.STUDIES"
@@ -28,7 +28,7 @@
             </FcButton>
             <FcButton
               v-if="reportExportMode !== ReportExportMode.COLLISIONS"
-              class="ml-2"
+              class="ma-1"
               :disabled="
                 collisionSummary.amount === 0
                 || reportExportMode === ReportExportMode.STUDIES"
@@ -63,7 +63,7 @@
           :study-total="studyTotal">
           <template v-slot:action>
             <FcButton
-              class="ml-2"
+              class="ma-1"
               v-if="studySummary.length > 0"
               :disabled="
                 studySummary.length === 0
@@ -82,7 +82,7 @@
             </FcButton>
             <FcButton
               v-if="reportExportMode !== ReportExportMode.STUDIES"
-              class="ml-2"
+              class="ma-1"
               :disabled="reportExportMode === ReportExportMode.COLLISIONS"
               type="secondary"
               @click="actionRequestStudy">

--- a/web/components/data/FcViewDataDetail.vue
+++ b/web/components/data/FcViewDataDetail.vue
@@ -37,8 +37,6 @@
           @show-reports="actionShowReportsStudy" />
       </section>
 
-      <v-divider></v-divider>
-
       <FcSectionStudyRequestsPending
         :study-requests-pending="studyRequestsPending" />
     </template>

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -36,7 +36,8 @@
                         class="mr-1"
                         type="icon"
                         @click="actionRemove"
-                        v-on="onTooltip">
+                        v-on="onTooltip"
+                        plain>
                         <v-icon>mdi-close</v-icon>
                       </FcButton>
                     </template>

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="fc-single-location-row">
-    <div class="fc-input-location-search elevation-2"
+  <div class="fc-single-location-row mb-1">
+    <div class="fc-input-location-search"
     :class="{ 'fc-location-search-home': !drawerOpen}">
       <v-menu
         v-model="showLocationSuggestions"

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="fc-single-location-row mb-1">
+  <div class="fc-single-location-row">
     <div class="fc-input-location-search"
-    :class="{ 'fc-location-search-home': !drawerOpen}">
+    :class="{ 'fc-location-search-home elevation-2': !drawerOpen}">
       <v-menu
         v-model="showLocationSuggestions"
         ref="menuLocationSuggestions"
@@ -35,7 +35,6 @@
                       <template v-slot:activator="{ on: onTooltip }">
                         <FcButton
                           aria-label="Clear Location"
-                          class="mr-1"
                           type="icon"
                           @click="actionRemove"
                           v-on="onTooltip"

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -307,6 +307,7 @@ export default {
   display: flex;
   flex-wrap: none;
   justify-content: space-between;
+  border-radius: 8px;
   & .nudge-right {
     left: 15px;
   }

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -28,6 +28,21 @@
             v-on="onMenu">
             <template v-slot:append>
               <template v-if="hasLocationIndex">
+                <template v-if="showClose">
+                  <FcTooltip right>
+                    <template v-slot:activator="{ on: onTooltip }">
+                      <FcButton
+                        aria-label="Clear Location"
+                        class="mr-1"
+                        type="icon"
+                        @click="actionRemove"
+                        v-on="onTooltip">
+                        <v-icon>mdi-close</v-icon>
+                      </FcButton>
+                    </template>
+                    <span>Clear Location</span>
+                  </FcTooltip>
+                </template>
               </template>
               <template v-else>
                 <FcTooltip
@@ -75,12 +90,14 @@
 </template>
 
 <script>
+import Vue from 'vue';
 import { Enum } from '@/lib/ClassUtils';
 import { debounce } from '@/lib/FunctionUtils';
 import { getLocationSuggestions } from '@/lib/api/WebApi';
 import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+import { mapMutations } from 'vuex';
 
 class LocationSearchState extends Enum {}
 LocationSearchState.init([
@@ -104,6 +121,10 @@ export default {
       default: null,
     },
     selected: {
+      type: Boolean,
+      default: false,
+    },
+    showClose: {
       type: Boolean,
       default: false,
     },
@@ -211,6 +232,13 @@ export default {
         this.$emit('location-remove', this.locationIndex);
       }
     },
+    actionRemove() {
+      const description = this.query || '';
+      this.setToastInfo(`Removed ${description} from selected locations.`);
+      this.setLocationsEditIndex(-1);
+      this.removeLocationEdit(this.locationIndex);
+      Vue.nextTick(() => this.autofocus());
+    },
     actionBlur(e) {
       /*
        * Clicking a location suggestion in the dropdown triggers a blur event.  However, if
@@ -255,6 +283,11 @@ export default {
       this.internalValue = location;
       this.state = LocationSearchState.VALUE_SELECTED;
     },
+    ...mapMutations([
+      'setLocationsEditIndex',
+      'removeLocationEdit',
+      'setToastInfo',
+    ]),
   },
 };
 </script>

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -1,92 +1,95 @@
 <template>
-  <div class="fc-input-location-search">
-    <v-menu
-      v-model="showLocationSuggestions"
-      ref="menuLocationSuggestions"
-      :attach="$el"
-      :close-on-click="false"
-      :close-on-content-click="false"
-      :offset-y="true"
-      :open-on-click="false">
-      <template v-slot:activator="{ attrs: attrsMenu, on: onMenu }">
-        <div v-bind="attrsMenu">
-          <v-text-field
-            v-model="query"
-            :aria-label="query"
-            autocomplete="off"
-            spellcheck="false"
-            dense
-            :flat="hasLocationIndex"
-            hide-details
-            label="Choose location or click on the map"
-            :loading="loading"
-            solo
-            v-bind="$attrs"
-            @blur="actionBlur"
-            @focus="actionFocus"
-            @input="actionInput"
-            v-on="onMenu">
-            <template v-slot:append>
-              <template v-if="hasLocationIndex">
-                <template v-if="showClose">
-                  <FcTooltip right>
-                    <template v-slot:activator="{ on: onTooltip }">
-                      <FcButton
-                        aria-label="Clear Location"
-                        class="mr-1"
-                        type="icon"
-                        @click="actionRemove"
-                        v-on="onTooltip"
-                        plain>
-                        <v-icon>mdi-close</v-icon>
-                      </FcButton>
-                    </template>
-                    <span>Clear Location</span>
-                  </FcTooltip>
+  <div class="fc-single-location-row">
+    <div class="fc-input-location-search elevation-2"
+    :class="{ 'fc-location-search-home': !drawerOpen}">
+      <v-menu
+        v-model="showLocationSuggestions"
+        ref="menuLocationSuggestions"
+        :attach="$el"
+        :close-on-click="false"
+        :close-on-content-click="false"
+        :offset-y="true"
+        :open-on-click="false">
+        <template v-slot:activator="{ attrs: attrsMenu, on: onMenu }">
+          <div v-bind="attrsMenu">
+            <v-text-field
+              v-model="query"
+              :aria-label="query"
+              autocomplete="off"
+              spellcheck="false"
+              dense
+              :flat="hasLocationIndex"
+              hide-details
+              label="Choose location or click on the map"
+              :loading="loading"
+              solo
+              v-bind="$attrs"
+              @blur="actionBlur"
+              @focus="actionFocus"
+              @input="actionInput"
+              v-on="onMenu">
+              <template v-slot:append>
+                <template v-if="hasLocationIndex">
+                  <template v-if="showClose">
+                    <FcTooltip right>
+                      <template v-slot:activator="{ on: onTooltip }">
+                        <FcButton
+                          aria-label="Clear Location"
+                          class="mr-1"
+                          type="icon"
+                          @click="actionRemove"
+                          v-on="onTooltip"
+                          plain>
+                          <v-icon>mdi-close</v-icon>
+                        </FcButton>
+                      </template>
+                      <span>Clear Location</span>
+                    </FcTooltip>
+                  </template>
+                </template>
+                <template v-else>
+                  <v-icon
+                    :color="hasFocus ? 'primary' : null"
+                    right>
+                    mdi-magnify
+                  </v-icon>
                 </template>
               </template>
-              <template v-else>
-                <FcTooltip
-                  v-if="internalValue !== null || query !== null"
-                  right>
-                  <template v-slot:activator="{ on: onTooltip }">
-                    <FcButton
-                      aria-label="Clear Location"
-                      class="mr-1"
-                      type="icon"
-                      @click="actionClear"
-                      v-on="onTooltip">
-                      <v-icon>mdi-close-circle</v-icon>
-                    </FcButton>
-                  </template>
-                  <span>Clear Location</span>
-                </FcTooltip>
-                <v-divider vertical />
-                <v-icon
-                  :color="hasFocus ? 'primary' : null"
-                  right>
-                  mdi-magnify
-                </v-icon>
-              </template>
-            </template>
-          </v-text-field>
-        </div>
-      </template>
-      <v-list
-        ref="listLocationSuggestions"
-        class="fc-list-location-suggestions">
-        <v-list-item
-          v-for="(location, i) in locationSuggestions"
-          :key="i"
-          @click="actionSelect(location)">
-          <v-list-item-content>
-            <v-list-item-title>
-              <span>{{location.description}}</span>
-            </v-list-item-title>
-          </v-list-item-content>
-        </v-list-item>
-      </v-list>
-    </v-menu>
+            </v-text-field>
+          </div>
+        </template>
+
+        <v-list
+          ref="listLocationSuggestions"
+          class="fc-list-location-suggestions">
+          <v-list-item
+            v-for="(location, i) in locationSuggestions"
+            :key="i"
+            @click="actionSelect(location)">
+            <v-list-item-content>
+              <v-list-item-title>
+                <span>{{location.description}}</span>
+              </v-list-item-title>
+            </v-list-item-content>
+          </v-list-item>
+        </v-list>
+      </v-menu>
+    </div>
+    <div v-if="isSingleMode && drawerOpen">
+      <FcTooltip right>
+          <template v-slot:activator="{ on: onTooltip }">
+            <FcButton
+              aria-label="Clear Location"
+              class="mr-1 nudge-right"
+              type="icon"
+              @click="actionClear"
+              v-on="onTooltip">
+              <v-icon>mdi-close-circle</v-icon>
+            </FcButton>
+          </template>
+          <span>Clear Location</span>
+        </FcTooltip>
+   </div>
   </div>
 </template>
 
@@ -98,7 +101,7 @@ import { getLocationSuggestions } from '@/lib/api/WebApi';
 import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
-import { mapMutations } from 'vuex';
+import { mapMutations, mapState } from 'vuex';
 
 class LocationSearchState extends Enum {}
 LocationSearchState.init([
@@ -126,6 +129,10 @@ export default {
       default: false,
     },
     showClose: {
+      type: Boolean,
+      default: false,
+    },
+    isSingleMode: {
       type: Boolean,
       default: false,
     },
@@ -166,6 +173,9 @@ export default {
         }
       },
     },
+    ...mapState('viewData', [
+      'drawerOpen',
+    ]),
   },
   watch: {
     internalValue() {
@@ -294,7 +304,17 @@ export default {
 </script>
 
 <style lang="scss">
+.fc-single-location-row {
+  display: flex;
+  flex-wrap: none;
+  justify-content: space-between;
+  & .nudge-right {
+    left: 15px;
+  }
+}
+
 .fc-input-location-search {
+  flex-grow: 1;
   & > .v-input--is-focused {
     box-shadow: 0 0 0 2px var(--v-primary-base);
   }
@@ -304,5 +324,8 @@ export default {
   &.v-select.v-select--is-menu-active .v-input__icon--append .v-icon {
     transform: none;
   }
+}
+.fc-location-search-home {
+  max-width: 448px;
 }
 </style>

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -37,6 +37,9 @@
     <div
       v-else
       class="flex-grow-1 flex-shrink-1 flex flex-column text-right">
+        <FcButton class="fc-close-top-right" type="tertiary" icon>
+          <v-icon color="grey">mdi-close-circle</v-icon>
+        </FcButton>
       <FcDisplayLocationMulti
         :locations="locations"
         :locations-index="locationsIndex"
@@ -402,6 +405,11 @@ export default {
       font-size: 0.875rem;
       padding-left: 0 !important;
     }
+  }
+  & .fc-close-top-right {
+    position: absolute;
+    right: 8px;
+    top: 4px;
   }
 }
 .edit-location-btn {

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -387,7 +387,7 @@ export default {
 
   & .fc-input-location-search-wrapper {
     width: 100%;
-    & > .fc-input-location-search {
+    & > .fc-single-location-row {
       &:not(:first-child) {
         border-top: 1px solid var(--v-border-base);
       }

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -123,7 +123,7 @@
             Cancel
           </FcButton>
           <FcButton
-            :disabled="loading || hasError || hasZeroLocations"
+            :disabled="loading || hasError"
             :loading="loading"
             type="primary"
             @click="saveAndThenView">

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -36,13 +36,13 @@
     </div>
     <div
       v-else
-      class="flex-grow-1 flex-shrink-1 flex-col pr-5 mr-5">
+      class="flex-grow-1 flex-shrink-1 flex flex-column text-right">
       <FcDisplayLocationMulti
         :locations="locations"
         :locations-index="locationsIndex"
         :locations-selection="locationsSelection" />
       <FcButton
-        class="ml-3 edit-location-btn mb-1 mt-1 justify-end"
+        class="ml-3 edit-location-btn"
         type="tertiary"
         @click="setLocationMode(LocationMode.MULTI_EDIT)">
         <v-icon color="primary" left>mdi-pencil</v-icon>

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -17,11 +17,12 @@
               <v-icon class="ma-1 dots" small >mdi-circle-double</v-icon>
               <div class="fc-connector-lines" :class="!internalCorridor ? 'hide': ''"></div>
             </div>
-            <div class="fc-input-location-search-wrapper elevation-2"
-            :class="i > 0 ? 'fc-input-has-border' : ''">
+            <div class="fc-input-location-search-wrapper" >
               <FcInputLocationSearch
               v-model="locationsEditSelection.locations[i]"
               :location-index="i"
+              class="elevation-2"
+              :class="i > 0 ? 'fc-input-has-border' : ''"
               :selected="i === locationsEditIndex"
               @focus="setLocationsEditIndex(i)"
               @location-remove="actionRemove"
@@ -31,10 +32,11 @@
 
           <div class="fc-multi-line">
             <v-icon class="ma-1 dots" small >mdi-circle-double</v-icon>
-            <div class="fc-input-location-search-wrapper elevation-2 fc-input-has-border">
+            <div class="fc-input-location-search-wrapper">
               <FcInputLocationSearch
                 v-if="!locationsEditFull"
                 ref="autofocus"
+                class="elevation-2 fc-input-has-border"
                 v-model="locationToAdd"
                 :location-index="-1"
                 @focus="setLocationsEditIndex(-1)"

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -18,7 +18,8 @@
             :location-index="i"
             :selected="i === locationsEditIndex"
             @focus="setLocationsEditIndex(i)"
-            @location-remove="actionRemove" />
+            @location-remove="actionRemove"
+            showClose />
           <FcInputLocationSearch
             v-if="!locationsEditFull"
             ref="autofocus"
@@ -31,20 +32,6 @@
           class="mt-2 mb-2"
           v-if="locationsEditFull"
           :value="messagesMaxLocations"></v-messages>
-      </div>
-      <div class="ml-2">
-        <div
-          v-for="(location, i) in locationsEditSelection.locations"
-          :key="'remove_' + i"
-          class="fc-input-location-search-remove">
-          <FcButtonAria
-            :aria-label="'Remove Location #' + (i + 1) + ': ' + location.description"
-            right
-            type="icon"
-            @click="actionRemove(i)">
-            <v-icon>mdi-close</v-icon>
-          </FcButtonAria>
-        </div>
       </div>
     </div>
     <div
@@ -178,7 +165,6 @@ import FcDialogConfirmMultiLocationLeave
   from '@/web/components/dialogs/FcDialogConfirmMultiLocationLeave.vue';
 import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
-import FcButtonAria from '@/web/components/inputs/FcButtonAria.vue';
 import FcInputLocationSearch from '@/web/components/inputs/FcInputLocationSearch.vue';
 import FcDisplayLocationMulti from '@/web/components/location/FcDisplayLocationMulti.vue';
 import FcHeaderSingleLocation from '@/web/components/location/FcHeaderSingleLocation.vue';
@@ -190,7 +176,6 @@ export default {
   mixins: [FcMixinInputAutofocus],
   components: {
     FcButton,
-    FcButtonAria,
     FcDialogConfirmMultiLocationLeave,
     FcDisplayLocationMulti,
     FcHeaderSingleLocation,

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     aria-label="Search for multiple locations in the map"
-    class="fc-selector-multi-location d-flex flex-column px-5 py-3"
+    class="fc-selector-multi-location d-flex flex-column px-5 pt-3"
     role="search">
     <FcDialogConfirmMultiLocationLeave
       v-model="showConfirmMultiLocationLeave" />
@@ -36,13 +36,13 @@
     </div>
     <div
       v-else
-      class="flex-grow-1 flex-shrink-1 text-right">
+      class="flex-grow-1 flex-shrink-1 flex-col pr-5 mr-5">
       <FcDisplayLocationMulti
         :locations="locations"
         :locations-index="locationsIndex"
         :locations-selection="locationsSelection" />
       <FcButton
-        class="ml-3 edit-location-btn mb-1 mt-1"
+        class="ml-3 edit-location-btn mb-1 mt-1 justify-end"
         type="tertiary"
         @click="setLocationMode(LocationMode.MULTI_EDIT)">
         <v-icon color="primary" left>mdi-pencil</v-icon>
@@ -86,9 +86,6 @@
             </template>
             <span>Next location</span>
           </FcTooltip>
-        </template>
-        <template v-else>
-          <h2 class="display-2 mb-4">{{locationsDescription}}</h2>
         </template>
       </div>
 

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     aria-label="Search for multiple locations in the map"
-    class="fc-selector-multi-location d-flex flex-column px-5 pt-3"
+    class="fc-selector-multi-location d-flex flex-column px-4 pt-3"
     role="search">
     <FcDialogConfirmMultiLocationLeave
       v-model="showConfirmMultiLocationLeave" />
@@ -10,23 +10,37 @@
       v-if="locationMode === LocationMode.MULTI_EDIT"
       class="align-start d-flex flex-grow-1 flex-shrink-1">
       <div class="fc-input-grow">
-        <div class="fc-input-location-search-wrapper elevation-2">
-          <FcInputLocationSearch
-            v-for="(_, i) in locationsEditSelection.locations"
-            :key="locationsEditKeys[i]"
-            v-model="locationsEditSelection.locations[i]"
-            :location-index="i"
-            :selected="i === locationsEditIndex"
-            @focus="setLocationsEditIndex(i)"
-            @location-remove="actionRemove"
-            showClose />
-          <FcInputLocationSearch
-            v-if="!locationsEditFull"
-            ref="autofocus"
-            v-model="locationToAdd"
-            :location-index="-1"
-            @focus="setLocationsEditIndex(-1)"
-            @location-add="actionAdd" />
+        <div >
+          <div class="fc-multi-line" v-for="(_, i) in locationsEditSelection.locations"
+          :key="locationsEditKeys[i]">
+            <div>
+              <v-icon class="ma-1 dots" small >mdi-circle-double</v-icon>
+              <div class="fc-connector-lines" :class="!internalCorridor ? 'hide': ''"></div>
+            </div>
+            <div class="fc-input-location-search-wrapper elevation-2"
+            :class="i > 0 ? 'fc-input-has-border' : ''">
+              <FcInputLocationSearch
+              v-model="locationsEditSelection.locations[i]"
+              :location-index="i"
+              :selected="i === locationsEditIndex"
+              @focus="setLocationsEditIndex(i)"
+              @location-remove="actionRemove"
+              showClose />
+            </div>
+          </div>
+
+          <div class="fc-multi-line">
+            <v-icon class="ma-1 dots" small >mdi-circle-double</v-icon>
+            <div class="fc-input-location-search-wrapper elevation-2 fc-input-has-border">
+              <FcInputLocationSearch
+                v-if="!locationsEditFull"
+                ref="autofocus"
+                v-model="locationToAdd"
+                :location-index="-1"
+                @focus="setLocationsEditIndex(-1)"
+                @location-add="actionAdd" />
+              </div>
+          </div>
         </div>
         <v-messages
           class="mt-2 mb-2"
@@ -387,11 +401,9 @@ export default {
 
   & .fc-input-location-search-wrapper {
     width: 100%;
-    & > .fc-single-location-row {
-      &:not(:first-child) {
-        border-top: 1px solid var(--v-border-base);
-      }
-    }
+  }
+  & .fc-input-has-border {
+    border-top: 1px solid var(--v-border-base);
   }
   & .fc-input-grow {
     width: 100%;
@@ -410,6 +422,24 @@ export default {
     position: absolute;
     right: 8px;
     top: 4px;
+  }
+  & .fc-multi-line {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+  }
+  & .dots {
+    opacity: 0.7;
+    margin-right: 8px !important;
+  }
+  & .fc-connector-lines {
+    position: absolute;
+    height:16px;
+    left:27px;
+    border-left:2px dotted grey;
+  }
+  & .hide {
+    display: none;
   }
 }
 .edit-location-btn {

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -71,7 +71,6 @@
     <div class="flex-grow-0 flex-shrink-0">
       <div class="d-flex align-center">
         <template v-if="locationMode === LocationMode.MULTI_EDIT">
-          <!-- <h2 class="display-2 mb-4 mt-4">{{locationsEditDescription}}</h2> -->
         </template>
         <template v-else-if="detailView">
           <FcHeaderSingleLocation

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -37,7 +37,7 @@
     <div
       v-else
       class="flex-grow-1 flex-shrink-1 flex flex-column text-right">
-        <FcButton class="fc-close-top-right" type="tertiary" icon>
+        <FcButton class="fc-close-top-right" type="tertiary" icon @click="actionClear">
           <v-icon color="grey">mdi-close-circle</v-icon>
         </FcButton>
       <FcDisplayLocationMulti
@@ -95,11 +95,11 @@
         <v-checkbox
             v-if="hasManyLocations"
             v-model="internalCorridor"
-            class="fc-multi-location-corridor mt-0 mb-1"
+            class="fc-multi-location-corridor mt-1 mb-1"
             hide-details
             label="Include corridor between locations" />
 
-      <div class="d-flex mt-2 justify-end">
+      <div class="d-flex mt-2 mb-2 justify-end">
         <template v-if="locationMode === LocationMode.MULTI_EDIT">
           <FcButton
             type="tertiary"
@@ -111,7 +111,7 @@
             :loading="loading"
             type="primary"
             @click="saveAndThenView">
-            View Data
+            Save
           </FcButton>
         </template>
         <template v-else-if="detailView">
@@ -402,7 +402,7 @@ export default {
 
   & .fc-multi-location-corridor {
     & .v-label {
-      font-size: 0.875rem;
+      font-size: 0.75rem;
       padding-left: 0 !important;
     }
   }

--- a/web/components/inputs/FcSelectorSingleLocation.vue
+++ b/web/components/inputs/FcSelectorSingleLocation.vue
@@ -5,8 +5,8 @@
     role="search">
     <FcInputLocationSearch
       ref="autofocus"
-      v-model="internalValue"
-      class="elevation-2" />
+      isSingleMode
+      v-model="internalValue" />
   </div>
 </template>
 
@@ -54,11 +54,3 @@ export default {
   },
 };
 </script>
-
-<style lang="scss">
-.fc-selector-single-location {
-  & > .fc-input-location-search {
-    max-width: 448px;
-  }
-}
-</style>

--- a/web/components/location/FcDisplayLocationMulti.vue
+++ b/web/components/location/FcDisplayLocationMulti.vue
@@ -1,14 +1,24 @@
 <template>
-  <div class="fc-input-summary text-left pa-1 pb-0">
+  <div class="fc-input-summary text-left pa-1 pb-0 mr-4">
     <!-- if in CORRIDOR-mode -->
     <div v-if="isCorridor">
-      <span>from </span>
-      <span class="fc-summary-name">{{ locationsSelection.locations[0].description }}</span>
-      <div class="fc-summary-indent">
-        <span>to </span>
-        <span class="fc-summary-name">
+      <div  class="fc-corridor-summary-line">
+        <div class="mr-2">from </div>
+        <div class="fc-summary-name">{{ locationsSelection.locations[0].description }}</div>
+      </div>
+      <div class="fc-corridor-summary-line fc-summary-indent">
+        <div class="mr-2">to </div>
+        <div class="fc-summary-name">
           {{ locationsSelection.locations[locationsSelection.locations.length - 1].description }}
-        </span>
+        </div>
+      </div>
+      <div v-if="locationsSelection.locations.length >= 3"
+        class="fc-corridor-summary-line ml-2">
+        <div class="mr-2">via </div>
+        <div class="fc-summary-name">
+          {{ locationsSelection.locations.length - 2 }}
+          &nbsp;locations
+        </div>
       </div>
     </div>
     <!-- support different sizes -->
@@ -88,8 +98,12 @@ export default {
     font-weight: bold;
   }
 
+  & .fc-corridor-summary-line {
+    display: flex;
+    flex-wrap: none;
+  }
   & .fc-summary-indent {
-    margin-left: 10px;
+    margin-left: 18px;
   }
 }
 </style>

--- a/web/components/location/FcDisplayLocationMulti.vue
+++ b/web/components/location/FcDisplayLocationMulti.vue
@@ -1,17 +1,37 @@
 <template>
-  <div class="fc-input-summary text-left pa-2">
-    <div
-      v-for="(_, i) in locationsSelection.locations"
-      :key="i"
-      class="fc-summary-line mb-1">
-      <span v-if="i>0">and </span>
-      <b>{{ locationsSelection.locations[i].description }}</b>
+  <div class="fc-input-summary text-left pa-1 pb-0">
+    <!-- if in CORRIDOR-mode -->
+    <div v-if="isCorridor">
+      <span>from </span>
+      <span class="fc-summary-name">{{ locationsSelection.locations[0].description }}</span>
+      <div class="fc-summary-indent">
+        <span>to </span>
+        <span class="fc-summary-name">
+          {{ locationsSelection.locations[locationsSelection.locations.length - 1].description }}
+        </span>
+      </div>
+    </div>
+    <!-- support different sizes -->
+    <div v-else-if="locationsSelection.locations.length === 1">
+      <div class="fc-summary-name">{{ locationsSelection.locations[0].description }}</div>
+    </div>
+    <div v-else-if="locationsSelection.locations.length === 2">
+      <div class="fc-summary-name">{{ locationsSelection.locations[0].description }}</div>
+      <span> and </span>
+      <span class="fc-summary-name">{{ locationsSelection.locations[1].description }}</span>
+    </div>
+    <div v-else>
+      <div class="fc-summary-name">{{ locationsSelection.locations[0].description }}</div>
+      <span class="fc-summary-indent"> and
+        <span class="fc-summary-name">{{ locationsSelection.locations.length - 1 }}</span>
+        more locations
+      </span>
     </div>
   </div>
 </template>
 
 <script>
-import { CentrelineType } from '@/lib/Constants';
+import { CentrelineType, LocationSelectionType } from '@/lib/Constants';
 import { getLocationsWaypointIndices } from '@/lib/geo/CentrelineUtils';
 
 export default {
@@ -23,6 +43,9 @@ export default {
     locationsSelection: Object,
   },
   computed: {
+    isCorridor() {
+      return this.locationsSelection.selectionType === LocationSelectionType.CORRIDOR;
+    },
     intersectionsByWaypoint() {
       let intersections = [];
       const intersectionsByWaypoint = [];
@@ -61,6 +84,12 @@ export default {
 </script>
 <style lang="scss">
 .fc-input-summary {
-  border-bottom: 1px solid lightgrey;
+  & .fc-summary-name {
+    font-weight: bold;
+  }
+
+  & .fc-summary-indent {
+    margin-left: 10px;
+  }
 }
 </style>

--- a/web/components/location/FcDisplayLocationMulti.vue
+++ b/web/components/location/FcDisplayLocationMulti.vue
@@ -1,20 +1,11 @@
 <template>
-  <div class="fc-input-location-search-wrapper elevation-2">
+  <div class="fc-input-summary text-left pa-2">
     <div
       v-for="(_, i) in locationsSelection.locations"
       :key="i"
-      class="fc-input-location-search">
-      <v-text-field
-        v-model="locationsSelection.locations[i].description"
-        :aria-label="'Location #' + (i + 1) + ': ' + locationsSelection.locations[i].description"
-        autocomplete="off"
-        dense
-        flat
-        hide-details
-        readonly
-        solo
-        tabindex="-1">
-      </v-text-field>
+      class="fc-summary-line mb-1">
+      <span v-if="i>0">and </span>
+      <b>{{ locationsSelection.locations[i].description }}</b>
     </div>
   </div>
 </template>
@@ -68,3 +59,8 @@ export default {
   },
 };
 </script>
+<style lang="scss">
+.fc-input-summary {
+  border-bottom: 1px solid lightgrey;
+}
+</style>

--- a/web/components/location/FcHeaderSingleLocation.vue
+++ b/web/components/location/FcHeaderSingleLocation.vue
@@ -8,6 +8,7 @@
       <FcButton
         type="tertiary"
         class="add-location-btn mb-2 mt-1"
+        small
         @click="actionAddLocation">
         <v-icon color="primary" left>mdi-plus</v-icon>
         Add Location

--- a/web/views/FcLayoutViewData.vue
+++ b/web/views/FcLayoutViewData.vue
@@ -346,7 +346,8 @@ export default {
         2px 1px 3px 0 rgba(0, 0, 0, 0.12);
       color: var(--ink);
       height: 38px;
-      top: 12px;
+      margin-top: -19px;
+      top: 50%;
       width: 16px;
 
       &:hover {


### PR DESCRIPTION
# Issue Addressed
2nd round of changes for Move 1122 - close the sidebar. Planned for `1.12.0` release.

# Description
* new, smaller *summary-mode* for sidebar
* visual indicator for **corridor-mode** in sidebar
* fix *dead-mode* when closing all in multi-location
* add a close-all button, in *multi-mode*
* move the close-all button, in *single-mode*
* hide more 0-displaying sidebar elements


the diff looks big for `FcInputLocationSearch.vue`, and `FcDisplayLocationMulti.vue` but it is just a bunch of nesting that was required for the new display layout.


![image](https://github.com/CityofToronto/bdit_flashcrow/assets/399657/84d98c26-aa78-470a-8457-4eb9b722ebd0)
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/399657/53ff5372-83ae-401d-971a-aa285716ee35)
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/399657/7f113d31-58ab-4dba-8218-480b7dfbbc18)
