### PR TITLE
Move 1148v3

### DIFF
--- a/web/components/geo/map/FcMapPopup.vue
+++ b/web/components/geo/map/FcMapPopup.vue
@@ -166,7 +166,7 @@ export default {
   methods: {
     createPopup() {
       const hoveredClassName = this.hovered ? ' hovered' : '';
-      const offset = this.hovered ? 0 : 40;
+      const offset = (this.hovered && this.layerId !== 'locations-markers') ? 0 : 40;
       this.popup = new maplibregl.Popup({
         anchor: 'bottom',
         className: `fc-map-popup elevation-2${hoveredClassName}`,

--- a/web/components/geo/map/FcMapPopup.vue
+++ b/web/components/geo/map/FcMapPopup.vue
@@ -149,6 +149,7 @@ export default {
         this.loadAsyncForFeature();
       },
       immediate: true,
+      deep: true,
     },
   },
   created() {


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-1148

# Description
Popup content is now re-generated when hovering between study request map pins, and the popup does not obscure the map pin when hovering.

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/64811136/ffd9ac13-ab44-49e4-b672-9a852929b108)


# Tests
Tested in MOVE local v1.12.0 using Firefox