### PR TITLE
MOVE-487: Requestors need a better way to interact between projects and their constituent study requests

### DIFF
--- a/lib/geo/CentrelineUtils.js
+++ b/lib/geo/CentrelineUtils.js
@@ -222,19 +222,19 @@ function groupRequestsByLocation(locationsState) {
   const locationGroups = {};
   for (let i = 0; i < locationsState.length; i++) {
     const studyRequest = locationsState[i];
-    const { description } = studyRequest.location;
-    if (description in locationGroups) {
+    const { centrelineId } = studyRequest.location;
+    if (centrelineId in locationGroups) {
       const {
         requestId, requestType, numDays, requestHours,
       } = studyRequest.location;
-      locationGroups[description].location.studyRequests.push({
+      locationGroups[centrelineId].location.studyRequests.push({
         requestId, requestType, numDays, requestHours,
       });
     } else {
       const {
         requestId, requestType, numDays, requestHours, ...rest
       } = studyRequest.location;
-      locationGroups[description] = {
+      locationGroups[centrelineId] = {
         location: {
           ...rest,
           studyRequests: [{

--- a/lib/geo/CentrelineUtils.js
+++ b/lib/geo/CentrelineUtils.js
@@ -174,6 +174,27 @@ function getStudyRequestLocation(studyRequest, location) {
   if (studyRequest === null) {
     return null;
   }
+  if (location !== null) {
+    return {
+      ...location,
+    };
+  }
+  const { geom } = studyRequest;
+  const [lng, lat] = geom.coordinates;
+  return {
+    centrelineId: null,
+    centrelineType: null,
+    description: `${lng.toFixed(6)}, ${lat.toFixed(6)}`,
+    geom,
+    lat,
+    lng,
+  };
+}
+
+function getStudyRequestInfo(studyRequest, location) {
+  if (studyRequest === null) {
+    return null;
+  }
   const { label } = studyRequest.studyType;
   const { id, hours, daysOfWeek } = studyRequest;
   if (location !== null) {
@@ -241,6 +262,7 @@ const CentrelineUtils = {
   getLocationsWaypointIndices,
   getMaplibreGlFeature,
   getStudyRequestLocation,
+  getStudyRequestInfo,
   groupRequestsByLocation,
 };
 
@@ -255,5 +277,6 @@ export {
   getLocationsWaypointIndices,
   getMaplibreGlFeature,
   getStudyRequestLocation,
+  getStudyRequestInfo,
   groupRequestsByLocation,
 };

--- a/lib/geo/GeoStyle.js
+++ b/lib/geo/GeoStyle.js
@@ -931,6 +931,7 @@ class GeoStyle {
                 'location-multi',
               ],
             ],
+            ['get', 'selected'], 'location-multi-selected',
             'location-single',
           ],
           'text-allow-overlap': true,

--- a/web/components/FcDataTableRequests.vue
+++ b/web/components/FcDataTableRequests.vue
@@ -75,7 +75,9 @@
       </div>
       <div
         v-else-if="item.location !== null"
-        class="text-wrap">
+        class="text-wrap"
+        @mouseover="setHoveredStudyRequest(item)"
+        @mouseleave="setHoveredStudyRequest(null)">
         {{item.location.description}}
       </div>
     </template>
@@ -336,7 +338,7 @@ export default {
       if (!full) label = customLabel;
       return label;
     },
-    ...mapMutations('trackRequests', ['setSortRequestSortBy', 'setSortRequestSortDesc']),
+    ...mapMutations('trackRequests', ['setSortRequestSortBy', 'setSortRequestSortDesc', 'setHoveredStudyRequest']),
   },
 };
 </script>

--- a/web/components/geo/map/FcMap.vue
+++ b/web/components/geo/map/FcMap.vue
@@ -451,8 +451,6 @@ export default {
           }
         });
       } else {
-        this.setHoveredFeature(null);
-
         // setting 'selected: false' for every location marker
         this.locationsMarkersGeoJson.features.forEach((item) => {
           item.properties.selected = false; // eslint-disable-line no-param-reassign

--- a/web/components/geo/map/FcMap.vue
+++ b/web/components/geo/map/FcMap.vue
@@ -331,7 +331,7 @@ export default {
       }
       return !this.drawerOpen || !featureMatchesRoute;
     },
-    ...mapState(['frontendEnv']),
+    ...mapState('trackRequests', ['frontendEnv', 'hoveredStudyRequest']),
   },
   created() {
     this.map = null;
@@ -433,6 +433,12 @@ export default {
         'active-midblocksCasing',
         ['in', ['get', 'centrelineId'], ['literal', this.centrelineActiveMidblocks]],
       );
+    },
+    hoveredStudyRequest() {
+      if (this.hoveredStudyRequest) {
+        const desiredCentrelineId = this.hoveredStudyRequest.location.centrelineId;
+        this.setHoveredFeature(this.getFeatureForLayerAndProperty('locations-markers', 'centrelineId', desiredCentrelineId));
+      }
     },
   },
   methods: {

--- a/web/components/geo/map/FcMap.vue
+++ b/web/components/geo/map/FcMap.vue
@@ -412,8 +412,12 @@ export default {
     locationsGeoJson() {
       this.updateLocationsSource();
     },
-    locationsMarkersGeoJson() {
-      this.updateLocationsMarkersSource();
+    locationsMarkersGeoJson: {
+      deep: true,
+      handler: function update() {
+        this.updateLocationsMarkersSource();
+      },
+      immediate: true,
     },
     locationsState() {
       this.easeToLocationbByMode();
@@ -436,17 +440,25 @@ export default {
     },
     hoveredStudyRequest() {
       if (this.hoveredStudyRequest) {
-        // We activate the tooltip here
         const desiredCentrelineId = this.hoveredStudyRequest.location.centrelineId;
-        this.setHoveredFeature(this.getFeatureForLayerAndProperty('locations-markers', 'centrelineId', desiredCentrelineId));
 
-        // We focus in on a specific location marker here
-        const desiredLocations = this.locationsState.filter(
-          item => item.location.centrelineId === desiredCentrelineId,
-        );
-        this.easeToLocationsState(desiredLocations);
+        // setting 'selected: true' on the right location marker
+        this.locationsMarkersGeoJson.features.forEach((item) => {
+          if (item.properties.centrelineId === desiredCentrelineId) {
+            item.properties.selected = true; // eslint-disable-line no-param-reassign
+          } else {
+            item.properties.selected = false; // eslint-disable-line no-param-reassign
+          }
+        });
+
+        this.updateLocationsMarkersSource();
       } else {
         this.setHoveredFeature(null);
+
+        // setting 'selected: false' for every location marker
+        this.locationsMarkersGeoJson.features.forEach((item) => {
+          item.properties.selected = false; // eslint-disable-line no-param-reassign
+        });
       }
     },
   },

--- a/web/components/geo/map/FcMap.vue
+++ b/web/components/geo/map/FcMap.vue
@@ -436,8 +436,17 @@ export default {
     },
     hoveredStudyRequest() {
       if (this.hoveredStudyRequest) {
+        // We activate the tooltip here
         const desiredCentrelineId = this.hoveredStudyRequest.location.centrelineId;
         this.setHoveredFeature(this.getFeatureForLayerAndProperty('locations-markers', 'centrelineId', desiredCentrelineId));
+
+        // We focus in on a specific location marker here
+        const desiredLocations = this.locationsState.filter(
+          item => item.location.centrelineId === desiredCentrelineId,
+        );
+        this.easeToLocationsState(desiredLocations);
+      } else {
+        this.setHoveredFeature(null);
       }
     },
   },

--- a/web/components/geo/map/FcMap.vue
+++ b/web/components/geo/map/FcMap.vue
@@ -450,8 +450,6 @@ export default {
             item.properties.selected = false; // eslint-disable-line no-param-reassign
           }
         });
-
-        this.updateLocationsMarkersSource();
       } else {
         this.setHoveredFeature(null);
 
@@ -460,6 +458,7 @@ export default {
           item.properties.selected = false; // eslint-disable-line no-param-reassign
         });
       }
+      this.updateLocationsMarkersSource();
     },
   },
   methods: {
@@ -605,12 +604,18 @@ export default {
       }
     },
     setHoveredFeature(feature) {
-      // this.hoveredFeature = feature;
-      this.hoveredFeature = this.fixStudyRequestInfo(feature);
+      if (this.isRequestPage) {
+        this.hoveredFeature = this.fixStudyRequestInfo(feature);
+      } else {
+        this.hoveredFeature = feature;
+      }
     },
     setSelectedFeature(feature) {
-      // this.selectedFeature = feature;
-      this.selectedFeature = this.fixStudyRequestInfo(feature);
+      if (this.isRequestPage) {
+        this.selectedFeature = this.fixStudyRequestInfo(feature);
+      } else {
+        this.selectedFeature = feature;
+      }
     },
     updateLocationsSource() {
       GeoStyle.setData('locations', this.locationsGeoJson);

--- a/web/components/geo/map/FcMapPopup.vue
+++ b/web/components/geo/map/FcMapPopup.vue
@@ -11,7 +11,7 @@
       <v-divider></v-divider>
 
       <v-card-text class="default--text"
-      :class="this.feature.properties.studyRequests ? 'px-0' : ''">
+      :class="this.feature.properties.studyRequests ? 'px-1' : ''">
         <FcProgressLinear
           v-if="loading"
           aria-label="Loading feature details" />

--- a/web/store/modules/trackRequests.js
+++ b/web/store/modules/trackRequests.js
@@ -15,6 +15,7 @@ export default {
       sortBy: 'ID',
       sortDesc: true,
     },
+    hoveredStudyRequest: null,
   },
   getters: {
     filterChipsRequest(state) {
@@ -132,6 +133,9 @@ export default {
     hasFiltersRequest(state, getters) {
       return getters.filterChipsRequest.length > 0 || state.searchRequest.query !== null;
     },
+    getHoveredStudyRequest(state) {
+      return state.hoveredStudyRequest;
+    },
   },
   mutations: {
     removeFilterRequest(state, { filter }) {
@@ -172,6 +176,9 @@ export default {
     },
     setSortRequestSortDesc(state, sortDesc) {
       state.sortRequest.sortDesc = sortDesc;
+    },
+    setHoveredStudyRequest(state, studyRequest) {
+      state.hoveredStudyRequest = studyRequest;
     },
   },
 };

--- a/web/views/FcRequestStudyBulkView.vue
+++ b/web/views/FcRequestStudyBulkView.vue
@@ -114,7 +114,7 @@ import { mapActions, mapMutations } from 'vuex';
 
 import { centrelineKey, ProjectMode, StudyRequestStatus } from '@/lib/Constants';
 import { getStudyRequestBulk } from '@/lib/api/WebApi';
-import { getStudyRequestLocation, groupRequestsByLocation } from '@/lib/geo/CentrelineUtils';
+import { getStudyRequestInfo, groupRequestsByLocation } from '@/lib/geo/CentrelineUtils';
 import { getStudyRequestItem } from '@/lib/requests/RequestItems';
 import RequestDataTableColumns from '@/lib/requests/RequestDataTableColumns';
 import FcDataTableRequests from '@/web/components/FcDataTableRequests.vue';
@@ -188,7 +188,7 @@ export default {
         if (this.studyRequestLocations.has(key)) {
           location = this.studyRequestLocations.get(key);
         }
-        location = getStudyRequestLocation(studyRequest, location);
+        location = getStudyRequestInfo(studyRequest, location);
         const state = {
           deselected: false,
           locationIndex: -1,

--- a/web/views/FcRequestStudyBulkView.vue
+++ b/web/views/FcRequestStudyBulkView.vue
@@ -46,72 +46,78 @@
           </v-row>
           <v-row class="d-flex flex-row">
             <v-col cols="8" class="flex-1">
-              <section
-                aria-labelledby="heading_bulk_request_requests"
-                class="mb-0 mx-0 py-0 flex-grow-0 flex-shrink-1">
-                <div class="align-center d-flex px-4 py-2">
-                  <v-checkbox
-                    v-model="selectAll"
-                    class="mt-0 mr-2 pt-0"
-                    hide-details
-                    :indeterminate="selectAll === null">
-                    <template v-slot:label>
-                      <span class="font-weight-medium">Select all</span>
-                      <FcTextNumberTotal
-                        class="ml-2"
-                        :k="selectedItems.length"
-                        :n="items.length" />
-                    </template>
-                  </v-checkbox>
-
-                  <template>
-                    <SetStatusDropdownForBulk
-                      v-if="userIsStudyRequestAdmin"
-                      :study-requests="selectedStudyRequests"
-                      @transition-status="updateSelectedRequestsStatus" />
-                    <CancelRequestButton
-                      v-else-if="userIsStudyRequester"
-                      :disabled="noRequestsSelected || userCannotCancelAllSelectedRequests"
-                      :nRequests="selectedRequestsCount"
-                      :projectContext="true"
-                      @cancel-request="cancelSelected">
-                    </CancelRequestButton>
-                  </template>
-
-                  <FcButton
-                    class="ml-2"
-                    :disabled="selectAll === false"
-                    type="secondary"
-                    @click="actionRemoveFromProject">
-                    <v-icon left>mdi-folder-remove</v-icon>
-                    Remove From Project
-                  </FcButton>
-                </div>
-
-                <v-divider></v-divider>
-
-                <FcDataTableRequests
-                  v-model="selectedItems"
+              <v-card dense outlined class="flex-grow-1 fill-height">
+                <section
                   aria-labelledby="heading_bulk_request_requests"
-                  :columns="columns"
-                  disable-pagination
-                  disable-sort
-                  :has-filters="false"
-                  :items="items"
-                  :loading="loadingItems"
-                  @update-item="actionUpdateItem" />
-              </section>
+                  class="mb-0 mx-0 py-0">
+                  <div class="align-center d-flex px-4 py-2">
+                    <v-checkbox
+                      v-model="selectAll"
+                      class="mt-0 mr-2 pt-0"
+                      hide-details
+                      :indeterminate="selectAll === null">
+                      <template v-slot:label>
+                        <span class="font-weight-medium">Select all</span>
+                        <FcTextNumberTotal
+                          class="ml-2"
+                          :k="selectedItems.length"
+                          :n="items.length" />
+                      </template>
+                    </v-checkbox>
+
+                    <template>
+                      <SetStatusDropdownForBulk
+                        v-if="userIsStudyRequestAdmin"
+                        :study-requests="selectedStudyRequests"
+                        @transition-status="updateSelectedRequestsStatus" />
+                      <CancelRequestButton
+                        v-else-if="userIsStudyRequester"
+                        :disabled="noRequestsSelected || userCannotCancelAllSelectedRequests"
+                        :nRequests="selectedRequestsCount"
+                        :projectContext="true"
+                        @cancel-request="cancelSelected">
+                      </CancelRequestButton>
+                    </template>
+
+                    <FcButton
+                      class="ml-2"
+                      :disabled="selectAll === false"
+                      type="secondary"
+                      @click="actionRemoveFromProject">
+                      <v-icon left>mdi-folder-remove</v-icon>
+                      Remove From Project
+                    </FcButton>
+                  </div>
+
+                  <v-divider></v-divider>
+
+                  <FcDataTableRequests
+                    v-model="selectedItems"
+                    aria-labelledby="heading_bulk_request_requests"
+                    :columns="columns"
+                    disable-pagination
+                    disable-sort
+                    fixed-header
+                    height="400px"
+                    calculate-widths
+                    :has-filters="false"
+                    :items="items"
+                    :loading="loadingItems"
+                    @update-item="actionUpdateItem" />
+                </section>
+              </v-card>
             </v-col>
 
             <v-col cols="4" class="flex-1">
               <FcMap
-                class="mx-2 fill-height"
+                class="mx-0 fill-height"
                 :locations-state="locationsState"
                 :show-legend="false"
                 :is-request-page="true"/>
             </v-col>
           </v-row>
         </v-container>
+
       </section>
     </div>
   </div>

--- a/web/views/FcRequestStudyBulkView.vue
+++ b/web/views/FcRequestStudyBulkView.vue
@@ -45,7 +45,7 @@
             </h3>
           </v-row>
           <v-row class="d-flex flex-row">
-            <v-col cols="8" class="flex-1">
+            <v-col cols="8" class="flex-1 pl-5">
               <v-card dense outlined class="flex-grow-1 fill-height">
                 <section
                   aria-labelledby="heading_bulk_request_requests"
@@ -108,7 +108,7 @@
               </v-card>
             </v-col>
 
-            <v-col cols="4" class="flex-1">
+            <v-col cols="4" class="flex-1 px-5 pl-0">
               <FcMap
                 class="mx-0 fill-height"
                 :locations-state="locationsState"

--- a/web/views/FcRequestStudyBulkView.vue
+++ b/web/views/FcRequestStudyBulkView.vue
@@ -34,75 +34,79 @@
               class="mx-5"
               :study-request-bulk="studyRequestBulk" />
           </v-col>
-          <v-col cols="6">
-            <FcMap
-              class="mx-5"
-              :locations-state="locationsState"
-              :show-legend="false"
-              :is-request-page="true"/>
-          </v-col>
         </v-row>
 
         <v-divider></v-divider>
 
-        <section
-          aria-labelledby="heading_bulk_request_requests"
-          class="mb-6 mx-5">
-          <h3 class="display-2 mt-6 mb-2" id="heading_bulk_request_requests">
-            <span>Requests</span>
-          </h3>
-          <div class="align-center d-flex px-4 py-2">
-            <v-checkbox
-              v-model="selectAll"
-              class="mt-0 mr-2 pt-0"
-              hide-details
-              :indeterminate="selectAll === null">
-              <template v-slot:label>
-                <span class="font-weight-medium">Select all</span>
-                <FcTextNumberTotal
-                  class="ml-2"
-                  :k="selectedItems.length"
-                  :n="items.length" />
-              </template>
-            </v-checkbox>
-
-            <template>
-              <SetStatusDropdownForBulk
-                v-if="userIsStudyRequestAdmin"
-                :study-requests="selectedStudyRequests"
-                @transition-status="updateSelectedRequestsStatus" />
-              <CancelRequestButton
-                v-else-if="userIsStudyRequester"
-                :disabled="noRequestsSelected || userCannotCancelAllSelectedRequests"
-                :nRequests="selectedRequestsCount"
-                :projectContext="true"
-                @cancel-request="cancelSelected">
-              </CancelRequestButton>
-            </template>
-
-            <FcButton
-              class="ml-2"
-              :disabled="selectAll === false"
-              type="secondary"
-              @click="actionRemoveFromProject">
-              <v-icon left>mdi-folder-remove</v-icon>
-              Remove From Project
-            </FcButton>
-          </div>
-
-          <v-divider></v-divider>
-
-          <FcDataTableRequests
-            v-model="selectedItems"
+        <div class="d-flex align-center justify-space-between">
+          <section
             aria-labelledby="heading_bulk_request_requests"
-            :columns="columns"
-            disable-pagination
-            disable-sort
-            :has-filters="false"
-            :items="items"
-            :loading="loadingItems"
-            @update-item="actionUpdateItem" />
-        </section>
+            class="flex-1 mb-6 mx-5">
+            <h3 class="display-2 mt-6 mb-2" id="heading_bulk_request_requests">
+              <span>Requests</span>
+            </h3>
+            <div class="align-center d-flex px-4 py-2">
+              <v-checkbox
+                v-model="selectAll"
+                class="mt-0 mr-2 pt-0"
+                hide-details
+                :indeterminate="selectAll === null">
+                <template v-slot:label>
+                  <span class="font-weight-medium">Select all</span>
+                  <FcTextNumberTotal
+                    class="ml-2"
+                    :k="selectedItems.length"
+                    :n="items.length" />
+                </template>
+              </v-checkbox>
+
+              <template>
+                <SetStatusDropdownForBulk
+                  v-if="userIsStudyRequestAdmin"
+                  :study-requests="selectedStudyRequests"
+                  @transition-status="updateSelectedRequestsStatus" />
+                <CancelRequestButton
+                  v-else-if="userIsStudyRequester"
+                  :disabled="noRequestsSelected || userCannotCancelAllSelectedRequests"
+                  :nRequests="selectedRequestsCount"
+                  :projectContext="true"
+                  @cancel-request="cancelSelected">
+                </CancelRequestButton>
+              </template>
+
+              <FcButton
+                class="ml-2"
+                :disabled="selectAll === false"
+                type="secondary"
+                @click="actionRemoveFromProject">
+                <v-icon left>mdi-folder-remove</v-icon>
+                Remove From Project
+              </FcButton>
+            </div>
+
+            <v-divider></v-divider>
+
+            <FcDataTableRequests
+              v-model="selectedItems"
+              aria-labelledby="heading_bulk_request_requests"
+              :columns="columns"
+              disable-pagination
+              disable-sort
+              :has-filters="false"
+              :items="items"
+              :loading="loadingItems"
+              @update-item="actionUpdateItem" />
+          </section>
+
+          <v-col cols="6" class="flex-shrink-1">
+            <FcMap
+              class="mx-2"
+              :locations-state="locationsState"
+              :show-legend="false"
+              :is-request-page="true"/>
+          </v-col>
+        </div>
+
       </section>
     </div>
   </div>


### PR DESCRIPTION
# Issue Addressed
This PR addresses MOVE-487

# Description
Improved the UI of the MOVE Project / Bulk Request View, added tooltips to map pins, and interactions between request table and map.
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/64811136/600d3112-3da7-42bb-830d-c1cb2fb527b8)


# Tests
Tested in MOVE v1.11.1 in Firefox
