### PR TITLE
Style changes to fit longer strings in table

### DIFF
--- a/web/components/FcDataTableRequests.vue
+++ b/web/components/FcDataTableRequests.vue
@@ -370,12 +370,12 @@ export default {
   }
   & td:nth-child(2),
   & th.fc-data-table-header-ID {
-    min-width: 40px;
+    min-width: 20px;
     width: 70px;
   }
   & td:nth-child(3),
   & th.fc-data-table-header-LOCATION {
-    min-width: 210px;
+    min-width: 190px;
     width: auto;
   }
   & td:nth-child(4),
@@ -385,7 +385,7 @@ export default {
   }
   & td:nth-child(5),
   & th.fc-data-table-header-STUDY_TYPE {
-    min-width: 210px;
+    min-width: 190px;
     width: 210px;
   }
   & td:nth-child(6),


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-1149.

# Description
Some style changes to allow request table to fit longer status strings.

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/64811136/279b3313-ed2d-400d-9c73-b0a92cc9258e)

# Tests
Tested in MOVE local v1.12.0 using Firefox, Chrome and Edge.
