### PR TITLE
MOVE:1194: Moved filters to end of page, filters section removed if there are no…

### DIFF
--- a/lib/reports/format/MovePdfGenerator.js
+++ b/lib/reports/format/MovePdfGenerator.js
@@ -646,22 +646,21 @@ class MovePdfGenerator {
   }
 
   generateContent() {
-    const starterList = [];
-    if (this.reportType.label === 'Collision Directory Report') {
-      starterList.push(
-        { text: 'Collision Filters:', bold: true, fontSize: 15 },
-        {
-          ul: this.filters,
-        },
+    const filtersList = [];
+    if (this.reportType.label === 'Collision Directory Report' && this.filters.length > 0) {
+      filtersList.push(
         {
           pageBreak: 'after',
           text: '',
         },
+        { text: 'Collision Filters:', bold: true, fontSize: 15 },
+        {
+          ul: this.filters,
+        },
       );
     }
     return Array.prototype.concat.apply(
-      starterList,
-      this.content.map(this.generateContentRow.bind(this)),
+      this.content.map(this.generateContentRow.bind(this)), filtersList,
     );
   }
 


### PR DESCRIPTION
# Issue Addressed
This issue closes MOVE-1194. 

# Description
Moves collision filters to the last page of pdf exports of collision directory reports. Also, the collision filters section does not appear if there are no filters.

(No filters)
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/64811136/ae4d87e9-80e3-46d9-9b3c-80b698a02dfa)

(Filters)
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/64811136/413dd854-2676-48ed-9786-40694198c9fb)

# Tests
Tested in MOVE local v1.12.0 using Firefox.