### PR TITLE
MOVE-591

### DIFF
--- a/web/store/modules/trackRequests.js
+++ b/web/store/modules/trackRequests.js
@@ -15,6 +15,7 @@ export default {
       sortBy: 'ID',
       sortDesc: true,
     },
+    pageNum: 1,
     hoveredStudyRequest: null,
   },
   getters: {
@@ -136,6 +137,9 @@ export default {
     getHoveredStudyRequest(state) {
       return state.hoveredStudyRequest;
     },
+    getPageNum(state) {
+      return state.pageNum;
+    },
   },
   mutations: {
     removeFilterRequest(state, { filter }) {
@@ -179,6 +183,9 @@ export default {
     },
     setHoveredStudyRequest(state, studyRequest) {
       state.hoveredStudyRequest = studyRequest;
+    },
+    setPageNum(state, pageNum) {
+      state.pageNum = pageNum;
     },
   },
 };

--- a/web/views/FcRequestsTrack.vue
+++ b/web/views/FcRequestsTrack.vue
@@ -283,16 +283,18 @@ export default {
   watch: {
     filterParamsRequest: {
       deep: true,
-      handler: debounce(async function updateTotal() {
+      handler: debounce(async function updateTotal(newValue, oldValue) {
         this.loadingTotal = true;
 
         const total = await getStudyRequestItemsTotal(this.filterParamsRequestWithPagination);
 
-        // Following logic only resets the page number if the user has applied filters
-        if (this.filtersExist()) {
-          this.page = 1;
-        } else {
+        // Following logic only remembers the page number if the user is navigating between pages
+        // without refreshing (i.e oldValue === undefined)
+
+        if (!oldValue) {
           this.page = this.getPageNum();
+        } else {
+          this.page = 1;
         }
 
         this.total = total;

--- a/web/views/FcRequestsTrack.vue
+++ b/web/views/FcRequestsTrack.vue
@@ -182,7 +182,7 @@ export default {
       loading: true,
       loadingDownload: false,
       loadingTotal: false,
-      page: 1,
+      page: this.getPageNum(),
       projectMode: ProjectMode.NONE,
       selectedItems: [],
       showDialogProjectMode: false,
@@ -288,7 +288,13 @@ export default {
 
         const total = await getStudyRequestItemsTotal(this.filterParamsRequestWithPagination);
 
-        this.page = 1;
+        // Following logic only resets the page number if the user has applied filters
+        if (this.filtersExist()) {
+          this.page = 1;
+        } else {
+          this.page = this.getPageNum();
+        }
+
         this.total = total;
 
         this.loadingTotal = false;
@@ -314,6 +320,9 @@ export default {
         this.loading = false;
       }, 200),
       immediate: true,
+    },
+    page() {
+      this.setPageNum(this.page);
     },
   },
   created() {
@@ -413,10 +422,14 @@ export default {
       }
       await this.loadAsync();
     },
-    ...mapMutations('trackRequests', ['setFiltersRequestUserOnly']),
+    filtersExist() {
+      return Object.keys(this.filterParamsRequest).length > 2;
+    },
+    ...mapMutations('trackRequests', ['setFiltersRequestUserOnly', 'setPageNum']),
     ...mapMutations(['setToastInfo', 'setDialog']),
     ...mapActions(['saveStudyRequest', 'updateStudyRequests', 'checkAuth']),
     ...mapActions('editRequests', ['updateStudyRequestsBulkRequests']),
+    ...mapGetters('trackRequests', ['getPageNum']),
   },
 };
 </script>


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-591.

# Description
Added a state variable to store the page number of the requests table in Track Requests. The page number will reset only if a refresh occurs, or if the user changes the filters. As a result, Track Requests will remember the page number when the user moves between pages.

# Tests
Tested in MOVE local v1.12.0  using Firefox. 
