### PR TITLE
MOVE-1216: Add status to map tooltip

### DIFF
--- a/lib/geo/CentrelineUtils.js
+++ b/lib/geo/CentrelineUtils.js
@@ -194,7 +194,9 @@ function getStudyRequestInfo(studyRequest, location) {
     return null;
   }
   const { label } = studyRequest.studyType;
-  const { id, hours, daysOfWeek } = studyRequest;
+  const {
+    id, hours, daysOfWeek, status: { text, color },
+  } = studyRequest;
   if (location !== null) {
     return {
       ...location,
@@ -202,6 +204,8 @@ function getStudyRequestInfo(studyRequest, location) {
       requestId: id,
       requestHours: (hours === null ? null : hours.description),
       numDays: daysOfWeek.length,
+      statusName: text,
+      statusColor: color,
     };
   }
   const { geom } = studyRequest;
@@ -223,20 +227,20 @@ function groupRequestsByLocation(locationsState) {
     const { centrelineId } = studyRequest.location;
     if (centrelineId in locationGroups) {
       const {
-        requestId, requestType, numDays, requestHours,
+        requestId, requestType, numDays, requestHours, statusName, statusColor,
       } = studyRequest.location;
       locationGroups[centrelineId].location.studyRequests.push({
-        requestId, requestType, numDays, requestHours,
+        requestId, requestType, numDays, requestHours, statusName, statusColor,
       });
     } else {
       const {
-        requestId, requestType, numDays, requestHours, ...rest
+        requestId, requestType, numDays, requestHours, statusName, statusColor, ...rest
       } = studyRequest.location;
       locationGroups[centrelineId] = {
         location: {
           ...rest,
           studyRequests: [{
-            requestId, requestType, numDays, requestHours,
+            requestId, requestType, numDays, requestHours, statusName, statusColor,
           }],
         },
         state: studyRequest.state,

--- a/web/components/geo/map/FcPopupDetailsStudyRequest.vue
+++ b/web/components/geo/map/FcPopupDetailsStudyRequest.vue
@@ -11,6 +11,8 @@
             class="body-0 mb-0">
             {{line}}
           </p>
+          <v-icon :color="item.statusColor" class="ml-n2">mdi-circle-medium</v-icon>
+          <span class="status-label">{{item.statusName}}</span>
         </div>
         <FcButtonAria @click="viewRequest(item)" type="tertiary"
         button-class="btn-show-request" right small


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-1216.

# Description
The status and corresponding icon of a study request is now displayed in the map tooltip.

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/64811136/189d9133-02b5-4f64-8fe0-b75d7c1c7050)

# Tests
Tested in MOVE local v1.12.0 using Firefox
