### PR TITLE
Move 1169

### DIFF
--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -43,27 +43,6 @@
 
           <v-spacer></v-spacer>
 
-          <v-tooltip bottom>
-            <template v-slot:activator="{ on, attrs }">
-              <span v-bind="attrs" v-on="on">
-                <v-icon v-if="collapseReport" class="mx-3" @click="toggleReport">
-                  mdi-chevron-up
-                </v-icon>
-                <v-icon v-else class="mx-3" @click="toggleReport">
-                  mdi-chevron-down
-                </v-icon>
-              </span>
-            </template>
-            <span>Toggle Report</span>
-          </v-tooltip>
-
-          <v-tooltip bottom>
-            <template v-slot:activator="{ on, attrs }">
-                <v-icon @click="closeReport" v-bind="attrs" v-on="on">mdi-close-circle</v-icon>
-            </template>
-            <span>Close Report</span>
-          </v-tooltip>
-
           <v-menu
             v-if="locationMode !== LocationMode.SINGLE"
             :max-height="320">
@@ -95,7 +74,7 @@
                 class="flex-grow-0 mt-0"
                 type="secondary">
                 <v-icon color="primary" left>mdi-calendar-month-outline</v-icon>
-                {{labelActiveStudy}}
+                <span class="fc-calendar-btn-label">{{labelActiveStudy}}</span>
                 <v-icon right>mdi-menu-down</v-icon>
               </FcButton>
             </template>
@@ -110,6 +89,27 @@
               </v-list-item>
             </v-list>
           </v-menu>
+
+          <v-tooltip bottom>
+            <template v-slot:activator="{ on, attrs }">
+              <span v-bind="attrs" v-on="on">
+                <v-icon v-if="collapseReport" class="mx-3" @click="toggleReport">
+                  mdi-chevron-up
+                </v-icon>
+                <v-icon v-else class="mx-3" @click="toggleReport">
+                  mdi-chevron-down
+                </v-icon>
+              </span>
+            </template>
+            <span>Toggle Report</span>
+          </v-tooltip>
+
+          <v-tooltip bottom>
+            <template v-slot:activator="{ on, attrs }">
+                <v-icon @click="closeReport" v-bind="attrs" v-on="on">mdi-close-circle</v-icon>
+            </template>
+            <span>Close Report</span>
+          </v-tooltip>
         </div>
 
         <div class="align-center d-flex pt-1 fc-bg-white" v-if="!collapseReport">
