### PR TITLE
Float sidebar

### DIFF
--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -16,7 +16,7 @@
       aria-label="Loading collision reports viewer" />
     <template v-else>
       <div>
-        <div class="align-center d-flex flex-grow-0 flex-shrink-0 px-3 pt-2">
+        <div class="align-center d-flex flex-grow-0 flex-shrink-0 px-3 py-2">
             <v-icon @click="actionNavigateBack" large>mdi-chevron-left</v-icon>
           <h2 class="ml-4">
             <span class="headline">Collisions</span>
@@ -32,8 +32,11 @@
           </h2>
           <v-spacer></v-spacer>
 
-          <v-icon class="mr-2">mdi-chevron-down</v-icon>
-          <v-icon>mdi-close-circle</v-icon>
+          <v-icon v-if="collapseReport" class="mx-3" @click="toggleReport">mdi-chevron-up</v-icon>
+          <v-icon v-else class="mx-3" @click="toggleReport">mdi-chevron-down</v-icon>
+
+          <v-icon @click="closeReport">mdi-close-circle</v-icon>
+
           <v-menu
             v-if="locationMode !== LocationMode.SINGLE && detailView"
             max-height="320">
@@ -57,7 +60,7 @@
           </v-menu>
         </div>
 
-        <div class="align-center d-flex">
+        <div class="align-center d-flex" v-if="!collapseReport">
           <nav>
             <v-tabs v-model="indexActiveReportType" show-arrows>
               <v-tab
@@ -97,7 +100,7 @@
         <v-divider></v-divider>
       </div>
 
-      <section class="flex-grow-1 flex-shrink-1 overflow-y-auto pt-2">
+      <section class="flex-grow-1 flex-shrink-1 overflow-y-auto pt-2"  v-if="!collapseReport">
         <div
           v-if="loadingReportLayout"
           class="ma-3 text-center">
@@ -195,6 +198,7 @@ export default {
         ReportType.COLLISION_TABULATION,
       ],
       showConfirmLeave: false,
