### PR TITLE
fixed the corridor error bug

### DIFF
--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -423,9 +423,9 @@ export default {
       this.loadingReportLayout = false;
 
       this.reportLayout = reportLayout;
-      // if (this.isDirectoryReport) {
-      //   this.extractMvcrRows(this.reportLayout);
-      // }
+      if (this.isDirectoryReport) {
+        this.extractMvcrRows(this.reportLayout);
+      }
     },
     parseFiltersFromRouteParams() {
       const routeParams = this.$route.params;

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -240,8 +240,8 @@ export default {
         const selectionType = LocationSelectionType.POINTS;
         return `${s1}/${selectionType.name}`;
       }
-      const { locations, selectionType } = this.locationsSelection;
-      const s1 = CompositeId.encode([locations[this.activeLocation]]);
+      const { selectionType } = this.locationsSelection;
+      const s1 = CompositeId.encode([this.locations[this.activeLocation]]);
       return `${s1}/${selectionType.name}`;
     },
     activeReportType() {
@@ -423,9 +423,9 @@ export default {
       this.loadingReportLayout = false;
 
       this.reportLayout = reportLayout;
-      if (this.isDirectoryReport) {
-        this.extractMvcrRows(this.reportLayout);
-      }
+      // if (this.isDirectoryReport) {
+      //   this.extractMvcrRows(this.reportLayout);
+      // }
     },
     parseFiltersFromRouteParams() {
       const routeParams = this.$route.params;


### PR DESCRIPTION
# Issue Addressed
This is an amendment to [MOVE-59](https://move-toronto.atlassian.net/browse/MOVE-59).

# Description
The previous change was only really tested with POINTS and not CORRIDOR type selections. The behaviour broke when a corridor was selected since we were using the location selection and not a list of all locations (which includes the spaces in between two selections). In the case of a POINTS selection, these intermediates will be dropped when generating the report but will remain in play when a CORRIDOR is selected.

