### PR TITLE
MOVE 1223 -> fixing scheduler for Corridor collision reports

### DIFF
--- a/lib/controller/JobController.js
+++ b/lib/controller/JobController.js
@@ -74,7 +74,7 @@ JobController.push({
     try {
       const features = CompositeId.decode(s1);
       if (features.length > MAX_CORRIDOR_POINTS) {
-        return Boom.badRequest(`cannot fetch reports on more than ${MAX_LOCATIONS} locations`);
+        return Boom.badRequest(`cannot fetch reports on more than ${MAX_CORRIDOR_POINTS} locations`);
       }
       const featuresSelection = { features, selectionType };
 
@@ -93,6 +93,27 @@ JobController.push({
         s1,
         selectionType,
       };
+      console.log(data.reports); // eslint-disable-line no-console
+      console.log(data.reports.length); // eslint-disable-line no-console
+      console.log(data.reports.length); // eslint-disable-line no-console
+      console.log(data.reports.length); // eslint-disable-line no-console
+      console.log(data.reports.length); // eslint-disable-line no-console
+      console.log(data.reports.length); // eslint-disable-line no-console
+      console.log(data.reports.length); // eslint-disable-line no-console
+      console.log(data.reports.length); // eslint-disable-line no-console
+      console.log(data.reports.length); // eslint-disable-line no-console
+      console.log(data.reports.length); // eslint-disable-line no-console
+      console.log(data.reports.length); // eslint-disable-line no-console
+      console.log(data.reports.length); // eslint-disable-line no-console
+      console.log(data.reports.length); // eslint-disable-line no-console
+      console.log(data.reports.length); // eslint-disable-line no-console
+      console.log(data.reports.length); // eslint-disable-line no-console
+      console.log(data.reports.length); // eslint-disable-line no-console
+      console.log(data.reports.length); // eslint-disable-line no-console
+      console.log(data.reports.length); // eslint-disable-line no-console
+      console.log(data.reports.length); // eslint-disable-line no-console
+      console.log(data.reports.length); // eslint-disable-line no-console
+      console.log(data.reports.length); // eslint-disable-line no-console
       const jobMetadata = await JobManager.publish(JobType.GENERATE_REPORTS, data, user);
       return jobMetadata;
     } catch (err) {

--- a/lib/controller/JobController.js
+++ b/lib/controller/JobController.js
@@ -93,27 +93,6 @@ JobController.push({
         s1,
         selectionType,
       };
-      console.log(data.reports); // eslint-disable-line no-console
-      console.log(data.reports.length); // eslint-disable-line no-console
-      console.log(data.reports.length); // eslint-disable-line no-console
-      console.log(data.reports.length); // eslint-disable-line no-console
-      console.log(data.reports.length); // eslint-disable-line no-console
-      console.log(data.reports.length); // eslint-disable-line no-console
-      console.log(data.reports.length); // eslint-disable-line no-console
-      console.log(data.reports.length); // eslint-disable-line no-console
-      console.log(data.reports.length); // eslint-disable-line no-console
-      console.log(data.reports.length); // eslint-disable-line no-console
-      console.log(data.reports.length); // eslint-disable-line no-console
-      console.log(data.reports.length); // eslint-disable-line no-console
-      console.log(data.reports.length); // eslint-disable-line no-console
-      console.log(data.reports.length); // eslint-disable-line no-console
-      console.log(data.reports.length); // eslint-disable-line no-console
-      console.log(data.reports.length); // eslint-disable-line no-console
-      console.log(data.reports.length); // eslint-disable-line no-console
-      console.log(data.reports.length); // eslint-disable-line no-console
-      console.log(data.reports.length); // eslint-disable-line no-console
-      console.log(data.reports.length); // eslint-disable-line no-console
-      console.log(data.reports.length); // eslint-disable-line no-console
       const jobMetadata = await JobManager.publish(JobType.GENERATE_REPORTS, data, user);
       return jobMetadata;
     } catch (err) {

--- a/lib/io/storage/StoragePath.js
+++ b/lib/io/storage/StoragePath.js
@@ -189,6 +189,13 @@ class StoragePath {
     return hashBuilder.digest('hex').slice(0, 8);
   }
 
+  static getPartIdHash(partId) {
+    const hashBuilder = crypto.createHash('md5');
+    // const n = partId.length;
+    hashBuilder.update(partId, 'utf8');
+    return hashBuilder.digest('hex').slice(0, 8);
+  }
+
   /**
    *
    * @param {ReportType} type
@@ -323,7 +330,14 @@ class StoragePath {
     const id = `${s1}/${selectionType.name}`;
     const partId = StoragePath.getId(id);
     const partReportHash = StoragePath.getReportHash(storagePaths);
-    const key = `COLLISION_${partId}_${partReportHash}.zip`;
+    let partIdHash = null;
+    // hashing part of the zip file path name if we are processing a corridor
+    if (partId.includes('CORRIDOR')) {
+      partIdHash = StoragePath.getPartIdHash(partId);
+    }
+    const key = partIdHash === null
+      ? `COLLISION_${partId}_${partReportHash}.zip`
+      : `COLLISION_${partIdHash}_${partReportHash}.zip`;
     return { namespace: StoragePath.NAMESPACE_REPORTS_COLLISION, key };
   }
 


### PR DESCRIPTION
# Issue Addressed
This addresses [MOVE-1223](https://move-toronto.atlassian.net/browse/MOVE-1223)

# Description
Corridor collision reports resulted in too large a zipfile name which caused the scheduler to crash. This PR adds a method that hashes the zipfile name if we are working on a corridor collision report.

# Tests
Need to test on dev to confirm that it works as we have more collisions available to add load to the scheduler.