+      collapseReport: false,
     };
   },
   computed: {
@@ -422,6 +426,15 @@ export default {
     reportSectionRows(section) {
       const reportContent = this.reportLayout.content[1].options;
       return reportContent[section];
+    },
+    closeReport() {
+      console.log('closing report'); //eslint-disable-line
+      this.$router.push({
+        name: 'viewData',
+      });
+    },
+    toggleReport() {
+      this.collapseReport = !this.collapseReport;
     },
     headerRowByIndex(index) {
       if (!this.isDirectoryReport) return false;

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -472,6 +472,12 @@ export default {
   & .fc-bg-white {
     background-color: #FFF;
   }
+  & .v-slide-group__prev--disabled {
+    visibility: hidden;
+  }
+  & .v-slide-group__next--disabled {
+    visibility: hidden;
+  }
 }
 
 .drawer-open .fc-drawer-view-collision-reports {

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -17,12 +17,7 @@
     <template v-else>
       <div>
         <div class="align-center d-flex flex-grow-0 flex-shrink-0 px-3 pt-2">
-          <FcButton
-            type="primary"
-            @click="actionNavigateBack">
-            <v-icon left>mdi-chevron-left</v-icon>
-            View Data
-          </FcButton>
+            <v-icon @click="actionNavigateBack" large>mdi-chevron-left</v-icon>
           <h2 class="ml-4">
             <span class="headline">Collisions</span>
             <span class="font-weight-light headline secondary--text">
@@ -35,9 +30,10 @@
               </span>
             </span>
           </h2>
-
           <v-spacer></v-spacer>
 
+          <v-icon class="mr-2">mdi-chevron-down</v-icon>
+          <v-icon>mdi-close-circle</v-icon>
           <v-menu
             v-if="locationMode !== LocationMode.SINGLE && detailView"
             max-height="320">

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -25,7 +25,14 @@
     <template v-else>
       <div>
         <div class="align-center d-flex flex-grow-0 flex-shrink-0 px-3 py-2">
-            <v-icon @click="actionNavigateBack" large>mdi-chevron-left</v-icon>
+          <v-tooltip bottom>
+            <template v-slot:activator="{ on, attrs }">
+              <v-icon @click="actionNavigateBack" v-bind="attrs" v-on="on" large>
+                mdi-chevron-left
+              </v-icon>
+            </template>
+            <span>View Data</span>
+          </v-tooltip>
           <h2 class="ml-4">
             <span class="headline">Collisions</span>
             <span class="font-weight-light headline secondary--text">
@@ -40,10 +47,28 @@
           </h2>
           <v-spacer></v-spacer>
 
-          <v-icon v-if="collapseReport" class="mx-3" @click="toggleReport">mdi-chevron-up</v-icon>
-          <v-icon v-else class="mx-3" @click="toggleReport">mdi-chevron-down</v-icon>
+          <v-tooltip bottom>
+            <template v-slot:activator="{ on, attrs }">
+              <span v-bind="attrs" v-on="on">
+                <v-icon v-if="collapseReport" class="mx-3" @click="toggleReport">
+                  mdi-chevron-up
+                </v-icon>
+                <v-icon v-else class="mx-3" @click="toggleReport">
+                  mdi-chevron-down
+                </v-icon>
+              </span>
+            </template>
+            <span>Toggle Report</span>
+          </v-tooltip>
 
-          <v-icon @click="closeReport">mdi-close-circle</v-icon>
+          <v-tooltip bottom>
+            <template v-slot:activator="{ on, attrs }">
+              <span v-bind="attrs" v-on="on">
+                <v-icon @click="closeReport">mdi-close-circle</v-icon>
+              </span>
+            </template>
+            <span>Close Report</span>
+          </v-tooltip>
 
           <v-menu
             v-if="locationMode !== LocationMode.SINGLE && detailView"

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -428,7 +428,6 @@ export default {
       return reportContent[section];
     },
     closeReport() {
-      console.log('closing report'); //eslint-disable-line
       this.$router.push({
         name: 'viewData',
       });

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -63,9 +63,7 @@
 
           <v-tooltip bottom>
             <template v-slot:activator="{ on, attrs }">
-              <span v-bind="attrs" v-on="on">
-                <v-icon @click="closeReport">mdi-close-circle</v-icon>
-              </span>
+                <v-icon @click="closeReport" v-bind="attrs" v-on="on">mdi-close-circle</v-icon>
             </template>
             <span>Close Report</span>
           </v-tooltip>

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -11,9 +11,17 @@
         Are you sure you want to leave?
       </span>
     </FcDialogConfirm>
-    <FcProgressLinear
-      v-if="loading"
-      aria-label="Loading collision reports viewer" />
+    <div class="fc-report-loading" v-if="loading">
+      <div class="align-center d-flex flex-grow-0 flex-shrink-0 px-3 py-2">
+        <v-icon @click="actionNavigateBack" large>mdi-chevron-left</v-icon>
+        <h2 class="ml-4">
+          <span class="headline">Collisions</span>
+        </h2>
+        <v-spacer></v-spacer>
+        <v-icon @click="closeReport">mdi-close-circle</v-icon>
+      </div>
+      <FcProgressLinear aria-label="Loading collision reports viewer" />
+    </div>
     <template v-else>
       <div>
         <div class="align-center d-flex flex-grow-0 flex-shrink-0 px-3 py-2">
@@ -60,7 +68,7 @@
           </v-menu>
         </div>
 
-        <div class="align-center d-flex" v-if="!collapseReport">
+        <div class="align-center d-flex fc-bg-white" v-if="!collapseReport">
           <nav>
             <v-tabs v-model="indexActiveReportType" show-arrows>
               <v-tab
@@ -460,6 +468,9 @@ export default {
       top: 0;
       right: 0;
     }
+  }
+  & .fc-bg-white {
+    background-color: #FFF;
   }
 }
 

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -15,7 +15,7 @@
         </div>
       </div>
     </header>
-    <section class="flex-grow-1 flex-shrink-1 overflow-y-auto">
+    <section class="flex-grow-1 flex-shrink-1">
       <v-divider></v-divider>
       <FcProgressLinear
         v-if="loading"

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fc-drawer-view-data d-flex flex-column pb-6">
+  <div class="fc-drawer-view-data d-flex flex-column">
     <header class="flex-grow-0 flex-shrink-0 fc-drawer-header">
       <FcSelectorMultiLocation
         v-if="locationMode.multi"
@@ -33,6 +33,7 @@
 
           <FcViewDataDetail
             v-if="locationMode === LocationMode.SINGLE || detailView"
+            class="pb-6"
             :location="locationActive" />
           <FcViewDataAggregate
             v-else

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -33,7 +33,6 @@
 
           <FcViewDataDetail
             v-if="locationMode === LocationMode.SINGLE || detailView"
-            class="pb-6"
             :location="locationActive" />
           <FcViewDataAggregate
             v-else
@@ -186,6 +185,7 @@ export default {
 <style lang="scss">
 .fc-drawer-view-data {
   max-height: var(--full-height);
+  min-height: 52px;
   & .fc-drawer-header {
     border-bottom: 1px solid lightgrey;
   }

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="fc-drawer-view-data d-flex flex-column">
-    <header class="flex-grow-0 flex-shrink-0 shading">
+    <header class="flex-grow-0 flex-shrink-0">
       <FcSelectorMultiLocation
         v-if="locationMode.multi"
         :detail-view="detailView">

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="fc-drawer-view-data d-flex flex-column">
-    <header class="flex-grow-0 flex-shrink-0">
+  <div class="fc-drawer-view-data d-flex flex-column pb-6">
+    <header class="flex-grow-0 flex-shrink-0 fc-drawer-header">
       <FcSelectorMultiLocation
         v-if="locationMode.multi"
         :detail-view="detailView">
@@ -15,8 +15,7 @@
         </div>
       </div>
     </header>
-    <section class="flex-grow-1 flex-shrink-1">
-      <v-divider></v-divider>
+    <section class="flex-grow-1 flex-shrink-1 overflow-y-auto">
       <FcProgressLinear
         v-if="loading"
         aria-label="Loading View Data drawer" />
@@ -186,5 +185,8 @@ export default {
 <style lang="scss">
 .fc-drawer-view-data {
   max-height: var(--full-height);
+  & .fc-drawer-header {
+    border-bottom: 1px solid lightgrey;
+  }
 }
 </style>

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -16,7 +16,7 @@
       aria-label="Loading study reports viewer" />
     <template v-else>
       <div>
-        <div class="align-center d-flex flex-grow-0 flex-shrink-0 px-3 pt-2">
+        <div class="align-center d-flex flex-grow-0 flex-shrink-0 px-3 py-2">
           <v-icon @click="actionNavigateBack" large>mdi-chevron-left</v-icon>
           <h2 class="ml-4">
             <span class="headline">{{studyType.label}}</span>
@@ -27,6 +27,10 @@
 
           <v-spacer></v-spacer>
 
+          <v-icon v-if="collapseReport" class="mx-3" @click="toggleReport">mdi-chevron-up</v-icon>
+          <v-icon v-else class="mx-3" @click="toggleReport">mdi-chevron-down</v-icon>
+
+          <v-icon @click="closeReport">mdi-close-circle</v-icon>
           <v-menu
             v-if="locationMode !== LocationMode.SINGLE"
             :max-height="320">
@@ -75,7 +79,7 @@
           </v-menu>
         </div>
 
-        <div class="align-center d-flex pt-1">
+        <div class="align-center d-flex pt-1" v-if="!collapseReport">
           <nav>
             <v-tabs v-model="indexActiveReportType" show-arrows>
               <v-tab
@@ -109,7 +113,7 @@
         <v-divider></v-divider>
       </div>
 
-      <section class="flex-grow-1 flex-shrink-1 overflow-y-auto pt-2">
+      <section class="flex-grow-1 flex-shrink-1 overflow-y-auto pt-2" v-if="!collapseReport">
         <FcReportParameters
           v-if="showReportParameters"
           :report-parameters="reportParameters"
@@ -227,6 +231,7 @@ export default {
       showReportParameters: false,
       studies: [],
       studyRetrievalError: false,
+      collapseReport: false,
       studySummaryPerLocation: [],
     };
   },
@@ -413,6 +418,14 @@ export default {
         name: 'viewDataAtLocation',
         params,
       });
+    },
+    closeReport() {
+      this.$router.push({
+        name: 'viewData',
+      });
+    },
+    toggleReport() {
+      this.collapseReport = !this.collapseReport;
     },
     handleError() {
       this.loadingReportLayout = false;

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -11,10 +11,19 @@
         Are you sure you want to leave?
       </span>
     </FcDialogConfirm>
-    <FcProgressLinear
-      v-if="loading"
-      aria-label="Loading study reports viewer" />
-    <template v-else>
+    <div class="fc-report-loading" v-if="loading">
+      <div class="align-center d-flex flex-grow-0 flex-shrink-0 px-3 py-2">
+        <v-icon @click="actionNavigateBack" large>mdi-chevron-left</v-icon>
+        <h2 class="ml-4">
+          <span class="headline">{{studyType.label}}</span>
+        </h2>
+        <v-spacer></v-spacer>
+        <v-icon @click="closeReport">mdi-close-circle</v-icon>
+      </div>
+      <FcProgressLinear aria-label="Loading study reports viewer" />
+    </div>
+
+      <template v-else>
       <div>
         <div class="align-center d-flex flex-grow-0 flex-shrink-0 px-3 py-2">
           <v-icon @click="actionNavigateBack" large>mdi-chevron-left</v-icon>
@@ -79,7 +88,7 @@
           </v-menu>
         </div>
 
-        <div class="align-center d-flex pt-1" v-if="!collapseReport">
+        <div class="align-center d-flex pt-1 fc-bg-white" v-if="!collapseReport">
           <nav>
             <v-tabs v-model="indexActiveReportType" show-arrows>
               <v-tab
@@ -504,6 +513,9 @@ export default {
       top: 0;
       right: 0;
     }
+  }
+  & .fc-bg-white {
+    background-color: #FFF;
   }
 }
 

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -17,12 +17,7 @@
     <template v-else>
       <div>
         <div class="align-center d-flex flex-grow-0 flex-shrink-0 px-3 pt-2">
-          <FcButton
-            type="primary"
-            @click="actionNavigateBack">
-            <v-icon left>mdi-chevron-left</v-icon>
-            View Data
-          </FcButton>
+          <v-icon @click="actionNavigateBack" large>mdi-chevron-left</v-icon>
           <h2 class="ml-4">
             <span class="headline">{{studyType.label}}</span>
             <span class="font-weight-light headline secondary--text">

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -23,10 +23,17 @@
       <FcProgressLinear aria-label="Loading study reports viewer" />
     </div>
 
-      <template v-else>
+    <template v-else>
       <div>
         <div class="align-center d-flex flex-grow-0 flex-shrink-0 px-3 py-2">
-          <v-icon @click="actionNavigateBack" large>mdi-chevron-left</v-icon>
+          <v-tooltip bottom>
+            <template v-slot:activator="{ on, attrs }">
+              <v-icon @click="actionNavigateBack" v-bind="attrs" v-on="on" large>
+                mdi-chevron-left
+              </v-icon>
+            </template>
+            <span>View Data</span>
+          </v-tooltip>
           <h2 class="ml-4">
             <span class="headline">{{studyType.label}}</span>
             <span class="font-weight-light headline secondary--text">
@@ -36,10 +43,27 @@
 
           <v-spacer></v-spacer>
 
-          <v-icon v-if="collapseReport" class="mx-3" @click="toggleReport">mdi-chevron-up</v-icon>
-          <v-icon v-else class="mx-3" @click="toggleReport">mdi-chevron-down</v-icon>
+          <v-tooltip bottom>
+            <template v-slot:activator="{ on, attrs }">
+              <span v-bind="attrs" v-on="on">
+                <v-icon v-if="collapseReport" class="mx-3" @click="toggleReport">
+                  mdi-chevron-up
+                </v-icon>
+                <v-icon v-else class="mx-3" @click="toggleReport">
+                  mdi-chevron-down
+                </v-icon>
+              </span>
+            </template>
+            <span>Toggle Report</span>
+          </v-tooltip>
 
-          <v-icon @click="closeReport">mdi-close-circle</v-icon>
+          <v-tooltip bottom>
+            <template v-slot:activator="{ on, attrs }">
+                <v-icon @click="closeReport" v-bind="attrs" v-on="on">mdi-close-circle</v-icon>
+            </template>
+            <span>Close Report</span>
+          </v-tooltip>
+
           <v-menu
             v-if="locationMode !== LocationMode.SINGLE"
             :max-height="320">

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -517,6 +517,12 @@ export default {
   & .fc-bg-white {
     background-color: #FFF;
   }
+  & .v-slide-group__prev--disabled {
+    visibility: hidden;
+  }
+  & .v-slide-group__next--disabled {
+    visibility: hidden;
+  }
 }
 
 .drawer-open .fc-drawer-view-study-reports {

--- a/web/components/data/FcSectionStudyRequestsPending.vue
+++ b/web/components/data/FcSectionStudyRequestsPending.vue
@@ -1,9 +1,9 @@
 <template>
-  <section class="pa-3 pl-5">
+  <section class="pl-5">
     <p
       v-for="studyRequest in studyRequestsPending"
       :key="studyRequest.id"
-      class="align-center d-flex mb-1">
+      class="align-center d-flex mb-1 pa-3">
       <v-icon
         color="warning"
         left>mdi-information</v-icon>

--- a/web/components/data/FcViewDataDetail.vue
+++ b/web/components/data/FcViewDataDetail.vue
@@ -37,8 +37,6 @@
           @show-reports="actionShowReportsStudy" />
       </section>
 
-      <v-divider></v-divider>
-
       <FcSectionStudyRequestsPending
         :study-requests-pending="studyRequestsPending" />
     </template>

--- a/web/components/location/FcSummaryPoi.vue
+++ b/web/components/location/FcSummaryPoi.vue
@@ -1,10 +1,7 @@
 <template>
   <div class="fc-summary-poi">
-    <FcProgressCircular
-      v-if="loading || location === null"
-      aria-label="Loading points of interest near this location"
-      silent
-      small />
+    <div v-if="loading || location === null"
+      aria-label="Loading points of interest near this location" />
     <dl v-else-if="poiChips.length > 0">
       <FcSummaryPoiChip
         v-for="(poiChip, i) in poiChips"
@@ -17,13 +14,11 @@
 
 <script>
 import { getPoiByCentrelineSummary } from '@/lib/api/WebApi';
-import FcProgressCircular from '@/web/components/dialogs/FcProgressCircular.vue';
 import FcSummaryPoiChip from '@/web/components/location/FcSummaryPoiChip.vue';
 
 export default {
   name: 'FcSummaryPoi',
   components: {
-    FcProgressCircular,
     FcSummaryPoiChip,
   },
   props: {

--- a/web/views/FcLayoutViewData.vue
+++ b/web/views/FcLayoutViewData.vue
@@ -1,14 +1,10 @@
 <template>
   <div
-    class="fc-layout-view-data fill-height"
-    :class="{
-      'drawer-open': drawerOpen,
-      horizontal: true
-    }">
+    class="fc-layout-view-data fill-height horizontal"
+    :class="{ 'drawer-open': drawerOpen }">
     <FcDialogConfirmMultiLocationLeave
       v-model="showConfirmMultiLocationLeave" />
-
-    <template v-if="hasDrawer">
+    <!-- <template v-if="hasDrawer">
       <FcTooltip right>
         <template v-slot:activator="{ on }">
           <FcButton
@@ -22,19 +18,12 @@
         </template>
         <span>{{labelDrawerToggle}}</span>
       </FcTooltip>
-    </template>
-    <div
-      class="fc-pane-wrapper d-flex fill-height">
-      <div
-        v-show="showDrawer"
-        class="fc-drawer flex-grow-1 flex-shrink-0">
+    </template> -->
+    <div class="fc-pane-wrapper fill-height">
+      <div v-show="showDrawer" class="fc-drawer shading elevation-4">
         <router-view></router-view>
       </div>
-      <div
-        class="fc-map-wrapper flex-shrink-0"
-        :class="{
-          'flex-grow-1': !mapBackground,
-        }">
+      <div class="fc-map-wrapper fill-height">
         <FcMap
           ref="map"
           class="fill-height"
@@ -90,23 +79,23 @@ import { getLocationsWaypointIndices } from '@/lib/geo/CentrelineUtils';
 
 import FcDialogConfirmMultiLocationLeave
   from '@/web/components/dialogs/FcDialogConfirmMultiLocationLeave.vue';
-import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
+// import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
 import FcGlobalFilterBox from '@/web/components/filters/FcGlobalFilterBox.vue';
 import FcMap from '@/web/components/geo/map/FcMap.vue';
 import FcMapPopupActionViewData from '@/web/components/geo/map/FcMapPopupActionViewData.vue';
-import FcButton from '@/web/components/inputs/FcButton.vue';
+// import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcSelectorCollapsedLocation from '@/web/components/inputs/FcSelectorCollapsedLocation.vue';
 import FcSelectorSingleLocation from '@/web/components/inputs/FcSelectorSingleLocation.vue';
 
 export default {
   name: 'FcLayoutViewData',
   components: {
-    FcButton,
+    // FcButton,
     FcDialogConfirmMultiLocationLeave,
     FcGlobalFilterBox,
     FcMap,
     FcMapPopupActionViewData,
-    FcTooltip,
+    // FcTooltip,
     FcSelectorCollapsedLocation,
     FcSelectorSingleLocation,
   },
@@ -200,8 +189,7 @@ export default {
       });
     },
     mapBackground() {
-      const { drawerOpen } = this;
-      return drawerOpen;
+      return true;
     },
     showDrawer() {
       const { drawerOpen, hasDrawer } = this;
@@ -312,8 +300,26 @@ export default {
         background-color: var(--v-shading-base);
       }
     }
-    & > .fc-pane-wrapper > div {
+  }
+
+  & .fc-pane-wrapper {
+    position:relative;
+    height: 100%;
+    & .fc-map-wrapper {
+      width: 100%;
+      height: 100%;
+    }
+    & .fc-drawer {
+      position:absolute;
+      top: 0;
+      left: 0;
+      margin: 10px;
       width: 50%;
+      max-width: 400px;
+      max-height: 90%;
+      z-index: 5;
+      border-radius: 8px;
+      border: 1px solid lightgrey !important;
     }
   }
 

--- a/web/views/FcLayoutViewData.vue
+++ b/web/views/FcLayoutViewData.vue
@@ -318,12 +318,13 @@ export default {
       width: 50%;
       max-width: 375px;
       min-width: 300px;
+      min-height: 50px;
       border-radius: 8px;
       border: 1px solid lightgrey !important;
       overflow-y: hidden;
       max-height: 95%;
       z-index: 106;
-      transition: min-width 0.5s ease-in;
+      transition: min-width 0.5s cubic-bezier(0.7, 0, 0.84, 0);
     }
     & .fc-full-drawer {
       min-width: 98% !important;

--- a/web/views/FcLayoutViewData.vue
+++ b/web/views/FcLayoutViewData.vue
@@ -323,7 +323,7 @@ export default {
       overflow-y: hidden;
       max-height: 95%;
       z-index: 106;
-      transition: min-width 0.7s ease-in;
+      transition: min-width 0.5s ease-in;
     }
     & .fc-full-drawer {
       min-width: 98% !important;

--- a/web/views/FcLayoutViewData.vue
+++ b/web/views/FcLayoutViewData.vue
@@ -327,7 +327,7 @@ export default {
       transition: min-width 0.25s cubic-bezier(0.7, 0, 0.84, 0);
     }
     & .fc-full-drawer {
-      min-width: 98% !important;
+      min-width: calc(100vw - 80px) !important;
       min-height: 52px;
     }
   }

--- a/web/views/FcLayoutViewData.vue
+++ b/web/views/FcLayoutViewData.vue
@@ -324,10 +324,11 @@ export default {
       overflow-y: hidden;
       max-height: 95%;
       z-index: 106;
-      transition: min-width 0.5s cubic-bezier(0.7, 0, 0.84, 0);
+      transition: min-width 0.25s cubic-bezier(0.7, 0, 0.84, 0);
     }
     & .fc-full-drawer {
       min-width: 98% !important;
+      min-height: 52px;
     }
   }
 

--- a/web/views/FcLayoutViewData.vue
+++ b/web/views/FcLayoutViewData.vue
@@ -315,11 +315,12 @@ export default {
       left: 0;
       margin: 10px;
       width: 50%;
-      max-width: 400px;
+      max-width: 375px;
       max-height: 90%;
       z-index: 5;
       border-radius: 8px;
       border: 1px solid lightgrey !important;
+      overflow-y: auto;
     }
   }
 

--- a/web/views/FcLayoutViewData.vue
+++ b/web/views/FcLayoutViewData.vue
@@ -3,24 +3,13 @@
     class="fc-layout-view-data fill-height"
     :class="{
       'drawer-open': drawerOpen,
-      horizontal: !vertical,
-      vertical
+      horizontal: true
     }">
     <FcDialogConfirmMultiLocationLeave
       v-model="showConfirmMultiLocationLeave" />
 
     <template v-if="hasDrawer">
