### PR TITLE
Added a 5 min expiry for non-prod environments.

### DIFF
--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -27,6 +27,7 @@ import {
   normalizeJobMetadatas,
 } from '@/lib/model/helpers/NormalizeUtils';
 import DateTime from '@/lib/time/DateTime';
+import config from '@/lib/config/MoveConfig';
 
 const apiClient = new AxiosBackendClient('/api');
 const reporterClient = new AxiosBackendClient('/reporter');
@@ -748,7 +749,11 @@ async function putUser(auth, newUserData) {
       if (!currentUserData.scope.includes(AuthScope.MVCR_READ)) {
         deltas.scope = [...authScope, AuthScope.MVCR_READ];
       }
-      deltas.mvcrExpiryDate = DateTime.local().plus({ weeks: 1 });
+      if (config.ENV === 'production') {
+        deltas.mvcrExpiryDate = DateTime.local().plus({ weeks: 1 });
+      } else {
+        deltas.mvcrExpiryDate = DateTime.local().plus({ minutes: 5 });
+      }
     } else if (newUserData.mvcrAcctType === 2) {
       if (!currentUserData.scope.includes(AuthScope.MVCR_READ)) {
         deltas.scope = [...authScope, AuthScope.MVCR_READ];


### PR DESCRIPTION
# Issue Addressed

See comments in [MOVE-1138](https://move-toronto.atlassian.net/browse/MOVE-1138)

# Description
This PR adds the functionality to have the MVCR permission expire after 5 mins in non-prod environments. It keeps the 1 month expiry in production.

# Tests
Tests pass.
