### PR TITLE
fix issue with multiple api calls on hover

### DIFF
--- a/web/components/geo/map/FcMapPopup.vue
+++ b/web/components/geo/map/FcMapPopup.vue
@@ -84,7 +84,6 @@ export default {
   },
   computed: {
     coordinates() {
-      this.loadAsyncForFeature();
       return getGeometryMidpoint(this.feature.geometry);
     },
     detailsSuffix() {


### PR DESCRIPTION
# Issue Addressed
This is an amendment to [MOVE-487](https://github.com/CityofToronto/bdit_flashcrow/pull/1206)

# Description
loadAsyncForFeatures being a computed property in the FcMapPopup component was resulting in multiple API calls going out for a single hover on/hover off event. This is likely not the way we want to be handling this. @imadsyed333, just a heads up that this will affect the project page popups.
