### PR TITLE
MOVE-1145 - Add project description to the Track Requests CSV export

### DIFF
--- a/lib/requests/RequestItemExport.js
+++ b/lib/requests/RequestItemExport.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { mapBy } from '@/lib/MapUtils';
 import { formatUsername } from '@/lib/StringFormatters';
 import TimeFormatters from '@/lib/time/TimeFormatters';

--- a/lib/requests/RequestItemExport.js
+++ b/lib/requests/RequestItemExport.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { mapBy } from '@/lib/MapUtils';
 import { formatUsername } from '@/lib/StringFormatters';
 import TimeFormatters from '@/lib/time/TimeFormatters';
@@ -22,6 +23,7 @@ const CSV_COLUMNS = [
   'Hours',
   'Collection Notes',
   'Comments',
+  'Project Description',
   'MOVE ID',
   'Date Requested',
   'Client',
@@ -52,7 +54,7 @@ class RequestItemExport {
       return null;
     }
     const studyRequestBulk = studyRequestsBulkById.get(studyRequestBulkId);
-    return studyRequestBulk.name;
+    return { name: studyRequestBulk.name, description: studyRequestBulk.notes };
   }
 
   static getItemRow(item, studyRequestsBulkById) {
@@ -84,7 +86,10 @@ class RequestItemExport {
     let studyTypeLabel = studyType.label;
     if (studyType.other) studyTypeLabel = `${studyTypeLabel} (${item.studyRequest.studyTypeOther})`;
     const dateRequested = TimeFormatters.formatCsvDate(item.studyRequest.createdAt);
-    const projectRequest = RequestItemExport.getItemProjectRequest(item, studyRequestsBulkById);
+    const {
+      name: projectRequest,
+      description: projectDescription,
+    } = RequestItemExport.getItemProjectRequest(item, studyRequestsBulkById);
 
     let { hours, duration } = item.studyRequest;
     if (hours === null) hours = '';
@@ -107,6 +112,7 @@ class RequestItemExport {
       hours,
       notes,
       comments,
+      projectDescription,
       id,
       dateRequested,
       client,

--- a/lib/requests/RequestItemExport.js
+++ b/lib/requests/RequestItemExport.js
@@ -47,10 +47,10 @@ class RequestItemExport {
   static getItemProjectRequest(item, studyRequestsBulkById) {
     const { studyRequestBulkId } = item.studyRequest;
     if (studyRequestBulkId === null) {
-      return null;
+      return { name: null, description: null };
     }
     if (!studyRequestsBulkById.has(studyRequestBulkId)) {
-      return null;
+      return { name: null, description: null };
     }
     const studyRequestBulk = studyRequestsBulkById.get(studyRequestBulkId);
     return { name: studyRequestBulk.name, description: studyRequestBulk.notes };


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-1145](https://move-toronto.atlassian.net/browse/MOVE-1145)

# Description
Adds a column - 'Project Description' to the CSV export. Each request within that project description will have the same description from the project.
Requests that are not part of a project will be empty.

# Tests
All tests are successfully running.
