### PR TITLE
Move 63v2

### DIFF
--- a/web/App.vue
+++ b/web/App.vue
@@ -139,6 +139,7 @@ export default {
 
   & .fc-navigation-drawer {
     overflow: visible;
+    z-index: 11;
   }
 
   & .v-input--selection-controls__input + .v-label {

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -70,10 +70,10 @@
             <template v-slot:activator="{ on, attrs }">
               <span v-bind="attrs" v-on="on">
                 <v-icon v-if="collapseReport" class="mx-3" @click="toggleReport">
-                  mdi-chevron-up
+                  mdi-chevron-down
                 </v-icon>
                 <v-icon v-else class="mx-3" @click="toggleReport">
-                  mdi-chevron-down
+                  mdi-chevron-up
                 </v-icon>
               </span>
             </template>

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -77,7 +77,8 @@
                 </v-icon>
               </span>
             </template>
-            <span>Collapse Report</span>
+            <span v-if="collapseReport">Expand Report</span>
+            <span v-else>Collapse Report</span>
           </v-tooltip>
 
           <v-tooltip bottom>

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -511,7 +511,7 @@ export default {
   & .fc-collision-btn-location {
     font-size: 12px;
     overflow: hidden;
-    max-width: 150px;
+    max-width: 250px;
     text-overflow: ellipsis;
   }
   & .fc-icon-dim {

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -97,10 +97,10 @@
             <template v-slot:activator="{ on, attrs }">
               <span v-bind="attrs" v-on="on">
                 <v-icon v-if="collapseReport" class="mx-3" @click="toggleReport">
-                  mdi-chevron-up
+                  mdi-chevron-down
                 </v-icon>
                 <v-icon v-else class="mx-3" @click="toggleReport">
-                  mdi-chevron-down
+                  mdi-chevron-up
                 </v-icon>
               </span>
             </template>

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -552,7 +552,7 @@ export default {
   & .fc-study-btn-label {
     font-size: 12px;
     overflow: hidden;
-    max-width: 150px;
+    max-width: 250px;
     text-overflow: ellipsis;
   }
   & .fc-icon-dim {
@@ -564,7 +564,7 @@ export default {
   max-height: var(--full-height);
 }
 
-@media only screen and (max-width: 800px) {
+@media only screen and (max-width: 900px) {
   .fc-study-btn-label {
     display: none;
   }

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -104,7 +104,8 @@
                 </v-icon>
               </span>
             </template>
-            <span>Collapse Report</span>
+            <span v-if="collapseReport">Expand Report</span>
+            <span v-else>Collapse Report</span>
           </v-tooltip>
 
           <v-tooltip bottom>

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -53,7 +53,12 @@
                 v-on="on"
                 class="flex-grow-0 mt-0 mr-2"
                 type="secondary">
-                <v-icon class="fc-icon-dim" size="20">mdi-map-marker</v-icon>
+                <span class="pr-1">
+                  <img v-if="locationActive.centrelineType == 1" title="Midblock"
+                  src="/icons/map/location-multi-midblock.svg" alt="Midblock icon" width="14"/>
+                  <img v-else title="Intersection"
+                  src="/icons/map/location-multi-intersection.svg" alt="Midblock icon" width="14"/>
+                </span>
                 <span class="pa-1 fc-study-btn-label">
                   {{locationActive.description}}
                 </span>
@@ -554,6 +559,8 @@ export default {
     overflow: hidden;
     max-width: 250px;
     text-overflow: ellipsis;
+    text-transform: none;
+    letter-spacing: normal;
   }
   & .fc-icon-dim {
     opacity: 0.6;

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -51,7 +51,10 @@
                       <template v-slot:activator="{ on }">
                         <FcButton
                           v-on="on"
-                          width="40px"
+                          v-if="itemsPerLocation[i][j].n !== 0"
+                          class="pa-0"
+                          max-width="50px"
+                          min-width="50px"
                           type="tertiary"
                           :disabled="itemsPerLocation[i][j].n === 0"
                           @click="$emit('show-reports', { item, locationsIndex: j })">
@@ -177,9 +180,6 @@ export default {
   }
   & .fc-study-list-number {
     min-width: 50px;
-  }
-  & .fc-chevron-wrapper {
-    min-width: 80px;
   }
 }
 </style>

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -169,9 +169,6 @@ export default {
     border-bottom: 1px solid var(--v-border-base);
     margin-bottom: 12px;
   }
-  & .fc-study-summary-header {
-    font-weight: bold;
-  }
   & .data-empty {
     opacity: 0.37;
   }

--- a/web/components/data/FcDetailCollisions.vue
+++ b/web/components/data/FcDetailCollisions.vue
@@ -49,6 +49,7 @@
             v-on="on"
             id="fc-detail-collision-btn"
             class="ma-1"
+            width="50px"
             type="secondary"
             :disabled="collisionSummary.amount === 0"
             @click="$emit('show-reports')">

--- a/web/components/data/FcDetailCollisions.vue
+++ b/web/components/data/FcDetailCollisions.vue
@@ -3,7 +3,7 @@
     <FcProgressLinear
       v-if="loading"
       aria-label="Loading Detail View collisions data" />
-    <div class="fc-collision-detail-row px-1 py-2 d-flex ml-5 justify-space-around"
+    <div class="fc-collision-detail-row pl-1 pr-3 py-2 d-flex ml-5 justify-space-around"
       v-else-if="collisionSummaryUnfiltered.amount > 0">
       <dl class="fc-collision-table d-flex flex-grow-1">
         <div class="collision-fact">

--- a/web/components/data/FcDetailStudies.vue
+++ b/web/components/data/FcDetailStudies.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fc-detail-studies mb-2 px-1">
+  <div class="fc-detail-studies mb-2 pl-1 pr-3">
     <FcProgressLinear
       v-if="loading"
       aria-label="Loading Detail View studies data" />

--- a/web/components/data/FcSectionStudyRequestsPending.vue
+++ b/web/components/data/FcSectionStudyRequestsPending.vue
@@ -3,7 +3,7 @@
     <p
       v-for="studyRequest in studyRequestsPending"
       :key="studyRequest.id"
-      class="align-center d-flex mb-1 pa-3">
+      class="align-center d-flex mb-3 pa-3">
       <v-icon
         color="warning"
         left>mdi-information</v-icon>

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -47,15 +47,12 @@
           <div v-if="collisionSummary.amount > 0" class="mr-5 align-self-end mb-2">
             <FcButton
               class="ma-1"
-              :disabled="
-                collisionSummary.amount === 0
-                || reportExportMode === ReportExportMode.STUDIES"
               :scope="[]"
               type="secondary"
               color="primary"
               @click="actionToggleReportExportMode(ReportExportMode.COLLISIONS)">
               <template v-if="reportExportMode === ReportExportMode.COLLISIONS">
-                <v-icon color="primary">mdi-cloud-check</v-icon>
+                Cancel&nbsp;<v-icon color="primary">mdi-cloud-check</v-icon>
                 <span class="sr-only">Cancel Export of Collision Reports</span>
               </template>
               <template v-else>
@@ -98,21 +95,18 @@
             <FcButton
               class="mb-1"
               v-if="studySummary.length > 0"
-              :disabled="
-                collisionSummary.amount === 0
-                || reportExportMode === ReportExportMode.STUDIES"
               :scope="[]"
               type="secondary"
               color="primary"
-              @click="actionToggleReportExportMode(ReportExportMode.COLLISIONS)">
-              <template v-if="reportExportMode === ReportExportMode.COLLISIONS">
-                <v-icon color="primary">mdi-cloud-check</v-icon>
-                <span class="sr-only">Cancel Export of Collision Reports</span>
+              @click="actionToggleReportExportMode(ReportExportMode.STUDIES)">
+              <template v-if="reportExportMode === ReportExportMode.STUDIES">
+                Cancel&nbsp;<v-icon color="primary">mdi-cloud-check</v-icon>
+                <span class="sr-only">Cancel Export of Study Reports</span>
               </template>
               <template v-else>
                 Export&nbsp;
                 <v-icon color="primary">mdi-cloud-download</v-icon>
-                <span class="sr-only">Export Collision Reports</span>
+                <span class="sr-only">Export Study Reports</span>
               </template>
             </FcButton>
 

--- a/web/components/data/FcViewDataDetail.vue
+++ b/web/components/data/FcViewDataDetail.vue
@@ -25,6 +25,9 @@
           :study-summary-unfiltered="studySummaryUnfiltered"
           @show-reports="actionShowReportsStudy" />
 
+          <FcSectionStudyRequestsPending
+            :study-requests-pending="studyRequestsPending" />
+
           <div class="mr-4 align-self-end text-left pb-4">
             <FcButton
               type="secondary"
@@ -38,8 +41,6 @@
           <div class="pb-5" v-if="studyTotal > 1"/>
       </section>
 
-      <FcSectionStudyRequestsPending
-        :study-requests-pending="studyRequestsPending" />
     </template>
   </div>
 </template>

--- a/web/components/data/FcViewDataDetail.vue
+++ b/web/components/data/FcViewDataDetail.vue
@@ -25,7 +25,7 @@
           :study-summary-unfiltered="studySummaryUnfiltered"
           @show-reports="actionShowReportsStudy" />
 
-          <div class="mr-5 align-self-end text-left pb-4">
+          <div class="mr-4 align-self-end text-left pb-4">
             <FcButton
               type="secondary"
               color="primary"

--- a/web/components/geo/map/FcMap.vue
+++ b/web/components/geo/map/FcMap.vue
@@ -726,7 +726,7 @@ export default {
   & > .fc-map-legend-wrapper {
     right: 20px;
     top: 12px;
-    z-index: 11;
+    z-index: 9;
   }
   & > .fc-map-navigate {
     bottom: 77px;

--- a/web/components/geo/map/FcMap.vue
+++ b/web/components/geo/map/FcMap.vue
@@ -726,7 +726,7 @@ export default {
   & > .fc-map-legend-wrapper {
     right: 20px;
     top: 12px;
-    z-index: 100;
+    z-index: 11;
   }
   & > .fc-map-navigate {
     bottom: 77px;

--- a/web/components/location/FcListLocationDropdown.vue
+++ b/web/components/location/FcListLocationDropdown.vue
@@ -12,10 +12,10 @@
           mdi-map-marker
         </v-icon>
         <div class="d-flex align-center truncate">
-          <div class="fc-list-dropdown-text body-1 truncate">
+          <div class="fc-list-dropdown-text truncate">
             <div class="truncate" :class="{
-                'body-1': locationsIconProps[i].locationIndex === -1,
-                title: locationsIconProps[i].locationIndex !== -1,
+                'fc-location-hidden': locationsIconProps[i].locationIndex === -1,
+                'fc-location-normal': locationsIconProps[i].locationIndex !== -1,
               }">
               {{location.description}}
             </div>
@@ -61,15 +61,14 @@ export default {
 <style lang="scss">
 .fc-list-location-dropdown {
   & .truncate {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    white-space: normal;
     max-width: 240px;
   }
   & .fc-list-dropdown-row {
     display: flex;
     flex-flow: row nowrap;
     justify-content: flex-start;
+    font-size: 12px
   }
   & .fc-list-dropdown-text {
     max-width: 250px;

--- a/web/components/location/FcListLocationDropdown.vue
+++ b/web/components/location/FcListLocationDropdown.vue
@@ -64,7 +64,7 @@ export default {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 180px;
+    max-width: 240px;
   }
   & .fc-list-dropdown-row {
     display: flex;
@@ -72,7 +72,7 @@ export default {
     justify-content: flex-start;
   }
   & .fc-list-dropdown-text {
-    max-width: 180px;
+    max-width: 250px;
   }
   & .v-list-item {
     padding: 0;

--- a/web/components/location/FcListLocationDropdown.vue
+++ b/web/components/location/FcListLocationDropdown.vue
@@ -6,11 +6,14 @@
       :disabled="disabledNormalized[i]"
       @click="$emit('click-location', i)">
       <v-list-item-title class="px-0 fc-list-dropdown-row">
-        <v-icon
-          :class="{'fc-icon-dim':disabledNormalized[i]}"
-          class="pa-2" size="20">
-          mdi-map-marker
-        </v-icon>
+        <span class="px-4">
+          <img v-if="location.centrelineType == 1" title="Midblock"
+          src="/icons/map/location-multi-midblock.svg" alt="Midblock icon"
+          width="14" :class="{'fc-icon-dim':disabledNormalized[i]}"/>
+          <img v-else title="Intersection"
+          src="/icons/map/location-multi-intersection.svg" alt="Midblock icon"
+          width="14" :class="{'fc-icon-dim':disabledNormalized[i]}"/>
+        </span>
         <div class="d-flex align-center truncate">
           <div class="fc-list-dropdown-text truncate">
             <div class="truncate" :class="{

--- a/web/components/location/FcListLocationMulti.vue
+++ b/web/components/location/FcListLocationMulti.vue
@@ -4,18 +4,18 @@
       v-for="(location, i) in locations"
       :key="i"
       :disabled="disabledNormalized[i]">
-      <v-list-item-title class="px-0 fc-list-multi-row">
+      <v-list-item-title class="pl-0 pr-1 fc-list-multi-row">
         <v-icon
           :class="{'fc-icon-dim':disabledNormalized[i]}"
           class="fc-location-list-icon pr-2" size="18">
           mdi-map-marker
         </v-icon>
         <div class="d-flex align-center">
-          <div class="fc-list-multi-text body-1 truncate">
-            <div class="truncate"
+          <div class="fc-list-multi-text">
+            <div class="fc-list-wrap"
               :class="{
-                'body-1': locationsIconProps[i].locationIndex === -1,
-                title: locationsIconProps[i].locationIndex !== -1,
+                'fc-location-hidden': locationsIconProps[i].locationIndex === -1,
+                'fc-location-normal': locationsIconProps[i].locationIndex !== -1,
               }">
               {{location.description}}
             </div>
@@ -62,20 +62,23 @@ export default {
 
 <style lang="scss">
 .fc-list-location-multi {
-  & .truncate {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
   & .fc-list-multi-row {
     display: flex;
     flex-flow: row nowrap;
     justify-content: flex-start;
+    margin-bottom: 15px;
+    margin-left: -10px; // couldn't style veutify wrapper
+    margin-right: -10px;
   }
   & .fc-list-multi-text {
-    max-width: 145px;
-    min-width: 145px;
-    font-style: italic;
+    max-width: 200px;
+    min-width: 200px;
+  }
+  & .fc-list-wrap {
+    max-width: 200px;
+    min-width: 200px;
+    white-space: normal;
+    font-size: 12px;
   }
   & .v-list-item {
     padding: 0;

--- a/web/components/location/FcListLocationMulti.vue
+++ b/web/components/location/FcListLocationMulti.vue
@@ -5,11 +5,6 @@
       :key="i"
       :disabled="disabledNormalized[i]">
       <v-list-item-title class="pl-0 pr-1 fc-list-multi-row">
-        <!-- <v-icon
-
-          class="fc-location-list-icon pr-2" size="18">
-          mdi-map-marker
-        </v-icon> -->
         <img v-if="location.centrelineType == 1" title="Midblock"
           src="/icons/map/location-multi-midblock.svg" alt="Midblock icon"
           width="14" class="mr-3" :class="{'fc-icon-dim':disabledNormalized[i]}"/>

--- a/web/components/location/FcListLocationMulti.vue
+++ b/web/components/location/FcListLocationMulti.vue
@@ -5,11 +5,17 @@
       :key="i"
       :disabled="disabledNormalized[i]">
       <v-list-item-title class="pl-0 pr-1 fc-list-multi-row">
-        <v-icon
-          :class="{'fc-icon-dim':disabledNormalized[i]}"
+        <!-- <v-icon
+
           class="fc-location-list-icon pr-2" size="18">
           mdi-map-marker
-        </v-icon>
+        </v-icon> -->
+        <img v-if="location.centrelineType == 1" title="Midblock"
+          src="/icons/map/location-multi-midblock.svg" alt="Midblock icon"
+          width="14" class="mr-3" :class="{'fc-icon-dim':disabledNormalized[i]}"/>
+        <img v-else title="Intersection"
+          src="/icons/map/location-multi-intersection.svg" alt="Midblock icon"
+          width="14" class="mr-3" :class="{'fc-icon-dim':disabledNormalized[i]}"/>
         <div class="d-flex align-center">
           <div class="fc-list-multi-text">
             <div class="fc-list-wrap"
@@ -84,7 +90,7 @@ export default {
     padding: 0;
   }
   & .fc-icon-dim {
-    opacity: 0.6;
+    opacity: 0.4;
   }
 }
 

--- a/web/components/reports/FcReportTable.vue
+++ b/web/components/reports/FcReportTable.vue
@@ -316,7 +316,7 @@ export default {
   & .fc-report-table-header {
     position: sticky;
     top: 0;
-    background-color: #98c2e3 !important;
+    background-color: #ACACAC !important;
     z-index: 2;
   }
 }

--- a/web/css/main.scss
+++ b/web/css/main.scss
@@ -1,6 +1,6 @@
 /* roboto-100 - latin */
 @font-face {
-  font-family: 'Roboto';
+  font-family: Roboto;
   font-style: normal;
   font-weight: 100;
   src:
@@ -12,7 +12,7 @@
 
 /* roboto-300 - latin */
 @font-face {
-  font-family: 'Roboto';
+  font-family: Roboto;
   font-style: normal;
   font-weight: 300;
   src:
@@ -24,7 +24,7 @@
 
 /* roboto-regular - latin */
 @font-face {
-  font-family: 'Roboto';
+  font-family: Roboto;
   font-style: normal;
   font-weight: 400;
   src:
@@ -36,7 +36,7 @@
 
 /* roboto-500 - latin */
 @font-face {
-  font-family: 'Roboto';
+  font-family: Roboto;
   font-style: normal;
   font-weight: 500;
   src:
@@ -48,7 +48,7 @@
 
 /* roboto-700 - latin */
 @font-face {
-  font-family: 'Roboto';
+  font-family: Roboto;
   font-style: normal;
   font-weight: 700;
   src:
@@ -60,7 +60,7 @@
 
 /* roboto-900 - latin */
 @font-face {
-  font-family: 'Roboto';
+  font-family: Roboto;
   font-style: normal;
   font-weight: 900;
   src:
@@ -119,7 +119,7 @@
 
   --border-default: 1px solid var(--base);
 
-  --z-index-controls: 99;
+  --z-index-controls: 9;
 }
 
 /* BOX SIZING */

--- a/web/views/FcLayoutViewData.vue
+++ b/web/views/FcLayoutViewData.vue
@@ -304,7 +304,7 @@ export default {
       border: 1px solid lightgrey !important;
       overflow-y: hidden;
       max-height: calc(100% - 20px);
-      z-index: 106;
+      z-index: 10;
       transition: min-width 0.25s cubic-bezier(0.7, 0, 0.84, 0);
     }
     & .fc-full-drawer {

--- a/web/views/FcLayoutViewData.vue
+++ b/web/views/FcLayoutViewData.vue
@@ -297,8 +297,8 @@ export default {
       left: 0;
       margin: 10px;
       width: 50%;
-      max-width: 375px;
-      min-width: 325px;
+      max-width: 400px;
+      min-width: 400px;
       min-height: 50px;
       border-radius: 8px;
       border: 1px solid lightgrey !important;


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-63](https://move-toronto.atlassian.net/browse/MOVE-63)

importantly, this PR fixes a breaking bug for export mode, introduced earlier.

# Description
* turn sticky header grey
* change z-indexes around, to accommodate veutify stuff
* reverse report toggle icon
* padding fixes for sidebar
* move pending request above request button
* use svg icons in location lists

for some reason, eslint made me remove the quotes on `font-family: 'Roboto';` after I touched that file for the z-index stuff.