### PR TITLE
Move 1097: Persisting filters on refresh/login

### DIFF
--- a/lib/time/TimeFormatters.js
+++ b/lib/time/TimeFormatters.js
@@ -1,4 +1,4 @@
-import { Info } from 'luxon';
+import { Info, DateTime } from 'luxon';
 
 import ArrayUtils from '@/lib/ArrayUtils';
 
@@ -214,6 +214,10 @@ class TimeFormatters {
       return `At ${startHuman}`;
     }
     return `${startHuman}\u2013${endHuman}`;
+  }
+
+  static convertToLuxonDatetime(datetime) {
+    return DateTime.fromFormat(datetime, 'yyyy-MM-dd HH:mm:ss.SSS');
   }
 }
 

--- a/tests/jest/unit/time/TimeFormatters.spec.js
+++ b/tests/jest/unit/time/TimeFormatters.spec.js
@@ -127,6 +127,12 @@ test('TimeFormatters.formatRangeTimeOfDay()', () => {
   expect(TimeFormatters.formatRangeTimeOfDay({ start, end })).toEqual('00:00\u201301:23');
 });
 
+test('TimeFormatters.convertToLuxonDatetime()', () => {
+  const t = '2024-04-09 00:00:00.000';
+  expect(TimeFormatters.convertToLuxonDatetime(t))
+    .toEqual(DateTime.local(2024, 4, 9, 0, 0, 0, 0));
+});
+
 test('TimeFormatters.DAYS_OF_WEEK', () => {
   expect(TimeFormatters.DAYS_OF_WEEK).toEqual([
     'Sun',

--- a/web/components/filters/FcGlobalFilterDrawer.vue
+++ b/web/components/filters/FcGlobalFilterDrawer.vue
@@ -100,7 +100,7 @@ import FcCommonFilters from '@/web/components/filters/FcCommonFilters.vue';
 import FcStudyFilters from '@/web/components/filters/FcStudyFilters.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
-import { saveFilterState } from '@/web/store/LoginState';
+import { saveCollisionFilterState, saveCommonFilterState, saveStudyFilterState } from '@/web/store/FilterState';
 
 function cloneCollisionFilters(filtersCollision) {
   const {
@@ -218,9 +218,11 @@ export default {
       this.internalFiltersStudy = defaultStudyFilters();
     },
     actionSave() {
-      saveFilterState(this.internalFiltersCollision);
+      saveCollisionFilterState(this.internalFiltersCollision);
       this.setFiltersCollision(this.internalFiltersCollision);
+      saveCommonFilterState(this.internalFiltersCommon);
       this.setFiltersCommon(this.internalFiltersCommon);
+      saveStudyFilterState(this.internalFiltersStudy);
       this.setFiltersStudy(this.internalFiltersStudy);
       this.setToastInfo('Updated request filters.');
       this.internalValue = false;

--- a/web/components/filters/FcGlobalFilterDrawer.vue
+++ b/web/components/filters/FcGlobalFilterDrawer.vue
@@ -100,6 +100,7 @@ import FcCommonFilters from '@/web/components/filters/FcCommonFilters.vue';
 import FcStudyFilters from '@/web/components/filters/FcStudyFilters.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+import { saveFilterState } from '@/web/store/LoginState';
 
 function cloneCollisionFilters(filtersCollision) {
   const {
@@ -217,6 +218,7 @@ export default {
       this.internalFiltersStudy = defaultStudyFilters();
     },
     actionSave() {
+      saveFilterState(this.internalFiltersCollision);
       this.setFiltersCollision(this.internalFiltersCollision);
       this.setFiltersCommon(this.internalFiltersCommon);
       this.setFiltersStudy(this.internalFiltersStudy);

--- a/web/components/nav/FcDashboardNavUser.vue
+++ b/web/components/nav/FcDashboardNavUser.vue
@@ -63,11 +63,14 @@
 </template>
 
 <script>
-import { mapGetters, mapState } from 'vuex';
+import { mapGetters, mapState, mapMutations } from 'vuex';
 import Login from '@/web/components/Login.vue';
 import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcMixinAuthScope from '@/web/mixins/FcMixinAuthScope';
+import { getFilterState } from '@/web/store/LoginState';
+// eslint-disable-next-line no-unused-vars, import/named
+import { CollisionDetail, CollisionEmphasisArea } from '@/lib/Constants';
 
 export default {
   name: 'FcDashboardNavUser',
@@ -83,6 +86,12 @@ export default {
     ...mapState(['auth']),
     ...mapGetters(['username']),
   },
+  mounted() {
+    const filters = JSON.parse(getFilterState());
+    filters.details = filters.details.map(element => CollisionDetail[element]);
+    filters.emphasisAreas = filters.emphasisAreas.map(element => CollisionEmphasisArea[element]);
+    this.setFiltersCollision(filters);
+  },
   methods: {
     actionAdmin() {
       this.$router.push({ name: 'admin' });
@@ -93,6 +102,9 @@ export default {
 
       this.$refs.formSignOut.submit();
     },
+    ...mapMutations('viewData', [
+      'setFiltersCollision',
+    ]),
   },
 };
 </script>

--- a/web/components/reports/cells/MvcrLink.vue
+++ b/web/components/reports/cells/MvcrLink.vue
@@ -83,7 +83,6 @@ export default {
     userLogin() {
       const route = this.$route;
       route.params.mvcrRead = true;
-      route.params.collisionFilters = JSON.stringify(this.filterParamsCollision);
       this.$refs.login.actionSignIn();
     },
   },

--- a/web/store/FilterState.js
+++ b/web/store/FilterState.js
@@ -1,0 +1,102 @@
+const STORAGE_KEY_COLLISION_FILTER_STATE = 'ca.toronto.move.collisionFilterState';
+const STORAGE_KEY_COMMON_FILTER_STATE = 'ca.toronto.move.commonFilterState';
+const STORAGE_KEY_STUDY_FILTER_STATE = 'ca.toronto.move.studyFilterState';
+
+function saveCollisionFilterState(filterState) {
+  const filters = JSON.stringify(filterState);
+  window.sessionStorage.setItem(STORAGE_KEY_COLLISION_FILTER_STATE, filters);
+}
+
+function saveCommonFilterState(filterState) {
+  const filters = JSON.stringify(filterState);
+  window.sessionStorage.setItem(STORAGE_KEY_COMMON_FILTER_STATE, filters);
+}
+
+function saveStudyFilterState(filterState) {
+  const filters = JSON.stringify(filterState);
+  window.sessionStorage.setItem(STORAGE_KEY_STUDY_FILTER_STATE, filters);
+}
+
+function getCollisionFilterState() {
+  return window.sessionStorage.getItem(STORAGE_KEY_COLLISION_FILTER_STATE);
+}
+
+function getCommonFilterState() {
+  return window.sessionStorage.getItem(STORAGE_KEY_COMMON_FILTER_STATE);
+}
+
+function getStudyFilterState() {
+  return window.sessionStorage.getItem(STORAGE_KEY_STUDY_FILTER_STATE);
+}
+function resetCollisionFilterState(filter) {
+  const currentFilters = JSON.parse(getCollisionFilterState());
+  if (filter === 'hoursOfDay') {
+    currentFilters.hoursOfDayStart = 0;
+    currentFilters.hoursOfDayEnd = 24;
+  } else if (filter === 'mvcr' || filter === 'validated') {
+    currentFilters[filter] = null;
+  } else {
+    currentFilters[filter] = [];
+  }
+  saveCollisionFilterState(currentFilters);
+}
+
+function resetCommonFilterState(filter) {
+  const currentFilters = JSON.parse(getCommonFilterState());
+  if (filter === 'dateRange') {
+    currentFilters.dateRangeStart = null;
+    currentFilters.dateRangeEnd = null;
+  } else {
+    currentFilters[filter] = [];
+  }
+  saveCommonFilterState(currentFilters);
+}
+
+function resetStudyFilterState(filter) {
+  const currentFilters = JSON.parse(getStudyFilterState());
+  currentFilters[filter] = [];
+  saveStudyFilterState(currentFilters);
+}
+
+function clearCollisionFilterState() {
+  window.sessionStorage.removeItem(STORAGE_KEY_COLLISION_FILTER_STATE);
+}
+
+function clearCommonFilterState() {
+  window.sessionStorage.removeItem(STORAGE_KEY_COMMON_FILTER_STATE);
+}
+
+function clearStudyFilterState() {
+  window.sessionStorage.removeItem(STORAGE_KEY_STUDY_FILTER_STATE);
+}
+
+const FilterState = {
+  clearCollisionFilterState,
+  clearCommonFilterState,
+  clearStudyFilterState,
+  getCollisionFilterState,
+  getCommonFilterState,
+  getStudyFilterState,
+  resetCollisionFilterState,
+  resetCommonFilterState,
+  resetStudyFilterState,
+  saveCollisionFilterState,
+  saveCommonFilterState,
+  saveStudyFilterState,
+};
+
+export {
+  FilterState as default,
+  clearCollisionFilterState,
+  clearCommonFilterState,
+  clearStudyFilterState,
+  getCollisionFilterState,
+  getCommonFilterState,
+  getStudyFilterState,
+  resetCollisionFilterState,
+  resetCommonFilterState,
+  resetStudyFilterState,
+  saveCollisionFilterState,
+  saveCommonFilterState,
+  saveStudyFilterState,
+};

--- a/web/store/LoginState.js
+++ b/web/store/LoginState.js
@@ -1,5 +1,4 @@
 const STORAGE_KEY_LOGIN_STATE = 'ca.toronto.move.loginState';
-const STORAGE_KEY_FILTER_STATE = 'ca.toronto.move.filterState';
 
 /**
  * Restores the navigation target saved by {@link saveLoginState}.  This is intended to
@@ -67,38 +66,13 @@ function saveLoginState(to) {
   window.sessionStorage.setItem(STORAGE_KEY_LOGIN_STATE, loginState);
 }
 
-function saveFilterState(filterState) {
-  const filters = JSON.stringify(filterState);
-  window.sessionStorage.setItem(STORAGE_KEY_FILTER_STATE, filters);
-}
-
-function getFilterState() {
-  return window.sessionStorage.getItem(STORAGE_KEY_FILTER_STATE);
-}
-
-function resetFilterState(filter) {
-  const currentFilters = JSON.parse(getFilterState());
-  currentFilters[filter] = [];
-  saveFilterState(currentFilters);
-}
-
-function clearFilterState() {
-  window.sessionStorage.removeItem(STORAGE_KEY_FILTER_STATE);
-}
-
 const LoginState = {
   restoreLoginState,
-  resetFilterState,
   saveLoginState,
-  saveFilterState,
-  clearFilterState,
 };
 
 export {
   LoginState as default,
   restoreLoginState,
-  resetFilterState,
   saveLoginState,
-  saveFilterState,
-  getFilterState,
 };

--- a/web/store/LoginState.js
+++ b/web/store/LoginState.js
@@ -1,4 +1,5 @@
 const STORAGE_KEY_LOGIN_STATE = 'ca.toronto.move.loginState';
+const STORAGE_KEY_FILTER_STATE = 'ca.toronto.move.filterState';
 
 /**
  * Restores the navigation target saved by {@link saveLoginState}.  This is intended to
@@ -66,13 +67,38 @@ function saveLoginState(to) {
   window.sessionStorage.setItem(STORAGE_KEY_LOGIN_STATE, loginState);
 }
 
+function saveFilterState(filterState) {
+  const filters = JSON.stringify(filterState);
+  window.sessionStorage.setItem(STORAGE_KEY_FILTER_STATE, filters);
+}
+
+function getFilterState() {
+  return window.sessionStorage.getItem(STORAGE_KEY_FILTER_STATE);
+}
+
+function resetFilterState(filter) {
+  const currentFilters = JSON.parse(getFilterState());
+  currentFilters[filter] = [];
+  saveFilterState(currentFilters);
+}
+
+function clearFilterState() {
+  window.sessionStorage.removeItem(STORAGE_KEY_FILTER_STATE);
+}
+
 const LoginState = {
   restoreLoginState,
+  resetFilterState,
   saveLoginState,
+  saveFilterState,
+  clearFilterState,
 };
 
 export {
   LoginState as default,
   restoreLoginState,
+  resetFilterState,
   saveLoginState,
+  saveFilterState,
+  getFilterState,
 };

--- a/web/store/modules/viewData.js
+++ b/web/store/modules/viewData.js
@@ -5,7 +5,7 @@ import {
   defaultCommonFilters,
   defaultStudyFilters,
 } from '@/lib/filters/DefaultFilters';
-import { resetFilterState } from '@/web/store/LoginState';
+import { resetCollisionFilterState, resetStudyFilterState, resetCommonFilterState } from '@/web/store/FilterState';
 import DateTime from '@/lib/time/DateTime';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 
@@ -321,7 +321,7 @@ export default {
   },
   mutations: {
     removeFilterCollision(state, { filter }) {
-      resetFilterState(filter);
+      resetCollisionFilterState(filter);
       if (filter === 'hoursOfDay') {
         state.filtersCollision.hoursOfDayStart = 0;
         state.filtersCollision.hoursOfDayEnd = 24;
@@ -332,6 +332,7 @@ export default {
       }
     },
     removeFilterCommon(state, { filter }) {
+      resetCommonFilterState(filter);
       if (filter === 'dateRange') {
         state.filtersCommon.dateRangeStart = null;
         state.filtersCommon.dateRangeEnd = null;
@@ -340,6 +341,7 @@ export default {
       }
     },
     removeFilterStudy(state, { filter }) {
+      resetStudyFilterState(filter);
       state.filtersStudy[filter] = [];
     },
     setCollisionFactors(state, collisionFactors) {

--- a/web/store/modules/viewData.js
+++ b/web/store/modules/viewData.js
@@ -5,6 +5,7 @@ import {
   defaultCommonFilters,
   defaultStudyFilters,
 } from '@/lib/filters/DefaultFilters';
+import { resetFilterState } from '@/web/store/LoginState';
 import DateTime from '@/lib/time/DateTime';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 
@@ -320,6 +321,7 @@ export default {
   },
   mutations: {
     removeFilterCollision(state, { filter }) {
+      resetFilterState(filter);
       if (filter === 'hoursOfDay') {
         state.filtersCollision.hoursOfDayStart = 0;
         state.filtersCollision.hoursOfDayEnd = 24;


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-1097](https://move-toronto.atlassian.net/browse/MOVE-1097)

# Description
Filters applied by users did not generally persist, with the notable exception of the MVCR download flow. This was because the app was using the router to send the filters to the next screen after login (using that mvcr login button). This could not be used for logins via the actual login button since it lives outside of the router-view.

The new flow does away with the above. Now we set the filter state in session storage. On refresh, this is used to populate filters (whether logged in or not). Filters can be removed as normal.

# Tests
Added a test for new time formatter function that converts formatted time strings to luxon time