-      <FcButton
-        v-if="vertical"
-        class="pane-drawer-toggle mb-2 d-none"
-        type="fab-text"
-        @click="setDrawerOpen(!drawerOpen)">
-        <v-icon
-          color="primary"
-          left>{{iconDrawerToggle}}</v-icon>
-        {{labelDrawerToggle}}
-      </FcButton>
-      <FcTooltip v-else right>
+      <FcTooltip right>
         <template v-slot:activator="{ on }">
           <FcButton
             :aria-label="labelDrawerToggle"
@@ -35,23 +24,16 @@
       </FcTooltip>
     </template>
     <div
-      class="fc-pane-wrapper d-flex fill-height"
-      :class="{
-        'flex-column': vertical,
-      }">
+      class="fc-pane-wrapper d-flex fill-height">
       <div
         v-show="showDrawer"
-        class="fc-drawer flex-grow-1 flex-shrink-0"
-        :class="{
-          'order-2': vertical,
-        }">
+        class="fc-drawer flex-grow-1 flex-shrink-0">
         <router-view></router-view>
       </div>
       <div
         class="fc-map-wrapper flex-shrink-0"
         :class="{
           'flex-grow-1': !mapBackground,
-          'order-1': vertical,
         }">
         <FcMap
           ref="map"
@@ -147,10 +129,7 @@ export default {
       return this.$route.name !== 'viewData';
     },
     iconDrawerToggle() {
-      const { drawerOpen, vertical } = this;
-      if (vertical) {
-        return drawerOpen ? 'mdi-arrow-collapse' : 'mdi-arrow-expand';
-      }
+      const { drawerOpen } = this;
       return drawerOpen ? 'mdi-menu-left' : 'mdi-menu-right';
     },
     internalLayers: {
@@ -170,10 +149,7 @@ export default {
       },
     },
     labelDrawerToggle() {
-      const { drawerOpen, vertical } = this;
-      if (vertical) {
-        return drawerOpen ? 'Collapse page' : 'Expand page';
-      }
+      const { drawerOpen } = this;
       return drawerOpen ? 'Collapse side panel' : 'Expand side panel';
     },
     locationsState() {
@@ -224,20 +200,16 @@ export default {
       });
     },
     mapBackground() {
-      const { drawerOpen, vertical } = this;
-      return drawerOpen && vertical;
+      const { drawerOpen } = this;
+      return drawerOpen;
     },
     showDrawer() {
-      const { drawerOpen, hasDrawer, vertical } = this;
-      return (hasDrawer && drawerOpen) || vertical;
+      const { drawerOpen, hasDrawer } = this;
+      return (hasDrawer && drawerOpen);
     },
     showLocationSelection() {
       const { showLocationSelection } = this.$route.meta;
       return showLocationSelection;
-    },
-    vertical() {
-      const { vertical } = this.$route.meta;
-      return vertical;
     },
     ...mapState([
       'locationMode',
@@ -320,20 +292,6 @@ export default {
     border-radius: 8px;
   }
 
-  &.vertical {
-    & > .pane-drawer-toggle {
-      bottom: 50%;
-      left: calc(50% - 80px);
-      width: 160px;
-    }
-    & > .fc-pane-wrapper > div {
-      height: 50%;
-      &.fc-drawer {
-        border-top: 1px solid rgba(0, 0, 0, 0.12);
-      }
-    }
-  }
-
   &.horizontal {
     & > .pane-drawer-toggle {
       background-color: var(--white);
@@ -368,28 +326,6 @@ export default {
       & > .fc-pane-wrapper > .fc-drawer {
         border-right: 1px solid rgba(0, 0, 0, 0.12);
       }
-    }
-    &.vertical {
-      & > .pane-drawer-toggle {
-        bottom: calc(100% - 60px);
-        left: calc(50% - 90px);
-        width: 180px;
-      }
-      & > .fc-pane-wrapper > .fc-map-wrapper {
-        height: 0;
-      }
-      & > .fc-pane-wrapper > .fc-drawer {
-        height: calc(100% - 60px);
-      }
-    }
-  }
-}
-
-@media screen and (max-height: 900px) {
-  .fc-layout-view-data {
-    &.vertical .fc-map-legend {
-      max-height: 218px;
-      overflow: auto;
     }
   }
 }

--- a/web/views/FcLayoutViewData.vue
+++ b/web/views/FcLayoutViewData.vue
@@ -20,7 +20,8 @@
       </FcTooltip>
     </template> -->
     <div class="fc-pane-wrapper fill-height">
-      <div v-show="showDrawer" class="fc-drawer shading elevation-4">
+      <div v-show="showDrawer" class="fc-drawer shading elevation-4"
+        :class="{'fc-full-drawer':!showLocationSelection}">
         <router-view></router-view>
       </div>
       <div class="fc-map-wrapper fill-height">
@@ -316,11 +317,16 @@ export default {
       margin: 10px;
       width: 50%;
       max-width: 375px;
-      z-index: 5;
+      min-width: 300px;
       border-radius: 8px;
       border: 1px solid lightgrey !important;
       overflow-y: hidden;
       max-height: 95%;
+      z-index: 106;
+      transition: min-width 0.7s ease-in;
+    }
+    & .fc-full-drawer {
+      min-width: 98% !important;
     }
   }
 

--- a/web/views/FcLayoutViewData.vue
+++ b/web/views/FcLayoutViewData.vue
@@ -4,21 +4,6 @@
     :class="{ 'drawer-open': drawerOpen }">
     <FcDialogConfirmMultiLocationLeave
       v-model="showConfirmMultiLocationLeave" />
-    <!-- <template v-if="hasDrawer">
-      <FcTooltip right>
-        <template v-slot:activator="{ on }">
-          <FcButton
-            :aria-label="labelDrawerToggle"
-            class="pane-drawer-toggle"
-            type="icon"
-            @click="setDrawerOpen(!drawerOpen)"
-            v-on="on">
-            <v-icon>{{iconDrawerToggle}}</v-icon>
-          </FcButton>
-        </template>
-        <span>{{labelDrawerToggle}}</span>
-      </FcTooltip>
-    </template> -->
     <div class="fc-pane-wrapper fill-height">
       <div v-show="showDrawer" class="fc-drawer shading elevation-4"
         :class="{'fc-full-drawer':!showLocationSelection}">
@@ -80,23 +65,19 @@ import { getLocationsWaypointIndices } from '@/lib/geo/CentrelineUtils';
 
 import FcDialogConfirmMultiLocationLeave
   from '@/web/components/dialogs/FcDialogConfirmMultiLocationLeave.vue';
-// import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
 import FcGlobalFilterBox from '@/web/components/filters/FcGlobalFilterBox.vue';
 import FcMap from '@/web/components/geo/map/FcMap.vue';
 import FcMapPopupActionViewData from '@/web/components/geo/map/FcMapPopupActionViewData.vue';
-// import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcSelectorCollapsedLocation from '@/web/components/inputs/FcSelectorCollapsedLocation.vue';
 import FcSelectorSingleLocation from '@/web/components/inputs/FcSelectorSingleLocation.vue';
 
 export default {
   name: 'FcLayoutViewData',
   components: {
-    // FcButton,
     FcDialogConfirmMultiLocationLeave,
     FcGlobalFilterBox,
     FcMap,
     FcMapPopupActionViewData,
-    // FcTooltip,
     FcSelectorCollapsedLocation,
     FcSelectorSingleLocation,
   },

--- a/web/views/FcLayoutViewData.vue
+++ b/web/views/FcLayoutViewData.vue
@@ -316,11 +316,11 @@ export default {
       margin: 10px;
       width: 50%;
       max-width: 375px;
-      max-height: 90%;
       z-index: 5;
       border-radius: 8px;
       border: 1px solid lightgrey !important;
-      overflow-y: auto;
+      overflow-y: hidden;
+      max-height: 95%;
     }
   }
 


### PR DESCRIPTION
# Issue Addressed
This PR closes **MOVE-1173**  *Reports page: bring back map peek ability* - and addresses **MOVE-1176** *Webapp should be more responsive*

# Description
Absolutely positions `fc-drawer` component, so that both the sidebar and report-view float above the map.
This allows users to peek back at the map, when viewing a report. It also allows us to control the width of the sidebar, instead of fixing it at 50%. It also allows us to only use the sidebar height that we need.

* changes are duplicated in Study and Collision report pages
* adds some min-sizing to reduce jumping in the css transition
* adds some sidebar styling so it will behave in floating-mode
* adds tooltips for the new report buttons
* removes unused **vertical-mode** feature code
* removes old sidebar toggle button, which was prev absolutely positioned
* did not change map zoom (easetolocation), but may need to be nudged a wee bit

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/399657/60d52346-99d4-4143-8c1f-abe92867b0df)

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/399657/12e9fad7-a04c-411e-b2fe-6e2c3d7cad16)

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/399657/386d977a-cf84-437e-80ff-2007f44171dc)
