### PR TITLE
catch and warn about router error

### DIFF
--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -131,6 +131,8 @@ export default {
           this.loading = true;
           this.$router.push({
             name: 'viewData',
+          }).catch((e) => {
+            console.warn('Caught Router Error:', e);//eslint-disable-line
           });
           return;
         }


### PR DESCRIPTION
# Issue Addressed
Runtime error being triggered on hitting the close button in the sidebar, which existed pre-2024.

I couldn't figure out how to fix it - something about the `internalValue` variable, and its subsequent watcher methods. Seems to be a async race condition, which calls the same router twice.

I simply adding a catch+console log, so that the error goes from red to yellow.

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/399657/6ae1219e-b230-48cf-89aa-562f15e6a99f)
