### PR TITLE
MOVE-479: fixed jumping input box issue on study request form

### DIFF
--- a/public/icons/map/study-nonmatch.svg
+++ b/public/icons/map/study-nonmatch.svg
@@ -1,3 +1,3 @@
 <svg width="34" height="34" viewBox="0 0 34 34" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="17" cy="17" r="11.5" fill="#404040" fill-opacity="0.4" stroke="#404040"/>
+<circle cx="17" cy="17" r="15.5" fill="#404040" fill-opacity="0.0" stroke="#3088D6"/>
 </svg>

--- a/web/components/location/FcIconLocationSingle.vue
+++ b/web/components/location/FcIconLocationSingle.vue
@@ -2,18 +2,23 @@
   <div
     class="fc-icon-location-single">
     <img
-      height="30"
       :src="src"
-      :width="24" />
+      />
+      <div class="overlay-text">
+        {{ index + 1 }}
+      </div>
   </div>
 </template>
 
 <script>
 export default {
+  props: {
+    index: Number,
+  },
   name: 'FcIconLocationSingle',
   computed: {
     src() {
-      return '/icons/map/location-single.svg';
+      return '/icons/map/study-nonmatch.svg';
     },
   },
 };
@@ -22,13 +27,22 @@ export default {
 <style lang="scss">
 .fc-icon-location-single {
   position: relative;
-  & > div {
-    left: 4.5px;
-    position: absolute;
-    top: 4.5px;
-    width: 15px;
-    white-space: nowrap;
-    text-align: center;
+  display: inline-block;
+
+  & > img {
+    display: block;
+  }
+
+  & > .overlay-text {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #3088D6;
+  font-weight: bolder;
+  padding: 5px 10px;
+  font-size: 20px;
+  text-align: center;
   }
 }
 </style>

--- a/web/components/requests/FcCardStudyRequest.vue
+++ b/web/components/requests/FcCardStudyRequest.vue
@@ -2,17 +2,16 @@
   <v-card
     @mouseover="addHoverLayer(index, $event)"
     @mouseleave="addHoverLayer(null, $event)"
-    class="fc-card-study-request pb-2 mb-3 d-flex flex-row"
+    class="fc-card-study-request pb-2 mb-3"
     :class="{ selected }"
     outlined
     :elevation="elevation">
     <div>
-      <FcIconLocationSingle
-        class="ml-3 mt-3"
-        />
-    </div>
-    <div>
     <v-card-title class="align-start pb-2">
+      <FcIconLocationSingle
+        class="mr-3"
+        :index="index"
+        />
       <div class="fc-card-study-request-title">
         <h3 class="headline mb-1">{{location.description}}</h3>
         <FcButtonAria

--- a/web/components/requests/StudyRequestForm.vue
+++ b/web/components/requests/StudyRequestForm.vue
@@ -23,7 +23,7 @@
       </v-col>
     </v-row>
     <v-row class="mt-1" v-else>
-      <v-col class="my-0 py-2" cols="6">
+      <v-col class="my-0 py-2 day-request" cols="6">
         <SrDayOptionsInput
           dense
           :v="v"
@@ -126,5 +126,9 @@ export default {
 .collection-notes textarea {
   margin: 14px 0 10px 0 !important;
   line-height: 1.4rem;
+}
+
+.day-request {
+  min-height: 6rem;
 }
 </style>

--- a/web/components/requests/fields/SrDayOptionsInput.vue
+++ b/web/components/requests/fields/SrDayOptionsInput.vue
@@ -174,7 +174,7 @@ export default {
 
 <style>
   .day-options .v-select__selections span {
-    max-width: 170px;
+    max-width: 200px;
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow:hidden;


### PR DESCRIPTION
# Issue Addressed
This PR is in support of MOVE-479 

# Description
After marker hover behaviour was added, the study request form began to jump around due to related changes (when inputs were selected from the dropdown). This has now been fixed.

# Tests
Tested on the form in the UI.