### PR TITLE
MOVE-1183 - Data Collection are moving to a unified Volume-Speed-Classification count

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -1084,6 +1084,7 @@ StudyType.init({
     other: false,
     hourOptions: null,
   },
+  // we'll create a new datatype when we get this data back.
   ATR_SVC: {
     label: 'Speed / Vol / Class Count',
     isMultiDay: true,

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -439,8 +439,8 @@ class ReportDataType extends Enum {
   }
 }
 ReportDataType.init([
-  // 'ATR_SPEED_VOLUME',
-  'ATR_SVC',
+  'ATR_SPEED_VOLUME', // cannot request, but still exists as a report
+  'ATR_SVC', // replaces ATR_SPEED_VOLUME and VEHICLE_CLASS
   'ATR_VOLUME',
   'COLLISION',
   'OTHER',
@@ -448,7 +448,7 @@ ReportDataType.init([
   'PXO_OBSERVE',
   'STUDY_REQUEST',
   'TMC',
-  // 'VEHICLE_CLASS',
+  'VEHICLE_CLASS', // cannot request, but still exists as a report
   'MULTI_MODAL',
   'VID_OBSERVE',
   'SCHOOL_CROSS',
@@ -1074,18 +1074,18 @@ class StudyType extends Enum {
   }
 }
 StudyType.init({
-  // ATR_SPEED_VOLUME: {
-  //   label: 'Speed / Volume ATR',
-  //   isMultiDay: true,
-  //   beta: null,
-  //   dataAvailable: true,
-  //   maskStudy: false,
-  //   dataType: ReportDataType.ATR_SPEED_VOLUME,
-  //   other: false,
-  //   hourOptions: null,
-  // },
+  ATR_SPEED_VOLUME: {
+    label: 'Speed / Volume ATR',
+    isMultiDay: true,
+    beta: null,
+    dataAvailable: true,
+    maskStudy: false,
+    dataType: ReportDataType.ATR_SPEED_VOLUME,
+    other: false,
+    hourOptions: null,
+  },
   ATR_SVC: {
-    label: 'Speed / Volume / Classification Count',
+    label: 'Speed / Vol / Class Count',
     isMultiDay: true,
     beta: null,
     dataAvailable: true,
@@ -1170,16 +1170,16 @@ StudyType.init({
     other: false,
     hourOptions: ['ROUTINE', 'SCHOOL', 'OTHER'],
   },
-  // VEHICLE_CLASS: {
-  //   label: 'Vehicle Classification ATR',
-  //   isMultiDay: true,
-  //   beta: null,
-  //   dataAvailable: false,
-  //   maskStudy: false,
-  //   dataType: ReportDataType.VEHICLE_CLASS,
-  //   other: false,
-  //   hourOptions: null,
-  // },
+  VEHICLE_CLASS: {
+    label: 'Vehicle Classification ATR',
+    isMultiDay: true,
+    beta: null,
+    dataAvailable: false,
+    maskStudy: false,
+    dataType: ReportDataType.VEHICLE_CLASS,
+    other: false,
+    hourOptions: null,
+  },
   MULTI_MODAL: {
     label: 'Multi-Modal Count (Video)',
     isMultiDay: false,

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -439,7 +439,8 @@ class ReportDataType extends Enum {
   }
 }
 ReportDataType.init([
-  'ATR_SPEED_VOLUME',
+  // 'ATR_SPEED_VOLUME',
+  'ATR_SVC',
   'ATR_VOLUME',
   'COLLISION',
   'OTHER',
@@ -447,7 +448,7 @@ ReportDataType.init([
   'PXO_OBSERVE',
   'STUDY_REQUEST',
   'TMC',
-  'VEHICLE_CLASS',
+  // 'VEHICLE_CLASS',
   'MULTI_MODAL',
   'VID_OBSERVE',
   'SCHOOL_CROSS',
@@ -1073,8 +1074,18 @@ class StudyType extends Enum {
   }
 }
 StudyType.init({
-  ATR_SPEED_VOLUME: {
-    label: 'Speed / Volume ATR',
+  // ATR_SPEED_VOLUME: {
+  //   label: 'Speed / Volume ATR',
+  //   isMultiDay: true,
+  //   beta: null,
+  //   dataAvailable: true,
+  //   maskStudy: false,
+  //   dataType: ReportDataType.ATR_SPEED_VOLUME,
+  //   other: false,
+  //   hourOptions: null,
+  // },
+  ATR_SVC: {
+    label: 'Speed / Volume / Classification Count',
     isMultiDay: true,
     beta: null,
     dataAvailable: true,
@@ -1159,16 +1170,16 @@ StudyType.init({
     other: false,
     hourOptions: ['ROUTINE', 'SCHOOL', 'OTHER'],
   },
-  VEHICLE_CLASS: {
-    label: 'Vehicle Classification ATR',
-    isMultiDay: true,
-    beta: null,
-    dataAvailable: false,
-    maskStudy: false,
-    dataType: ReportDataType.VEHICLE_CLASS,
-    other: false,
-    hourOptions: null,
-  },
+  // VEHICLE_CLASS: {
+  //   label: 'Vehicle Classification ATR',
+  //   isMultiDay: true,
+  //   beta: null,
+  //   dataAvailable: false,
+  //   maskStudy: false,
+  //   dataType: ReportDataType.VEHICLE_CLASS,
+  //   other: false,
+  //   hourOptions: null,
+  // },
   MULTI_MODAL: {
     label: 'Multi-Modal Count (Video)',
     isMultiDay: false,

--- a/lib/db/StudyDataDAO.js
+++ b/lib/db/StudyDataDAO.js
@@ -85,7 +85,7 @@ ORDER BY "countInfoId" ASC, "zone" ASC, "start" ASC`;
     }
     const { studyType } = study;
     const countInfoIds = counts.map(({ id }) => id);
-    if (studyType === StudyType.ATR_SPEED_VOLUME) {
+    if (studyType === StudyType.ATR_SVC) {
       return StudyDataDAO.atrSpeedByCounts(countInfoIds);
     }
     if (studyType === StudyType.PED_DELAY) {

--- a/lib/geo/CentrelineUtils.js
+++ b/lib/geo/CentrelineUtils.js
@@ -40,17 +40,15 @@ function getLocationStudyTypes(location) {
   }
   if (locationFeatureType === RoadSegmentType.EXPRESSWAY_RAMP) {
     return [
-      StudyType.ATR_SPEED_VOLUME,
-      StudyType.VEHICLE_CLASS,
+      StudyType.ATR_SVC,
       StudyType.VID_OBSERVE,
     ];
   }
   if (locationFeatureType === RoadSegmentType.MAJOR_ARTERIAL
     || locationFeatureType === RoadSegmentType.MAJOR_ARTERIAL_RAMP) {
     return [
-      StudyType.ATR_SPEED_VOLUME,
+      StudyType.ATR_SVC,
       StudyType.ATR_VOLUME_BICYCLE,
-      StudyType.VEHICLE_CLASS,
       StudyType.PED_DELAY,
       StudyType.PXO_OBSERVE,
       StudyType.TMC,
@@ -61,9 +59,8 @@ function getLocationStudyTypes(location) {
     ];
   }
   return [
-    StudyType.ATR_SPEED_VOLUME,
+    StudyType.ATR_SVC,
     StudyType.ATR_VOLUME_BICYCLE,
-    StudyType.VEHICLE_CLASS,
     StudyType.PED_DELAY,
     StudyType.PXO_OBSERVE,
     StudyType.TMC,

--- a/lib/requests/RequestEmpty.js
+++ b/lib/requests/RequestEmpty.js
@@ -43,7 +43,7 @@ function makeStudyRequest(now = null, location = null) {
     studyType = StudyType.TMC;
     duration = 24;
   } else {
-    studyType = StudyType.ATR_SPEED_VOLUME;
+    studyType = StudyType.ATR_SVC;
     duration = 72;
   }
   return {

--- a/web/components/requests/StudyRequestForm.vue
+++ b/web/components/requests/StudyRequestForm.vue
@@ -99,7 +99,7 @@ export default {
       if (centrelineType === CentrelineType.INTERSECTION) {
         studyType = StudyType.TMC;
       } else {
-        studyType = StudyType.ATR_SPEED_VOLUME;
+        studyType = StudyType.ATR_SVC;
       }
       this.studyType = studyType;
     },

--- a/web/components/requests/fields/FcStudyRequestDuration.vue
+++ b/web/components/requests/fields/FcStudyRequestDuration.vue
@@ -45,7 +45,7 @@ export default {
     },
     itemsDuration() {
       if (this.studyType === StudyType.ATR_VOLUME_BICYCLE
-      || this.studyType === StudyType.ATR_SPEED_VOLUME) {
+      || this.studyType === StudyType.ATR_SVC) {
         const itemsDuration = [
           { text: '1 day', value: 24 },
           { text: '3 days', value: 72 },


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-1183](https://move-toronto.atlassian.net/browse/MOVE-1183)

# Description
Added a new StudyType - Speed / Vol / Class Count as `ATR_SVC`. This is the combination of ATR_SPEED_VOLUME and VEHICLE_CLASS. The other two have been deprecated from the request view, but their StudyType needs to persist since there is both existing studies and requests in process.

# Tests
All existing tests are passing.
