### PR TITLE
MOVE-1183: Set dataAvailable for ATR_SVC to false to hide it from filter views.

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -1089,7 +1089,7 @@ StudyType.init({
     label: 'Speed / Vol / Class Count',
     isMultiDay: true,
     beta: null,
-    dataAvailable: true,
+    dataAvailable: false,
     maskStudy: false,
     dataType: ReportDataType.ATR_SPEED_VOLUME,
     other: false,


### PR DESCRIPTION
# Issue Addressed
Update for [MOVE-1183](https://move-toronto.atlassian.net/browse/MOVE-1183)

# Description
Set ATR_SVC.dataAvailable to false since there is no data available right now. We'll need to flip this back when the data is available, so it will appear back in the Filters list.

# Tests
Tests all pass.
