### PR TITLE
MOVE-1191 - Spell out study hours in TMC report header

### DIFF
--- a/lib/reports/ReportCountSummaryTurningMovement.js
+++ b/lib/reports/ReportCountSummaryTurningMovement.js
@@ -566,7 +566,7 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
       {
         cols: 3, name: 'Study Hours', value: hoursStr, subtext: hourRanges,
       },
-      { cols: 3, name: 'Traffic Signal Number', value: pxStr },
+      { cols: 6, name: 'Traffic Signal Number', value: pxStr },
       { cols: 3, name: 'Total Volume', value: TOTAL },
       { cols: 3, name: 'Total Vehicles', value: VEHICLE_TOTAL },
       { cols: 3, name: 'Total Cyclists', value: BIKE_TOTAL },

--- a/lib/reports/ReportCountSummaryTurningMovement.js
+++ b/lib/reports/ReportCountSummaryTurningMovement.js
@@ -564,7 +564,7 @@ class ReportCountSummaryTurningMovement extends ReportBaseFlow {
     const entries = [
       { cols: 3, name: 'Date', value: fullDateStr },
       {
-        cols: 3, name: 'Study Hours', value: hoursStr, subtext: hourRanges,
+        cols: 3, name: 'Study Hours', value: hoursStr, tooltip: hourRanges,
       },
       { cols: 6, name: 'Traffic Signal Number', value: pxStr },
       { cols: 3, name: 'Total Volume', value: TOTAL },

--- a/web/components/reports/FcReportMetadata.vue
+++ b/web/components/reports/FcReportMetadata.vue
@@ -6,7 +6,7 @@
         <dd v-if="tooltip != null" class="mt-1 display-1 font-weight-medium">
           <v-tooltip bottom>
             <template v-slot:activator="{ on }">
-              <FcTextReportValue text-null="None" :value="value" />
+              <FcTextReportValue text-null="None" :value="value" style="padding-right: 0.5rem;"/>
               <v-icon v-on="on">mdi-help-circle-outline</v-icon>
             </template>
             <span>{{ tooltip }}</span>

--- a/web/components/reports/FcReportMetadata.vue
+++ b/web/components/reports/FcReportMetadata.vue
@@ -1,55 +1,59 @@
 <template>
   <div>
-  <v-row class="mb-6" tag="dl">
-    <v-col
-      v-for="({ cols, name, value, subtext }, i) in entries"
-      :key="i"
-      :cols="cols">
-      <dt class="subtitle-1 font-weight-medium">{{name}}</dt>
-      <dd class="mt-1 display-1 font-weight-medium">
+    <v-row class="mb-6" tag="dl">
+      <v-col v-for="({ cols, name, value, tooltip }, i) in entries" :key="i" :cols="cols">
+        <dt class="subtitle-1 font-weight-medium">{{ name }}</dt>
+        <dd v-if="tooltip != null" class="mt-1 display-1 font-weight-medium">
+          <v-tooltip bottom>
+            <template v-slot:activator="{ on }">
+              <FcTextReportValue text-null="None" :value="value" />
+              <v-icon v-on="on">mdi-help-circle-outline</v-icon>
+            </template>
+            <span>{{ tooltip }}</span>
+          </v-tooltip>
+        </dd>
+        <dd v-else class="mt-1 display-1 font-weight-medium">
         <FcTextReportValue
           text-null="None"
           :value="value" />
       </dd>
-      <dd v-if="subtext != null" class="v-messages theme--light subtext">
-        <FcTextReportValue
-          :value="subtext" />
-      </dd>
-    </v-col>
-  </v-row>
-
-  <div v-if="numFilters > 0 && this.type.label.startsWith('Collision')" class="px-0">
-    <v-row class="align-center mx-0 px-1">
-      <h3 class="flex-1">{{ numFilters }} Filter{{ this.numFilters > 1 ? 's' : '' }}</h3>
-      <FcButton @click="isExpanded = !isExpanded" type="icon" class="flex-1">
-        <v-icon v-if="isExpanded">mdi-menu-up</v-icon>
-        <v-icon v-else>mdi-menu-down</v-icon>
-      </FcButton>
+      </v-col>
     </v-row>
-    <v-expand-transition>
-      <ul v-show="isExpanded" class="pt-1">
-        <li v-for="(item, i) in collisionFilters" :key="i">
-          <b>{{ item.filter }}: </b> {{ item.label }}
-        </li>
-      </ul>
-    </v-expand-transition>
-  </div>
 
-  <div class="callout-container" v-if="this.showCallOut">
-    <div class="callout ma-3">
-      <div class="ma-3">
-        <v-icon color="blue">mdi-information</v-icon>
-      </div>
-      <div class="ml-1 mr-2 pr-2 py-2">
-        For an in-depth explanation of how to interpret this data,
-        <a class="link" href="https://bditto.notion.site/How-to-interpret-a-TMC-Summary-Report-310c8b7e9ca74b18b99aadc50dc27196" target="_blank" rel="noopener noreferrer">
-          see here
-        </a>
+    <div v-if="numFilters > 0 && this.type.label.startsWith('Collision')" class="px-0">
+      <v-row class="align-center mx-0 px-1">
+        <h3 class="flex-1">{{ numFilters }} Filter{{ this.numFilters > 1 ? 's' : '' }}</h3>
+        <FcButton @click="isExpanded = !isExpanded" type="icon" class="flex-1">
+          <v-icon v-if="isExpanded">mdi-menu-up</v-icon>
+          <v-icon v-else>mdi-menu-down</v-icon>
+        </FcButton>
+      </v-row>
+      <v-expand-transition>
+        <ul v-show="isExpanded" class="pt-1">
+          <li v-for="(item, i) in collisionFilters" :key="i">
+            <b>{{ item.filter }}: </b> {{ item.label }}
+          </li>
+        </ul>
+      </v-expand-transition>
+    </div>
+
+    <div class="callout-container" v-if="this.showCallOut">
+      <div class="callout ma-3">
+        <div class="ma-3">
+          <v-icon color="blue">mdi-information</v-icon>
+        </div>
+        <div class="ml-1 mr-2 pr-2 py-2">
+          For an in-depth explanation of how to interpret this data,
+          <a class="link"
+            href="https://bditto.notion.site/How-to-interpret-a-TMC-Summary-Report-310c8b7e9ca74b18b99aadc50dc27196"
+            target="_blank" rel="noopener noreferrer">
+            see here
+          </a>
+        </div>
       </div>
     </div>
-  </div>
 
-</div>
+  </div>
 </template>
 
 <script>
@@ -133,11 +137,13 @@ export default {
   font-size: 14px;
   max-width: 300px;
 }
+
 .callout-container {
   display: flex;
   justify-content: flex-end;
 }
-.subtext {
+
+.tooltip {
   width: 60%;
 }
 
@@ -147,5 +153,4 @@ export default {
     display: none !important;
   }
 }
-
 </style>


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-1191](https://move-toronto.atlassian.net/browse/MOVE-1191)

# Description
@mkewins thought the initial idea of having the hours displayed below the term caused the header to have too much whitespace (I agree!), so we are trying tooltips for this now.

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/5003768/50e2878e-2ef2-4a76-b13e-7c53310a9fae)

# Tests
All tests are passing.
