### PR TITLE
MOVE 59 -> downloading multiple report experiment

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -313,6 +313,7 @@ MapZoom.MAX = MapZoom.LEVEL_1.maxzoomSource;
  * {@link CompositeId} for the maximum number of locations in a routed corridor.
  */
 const MAX_LOCATIONS = 5;
+const MAX_CORRIDOR_POINTS = 100;
 
 /**
  * Official name of the organization / division that is responsible for data products and services
@@ -1328,6 +1329,7 @@ const Constants = {
   LocationSelectionType,
   MapZoom,
   MAX_LOCATIONS,
+  MAX_CORRIDOR_POINTS,
   MvcrPermissions,
   ORG_NAME,
   PageOrientation,
@@ -1372,6 +1374,7 @@ export {
   LocationSelectionType,
   MapZoom,
   MAX_LOCATIONS,
+  MAX_CORRIDOR_POINTS,
   MvcrPermissions,
   ORG_NAME,
   PageOrientation,

--- a/lib/controller/JobController.js
+++ b/lib/controller/JobController.js
@@ -4,6 +4,7 @@ import {
   HttpStatus,
   LocationSelectionType,
   MAX_LOCATIONS,
+  MAX_CORRIDOR_POINTS,
   ReportExportMode,
   ReportFormat,
   AuthScope,
@@ -72,7 +73,7 @@ JobController.push({
 
     try {
       const features = CompositeId.decode(s1);
-      if (features.length > MAX_LOCATIONS) {
+      if (features.length > MAX_CORRIDOR_POINTS) {
         return Boom.badRequest(`cannot fetch reports on more than ${MAX_LOCATIONS} locations`);
       }
       const featuresSelection = { features, selectionType };

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -135,7 +135,7 @@
 <script>
 import { mapGetters, mapMutations, mapState } from 'vuex';
 
-import { ReportExportMode } from '@/lib/Constants';
+import { ReportExportMode, LocationSelectionType } from '@/lib/Constants';
 import {
   getCollisionsByCentrelineSummary,
   getCollisionsByCentrelineSummaryPerLocation,
@@ -195,6 +195,7 @@ export default {
         ksi: 0,
         validated: 0,
       },
+      locationsSelectionForCorridorReport: null,
       collisionSummaryPerLocation,
       collisionSummaryPerLocationUnfiltered,
       collisionTotal: 0,
@@ -265,12 +266,26 @@ export default {
   },
   methods: {
     async actionDownloadReportFormatCollisions(reportFormat) {
-      const job = await postJobGenerateCollisionReports(
-        this.auth.csrf,
-        this.locationsSelection,
-        this.filterParamsCollision,
-        reportFormat,
-      );
+      let job;
+      if (this.locationsSelection.selectionType === LocationSelectionType.CORRIDOR) {
+        this.locationsSelectionForCorridorReport = JSON.parse(
+          JSON.stringify(this.locationsSelection),
+        );
+        this.locationsSelectionForCorridorReport.locations = this.locations;
+        job = await postJobGenerateCollisionReports(
+          this.auth.csrf,
+          this.locationsSelectionForCorridorReport,
+          this.filterParamsCollision,
+          reportFormat,
+        );
+      } else {
+        job = await postJobGenerateCollisionReports(
+          this.auth.csrf,
+          this.locationsSelection,
+          this.filterParamsCollision,
+          reportFormat,
+        );
+      }
 
       this.setToast({
         toast: 'Job',

--- a/web/components/location/FcIconLocationSingle.vue
+++ b/web/components/location/FcIconLocationSingle.vue
@@ -40,9 +40,9 @@ export default {
   transform: translate(-50%, -50%);
   color: #3088D6;
   font-weight: bolder;
-  padding: 5px 10px;
-  font-size: 20px;
+  font-size: 15px;
   text-align: center;
+  width: 100%;
   }
 }
 </style>


### PR DESCRIPTION
# Issue Addressed
Again, MOVE-59.

# Description
We want to display reports separately on the web app, that's fine and is working. Downloading reports for individual points in a multi selection is great as well. What wasn't working was the downloading of reports for the corridor locations (i.e. the potential scores of locations between our actual selections).

This change takes the corridor and breaks it up into a series of points and then generates a report for each of those points. This is a test to see how long report generation takes on the dev server.
