### PR TITLE
MOVE-1191 - Spell out study hours in TMC report header

### DIFF
--- a/lib/reports/ReportCountSummaryTurningMovement.js
+++ b/lib/reports/ReportCountSummaryTurningMovement.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 /* eslint-disable class-methods-use-this */
 import ArrayUtils from '@/lib/ArrayUtils';
 import { REPORT_CONSTANTS, ReportBlock, ReportType } from '@/lib/Constants';
@@ -564,17 +563,15 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
     } = stats.all.sum;
     const entries = [
       { cols: 3, name: 'Date', value: fullDateStr },
-      { cols: 3, name: 'Study Hours', value: hoursStr },
-      { cols: 3, name: 'Study Time', value: hourRanges },
+      {
+        cols: 3, name: 'Study Hours', value: hoursStr, subtext: hourRanges,
+      },
       { cols: 3, name: 'Traffic Signal Number', value: pxStr },
       { cols: 3, name: 'Total Volume', value: TOTAL },
       { cols: 3, name: 'Total Vehicles', value: VEHICLE_TOTAL },
       { cols: 3, name: 'Total Cyclists', value: BIKE_TOTAL },
       { cols: 3, name: 'Total Pedestrians', value: PEDS_TOTAL },
     ];
-    console.log('===========================');
-    console.log(hourRanges);
-    console.log('===========================');
     return { entries };
   }
 

--- a/lib/reports/ReportCountSummaryTurningMovement.js
+++ b/lib/reports/ReportCountSummaryTurningMovement.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /* eslint-disable class-methods-use-this */
 import ArrayUtils from '@/lib/ArrayUtils';
 import { REPORT_CONSTANTS, ReportBlock, ReportType } from '@/lib/Constants';
@@ -553,6 +554,7 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
     const dayOfWeekStr = TimeFormatters.formatDayOfWeek(date);
     const fullDateStr = `${dateStr} (${dayOfWeekStr})`;
     const hoursStr = hours === null ? null : hours.description;
+    const hourRanges = hours === null ? null : hours.hint;
     const pxStr = px === null ? null : px.toString();
     const {
       BIKE_TOTAL,
@@ -563,12 +565,16 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
     const entries = [
       { cols: 3, name: 'Date', value: fullDateStr },
       { cols: 3, name: 'Study Hours', value: hoursStr },
-      { cols: 6, name: 'Traffic Signal Number', value: pxStr },
+      { cols: 3, name: 'Study Time', value: hourRanges },
+      { cols: 3, name: 'Traffic Signal Number', value: pxStr },
       { cols: 3, name: 'Total Volume', value: TOTAL },
       { cols: 3, name: 'Total Vehicles', value: VEHICLE_TOTAL },
       { cols: 3, name: 'Total Cyclists', value: BIKE_TOTAL },
       { cols: 3, name: 'Total Pedestrians', value: PEDS_TOTAL },
     ];
+    console.log('===========================');
+    console.log(hourRanges);
+    console.log('===========================');
     return { entries };
   }
 

--- a/web/components/reports/FcReportMetadata.vue
+++ b/web/components/reports/FcReportMetadata.vue
@@ -2,7 +2,7 @@
   <div>
   <v-row class="mb-6" tag="dl">
     <v-col
-      v-for="({ cols, name, value }, i) in entries"
+      v-for="({ cols, name, value, subtext }, i) in entries"
       :key="i"
       :cols="cols">
       <dt class="subtitle-1 font-weight-medium">{{name}}</dt>
@@ -10,6 +10,10 @@
         <FcTextReportValue
           text-null="None"
           :value="value" />
+      </dd>
+      <dd v-if="subtext != null" class="v-messages theme--light subtext">
+        <FcTextReportValue
+          :value="subtext" />
       </dd>
     </v-col>
   </v-row>
@@ -64,6 +68,9 @@ export default {
 .callout-container {
   display: flex;
   justify-content: flex-end;
+}
+.subtext {
+  width: 60%;
 }
 
 // only show callout button if there's room


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-1191](https://move-toronto.atlassian.net/browse/MOVE-1191)

# Description
Added the actual hours / hours ranges to decode our hour descriptions to the metadata section of TMC reports:
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/5003768/93a4caac-a482-40c1-84bd-81cc18babb7e)

# Tests
All current tests are passing.
