### PR TITLE
MOVE-63

### DIFF
--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -127,7 +127,7 @@
         <v-divider></v-divider>
       </div>
 
-      <section class="flex-grow-1 flex-shrink-1 overflow-y-auto pt-2"  v-if="!collapseReport">
+      <section class="flex-grow-1 flex-shrink-1 overflow-y-auto"  v-if="!collapseReport">
         <div
           v-if="loadingReportLayout"
           class="ma-3 text-center">

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -149,7 +149,7 @@
         <v-divider></v-divider>
       </div>
 
-      <section class="flex-grow-1 flex-shrink-1 overflow-y-auto pt-2" v-if="!collapseReport">
+      <section class="flex-grow-1 flex-shrink-1 overflow-y-auto" v-if="!collapseReport">
         <FcReportParameters
           v-if="showReportParameters"
           :report-parameters="reportParameters"

--- a/web/components/reports/FcReportTable.vue
+++ b/web/components/reports/FcReportTable.vue
@@ -25,7 +25,7 @@
           :key="'col_' + c"
           v-bind="attrs" />
       </colgroup>
-      <thead v-if="header.length > 0">
+      <thead class="fc-report-table-header" v-if="header.length > 0">
         <tr
           v-for="(row, r) in headerNormalized"
           :key="'row_header_' + r">
@@ -312,6 +312,12 @@ export default {
     & > thead {
       background-color: var(--base-lighter);
     }
+  }
+  & .fc-report-table-header {
+    position: sticky;
+    top: 0;
+    background-color: #98c2e3 !important;
+    z-index: 2;
   }
 }
 </style>


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-63](https://move-toronto.atlassian.net/browse/MOVE-63) - sticky headers on reports 

# Description
ended up being really easy - adds a css  `position: sticky;` to report headers, so they stop scrolling, once they reach the top.
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/399657/83da56cb-f0d0-4f75-8668-1aeb351ab47c)

the grey blurred into the other rows, when they scrolled into it, so I made it blue.

multiple-table reports just work as expected. 
I tested the pdfs, and they are unchanged, and not blue.