### PR TITLE
MOVE-1191 - Spell out study hours in TMC report header

### DIFF
--- a/lib/reports/ReportCountSummaryTurningMovementDetailed.js
+++ b/lib/reports/ReportCountSummaryTurningMovementDetailed.js
@@ -249,6 +249,7 @@ class ReportCountSummaryTurningMovementDetailed extends ReportBaseFlow {
     const dayOfWeekStr = TimeFormatters.formatDayOfWeek(date);
     const fullDateStr = `${dateStr} (${dayOfWeekStr})`;
     const hoursStr = hours === null ? null : hours.description;
+    const hourRanges = hours === null ? null : hours.hint;
     const pxStr = px === null ? null : px.toString();
     const {
       BIKE_TOTAL,
@@ -258,7 +259,9 @@ class ReportCountSummaryTurningMovementDetailed extends ReportBaseFlow {
     } = all;
     const entries = [
       { cols: 3, name: 'Date', value: fullDateStr },
-      { cols: 3, name: 'Study Hours', value: hoursStr },
+      {
+        cols: 3, name: 'Study Hours', value: hoursStr, tooltip: hourRanges,
+      },
       { cols: 6, name: 'Traffic Signal Number', value: pxStr },
       { cols: 3, name: 'Total Volume', value: TOTAL },
       { cols: 3, name: 'Total Vehicles', value: VEHICLE_TOTAL },

--- a/lib/reports/ReportIntersectionSummary.js
+++ b/lib/reports/ReportIntersectionSummary.js
@@ -340,6 +340,7 @@ class ReportIntersectionSummary extends ReportBaseFlowDirectional {
     const dayOfWeekStr = TimeFormatters.formatDayOfWeek(date);
     const fullDateStr = `${dateStr} (${dayOfWeekStr})`;
     const hoursStr = hours === null ? null : hours.description;
+    const hourRanges = hours === null ? null : hours.hint;
     const pxStr = px === null ? null : px.toString();
     const {
       MAJOR_APPROACHES,
@@ -349,7 +350,9 @@ class ReportIntersectionSummary extends ReportBaseFlowDirectional {
     } = totals;
     const entries = [
       { cols: 3, name: 'Date', value: fullDateStr },
-      { cols: 3, name: 'Study Hours', value: hoursStr },
+      {
+        cols: 3, name: 'Study Hours', value: hoursStr, tooltip: hourRanges,
+      },
       { cols: 6, name: 'Traffic Signal Number', value: pxStr },
       { cols: 3, name: 'Total Approaches', value: TOTAL },
       { cols: 3, name: 'Total Major Approaches', value: MAJOR_APPROACHES },

--- a/lib/reports/ReportPeakHourFactor.js
+++ b/lib/reports/ReportPeakHourFactor.js
@@ -315,13 +315,16 @@ class ReportPeakHourFactor extends ReportBaseFlow {
     const dayOfWeekStr = TimeFormatters.formatDayOfWeek(date);
     const fullDateStr = `${dateStr} (${dayOfWeekStr})`;
     const hoursStr = hours === null ? null : hours.description;
+    const hourRanges = hours === null ? null : hours.hint;
     const pxStr = px === null ? null : px.toString();
     const amPeakTimeRangeHuman = TimeFormatters.formatRangeTimeOfDay(amPeak.timeRange);
     const pmPeakTimeRangeHuman = TimeFormatters.formatRangeTimeOfDay(pmPeak.timeRange);
 
     const entries = [
       { cols: 3, name: 'Date', value: fullDateStr },
-      { cols: 3, name: 'Study Hours', value: hoursStr },
+      {
+        cols: 3, name: 'Study Hours', value: hoursStr, tooltip: hourRanges,
+      },
       { cols: 6, name: 'Traffic Signal Number', value: pxStr },
       { cols: 3, name: 'AM Peak', value: amPeakTimeRangeHuman },
       { cols: 3, name: 'AM Factor', value: amPeak.total },

--- a/lib/reports/ReportPedDelaySummary.js
+++ b/lib/reports/ReportPedDelaySummary.js
@@ -418,12 +418,15 @@ class ReportPedDelaySummary extends ReportBaseFlow {
     const dayOfWeekStr = TimeFormatters.formatDayOfWeek(date);
     const fullDateStr = `${dateStr} (${dayOfWeekStr})`;
     const hoursStr = hours === null ? null : hours.description;
+    const hourRanges = hours === null ? null : hours.hint;
 
     const { totals, zones } = stats;
 
     const entries = [
       { cols: 3, name: 'Date', value: fullDateStr },
-      { cols: 3, name: 'Study Hours', value: hoursStr },
+      {
+        cols: 3, name: 'Study Hours', value: hoursStr, tooltip: hourRanges,
+      },
       { cols: 6, name: 'Weather', value: weather },
       ...zones.map(zone => ({
         cols: 3,

--- a/lib/reports/ReportWarrantTrafficSignalControl.js
+++ b/lib/reports/ReportWarrantTrafficSignalControl.js
@@ -816,12 +816,15 @@ class ReportWarrantTrafficSignalControl extends ReportBaseFlowDirectional {
     const dayOfWeekStr = TimeFormatters.formatDayOfWeek(date);
     const fullDateStr = `${dateStr} (${dayOfWeekStr})`;
     const hoursStr = hours === null ? null : hours.description;
+    const hourRanges = hours === null ? null : hours.hint;
     const pxStr = px === null ? null : px.toString();
     const intersectionTypeStr = isXIntersection ? 'X (4-way)' : 'T (3-way)';
     const lanesStr = isTwoLane ? '1-2 lanes' : '3+ lanes';
     const entries = [
       { cols: 3, name: 'Date', value: fullDateStr },
-      { cols: 3, name: 'Study Hours', value: hoursStr },
+      {
+        cols: 3, name: 'Study Hours', value: hoursStr, tooltip: hourRanges,
+      },
       { cols: 6, name: 'Traffic Signal Number', value: pxStr },
       { cols: 3, name: 'Intersection Type', value: intersectionTypeStr },
       { cols: 3, name: 'Road Width', value: lanesStr },

--- a/web/components/reports/FcReportMetadata.vue
+++ b/web/components/reports/FcReportMetadata.vue
@@ -7,7 +7,7 @@
           <v-tooltip bottom>
             <template v-slot:activator="{ on }">
               <FcTextReportValue text-null="None" :value="value" style="padding-right: 0.5rem;"/>
-              <v-icon v-on="on">mdi-help-circle-outline</v-icon>
+              <FcButton type="icon" v-on="on"><v-icon>mdi-help-circle-outline</v-icon></FcButton>
             </template>
             <span>{{ tooltip }}</span>
           </v-tooltip>


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-1191](https://move-toronto.atlassian.net/browse/MOVE-1191)
# Description
Add Study Hours tooltip to other reports, and make ? a button
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/5003768/93a5806f-29cc-480e-95ed-04641c1e067a)

# Tests
All current tests are passing.
