### PR TITLE
MOVE-1184: Remove Gap Study from intersections

### DIFF
--- a/lib/geo/CentrelineUtils.js
+++ b/lib/geo/CentrelineUtils.js
@@ -33,7 +33,6 @@ function getLocationStudyTypes(location) {
       StudyType.PXO_OBSERVE,
       StudyType.VID_OBSERVE,
       StudyType.SCHOOL_CROSS,
-      StudyType.GAP_STUDY,
     ];
   }
   if (locationFeatureType === RoadSegmentType.EXPRESSWAY) {

--- a/tests/jest/unit/geo/CentrelineUtils.spec.js
+++ b/tests/jest/unit/geo/CentrelineUtils.spec.js
@@ -57,7 +57,6 @@ test('CentrelineUtils.getLocationStudyTypes', () => {
       StudyType.PXO_OBSERVE,
       StudyType.VID_OBSERVE,
       StudyType.SCHOOL_CROSS,
-      StudyType.GAP_STUDY,
     ]);
   });
   RoadSegmentType.enumValues.forEach(({ featureCode }) => {


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-1184.

# Description
Removed 'Gap Study' from the types of studies that a user that a user can request at an intersection.

# Tests
Tested in MOVE local v1.12.0 using Firefox.
