### PR TITLE
MOVE-1182 - Limit ATR (VSC) counts to 1, 3, and 7 days

### DIFF
--- a/web/components/requests/fields/FcStudyRequestDuration.vue
+++ b/web/components/requests/fields/FcStudyRequestDuration.vue
@@ -44,7 +44,8 @@ export default {
       return caption;
     },
     itemsDuration() {
-      if (this.studyType === StudyType.ATR_VOLUME_BICYCLE) {
+      if (this.studyType === StudyType.ATR_VOLUME_BICYCLE
+      || this.studyType === StudyType.ATR_SPEED_VOLUME) {
         const itemsDuration = [
           { text: '1 day', value: 24 },
           { text: '3 days', value: 72 },


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-1182](https://move-toronto.atlassian.net/browse/MOVE-1182)

# Description
Changes the ATR_SPEED_VOLUME studytype to have a duration of '1 day', '3 days', or '1 week'. Previously was '1 day', '2 days', '3 days', '4 days', '5 days', '1 week, or '2 weeks'

# Tests
All tests have been run and are passing.
