### PR TITLE
MOVE-1138 - Switch the mvcrExpiryDate back to 1 week

### DIFF
--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -748,8 +748,7 @@ async function putUser(auth, newUserData) {
       if (!currentUserData.scope.includes(AuthScope.MVCR_READ)) {
         deltas.scope = [...authScope, AuthScope.MVCR_READ];
       }
-      // deltas.mvcrExpiryDate = DateTime.local().plus({ weeks: 1 });
-      deltas.mvcrExpiryDate = DateTime.local().plus({ minutes: 5 });
+      deltas.mvcrExpiryDate = DateTime.local().plus({ weeks: 1 });
     } else if (newUserData.mvcrAcctType === 2) {
       if (!currentUserData.scope.includes(AuthScope.MVCR_READ)) {
         deltas.scope = [...authScope, AuthScope.MVCR_READ];


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-1138](https://move-toronto.atlassian.net/browse/MOVE-1138)

# Description
We switched the expiration time to 5 mins for testing. This testing is complete, so we need to move the expiration time back to 1 week.

# Tests
All tests are passing.
