### PR TITLE
Fc map state fix

### DIFF
--- a/web/components/geo/map/FcMap.vue
+++ b/web/components/geo/map/FcMap.vue
@@ -371,7 +371,8 @@ export default {
       );
       return markersById;
     },
-    ...mapState('trackRequests', ['frontendEnv', 'hoveredStudyRequest']),
+    ...mapState(['frontendEnv']),
+    ...mapState('trackRequests', ['hoveredStudyRequest']),
   },
   created() {
     this.map = null;

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="fc-single-location-row">
     <div class="fc-input-location-search"
-    :class="{ 'fc-location-search-home elevation-2': !drawerOpen}">
+    :class="[{ 'fc-location-search-home elevation-2': !drawerOpen && !limitSizeOfBar}
+      , {'elevation-2': !drawerOpen}]">
       <v-menu
         v-model="showLocationSuggestions"
         ref="menuLocationSuggestions"
@@ -132,6 +133,10 @@ export default {
       default: false,
     },
     isSingleMode: {
+      type: Boolean,
+      default: false,
+    },
+    limitSizeOfBar: {
       type: Boolean,
       default: false,
     },

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -2,7 +2,7 @@
   <div class="fc-single-location-row">
     <div class="fc-input-location-search"
     :class="[{ 'fc-location-search-home elevation-2': !drawerOpen && !limitSizeOfBar}
-      , {'elevation-2': !drawerOpen}]">
+      , {'elevation-2': !drawerOpen && limitSizeOfBar}]">
       <v-menu
         v-model="showLocationSuggestions"
         ref="menuLocationSuggestions"

--- a/web/views/FcLayoutRequestEditor.vue
+++ b/web/views/FcLayoutRequestEditor.vue
@@ -22,7 +22,7 @@
           :show-legend="false">
           <template v-slot:top-left>
             <FcInputLocationSearch
-              limit-size-of-bar="true"
+              :limit-size-of-bar="true"
               ref="locationSearch"
               v-if="showLocationSearch"
               v-model="locationToAdd"

--- a/web/views/FcLayoutRequestEditor.vue
+++ b/web/views/FcLayoutRequestEditor.vue
@@ -22,6 +22,7 @@
           :show-legend="false">
           <template v-slot:top-left>
             <FcInputLocationSearch
+              limit-size-of-bar="true"
               ref="locationSearch"
               v-if="showLocationSearch"
               v-model="locationToAdd"


### PR DESCRIPTION
This is a quick PR to fix two bugs that I found. 

1. The first was the location search bar on the study request page (bulk). Because the size of the map has been changed, old css rules were causing the bar to display weird transparency behaviour in this view specifically:

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/26462466/815f835d-2e02-445c-b2cc-d97c29364c13)

Any css sizing rules applied to this component elsewhere had to be nullified here. A check is added to see if the input is being rendered on the study request view, if so, the max-size rule applied anywhere else is not applied here.

2. The second one was the loss of the zoom widget in local and dev. This was because new state properties were being incorrectly  pulled into the FcMap component. i.e. the frontendEnv was pulled into the trackRequests module where it should actually have been called into the component separately. This separation is now applied and the widget is back in the correct environments.
