### PR TITLE
Move 1149v3

### DIFF
--- a/web/components/FcDataTableRequests.vue
+++ b/web/components/FcDataTableRequests.vue
@@ -354,7 +354,7 @@ export default {
   }
   & td:nth-child(2),
   & th.fc-data-table-header-ID {
-    min-width: 70px;
+    min-width: 40px;
     width: 70px;
   }
   & td:nth-child(3),
@@ -364,7 +364,7 @@ export default {
   }
   & td:nth-child(4),
   & th.fc-data-table-header-data-table-expand {
-    min-width: 70px !important;
+    min-width: 1px !important;
     width: 70px !important;
   }
   & td:nth-child(5),
@@ -374,27 +374,27 @@ export default {
   }
   & td:nth-child(6),
   & th.fc-data-table-header-REQUESTER {
-    min-width: 140px;
+    min-width: 80px;
     width: 140px;
   }
   & td:nth-child(7),
   & th.fc-data-table-header-CREATED_AT {
-    min-width: 140px;
+    min-width: 90px;
     width: 140px;
   }
   & td:nth-child(8),
   & th.fc-data-table-header-DUE_DATE {
-    min-width: 140px;
+    min-width: 60px;
     width: 140px;
   }
   & td:nth-child(9),
   & th.fc-data-table-header-STATUS {
-    min-width: 140px;
+    min-width: 60px;
     width: 140px;
   }
   & td:nth-child(10),
   & th.fc-data-table-header-ACTIONS {
-    min-width: 105px;
+    min-width: 60px;
     width: 105px;
   }
 

--- a/web/components/requests/summary/FcSummaryStudyRequestBulk.vue
+++ b/web/components/requests/summary/FcSummaryStudyRequestBulk.vue
@@ -1,6 +1,15 @@
 <template>
   <section>
     <v-row class="mt-1 mb-2" tag="dl">
+      <v-col cols="12">
+        <dt class="subtitle-1">Project Description</dt>
+        <dd class="mt-1 display-1">
+          <span v-if="studyRequestBulk.notes">
+            {{studyRequestBulk.notes}}
+          </span>
+          <span v-else>None</span>
+        </dd>
+      </v-col>
       <v-col cols="6">
         <template v-if="!isCreate">
           <dt class="subtitle-1">Staff Subscribed</dt>
@@ -19,16 +28,6 @@
             </span>
           </dd>
         </template>
-      </v-col>
-
-      <v-col cols="12">
-        <dt class="subtitle-1">Project Description</dt>
-        <dd class="mt-1 display-1">
-          <span v-if="studyRequestBulk.notes">
-            {{studyRequestBulk.notes}}
-          </span>
-          <span v-else>None</span>
-        </dd>
       </v-col>
     </v-row>
   </section>

--- a/web/views/FcRequestStudyBulkView.vue
+++ b/web/views/FcRequestStudyBulkView.vue
@@ -45,7 +45,7 @@
             </h3>
           </v-row>
           <v-row class="d-flex flex-row">
-            <v-col cols="8" class="flex-1 pl-5">
+            <v-col cols="7" class="flex-1 pl-5">
               <v-card dense outlined class="flex-grow-1 fill-height">
                 <section
                   aria-labelledby="heading_bulk_request_requests"
@@ -108,7 +108,7 @@
               </v-card>
             </v-col>
 
-            <v-col cols="4" class="flex-1 px-5 pl-0">
+            <v-col cols="5" class="flex-1 px-5 pl-0">
               <FcMap
                 class="mx-0 fill-height"
                 :locations-state="locationsState"

--- a/web/views/FcRequestStudyBulkView.vue
+++ b/web/views/FcRequestStudyBulkView.vue
@@ -98,7 +98,7 @@
                     disable-pagination
                     disable-sort
                     fixed-header
-                    height="400px"
+                    height="417px"
                     calculate-widths
                     :has-filters="false"
                     :items="items"


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-1149

# Description
Made map bigger, while also retaining important study request info.

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/64811136/6f14b490-5d27-4b76-b2af-aa9e81732534)

Also swapped the placement of bulk request details.

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/64811136/2b8d2bec-7d71-46b8-bc7d-d5c9046f03a5)

# Tests
Tested in MOVE local v1.12.0 using Firefox on various screen sizes.
