### PR TITLE
Move 1225v2

### DIFF
--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -42,6 +42,30 @@
             </span>
           </h2>
           <v-spacer></v-spacer>
+
+          <v-menu
+            v-if="locationMode !== LocationMode.SINGLE"
+            max-height="320">
+            <template v-slot:activator="{ on, attrs }">
+              <FcButton
+                v-bind="attrs"
+                v-on="on"
+                class="flex-grow-0 mt-0 ml-2"
+                type="secondary">
+                <v-icon class="fc-icon-dim" size="20">mdi-map-marker</v-icon>
+                <span class="pl-2 fc-collision-btn-location">{{locationActive.description}}</span>
+                <v-icon right>mdi-menu-down</v-icon>
+              </FcButton>
+            </template>
+            <FcListLocationMulti
+              :disabled="disabledPerLocation"
+              icon-classes="mr-2"
+              :locations="locations"
+              :locations-selection="locationsSelection"
+              @click-location="changeLocation"
+              />
+          </v-menu>
+
           <v-tooltip bottom>
             <template v-slot:activator="{ on, attrs }">
               <span v-bind="attrs" v-on="on">
@@ -89,28 +113,6 @@
               </FcButton>
             </div>
           </template>
-          <v-menu
-            v-if="locationMode !== LocationMode.SINGLE"
-            max-height="320">
-            <template v-slot:activator="{ on, attrs }">
-              <FcButton
-                v-bind="attrs"
-                v-on="on"
-                class="flex-grow-0 mt-0 ml-2"
-                type="secondary">
-                <v-icon class="fc-icon-dim" size="20">mdi-map-marker</v-icon>
-                <span class="pl-2 fc-collision-btn-location">{{locationActive.description}}</span>
-                <v-icon right>mdi-menu-down</v-icon>
-              </FcButton>
-            </template>
-            <FcListLocationMulti
-              :disabled="disabledPerLocation"
-              icon-classes="mr-2"
-              :locations="locations"
-              :locations-selection="locationsSelection"
-              @click-location="changeLocation"
-              />
-          </v-menu>
           <div class="mr-3">
             <FcMenuDownloadReportFormat
               :disabled="reportRetrievalError"

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -57,7 +57,7 @@
                 <v-icon right>mdi-menu-down</v-icon>
               </FcButton>
             </template>
-            <FcListLocationMulti
+            <FcListLocationDropdown
               :disabled="disabledPerLocation"
               icon-classes="mr-2"
               :locations="locations"
@@ -186,7 +186,7 @@ import FcProgressCircular from '@/web/components/dialogs/FcProgressCircular.vue'
 import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcMenuDownloadReportFormat from '@/web/components/inputs/FcMenuDownloadReportFormat.vue';
-import FcListLocationMulti from '@/web/components/location/FcListLocationMulti.vue';
+import FcListLocationDropdown from '@/web/components/location/FcListLocationDropdown.vue';
 import FcReport from '@/web/components/reports/FcReport.vue';
 import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
 import DateTime from '@/lib/time/DateTime';
