### PR TITLE
Move 1209: temp fix for speed percentile studies

### DIFF
--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -27,7 +27,6 @@ import {
   normalizeJobMetadatas,
 } from '@/lib/model/helpers/NormalizeUtils';
 import DateTime from '@/lib/time/DateTime';
-import config from '@/lib/config/MoveConfig';
 
 const apiClient = new AxiosBackendClient('/api');
 const reporterClient = new AxiosBackendClient('/reporter');
@@ -749,11 +748,8 @@ async function putUser(auth, newUserData) {
       if (!currentUserData.scope.includes(AuthScope.MVCR_READ)) {
         deltas.scope = [...authScope, AuthScope.MVCR_READ];
       }
-      if (config.ENV === 'production') {
-        deltas.mvcrExpiryDate = DateTime.local().plus({ weeks: 1 });
-      } else {
-        deltas.mvcrExpiryDate = DateTime.local().plus({ minutes: 5 });
-      }
+      // deltas.mvcrExpiryDate = DateTime.local().plus({ weeks: 1 });
+      deltas.mvcrExpiryDate = DateTime.local().plus({ minutes: 5 });
     } else if (newUserData.mvcrAcctType === 2) {
       if (!currentUserData.scope.includes(AuthScope.MVCR_READ)) {
         deltas.scope = [...authScope, AuthScope.MVCR_READ];

--- a/lib/db/StudyDataDAO.js
+++ b/lib/db/StudyDataDAO.js
@@ -85,7 +85,7 @@ ORDER BY "countInfoId" ASC, "zone" ASC, "start" ASC`;
     }
     const { studyType } = study;
     const countInfoIds = counts.map(({ id }) => id);
-    if (studyType === StudyType.ATR_SVC) {
+    if (studyType === StudyType.ATR_SVC || studyType === StudyType.ATR_SPEED_VOLUME) {
       return StudyDataDAO.atrSpeedByCounts(countInfoIds);
     }
     if (studyType === StudyType.PED_DELAY) {


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-1209](https://move-toronto.atlassian.net/jira/software/projects/MOVE/boards/1?assignee=712020%3A76a74782-6a99-4d85-bbb2-b0e95058d6b0&selectedIssue=MOVE-1209)

# Description
After a recent change, speed percentile reports seemed to be broken and displaying only 0's and nulls.
This happened because we are in the process of bringing in a new study type (speed/volume/classification) and the conditional logic to render the report data was preemptively changed. 

For now, an OR operator is being used to check whether the study type is ATR_SVC or ATR_SPEED_VOLUME and rendering the data for either (which at the moment really is only ATR_SPEED_VOLUME).

# Tests
Reports rendering as expected.