@@ -551,5 +551,11 @@ export default {
 
 .drawer-open .fc-drawer-view-study-reports {
   max-height: var(--full-height);
+}
+
+@media only screen and (max-width: 800px) {
+  .fc-calendar-btn-label {
+    display: none;
+  }
 }
 </style>

--- a/web/components/geo/map/FcMap.vue
+++ b/web/components/geo/map/FcMap.vue
@@ -606,7 +606,7 @@ export default {
       if (features.length > 0) {
         // see if a feature was clicked ... if so choose that one
         // if a feature was not clicked then get features in a bounding box
-        return features[0];
+        return this.pickTooltipFeature(features);
       }
       const { x, y } = point;
       const bbox = [[x - 10, y - 10], [x + 10, y + 10]];
@@ -614,6 +614,22 @@ export default {
       if (features.length === 0) {
         return null;
       }
+      return this.pickTooltipFeature(features);
+    },
+    pickTooltipFeature(features) {
+      if (features.length === 1) {
+        return features[0];
+      }
+      const preference = {
+        studies: 3,
+        intersections: 2,
+        midblocks: 1,
+      };
+      features.sort((a, b) => {
+        const left = preference[a.source] || 0;
+        const right = preference[b.source] || 0;
+        return right - left;
+      });
       return features[0];
     },
     onMapClick(e) {

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -33,6 +33,24 @@
                 <template v-if="hasLocationIndex">
                 </template>
                 <template v-else>
+                  <template v-if="!drawerOpen">
+                    <FcTooltip
+                      v-if="internalValue !== null || query !== null"
+                      right>
+                      <template v-slot:activator="{ on: onTooltip }">
+                        <FcButton
+                          aria-label="Clear Location"
+                          class="fc-close-btn-inside mr-1"
+                          type="icon"
+                          @click="actionClear"
+                          v-on="onTooltip">
+                          <v-icon>mdi-close-circle</v-icon>
+                        </FcButton>
+                      </template>
+                      <span>Clear Location</span>
+                    </FcTooltip>
+                    <v-divider vertical />
+                  </template>
                   <v-icon
                     :color="hasFocus ? 'primary' : null"
                     right>
@@ -306,5 +324,8 @@ export default {
 }
 .fc-location-search-home {
   max-width: 448px;
+}
+.fc-close-btn-inside {
+  opacity: 0.4;
 }
 </style>

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -31,21 +31,6 @@
               v-on="onMenu">
               <template v-slot:append>
                 <template v-if="hasLocationIndex">
-                  <template v-if="showClose">
-                    <FcTooltip right>
-                      <template v-slot:activator="{ on: onTooltip }">
-                        <FcButton
-                          aria-label="Clear Location"
-                          type="icon"
-                          @click="actionRemove"
-                          v-on="onTooltip"
-                          plain>
-                          <v-icon>mdi-close</v-icon>
-                        </FcButton>
-                      </template>
-                      <span>Clear Location</span>
-                    </FcTooltip>
-                  </template>
                 </template>
                 <template v-else>
                   <v-icon
@@ -94,7 +79,6 @@
 </template>
 
 <script>
-import Vue from 'vue';
 import { Enum } from '@/lib/ClassUtils';
 import { debounce } from '@/lib/FunctionUtils';
 import { getLocationSuggestions } from '@/lib/api/WebApi';
@@ -125,10 +109,6 @@ export default {
       default: null,
     },
     selected: {
-      type: Boolean,
-      default: false,
-    },
-    showClose: {
       type: Boolean,
       default: false,
     },
@@ -247,17 +227,6 @@ export default {
         this.$emit('location-remove', this.locationIndex);
       }
     },
-    actionRemove() {
-      const description = this.query || '';
-      this.setToastInfo(`Removed ${description} from selected locations.`);
-      this.setLocationsEditIndex(-1);
-      this.removeLocationEdit(this.locationIndex);
-      Vue.nextTick(() => {
-        if (this.autofocus) {
-          this.autofocus();
-        }
-      });
-    },
     actionBlur(e) {
       /*
        * Clicking a location suggestion in the dropdown triggers a blur event.  However, if
@@ -317,6 +286,7 @@ export default {
   flex-wrap: none;
   justify-content: space-between;
   border-radius: 8px;
+  flex-grow: 1;
   & .nudge-right {
     left: 15px;
   }

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -29,8 +29,22 @@
               :selected="i === locationsEditIndex"
               @focus="setLocationsEditIndex(i)"
               @location-remove="actionRemove"
-              showClose />
+               />
+               <FcTooltip right>
+                  <template v-slot:activator="{ on: onTooltip }">
+                    <FcButton
+                      aria-label="Clear Location"
+                      type="icon"
+                      @click="actionRemove(i)"
+                      v-on="onTooltip"
+                      plain>
+                      <v-icon>mdi-close</v-icon>
+                    </FcButton>
+                  </template>
+                  <span>Clear Location</span>
+                </FcTooltip>
             </div>
+
           </div>
 
           <div class="fc-multi-line">
@@ -46,6 +60,7 @@
                 @focus="setLocationsEditIndex(-1)"
                 @location-add="actionAdd" />
               </div>
+              <div class="fc-btn-spacer"></div>
           </div>
         </div>
         <v-messages
@@ -411,6 +426,7 @@ export default {
   position: relative;
 
   & .fc-input-location-search-wrapper {
+    display: flex;
     width: 100%;
   }
   & .fc-input-has-border {
@@ -451,6 +467,9 @@ export default {
   }
   & .hide {
     display: none;
+  }
+  & .fc-btn-spacer {
+    width:45px;
   }
 }
 .edit-location-btn {


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-208](https://move-toronto.atlassian.net/browse/MOVE-208) [MOVE-1170](https://move-toronto.atlassian.net/browse/MOVE-1170) and [MOVE-1178](https://move-toronto.atlassian.net/browse/MOVE-1178)

# Description
first-half of parent issue [Move-1169](https://move-toronto.atlassian.net/browse/MOVE-1169), it fixes some issues not-addressed by Web 1.12.0.

1. set preference of tooltip, when there are many under the mouse
2. move **x** buttons in multi-location back inside the search bar
3. re-add a clear button to home-screen search bar
4. fix order of buttons in multi-study report
5. add a media-query for this multi-study button, too