@@ -199,7 +199,7 @@ export default {
     FcButton,
     FcCallout,
     FcDialogConfirm,
-    FcListLocationMulti,
+    FcListLocationDropdown,
     FcMenuDownloadReportFormat,
     FcProgressCircular,
     FcProgressLinear,
@@ -521,5 +521,11 @@ export default {
 
 .drawer-open .fc-drawer-view-collision-reports {
   max-height: var(--full-height);
+}
+
+@media only screen and (max-width: 800px) {
+  .fc-collision-btn-location {
+    display: none;
+  }
 }
 </style>

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -98,8 +98,8 @@
                 v-on="on"
                 class="flex-grow-0 mt-0 ml-2"
                 type="secondary">
-                <FcIconLocationMulti v-bind="locationsIconProps[locationsIndex]" />
-                <span class="pl-2">{{locationActive.description}}</span>
+                <v-icon class="fc-icon-dim" size="20">mdi-map-marker</v-icon>
+                <span class="pl-2 fc-collision-btn-location">{{locationActive.description}}</span>
                 <v-icon right>mdi-menu-down</v-icon>
               </FcButton>
             </template>
@@ -184,7 +184,6 @@ import FcProgressCircular from '@/web/components/dialogs/FcProgressCircular.vue'
 import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcMenuDownloadReportFormat from '@/web/components/inputs/FcMenuDownloadReportFormat.vue';
-import FcIconLocationMulti from '@/web/components/location/FcIconLocationMulti.vue';
 import FcListLocationMulti from '@/web/components/location/FcListLocationMulti.vue';
 import FcReport from '@/web/components/reports/FcReport.vue';
 import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
@@ -198,7 +197,6 @@ export default {
     FcButton,
     FcCallout,
     FcDialogConfirm,
-    FcIconLocationMulti,
     FcListLocationMulti,
     FcMenuDownloadReportFormat,
     FcProgressCircular,
@@ -507,6 +505,15 @@ export default {
   }
   & .v-slide-group__next--disabled {
     visibility: hidden;
+  }
+  & .fc-collision-btn-location {
+    font-size: 12px;
+    overflow: hidden;
+    max-width: 150px;
+    text-overflow: ellipsis;
+  }
+  & .fc-icon-dim {
+    opacity: 0.6;
   }
 }
 

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -53,7 +53,7 @@
                 </v-icon>
               </span>
             </template>
-            <span>Toggle Report</span>
+            <span>Collapse Report</span>
           </v-tooltip>
 
           <v-tooltip bottom>

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -60,7 +60,7 @@
                 <v-icon right>mdi-menu-down</v-icon>
               </FcButton>
             </template>
-            <FcListLocationMulti
+            <FcListLocationDropdown
               :disabled="disabledPerLocation"
               icon-classes="mr-2"
               :locations="locations"
@@ -220,7 +220,7 @@ import FcProgressCircular from '@/web/components/dialogs/FcProgressCircular.vue'
 import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcMenuDownloadReportFormat from '@/web/components/inputs/FcMenuDownloadReportFormat.vue';
-import FcListLocationMulti from '@/web/components/location/FcListLocationMulti.vue';
+import FcListLocationDropdown from '@/web/components/location/FcListLocationDropdown.vue';
 import FcReport from '@/web/components/reports/FcReport.vue';
 import FcReportParameters from '@/web/components/reports/FcReportParameters.vue';
 import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
@@ -233,7 +233,7 @@ export default {
     FcButton,
     FcCallout,
     FcDialogConfirm,
-    FcListLocationMulti,
+    FcListLocationDropdown,
     FcMenuDownloadReportFormat,
     FcProgressCircular,
     FcProgressLinear,

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -104,7 +104,7 @@
                 </v-icon>
               </span>
             </template>
-            <span>Toggle Report</span>
+            <span>Collapse Report</span>
           </v-tooltip>
 
           <v-tooltip bottom>

--- a/web/components/data/FcAggregateCollisions.vue
+++ b/web/components/data/FcAggregateCollisions.vue
@@ -147,6 +147,8 @@ export default {
   }
   & .fc-aggregate-collisions-row {
     border-radius: 5px;
+    flex-grow: 1;
+    justify-content: space-around;
   }
   & .fc-detail-row {
     display: flex;

--- a/web/components/data/FcAggregateCollisions.vue
+++ b/web/components/data/FcAggregateCollisions.vue
@@ -57,22 +57,22 @@
               Details
           </FcButton>
         </div>
-        <div v-if="showDetails" class="fc-collision-detail-table elevation-1 pa-2">
-          <div class="fc-detail-row fc-detail-header">
-            <div class="fc-detail-desc"></div>
-            <div class="fc-detail-num">Total</div>
-            <div class="fc-detail-num">KSI</div>
-            <div class="fc-detail-num">Verified</div>
-          </div>
-          <div v-for="(location, i) in locations"
+        <table v-if="showDetails" class="fc-collision-detail-table elevation-1 pa-2">
+          <th class="fc-detail-row fc-detail-header">
+            <td class="fc-detail-desc"></td>
+            <td class="fc-detail-num">Total</td>
+            <td class="fc-detail-num">KSI</td>
+            <td class="fc-detail-num">Verified</td>
+          </th>
+          <tr v-for="(location, i) in locations"
            :key="location.centrelineId"
             class="fc-detail-row">
-            <div class="fc-detail-desc text-sm">{{location.description}}</div>
-            <div class="fc-detail-num">{{collisionSummaryPerLocation[i].amount}}</div>
-            <div class="fc-detail-num">{{collisionSummaryPerLocation[i].ksi}}</div>
-            <div class="fc-detail-num">{{collisionSummaryPerLocation[i].validated}}</div>
-          </div>
-        </div>
+            <td class="fc-detail-desc text-sm">{{location.description}}</td>
+            <td class="fc-detail-num">{{collisionSummaryPerLocation[i].amount}}</td>
+            <td class="fc-detail-num">{{collisionSummaryPerLocation[i].ksi}}</td>
+            <td class="fc-detail-num">{{collisionSummaryPerLocation[i].validated}}</td>
+           </tr>
+        </table>
       </div>
     </template>
   </div>
@@ -178,6 +178,7 @@ export default {
     color: var(--v-default-base);
   }
   & .fc-collision-detail-table {
+    width: 100%;
     text-align: center;
     background: #fff;
   }

--- a/web/components/data/FcAggregateCollisions.vue
+++ b/web/components/data/FcAggregateCollisions.vue
@@ -148,11 +148,6 @@ export default {
   & .fc-aggregate-collisions-row {
     border-radius: 5px;
   }
-  & .fc-aggregate-collisions-row:hover {
-    box-shadow: 0 2px 1px -1px rgba(0, 0, 0, 0.2),
-    0 1px 1px 0 rgba(0, 0, 0, 0.14),
-    2px 1px 3px 0 rgba(0, 0, 0, 0.12);
-  }
   & .fc-detail-row {
     display: flex;
     flex-direction: row;

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -15,7 +15,8 @@
           :aria-disabled="item.n === 0"
           class="fc-studies-summary-per-location"
           :disabled="item.n === 0">
-          <v-expansion-panel-header class="pr-8" ripple>
+          <v-expansion-panel-header class="pa-1 pr-4 fc-study-expansion-header" ripple>
+            <v-icon small color="primary" class="fc-study-header-icon">mdi-briefcase</v-icon>
             <div class="body-1 fc-study-summary-header">
               {{item.studyType.label}}
               <FcTextStudyTypeBeta
@@ -149,6 +150,9 @@ export default {
 
 <style lang="scss">
 .fc-aggregate-studies {
+  & .fc-study-header-icon {
+    max-width: 32px;
+  }
   & .fc-studies-summary-per-location {
     border-radius: 5px;
     margin-right: 12px;
@@ -160,7 +164,7 @@ export default {
   }
   & .fc-studies-summary-per-location:not(:last-child) {
     border-bottom: 1px solid var(--v-border-base);
-    margin-bottom: 8px;
+    margin-bottom: 12px;
   }
   & .fc-study-summary-header {
     font-weight: bold;

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -48,6 +48,7 @@
                   <div class="fc-chevron-wrapper">
                     <FcButton
                       class="mr-n4 mt-1"
+                      width="50px"
                       type="tertiary"
                       :disabled="itemsPerLocation[i][j].n === 0"
                       @click="$emit('show-reports', { item, locationsIndex: j })">

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -15,8 +15,8 @@
           :aria-disabled="item.n === 0"
           class="fc-studies-summary-per-location"
           :disabled="item.n === 0">
-          <v-expansion-panel-header class="pr-8">
-            <div class="body-1">
+          <v-expansion-panel-header class="pr-8" ripple>
+            <div class="body-1 fc-study-summary-header">
               {{item.studyType.label}}
               <FcTextStudyTypeBeta
                 class="ml-2"
@@ -149,8 +149,21 @@ export default {
 
 <style lang="scss">
 .fc-aggregate-studies {
+  & .fc-studies-summary-per-location {
+    border-radius: 5px;
+    margin-right: 12px;
+    box-shadow:
+        0 3px 1px -2px rgba(0, 0, 0, 0.2),
+        0 2px 2px 0 rgba(0, 0, 0, 0.14),
+        0 1px 5px 0 rgba(0, 0, 0, 0.12);
+
+  }
   & .fc-studies-summary-per-location:not(:last-child) {
     border-bottom: 1px solid var(--v-border-base);
+    margin-bottom: 8px;
+  }
+  & .fc-study-summary-header {
+    font-weight: bold;
   }
   & .data-empty {
     opacity: 0.37;

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -47,8 +47,7 @@
                     small />
                   <div class="fc-chevron-wrapper">
                     <FcButton
-                      class="mr-n4 mt-1"
-                      width="50px"
+                      width="40px"
                       type="tertiary"
                       :disabled="itemsPerLocation[i][j].n === 0"
                       @click="$emit('show-reports', { item, locationsIndex: j })">

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -46,13 +46,19 @@
                     :show-b="hasFiltersCommon || hasFiltersStudy"
                     small />
                   <div class="fc-chevron-wrapper">
-                    <FcButton
-                      width="40px"
-                      type="tertiary"
-                      :disabled="itemsPerLocation[i][j].n === 0"
-                      @click="$emit('show-reports', { item, locationsIndex: j })">
-                      <v-icon x-large>mdi-chevron-right</v-icon>
-                    </FcButton>
+                    <v-tooltip right z-index="110">
+                      <template v-slot:activator="{ on }">
+                        <FcButton
+                          v-on="on"
+                          width="40px"
+                          type="tertiary"
+                          :disabled="itemsPerLocation[i][j].n === 0"
+                          @click="$emit('show-reports', { item, locationsIndex: j })">
+                          <v-icon x-large>mdi-chevron-right</v-icon>
+                        </FcButton>
+                      </template>
+                      <span>View Report</span>
+                    </v-tooltip>
                   </div>
                 </div>
               </template>

--- a/web/components/data/FcDetailCollisions.vue
+++ b/web/components/data/FcDetailCollisions.vue
@@ -45,10 +45,10 @@
       </dl>
       <FcButton
         class="ma-1"
-        type="tertiary"
+        type="secondary"
         :disabled="collisionSummary.amount === 0"
         @click="$emit('show-reports')">
-          <v-icon x-large>mdi-chevron-right</v-icon>
+          <v-icon color="primary" x-large>mdi-chevron-right</v-icon>
       </FcButton>
     </div>
   </div>

--- a/web/components/data/FcDetailCollisions.vue
+++ b/web/components/data/FcDetailCollisions.vue
@@ -3,7 +3,7 @@
     <FcProgressLinear
       v-if="loading"
       aria-label="Loading Detail View collisions data" />
-    <div class="fc-collision-detail-row px-1 py-2 d-flex ml-5 mr-2 justify-space-around"
+    <div class="fc-collision-detail-row px-1 py-2 d-flex ml-5 justify-space-around"
       v-else-if="collisionSummaryUnfiltered.amount > 0">
       <dl class="fc-collision-table d-flex flex-grow-1">
         <div class="collision-fact">

--- a/web/components/data/FcDetailCollisions.vue
+++ b/web/components/data/FcDetailCollisions.vue
@@ -94,11 +94,6 @@ export default {
 .fc-collision-detail-row {
   border-radius: 5px;
 }
-.fc-collision-detail-row:hover {
-  box-shadow: 0 2px 1px -1px rgba(0, 0, 0, 0.2),
-        0 1px 1px 0 rgba(0, 0, 0, 0.14),
-        2px 1px 3px 0 rgba(0, 0, 0, 0.12);
-}
 
 @media only screen and (max-width: 600px) {
   .fc-collisions-validated {

--- a/web/components/data/FcDetailCollisions.vue
+++ b/web/components/data/FcDetailCollisions.vue
@@ -43,13 +43,20 @@
           </dd>
         </div>
       </dl>
-      <FcButton
-        class="ma-1"
-        type="secondary"
-        :disabled="collisionSummary.amount === 0"
-        @click="$emit('show-reports')">
-          <v-icon color="primary" x-large>mdi-chevron-right</v-icon>
-      </FcButton>
+      <v-tooltip right>
+        <template v-slot:activator="{ on }">
+          <FcButton
+            v-on="on"
+            id="fc-detail-collision-btn"
+            class="ma-1"
+            type="secondary"
+            :disabled="collisionSummary.amount === 0"
+            @click="$emit('show-reports')">
+            <v-icon color="primary" x-large>mdi-chevron-right</v-icon>
+          </FcButton>
+        </template>
+        <span>View Report</span>
+      </v-tooltip>
     </div>
   </div>
 </template>

--- a/web/components/data/FcDetailStudies.vue
+++ b/web/components/data/FcDetailStudies.vue
@@ -31,13 +31,19 @@
               :b="item.nUnfiltered"
               :show-b="hasFiltersCommon || hasFiltersStudy" />
           </div>
-          <FcButton
-            width="50px"
-            :disabled="!item.studyType.dataAvailable || item.n === 0"
-            type="secondary"
-            @click="$emit('show-reports', item)">
-            <v-icon color="primary" x-large>mdi-chevron-right</v-icon>
-          </FcButton>
+          <v-tooltip right>
+            <template v-slot:activator="{ on }">
+              <FcButton
+                v-on="on"
+                width="50px"
+                :disabled="!item.studyType.dataAvailable || item.n === 0"
+                type="secondary"
+                @click="$emit('show-reports', item)">
+                <v-icon color="primary" x-large>mdi-chevron-right</v-icon>
+              </FcButton>
+            </template>
+            <span>View Report</span>
+          </v-tooltip>
         </div>
       </div>
     </template>

--- a/web/components/data/FcDetailStudies.vue
+++ b/web/components/data/FcDetailStudies.vue
@@ -98,11 +98,6 @@ export default {
     align-items: center;
     border-radius: 5px;
   }
-  .fc-study-detail-row:hover {
-    box-shadow: 0 2px 1px -1px rgba(0, 0, 0, 0.2),
-          0 1px 1px 0 rgba(0, 0, 0, 0.14),
-          2px 1px 3px 0 rgba(0, 0, 0, 0.12);
-  }
   & .fc-studies-n {
     width: 60px;
     text-align: center;

--- a/web/components/data/FcDetailStudies.vue
+++ b/web/components/data/FcDetailStudies.vue
@@ -34,9 +34,9 @@
           <FcButton
             class=""
             :disabled="!item.studyType.dataAvailable || item.n === 0"
-            type="tertiary"
+            type="secondary"
             @click="$emit('show-reports', item)">
-            <v-icon x-large>mdi-chevron-right</v-icon>
+            <v-icon color="primary" x-large>mdi-chevron-right</v-icon>
           </FcButton>
         </div>
       </div>

--- a/web/components/data/FcDetailStudies.vue
+++ b/web/components/data/FcDetailStudies.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fc-detail-studies mb-2">
+  <div class="fc-detail-studies mb-2 px-1">
     <FcProgressLinear
       v-if="loading"
       aria-label="Loading Detail View studies data" />
@@ -32,7 +32,7 @@
               :show-b="hasFiltersCommon || hasFiltersStudy" />
           </div>
           <FcButton
-            class=""
+            width="50px"
             :disabled="!item.studyType.dataAvailable || item.n === 0"
             type="secondary"
             @click="$emit('show-reports', item)">

--- a/web/components/data/FcTextSummaryFraction.vue
+++ b/web/components/data/FcTextSummaryFraction.vue
@@ -4,7 +4,7 @@
     :class="{ 'font-weight-medium': !small }">
     {{a}}
     <span
-      v-if="showB"
+      v-if="showB && a!== b"
       class="body-1 secondary--text">
       / {{b}}
     </span>

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -26,17 +26,23 @@
           :locations="locations"
           :locations-selection="locationsSelection"
           @show-collisions="actionShowReportsCollision" >
-            <FcButton
-              v-if="reportExportMode !== ReportExportMode.COLLISIONS"
-              width="50px"
-              :disabled="
-                collisionSummary.amount === 0
-                || reportExportMode === ReportExportMode.STUDIES"
-              type="secondary"
-              @click="actionShowReportsCollision">
-              <v-icon color="primary" x-large>mdi-chevron-right</v-icon>
-              <span class="sr-only">View Collision Report</span>
-            </FcButton>
+          <v-tooltip right>
+            <template v-slot:activator="{ on }">
+              <FcButton
+                v-on="on"
+                v-if="reportExportMode !== ReportExportMode.COLLISIONS"
+                width="50px"
+                :disabled="
+                  collisionSummary.amount === 0
+                  || reportExportMode === ReportExportMode.STUDIES"
+                type="secondary"
+                @click="actionShowReportsCollision">
+                <v-icon color="primary" x-large>mdi-chevron-right</v-icon>
+                <span class="sr-only">View Collision Report</span>
+              </FcButton>
+              </template>
+              <span>View Report</span>
+            </v-tooltip>
         </FcAggregateCollisions>
           <div v-if="collisionSummary.amount > 0" class="mr-5 align-self-end mb-2">
             <FcButton

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -28,7 +28,7 @@
           @show-collisions="actionShowReportsCollision" >
             <FcButton
               v-if="reportExportMode !== ReportExportMode.COLLISIONS"
-              class="ma-1"
+              width="50px"
               :disabled="
                 collisionSummary.amount === 0
                 || reportExportMode === ReportExportMode.STUDIES"

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -32,7 +32,7 @@
               :disabled="
                 collisionSummary.amount === 0
                 || reportExportMode === ReportExportMode.STUDIES"
-              type="tertiary"
+              type="secondary"
               @click="actionShowReportsCollision">
               <v-icon color="primary" x-large>mdi-chevron-right</v-icon>
               <span class="sr-only">View Collision Report</span>

--- a/web/components/inputs/FcInputLocationSearch.vue
+++ b/web/components/inputs/FcInputLocationSearch.vue
@@ -44,7 +44,7 @@
                           type="icon"
                           @click="actionClear"
                           v-on="onTooltip">
-                          <v-icon>mdi-close-circle</v-icon>
+                          <v-icon color="light-grey">mdi-close-circle</v-icon>
                         </FcButton>
                       </template>
                       <span>Clear Location</span>
@@ -324,8 +324,5 @@ export default {
 }
 .fc-location-search-home {
   max-width: 448px;
-}
-.fc-close-btn-inside {
-  opacity: 0.4;
 }
 </style>

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -75,8 +75,8 @@
       <FcTooltip right>
           <template v-slot:activator="{ on: onTooltip }">
             <FcButton class="fc-close-top-right" type="tertiary" icon
-              @click="actionClear" v-on="onTooltip">
-              <v-icon color="grey">mdi-close-circle</v-icon>
+              @click="actionClear" v-on="onTooltip" color="light-grey">
+              <v-icon>mdi-close-circle</v-icon>
             </FcButton>
           </template>
           <span>Clear Location</span>

--- a/web/components/location/FcDisplayLocationMulti.vue
+++ b/web/components/location/FcDisplayLocationMulti.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fc-input-summary text-left pa-1 pb-0 mr-4">
+  <div class="fc-input-summary text-left pa-1 pb-0 mr-5">
     <!-- if in CORRIDOR-mode -->
     <div v-if="isCorridor">
       <div  class="fc-corridor-summary-line">

--- a/web/components/location/FcListLocationDropdown.vue
+++ b/web/components/location/FcListLocationDropdown.vue
@@ -1,29 +1,26 @@
 <template>
-  <v-list class="fc-list-location-multi">
+  <v-list class="fc-list-location-dropdown">
     <v-list-item
       v-for="(location, i) in locations"
       :key="i"
       :disabled="disabledNormalized[i]"
       @click="$emit('click-location', i)">
-      <v-list-item-title class="px-0 fc-list-multi-row">
+      <v-list-item-title class="px-0 fc-list-dropdown-row">
         <v-icon
           :class="{'fc-icon-dim':disabledNormalized[i]}"
           class="pa-2" size="20">
           mdi-map-marker
         </v-icon>
-        <div class="d-flex align-center">
-          <div class="fc-list-multi-text body-1 truncate">
-            <div class="truncate"
-              :class="{
+        <div class="d-flex align-center truncate">
+          <div class="fc-list-dropdown-text body-1 truncate">
+            <div class="truncate" :class="{
                 'body-1': locationsIconProps[i].locationIndex === -1,
                 title: locationsIconProps[i].locationIndex !== -1,
               }">
               {{location.description}}
             </div>
-            <slot name="subtitle" class="truncate" v-bind="{ location, i }" />
           </div>
         </div>
-        <slot name="action" v-bind="{ location, i }" />
       </v-list-item-title>
     </v-list-item>
   </v-list>
@@ -62,22 +59,26 @@ export default {
 </script>
 
 <style lang="scss">
-.fc-list-location-multi {
+.fc-list-location-dropdown {
   & .truncate {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    max-width: 180px;
   }
-  & .fc-list-multi-row {
+  & .fc-list-dropdown-row {
     display: flex;
     flex-flow: row nowrap;
-    justify-content: space-between;
+    justify-content: flex-start;
   }
-  & .fc-list-multi-text {
-    max-width: 150px;
+  & .fc-list-dropdown-text {
+    max-width: 180px;
   }
   & .v-list-item {
     padding: 0;
+  }
+  & .fc-icon-dim {
+    opacity: 0.6;
   }
 }
 </style>

--- a/web/components/location/FcListLocationMulti.vue
+++ b/web/components/location/FcListLocationMulti.vue
@@ -8,7 +8,7 @@
       <v-list-item-title class="px-0 fc-list-multi-row">
         <v-icon
           :class="{'fc-icon-dim':disabledNormalized[i]}"
-          class="pa-2" size="20">
+          class="pa-1" size="18">
           mdi-map-marker
         </v-icon>
         <div class="d-flex align-center">
@@ -71,10 +71,11 @@ export default {
   & .fc-list-multi-row {
     display: flex;
     flex-flow: row nowrap;
-    justify-content: space-between;
+    justify-content: flex-start;
   }
   & .fc-list-multi-text {
-    max-width: 150px;
+    max-width: 145px;
+    min-width: 145px;
   }
   & .v-list-item {
     padding: 0;

--- a/web/components/location/FcListLocationMulti.vue
+++ b/web/components/location/FcListLocationMulti.vue
@@ -3,12 +3,11 @@
     <v-list-item
       v-for="(location, i) in locations"
       :key="i"
-      :disabled="disabledNormalized[i]"
-      @click="$emit('click-location', i)">
+      :disabled="disabledNormalized[i]">
       <v-list-item-title class="px-0 fc-list-multi-row">
         <v-icon
           :class="{'fc-icon-dim':disabledNormalized[i]}"
-          class="pa-1" size="18">
+          class="fc-location-list-icon pa-1" size="18">
           mdi-map-marker
         </v-icon>
         <div class="d-flex align-center">
@@ -79,6 +78,12 @@ export default {
   }
   & .v-list-item {
     padding: 0;
+  }
+}
+
+@media only screen and (max-width: 750px) {
+  .fc-location-list-icon {
+    display: none !important;
   }
 }
 </style>

--- a/web/components/location/FcListLocationMulti.vue
+++ b/web/components/location/FcListLocationMulti.vue
@@ -7,7 +7,7 @@
       <v-list-item-title class="px-0 fc-list-multi-row">
         <v-icon
           :class="{'fc-icon-dim':disabledNormalized[i]}"
-          class="fc-location-list-icon pa-1" size="18">
+          class="fc-location-list-icon pr-2" size="18">
           mdi-map-marker
         </v-icon>
         <div class="d-flex align-center">
@@ -75,9 +75,13 @@ export default {
   & .fc-list-multi-text {
     max-width: 145px;
     min-width: 145px;
+    font-style: italic;
   }
   & .v-list-item {
     padding: 0;
+  }
+  & .fc-icon-dim {
+    opacity: 0.6;
   }
 }
 

--- a/web/components/location/FcSummaryPoiChip.vue
+++ b/web/components/location/FcSummaryPoiChip.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="fc-summary-poi-chip">
-    <FcTooltip attach=".fc-summary-poi" bottom>
+    <v-tooltip bottom>
       <template v-slot:activator="{ on }">
         <v-chip
           v-on="on"
@@ -14,19 +14,15 @@
         </v-chip>
       </template>
       <span>{{ariaLabel}}</span>
-    </FcTooltip>
+    </v-tooltip>
     <dd class="sr-only">{{ariaLabel}}</dd>
   </div>
 </template>
 
 <script>
-import FcTooltip from '@/web/components/dialogs/FcTooltip.vue';
-
 export default {
   name: 'FcSummaryPoiChip',
-  components: {
-    FcTooltip,
-  },
+  components: {},
   props: {
     ariaLabel: String,
     color: String,

--- a/web/components/location/FcSummaryPoiChip.vue
+++ b/web/components/location/FcSummaryPoiChip.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="fc-summary-poi-chip">
-    <FcTooltip bottom>
+    <FcTooltip attach=".fc-summary-poi" bottom>
       <template v-slot:activator="{ on }">
         <v-chip
           v-on="on"


### PR DESCRIPTION
# Issue Addressed
This PR closes:
* [MOVE-1176](https://move-toronto.atlassian.net/browse/MOVE-1176) - Webapp should be more responsive
* [MOVE-1210](https://move-toronto.atlassian.net/browse/MOVE-1210) - POI chips should display information on hover-over
* [MOVE-1170](https://move-toronto.atlassian.net/browse/MOVE-1170) - Search bar should have a clear button (x)
* [MOVE-1173](https://move-toronto.atlassian.net/browse/MOVE-1173) - Reports page: bring back map peek ability

it's a follow-up with fixes from #1225  - notably, it splits `<FcListLocationMulti` into two componenents, so they can be styled differently in the view-data component.

# Description
* changes **view report** caret buttons to secondary, so they're clearer
* adds tooltips to new buttons
* only show filter fraction numbers if numerator+denomintor are different
* turn collision details table into a html table, so it will copy+paste into excel properly
* moves omar's new location-menu into top-bar in collision report
* fixes POI tooltips not showing up in floating sidebar
* small styling tweaks for expansion panels