### PR TITLE
MOVE-59: changes to multi location collision directory report

### DIFF
--- a/lib/controller/JobController.js
+++ b/lib/controller/JobController.js
@@ -82,6 +82,7 @@ JobController.push({
         collisionQuery,
         reportFormat,
       );
+
       if (reports.length === 0) {
         return Boom.notFound('no reports for given filters');
       }

--- a/lib/db/ReportDAO.js
+++ b/lib/db/ReportDAO.js
@@ -30,17 +30,20 @@ class ReportDAO {
 
   static async byCentrelineAndCollisionQuery(featuresSelection, collisionQuery, reportFormat) {
     const { features, selectionType } = featuresSelection;
-    const s1 = CompositeId.encode(features);
-    const id = `${s1}/${selectionType.name}`;
 
-    return REPORT_TYPES_COLLISION
-      .filter(reportType => reportType.formats.includes(reportFormat))
-      .map(reportType => ({
-        type: reportType,
-        id,
-        format: reportFormat,
-        ...collisionQuery,
-      }));
+    const reports = [];
+    features.forEach((element) => {
+      const item = REPORT_TYPES_COLLISION
+        .filter(reportType => reportType.formats.includes(reportFormat))
+        .map(reportType => ({
+          type: reportType,
+          id: `${CompositeId.encode([element])}/${selectionType.name}`,
+          format: reportFormat,
+          ...collisionQuery,
+        }));
+      reports.push(item);
+    });
+    return reports.flat();
   }
 
   static async byCentrelineAndStudyQuery(featuresSelection, studyQuery, reportFormat) {

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -226,12 +226,6 @@ export default {
       collapseReport: false,
     };
   },
-  props: {
-    currentLocationSelection: {
-      type: Number,
-      default: null,
-    },
-  },
   computed: {
     userLoggedIn() {
       return this.auth.loggedIn;
@@ -488,8 +482,6 @@ export default {
     ...mapMutations(['setLocationsIndex', 'setToast', 'setToastError']),
     ...mapMutations('viewData', ['setFiltersCollision', 'setFiltersCommon']),
     ...mapActions(['initLocations']),
-  },
-  mounted() {
   },
 };
 </script>

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -37,16 +37,10 @@
             <span class="headline">Collisions</span>
             <span class="font-weight-light headline secondary--text">
               &#x2022;
-              <span v-if="locationMode === LocationMode.SINGLE || detailView">
-                {{locationActive.description}}
-              </span>
-              <span v-else>
-                {{locationsDescription}}
-              </span>
+              {{locationActive.description}}
             </span>
           </h2>
           <v-spacer></v-spacer>
-
           <v-tooltip bottom>
             <template v-slot:activator="{ on, attrs }">
               <span v-bind="attrs" v-on="on">
@@ -67,28 +61,6 @@
             </template>
             <span>Close Report</span>
           </v-tooltip>
-
-          <v-menu
-            v-if="locationMode !== LocationMode.SINGLE && detailView"
-            max-height="320">
-            <template v-slot:activator="{ on, attrs }">
-              <FcButton
-                v-bind="attrs"
-                v-on="on"
-                class="flex-grow-0 mt-0 ml-2"
-                type="secondary">
-                <FcIconLocationMulti v-bind="locationsIconProps[locationsIndex]" />
-                <span class="pl-2">{{locationActive.description}}</span>
-                <v-icon right>mdi-menu-down</v-icon>
-              </FcButton>
-            </template>
-            <FcListLocationMulti
-              :disabled="disabledPerLocation"
-              icon-classes="mr-2"
-              :locations="locations"
-              :locations-selection="locationsSelection"
-              @click-location="setLocationsIndex" />
-          </v-menu>
         </div>
 
         <div class="align-center d-flex fc-bg-white" v-if="!collapseReport">
@@ -116,7 +88,28 @@
               </FcButton>
             </div>
           </template>
-
+          <v-menu
+            v-if="locationMode !== LocationMode.SINGLE"
+            max-height="320">
+            <template v-slot:activator="{ on, attrs }">
+              <FcButton
+                v-bind="attrs"
+                v-on="on"
+                class="flex-grow-0 mt-0 ml-2"
+                type="secondary">
+                <FcIconLocationMulti v-bind="locationsIconProps[locationsIndex]" />
+                <span class="pl-2">{{locationActive.description}}</span>
+                <v-icon right>mdi-menu-down</v-icon>
+              </FcButton>
+            </template>
+            <FcListLocationMulti
+              :disabled="disabledPerLocation"
+              icon-classes="mr-2"
+              :locations="locations"
+              :locations-selection="locationsSelection"
+              @click-location="changeLocation"
+              />
+          </v-menu>
           <div class="mr-3">
             <FcMenuDownloadReportFormat
               :disabled="reportRetrievalError"
@@ -213,6 +206,7 @@ export default {
   },
   data() {
     return {
+      activeLocation: 0,
       collisionSummaryPerLocation: [],
       indexActiveReportType: 0,
       leaveConfirmed: false,
@@ -232,6 +226,12 @@ export default {
       collapseReport: false,
     };
   },
+  props: {
+    currentLocationSelection: {
+      type: Number,
+      default: null,
+    },
+  },
   computed: {
     userLoggedIn() {
       return this.auth.loggedIn;
@@ -246,7 +246,7 @@ export default {
         return `${s1}/${selectionType.name}`;
       }
       const { locations, selectionType } = this.locationsSelection;
-      const s1 = CompositeId.encode(locations);
+      const s1 = CompositeId.encode([locations[this.activeLocation]]);
       return `${s1}/${selectionType.name}`;
     },
     activeReportType() {
@@ -275,7 +275,7 @@ export default {
       if (this.locationMode === LocationMode.SINGLE || this.detailView) {
         return [this.locationActive];
       }
-      return this.locations;
+      return this.loations;
     },
     locationsIconProps() {
       const locationsIconProps = getLocationsIconProps(
@@ -308,7 +308,13 @@ export default {
       this.updateReportLayout();
     },
   },
-  beforeMount() {
+  async beforeMount() {
+    const collisionSummaryPerLocation = await getCollisionsByCentrelineSummaryPerLocation(
+      this.locations,
+      this.filterParamsCollision,
+    );
+    this.activeLocation = collisionSummaryPerLocation.findIndex(element => element.amount > 0);
+    this.setLocationsIndex(this.activeLocation);
     this.parseFiltersFromRouteParams();
   },
   beforeRouteLeave(to, from, next) {
@@ -332,6 +338,11 @@ export default {
     next(false);
   },
   methods: {
+    changeLocation(num) {
+      this.setLocationsIndex(num);
+      this.activeLocation = num;
+      this.updateReportLayout();
+    },
     async actionDownload(format) {
       if (this.activeReportType === null) {
         return;
@@ -414,6 +425,7 @@ export default {
         this.activeReportId,
         this.filterParamsCollision,
       ).catch(err => this.handleError(err));
+
       this.loadingReportLayout = false;
 
       this.reportLayout = reportLayout;
@@ -476,6 +488,8 @@ export default {
     ...mapMutations(['setLocationsIndex', 'setToast', 'setToastError']),
     ...mapMutations('viewData', ['setFiltersCollision', 'setFiltersCommon']),
     ...mapActions(['initLocations']),
+  },
+  mounted() {
   },
 };
 </script>

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -269,7 +269,7 @@ export default {
       if (this.locationMode === LocationMode.SINGLE || this.detailView) {
         return [this.locationActive];
       }
-      return this.loations;
+      return this.locations;
     },
     locationsIconProps() {
       const locationsIconProps = getLocationsIconProps(

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -52,7 +52,8 @@
           :collision-summary-per-location-unfiltered="collisionSummaryPerLocationUnfiltered"
           :loading="loadingCollisions"
           :locations="locations"
-          :locations-selection="locationsSelection" />
+          :locations-selection="locationsSelection"
+          @show-collisions="actionShowReportsCollision"  />
       </section>
 
       <v-divider></v-divider>
@@ -105,7 +106,8 @@
           :loading="loadingStudies"
           :locations="locations"
           :locations-selection="locationsSelection"
-          @show-reports="actionShowReportsStudy" />
+          @show-reports="actionShowReportsStudy"
+          />
 
       </section>
     </template>
@@ -282,7 +284,10 @@ export default {
       });
     },
     actionShowReportsCollision() {
-      const params = this.locationsRouteParams;
+      const params = {
+        ...this.locationsRouteParams,
+      };
+
       this.$router.push({
         name: 'viewCollisionReportsAtLocation',
         params,


### PR DESCRIPTION
# Issue Addressed
This PR addresses [MOVE-59](https://move-toronto.atlassian.net/browse/MOVE-59)

# Description
When a user selects multiple locations and then views the collision directory report, the current behaviour dumps all the locations in one report with no distinction between them. For example, this is the report for 3 separate locations:

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/26462466/99ea8ba4-9618-455a-951a-9571452ac23b)

The new behaviour adds a drop down at the top of the report that allows the user to pick which location they'd like to view a report for.
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/26462466/afed409a-e6e6-46df-9c50-943cce852285)
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/26462466/91198cd7-acac-4ad2-88ef-12b178b44020)
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/26462466/fa5295de-b972-439c-966e-9bcb612bd22b)

This allows for users to differentiate between locations and make more sense of the collision reports.

This does not change how pdf and csv exports are handled, they still dump all three locations into one report. That is a feature that needs to be worked on after this.

# Tests
Tested with multiple locations, locations with no collisions, mvcrs downloaded successfully as well.