### PR TITLE
remove strict browserlist requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,11 +120,6 @@
     "vuetify-loader": "^1.9.2",
     "webpack-bundle-analyzer": "^4.9.0"
   },
-  "browserslist": [
-    "last 1 Chrome version",
-    "last 1 Edge version",
-    "last 1 Firefox version"
-  ],
   "_moduleAliases": {
     "@": "."
   },


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-1200 - speed-up development script

Tried a bunch of different webpack updates and configs, and nothing worked.

# Description
* removes our over-strict browser-list requirements, which force a check every day

please let me know if caniuse continues to update every day.