### PR TITLE
MOVE-479: reverting to 50/50 map/study split on study request page

### DIFF
--- a/web/views/FcLayoutRequestEditor.vue
+++ b/web/views/FcLayoutRequestEditor.vue
@@ -170,7 +170,7 @@ export default {
   }
 
   & > .fc-pane-wrapper > .map {
-    flex-grow: 2;
+    flex-grow: 1;
   }
 }
 .fc-layout-request-editor .fc-map-top-left .fc-input-location-search {


### PR DESCRIPTION
# Issue Addressed
This PR address [MOVE-479](https://move-toronto.atlassian.net/browse/MOVE-479)

# Description
This is just a fix that reverts the map/study request drawer split on the bulk study request page.

