### PR TITLE
Move 1214: Fixing broken study request list behaviour

### DIFF
--- a/web/components/requests/FcCardStudyRequest.vue
+++ b/web/components/requests/FcCardStudyRequest.vue
@@ -84,6 +84,17 @@ export default {
       return 'Midblock';
     },
   },
+  watch: {
+    locationType() {
+      let studyType;
+      if (this.location.centrelineType === CentrelineType.INTERSECTION) {
+        studyType = StudyType.TMC;
+      } else {
+        studyType = StudyType.ATR_SVC;
+      }
+      this.v.studyType.$model = studyType;
+    },
+  },
   methods: {
     async addHoverLayer(index, event) {
       const {

--- a/web/components/requests/StudyRequestForm.vue
+++ b/web/components/requests/StudyRequestForm.vue
@@ -52,7 +52,6 @@ import FcStudyRequestDuration from '@/web/components/requests/fields/FcStudyRequ
 import FcStudyRequestHours from '@/web/components/requests/fields/FcStudyRequestHours.vue';
 import FcStudyRequestNotes from '@/web/components/requests/fields/FcStudyRequestNotes.vue';
 import FcStudyRequestStudyType from '@/web/components/requests/fields/FcStudyRequestStudyType.vue';
-import { StudyHours, StudyType, CentrelineType } from '@/lib/Constants';
 
 export default {
   name: 'StudyRequestForm',
@@ -84,24 +83,6 @@ export default {
     },
     isMultiDayStudy() {
       return this.studyType.isMultiDay;
-    },
-  },
-  methods: {
-    resetHoursValue() {
-      let value = null;
-      if (!this.isMultiDayStudy) {
-        value = StudyHours[this.studyType.hourOptions[0]];
-      }
-      this.v.hours.$model = value;
-    },
-    resetStudyType(centrelineType) {
-      let studyType;
-      if (centrelineType === CentrelineType.INTERSECTION) {
-        studyType = StudyType.TMC;
-      } else {
-        studyType = StudyType.ATR_SVC;
-      }
-      this.studyType = studyType;
     },
   },
   watch: {

--- a/web/components/requests/StudyRequestForm.vue
+++ b/web/components/requests/StudyRequestForm.vue
@@ -109,12 +109,6 @@ export default {
       this.v.duration.$model = (newVal ? 72 : 24);
       this.v.daysOfWeek.$model = [2, 3, 4];
     },
-    studyType() {
-      this.resetHoursValue();
-    },
-    location(newLocation) {
-      this.resetStudyType(newLocation.centrelineType);
-    },
     'v.hours.$model': function watchHour() {
       this.componentKey += 1;
     },

--- a/web/components/requests/fields/FcStudyRequestHours.vue
+++ b/web/components/requests/fields/FcStudyRequestHours.vue
@@ -20,13 +20,12 @@ export default {
     v: Object,
   },
   watch: {
-    'v.hours.$model': function test() {
-      let value = null;
-      if (!this.v.studyType.$model.isMultiDay) {
-        value = StudyHours[this.studyType.hourOptions[0]];
-      }
-      this.v.hours.$model = value;
+    'v.hours.$model': function watchHour() {
+      this.componentKey += 1;
     },
+  },
+  beforeMount() {
+    this.store = StudyHours.enumValueOf(this.v.studyType.$model.hourOptions);
   },
   computed: {
     hourOptions() {
@@ -38,14 +37,6 @@ export default {
       }
       return options;
     },
-    store: {
-      get() {
-        return this.v.hours.$model;
-      },
-      set(val) {
-        this.v.hours.$model = val;
-      },
-    },
     storeEnumToStrInterface: {
       get() {
         return this.store.name;
@@ -54,10 +45,18 @@ export default {
         this.store = StudyHours.enumValueOf(val);
       },
     },
+    store: {
+      get() {
+        return this.v.hours.$model;
+      },
+      set(val) {
+        this.v.hours.$model = val;
+      },
+    },
     caption() {
-      let { hint } = this.store;
-      if (this.isHourTypeOther) hint = 'Specify hours in Collection Notes';
-      return hint;
+      // let { hint } = this.store;
+      // if (this.isHourTypeOther) hint = 'Specify hours in Collection Notes';
+      return 'awd';
     },
     hourOptionsByStudyType() {
       return this.studyType.hourOptions;

--- a/web/components/requests/fields/FcStudyRequestHours.vue
+++ b/web/components/requests/fields/FcStudyRequestHours.vue
@@ -19,6 +19,15 @@ export default {
   props: {
     v: Object,
   },
+  watch: {
+    'v.hours.$model': function test() {
+      let value = null;
+      if (!this.v.studyType.$model.isMultiDay) {
+        value = StudyHours[this.studyType.hourOptions[0]];
+      }
+      this.v.hours.$model = value;
+    },
+  },
   computed: {
     hourOptions() {
       const options = StudyHours.enumValues.filter(

--- a/web/components/requests/fields/FcStudyRequestHours.vue
+++ b/web/components/requests/fields/FcStudyRequestHours.vue
@@ -8,7 +8,8 @@
     outlined
     label="Hours"
     :messages="caption"
-    v-bind="$attrs" />
+    v-bind="$attrs"
+    />
 </template>
 
 <script>
@@ -19,13 +20,13 @@ export default {
   props: {
     v: Object,
   },
-  watch: {
-    'v.hours.$model': function watchHour() {
-      this.componentKey += 1;
-    },
-  },
   beforeMount() {
-    this.store = StudyHours.enumValueOf(this.v.studyType.$model.hourOptions);
+    this.resetHoursValue();
+  },
+  watch: {
+    'v.studyType.$model.name': function studyTypeChange() {
+      this.resetHoursValue();
+    },
   },
   computed: {
     hourOptions() {
@@ -37,14 +38,6 @@ export default {
       }
       return options;
     },
-    storeEnumToStrInterface: {
-      get() {
-        return this.store.name;
-      },
-      set(val) {
-        this.store = StudyHours.enumValueOf(val);
-      },
-    },
     store: {
       get() {
         return this.v.hours.$model;
@@ -53,10 +46,18 @@ export default {
         this.v.hours.$model = val;
       },
     },
+    storeEnumToStrInterface: {
+      get() {
+        return this.store.name;
+      },
+      set(val) {
+        this.store = StudyHours.enumValueOf(val);
+      },
+    },
     caption() {
-      // let { hint } = this.store;
-      // if (this.isHourTypeOther) hint = 'Specify hours in Collection Notes';
-      return 'awd';
+      let { hint } = this.store;
+      if (this.isHourTypeOther) hint = 'Specify hours in Collection Notes';
+      return hint;
     },
     hourOptionsByStudyType() {
       return this.studyType.hourOptions;
@@ -72,6 +73,15 @@ export default {
     },
     studyType() {
       return this.v.studyType.$model;
+    },
+  },
+  methods: {
+    resetHoursValue() {
+      let value = null;
+      if (!this.v.studyType.$model.isMultiDayStudy) {
+        value = StudyHours[this.studyType.hourOptions[0]];
+      }
+      this.v.hours.$model = value;
     },
   },
 };

--- a/web/components/requests/fields/FcStudyRequestStudyType.vue
+++ b/web/components/requests/fields/FcStudyRequestStudyType.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script>
-import { StudyType, CentrelineType } from '@/lib/Constants';
+import { StudyType } from '@/lib/Constants';
 import { getLocationStudyTypes } from '@/lib/geo/CentrelineUtils';
 import {
   REQUEST_STUDY_REQUIRES_STUDY_TYPE,
@@ -57,15 +57,6 @@ export default {
       studyTypeOther: null,
       StudyType,
     };
-  },
-  mounted() {
-    let studyType;
-    if (this.location.centrelineType === CentrelineType.INTERSECTION) {
-      studyType = StudyType.TMC;
-    } else {
-      studyType = StudyType.ATR_SVC;
-    }
-    this.studyType = studyType;
   },
   computed: {
     errorMessagesStudyType() {

--- a/web/components/requests/fields/FcStudyRequestStudyType.vue
+++ b/web/components/requests/fields/FcStudyRequestStudyType.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script>
-import { StudyType } from '@/lib/Constants';
+import { StudyType, CentrelineType } from '@/lib/Constants';
 import { getLocationStudyTypes } from '@/lib/geo/CentrelineUtils';
 import {
   REQUEST_STUDY_REQUIRES_STUDY_TYPE,
@@ -57,6 +57,15 @@ export default {
       studyTypeOther: null,
       StudyType,
     };
+  },
+  mounted() {
+    let studyType;
+    if (this.location.centrelineType === CentrelineType.INTERSECTION) {
+      studyType = StudyType.TMC;
+    } else {
+      studyType = StudyType.ATR_SVC;
+    }
+    this.studyType = studyType;
   },
   computed: {
     errorMessagesStudyType() {


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-1214](https://move-toronto.atlassian.net/browse/MOVE-1214)

# Description
For some reason the study request page was doing things that it wasn't doing before. i.e. studies were being reset to the default values every time a new study was added. This is not good. 

It is unclear what changed to make this happen, however it does seem that the existing pattern of a 'global' watcher on the parent component was the cause of the new problem. That watched logic is now moved inside of the input components that care about that specific piece of logic.

# Tests
Tested by adding and messing around with multiple study requests.
