### PR TITLE
add ctrl-click handler

### DIFF
--- a/web/components/FcDataTableRequests.vue
+++ b/web/components/FcDataTableRequests.vue
@@ -153,11 +153,10 @@
       <div class="text-right">
         <FcButtonAria
           :aria-label="'View ' + item.ariaLabel"
-          button-class="btn-show-request"
-          left
-          type="secondary"
+          button-class="btn-show-request" left type="secondary"
+          @click.ctrl.capture="(event) => actionShowItemNewTab(item, event)"
           @click="actionShowItem(item)">
-          <v-icon>mdi-open-in-new</v-icon>
+            <v-icon>mdi-open-in-new</v-icon>
         </FcButtonAria>
       </div>
     </template>
@@ -322,6 +321,25 @@ export default {
         };
       }
       this.$router.push(route);
+    },
+    actionShowItemNewTab(item, event) {
+      let route;
+      if (item.type === ItemType.STUDY_REQUEST_BULK) {
+        const { id } = item.studyRequestBulk;
+        route = {
+          name: 'requestStudyBulkView',
+          params: { id },
+        };
+      } else {
+        const { id } = item.studyRequest;
+        route = {
+          name: 'requestStudyView',
+          params: { id },
+        };
+      }
+      const routeData = this.$router.resolve(route);
+      window.open(routeData.href, '_blank');
+      event.stopPropagation(); // prevent the normal click handler
     },
     actionUpdateItem(item) {
       this.$emit('update-item', item);


### PR DESCRIPTION
# Issue Addressed
This PR closes #X [MOVE-1217](https://move-toronto.atlassian.net/browse/MOVE-1217) - add ctrl+click to study view btn.

# Description
using the neat vue `@click.ctrl` modifier, adds a 2nd callback that opens the route in a new tab, instead of the current tab.
passes an event, so it can stop propagation to the regular click handler. Seems to work 👍 