### PR TITLE
MOVE-1183 - Data Collection are moving to a unified Volume-Speed-Classification count

### DIFF
--- a/web/components/data/FcTextMostRecent.vue
+++ b/web/components/data/FcTextMostRecent.vue
@@ -9,14 +9,13 @@
         {{study.startDate | date}} ({{study.startDate | dayOfWeek}})
       </span>
       <template v-if="!minimal">
-        <br/>
         <span v-if="study.duration !== null">
-          {{study.duration | durationHuman}} ({{study.duration}} hrs)
+          &bull; {{study.duration | durationHuman}} ({{study.duration}} hrs)
         </span>
         <span
           v-else-if="study.hours !== null"
           :title="study.hours.hint">
-          {{study.hours.description}}
+          &bull; {{study.hours.description}}
         </span>
       </template>
     </template>

--- a/web/components/requests/FcCardStudyRequest.vue
+++ b/web/components/requests/FcCardStudyRequest.vue
@@ -24,7 +24,7 @@
         </FcButtonAria>
         <FcTextMostRecent
           v-if="studyRequest.studyType !== null"
-          :study="mostRecent.get(studyRequest.studyType)" />
+          :study="this.getMostRecent(studyRequest)" />
       </div>
       <v-spacer></v-spacer>
       <span class="font-weight-regular secondary--text">{{locationType}}</span>
@@ -109,6 +109,13 @@ export default {
         this.addHoveredStudyIndex(index);
         this.elevation = 0;
       }
+    },
+    getMostRecent(request) {
+      if (request.studyType === StudyType.ATR_SVC) {
+        return this.mostRecent.get(StudyType.ATR_SVC)
+        || this.mostRecent.get(StudyType.ATR_SPEED_VOLUME);
+      }
+      return this.mostRecent.get(request.studyType);
     },
     ...mapActions('editRequests', [
       'addHoveredStudyIndex',


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-1183](https://move-toronto.atlassian.net/browse/MOVE-1183)

# Description
Now returns the latest study for either SVC or SPEED_VOLUME when user is requesting new SVC study.

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/5003768/28205022-d0ae-4f6f-ab61-893e3ff936a7)

# Tests
All current tests pass.
