### PR TITLE
Move 1149v4

### DIFF
--- a/web/components/FcDataTable.vue
+++ b/web/components/FcDataTable.vue
@@ -40,6 +40,7 @@
 </template>
 
 <script>
+import { mapMutations } from 'vuex';
 import { Ripple } from 'vuetify/lib/directives';
 
 import { KeyCode } from '@/lib/Constants';
@@ -182,6 +183,18 @@ export default {
         }
       });
     });
+
+    // Adds hover event listeners to table rows
+    const $tableRows = this.$el.querySelectorAll('tbody tr');
+    $tableRows.forEach(($tr) => {
+      $tr.addEventListener('mouseover', () => {
+        const requestId = parseInt($tr.children[1].innerText.trim(), 10);
+        this.setHoveredStudyRequest(requestId);
+      });
+      $tr.addEventListener('mouseleave', () => {
+        this.setHoveredStudyRequest(null);
+      });
+    });
   },
   methods: {
     customSort(items, sortBy, sortDesc) {
@@ -196,6 +209,7 @@ export default {
         return compareKeys(ka, kb, kf);
       });
     },
+    ...mapMutations('trackRequests', ['setHoveredStudyRequest']),
   },
 };
 </script>

--- a/web/components/FcDataTableRequests.vue
+++ b/web/components/FcDataTableRequests.vue
@@ -75,9 +75,7 @@
       </div>
       <div
         v-else-if="item.location !== null"
-        class="text-wrap"
-        @mouseover="setHoveredStudyRequest(item.location.centrelineId)"
-        @mouseleave="setHoveredStudyRequest(null)">
+        class="text-wrap">
         {{item.location.description}}
       </div>
     </template>

--- a/web/components/FcDataTableRequests.vue
+++ b/web/components/FcDataTableRequests.vue
@@ -354,7 +354,7 @@ export default {
   }
   & td:nth-child(2),
   & th.fc-data-table-header-ID {
-    min-width: 70px;
+    min-width: 40px;
     width: 70px;
   }
   & td:nth-child(3),
@@ -364,7 +364,7 @@ export default {
   }
   & td:nth-child(4),
   & th.fc-data-table-header-data-table-expand {
-    min-width: 70px !important;
+    min-width: 1px !important;
     width: 70px !important;
   }
   & td:nth-child(5),
@@ -374,27 +374,27 @@ export default {
   }
   & td:nth-child(6),
   & th.fc-data-table-header-REQUESTER {
-    min-width: 140px;
+    min-width: 80px;
     width: 140px;
   }
   & td:nth-child(7),
   & th.fc-data-table-header-CREATED_AT {
-    min-width: 140px;
+    min-width: 90px;
     width: 140px;
   }
   & td:nth-child(8),
   & th.fc-data-table-header-DUE_DATE {
-    min-width: 140px;
+    min-width: 60px;
     width: 140px;
   }
   & td:nth-child(9),
   & th.fc-data-table-header-STATUS {
-    min-width: 140px;
+    min-width: 60px;
     width: 140px;
   }
   & td:nth-child(10),
   & th.fc-data-table-header-ACTIONS {
-    min-width: 105px;
+    min-width: 60px;
     width: 105px;
   }
 

--- a/web/components/geo/map/FcMap.vue
+++ b/web/components/geo/map/FcMap.vue
@@ -371,6 +371,15 @@ export default {
       );
       return markersById;
     },
+    locationMarkersByRequestId() {
+      const markersById = {};
+      this.locationsMarkersGeoJson.features.forEach((feature) => {
+        feature.properties.studyRequests.forEach((studyRequest) => {
+          markersById[studyRequest.requestId] = feature;
+        });
+      });
+      return markersById;
+    },
     ...mapState(['frontendEnv']),
     ...mapState('trackRequests', ['hoveredStudyRequest']),
   },
@@ -482,11 +491,11 @@ export default {
     },
     hoveredStudyRequest(newValue, oldValue) {
       if (newValue !== null) {
-        const feature = this.locationMarkersByCentreline[newValue];
+        const feature = this.locationMarkersByRequestId[newValue];
         feature.properties.selected = true;
       }
       if (oldValue !== null) {
-        const feature = this.locationMarkersByCentreline[oldValue];
+        const feature = this.locationMarkersByRequestId[oldValue];
         feature.properties.selected = false;
       }
       this.updateLocationsMarkersSource();

--- a/web/components/geo/map/FcMapPopup.vue
+++ b/web/components/geo/map/FcMapPopup.vue
@@ -90,8 +90,8 @@ export default {
       return getFeatureDetailsSuffix(this.layerId);
     },
     featureKey() {
-      const { layerId, feature: { id } } = this;
-      return `${layerId}:${id}`;
+      const { layerId, feature: { id, properties: { centrelineId } } } = this;
+      return `${layerId}:${id || centrelineId}`;
     },
     featureSelectable() {
       return SELECTABLE_LAYERS.includes(this.feature.layer.id);

--- a/web/components/requests/summary/FcSummaryStudyRequestBulk.vue
+++ b/web/components/requests/summary/FcSummaryStudyRequestBulk.vue
@@ -1,6 +1,15 @@
 <template>
   <section>
     <v-row class="mt-1 mb-2" tag="dl">
+      <v-col cols="12">
+        <dt class="subtitle-1">Project Description</dt>
+        <dd class="mt-1 display-1">
+          <span v-if="studyRequestBulk.notes">
+            {{studyRequestBulk.notes}}
+          </span>
+          <span v-else>None</span>
+        </dd>
+      </v-col>
       <v-col cols="6">
         <template v-if="!isCreate">
           <dt class="subtitle-1">Staff Subscribed</dt>
@@ -19,16 +28,6 @@
             </span>
           </dd>
         </template>
-      </v-col>
-
-      <v-col cols="12">
-        <dt class="subtitle-1">Project Description</dt>
-        <dd class="mt-1 display-1">
-          <span v-if="studyRequestBulk.notes">
-            {{studyRequestBulk.notes}}
-          </span>
-          <span v-else>None</span>
-        </dd>
       </v-col>
     </v-row>
   </section>

--- a/web/views/FcRequestStudyBulkView.vue
+++ b/web/views/FcRequestStudyBulkView.vue
@@ -45,7 +45,7 @@
             </h3>
           </v-row>
           <v-row class="d-flex flex-row">
-            <v-col cols="8" class="flex-1 pl-5">
+            <v-col cols="7" class="flex-1 pl-5">
               <v-card dense outlined class="flex-grow-1 fill-height">
                 <section
                   aria-labelledby="heading_bulk_request_requests"
@@ -108,7 +108,7 @@
               </v-card>
             </v-col>
 
-            <v-col cols="4" class="flex-1 px-5 pl-0">
+            <v-col cols="5" class="flex-1 px-5 pl-0">
               <FcMap
                 class="mx-0 fill-height"
                 :locations-state="locationsState"

--- a/web/views/FcRequestStudyBulkView.vue
+++ b/web/views/FcRequestStudyBulkView.vue
@@ -98,7 +98,7 @@
                     disable-pagination
                     disable-sort
                     fixed-header
-                    height="400px"
+                    height="417px"
                     calculate-widths
                     :has-filters="false"
                     :items="items"


### PR DESCRIPTION
# Issue Addressed
Part of MOVE-1194

# Description
You can now hover over any part of the row, and the corresponding map pin will be highlighted.

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/64811136/9876748a-7452-4124-bf24-d60aac330fed)


# Tests
Tested in MOVE local v1.12.0 using Firefox
