### PR TITLE
MOVE-1195: Package filters with report CSV

### DIFF
--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -203,8 +203,8 @@ function getReportOptions(type, id, format, reportParameters) {
       type,
       id,
       format,
+      singleFile: true,
       ...reportParameters,
-      single: true,
     },
     responseType,
   };

--- a/lib/api/WebApi.js
+++ b/lib/api/WebApi.js
@@ -204,6 +204,7 @@ function getReportOptions(type, id, format, reportParameters) {
       id,
       format,
       ...reportParameters,
+      single: true,
     },
     responseType,
   };

--- a/lib/controller/ReportController.js
+++ b/lib/controller/ReportController.js
@@ -13,6 +13,9 @@ import CollisionFilters from '@/lib/model/CollisionFilters';
 import Joi from '@/lib/model/Joi';
 import StudyRequestFilters from '@/lib/model/StudyRequestFilters';
 import ReportFactory from '@/lib/reports/ReportFactory';
+import archiver from 'archiver';
+import stream from 'stream';
+import { generateCollisionFilters, formatFilters } from '../filters/prettyCollisionFilters';
 
 /**
  * Reporting-related routes.  Note that routes in this controller are handled by `reporter`.
@@ -108,11 +111,9 @@ ReportController.push({
       type: reportType,
       id,
       format: reportFormat,
+      singleFile,
       ...options
     } = request.query;
-
-    // eslint-disable-next-line no-console
-    console.log('request info:', options);
 
     const user = request.auth.credentials;
     if (reportType.scope && !hasAuthScope(user, reportType.scope)) {
@@ -136,7 +137,8 @@ ReportController.push({
       const { statusCode } = HttpStatus.INTERNAL_SERVER_ERROR;
       return Boom.boomify(err, { statusCode, override: false, message: 'bad data preventing report generation' });
     }
-    const response = h.response(reportStream)
+    let response;
+    response = h.response(reportStream)
       .type(reportFormat.mimeType);
 
     if (reportFormat.download) {
@@ -146,8 +148,25 @@ ReportController.push({
         format: reportFormat,
         ...reportOptions,
       };
+
       const { key } = await StoragePath.forReport(report);
-      response.header('Content-Disposition', `attachment; filename="${key}"`);
+
+      if (singleFile && reportFormat === ReportFormat.CSV) {
+        const filters = await generateCollisionFilters(reportOptions);
+        if (filters.length > 1) {
+          const prettyFilters = formatFilters(filters);
+          const archive = archiver('zip');
+          const duplexStream = new stream.PassThrough();
+          archive.pipe(duplexStream);
+          archive.append(reportStream, { name: key });
+          archive.append(prettyFilters.join('\n'), { name: 'filters.txt' });
+          archive.finalize();
+          response = h.response(duplexStream).type(reportFormat.mimeType);
+          response.header('Content-Disposition', `attachment; filename="${key.replace('.csv', '.zip')}"`);
+        }
+      } else {
+        response.header('Content-Disposition', `attachment; filename="${key}"`);
+      }
     }
 
     return response;

--- a/lib/controller/ReportController.js
+++ b/lib/controller/ReportController.js
@@ -111,6 +111,9 @@ ReportController.push({
       ...options
     } = request.query;
 
+    // eslint-disable-next-line no-console
+    console.log('request info:', options);
+
     const user = request.auth.credentials;
     if (reportType.scope && !hasAuthScope(user, reportType.scope)) {
       return Boom.forbidden(`not authorized to generate reports of type ${reportType.name}`);

--- a/lib/filters/prettyCollisionFilters.js
+++ b/lib/filters/prettyCollisionFilters.js
@@ -24,8 +24,12 @@ async function generateCollisionFilters(filters) {
   } = filters;
   const collisionFilters = [];
   if (details.length > 0) {
+    const mapDetails = {
+      CITY_DAMAGE: 'Damage to City Property',
+      RED_LIGHT: 'Running Red Light',
+    };
     const label = details
-      .map(({ text }) => text)
+      .map(item => item.text || mapDetails[item])
       .join(', ');
     const collisionFilter = { filter: 'details', label, value: details };
     collisionFilters.push(collisionFilter);

--- a/lib/filters/prettyCollisionFilters.js
+++ b/lib/filters/prettyCollisionFilters.js
@@ -3,6 +3,15 @@ import TimeFormatters from '@/lib/time/TimeFormatters';
 import { getCollisionFilterChip } from '../../web/store/modules/viewData';
 import CollisionFactorDAO from '../db/CollisionFactorDAO';
 
+function generateDateRange(filters) {
+  const { dateRangeStart, dateRangeEnd } = filters;
+  if (dateRangeStart !== null || dateRangeEnd !== null) {
+    const label = `${dateRangeStart.slice(0, 10)} to ${dateRangeEnd.slice(0, 10)}`;
+    return label;
+  }
+  return '1985 to Present';
+}
+
 async function generateCollisionFilters(filters) {
   const collisionFactors = await CollisionFactorDAO.all();
   const {
@@ -23,6 +32,7 @@ async function generateCollisionFilters(filters) {
     vehtype,
   } = filters;
   const collisionFilters = [];
+  collisionFilters.push({ filter: 'dateRange', label: generateDateRange(filters) });
   if (details.length > 0) {
     const mapDetails = {
       CITY_DAMAGE: 'Damage to City Property',
@@ -107,18 +117,6 @@ async function generateCollisionFilters(filters) {
   return collisionFilters;
 }
 
-function generateDateRange(filters) {
-  const { dateRangeStart, dateRangeEnd } = filters;
-  if (dateRangeStart !== null || dateRangeEnd !== null) {
-    const label = TimeFormatters.formatRangeDate({
-      start: dateRangeStart,
-      end: dateRangeEnd,
-    });
-    return label;
-  }
-  return '1985 to Present';
-}
-
 function formatFilters(filters) {
   const filtersMap = {
     validated: 'Verification',
@@ -135,6 +133,7 @@ function formatFilters(filters) {
     rdsfcond: 'Weather',
     vehtype: 'Vehicle Type',
     manoeuver: 'Manoeuvre',
+    dateRange: 'Date Range',
   };
 
   const formattedFilters = filters.map(item => (

--- a/lib/filters/prettyCollisionFilters.js
+++ b/lib/filters/prettyCollisionFilters.js
@@ -1,0 +1,145 @@
+import DateTime from '@/lib/time/DateTime';
+import TimeFormatters from '@/lib/time/TimeFormatters';
+import { getCollisionFilterChip } from '../../web/store/modules/viewData';
+import CollisionFactorDAO from '../db/CollisionFactorDAO';
+
+async function generateCollisionFilters(filters) {
+  const collisionFactors = await CollisionFactorDAO.all();
+  const {
+    daysOfWeek,
+    details,
+    drivact,
+    drivcond,
+    emphasisAreas,
+    hoursOfDayEnd,
+    hoursOfDayStart,
+    impactype,
+    initdir,
+    injury,
+    manoeuver,
+    mvcr,
+    rdsfcond,
+    validated,
+    vehtype,
+  } = filters;
+  const collisionFilters = [];
+  if (details.length > 0) {
+    const label = details
+      .map(({ text }) => text)
+      .join(', ');
+    const collisionFilter = { filter: 'details', label, value: details };
+    collisionFilters.push(collisionFilter);
+  }
+  if (mvcr !== null) {
+    const label = mvcr ? 'MVCR Available' : 'MVCR Missing';
+    const collisionFilter = { filter: 'mvcr', label, value: mvcr };
+    collisionFilters.push(collisionFilter);
+  }
+  if (emphasisAreas.length > 0) {
+    const mapAreas = {
+      AGGRESSIVE_DRIVING: 'Aggressive Driving',
+      CYCLISTS: 'Cyclists',
+      PEDESTRIANS: 'Pedestrians',
+      MOTORCYCLISTS: 'Motorcyclists',
+      OLDER_ADULTS: 'Older Adults',
+      SCHOOL_CHILDREN: 'School Children',
+    };
+    const label = emphasisAreas
+      .map(item => item.text || mapAreas[item])
+      .join(', ');
+    const collisionFilter = { filter: 'emphasisAreas', label, value: emphasisAreas };
+    collisionFilters.push(collisionFilter);
+  }
+  if (hoursOfDayStart !== 0 || hoursOfDayEnd !== 24) {
+    const dtStart = DateTime.fromObject({ hour: hoursOfDayStart });
+    const dtEnd = DateTime.fromObject({ hour: hoursOfDayEnd });
+    const label = TimeFormatters.formatRangeTimeOfDay({ start: dtStart, end: dtEnd });
+    const value = { hoursOfDayStart, hoursOfDayEnd };
+    const collisionFilter = { filter: 'hoursOfDay', label, value };
+    collisionFilters.push(collisionFilter);
+  }
+  if (daysOfWeek.length > 0) {
+    const label = TimeFormatters.formatDaysOfWeek(daysOfWeek);
+    const collisionFilter = { filter: 'daysOfWeek', label, value: daysOfWeek };
+    collisionFilters.push(collisionFilter);
+  }
+  if (validated !== null) {
+    const label = validated ? 'Verified' : 'Not Verified';
+    const collisionFilter = { filter: 'validated', label, value: validated };
+    collisionFilters.push(collisionFilter);
+  }
+  if (drivact.length > 0) {
+    const collisionFilter = getCollisionFilterChip('drivact', drivact, collisionFactors);
+    collisionFilters.push(collisionFilter);
+  }
+  if (drivcond.length > 0) {
+    const collisionFilter = getCollisionFilterChip('drivcond', drivcond, collisionFactors);
+    collisionFilters.push(collisionFilter);
+  }
+  if (impactype.length > 0) {
+    const collisionFilter = getCollisionFilterChip('impactype', impactype, collisionFactors);
+    collisionFilters.push(collisionFilter);
+  }
+  if (initdir.length > 0) {
+    const collisionFilter = getCollisionFilterChip('initdir', initdir, collisionFactors);
+    collisionFilters.push(collisionFilter);
+  }
+  if (injury.length > 0) {
+    const collisionFilter = getCollisionFilterChip('injury', injury, collisionFactors);
+    collisionFilters.push(collisionFilter);
+  }
+  if (manoeuver.length > 0) {
+    const collisionFilter = getCollisionFilterChip('manoeuver', manoeuver, collisionFactors);
+    collisionFilters.push(collisionFilter);
+  }
+  if (rdsfcond.length > 0) {
+    const collisionFilter = getCollisionFilterChip('rdsfcond', rdsfcond, collisionFactors);
+    collisionFilters.push(collisionFilter);
+  }
+  if (vehtype.length > 0) {
+    const collisionFilter = getCollisionFilterChip('vehtype', vehtype, collisionFactors);
+    collisionFilters.push(collisionFilter);
+  }
+  return collisionFilters;
+}
+
+function generateDateRange(filters) {
+  const { dateRangeStart, dateRangeEnd } = filters;
+  if (dateRangeStart !== null || dateRangeEnd !== null) {
+    const label = TimeFormatters.formatRangeDate({
+      start: dateRangeStart,
+      end: dateRangeEnd,
+    });
+    return label;
+  }
+  return '1985 to Present';
+}
+
+function formatFilters(filters) {
+  const filtersMap = {
+    validated: 'Verification',
+    daysOfWeek: 'Days of the Week',
+    details: 'Collision Details',
+    emphasisAreas: 'Vision Zero Emphasis Areas',
+    mvcr: 'MVCR',
+    injury: 'Injuries',
+    drivact: 'Driver Action',
+    drivcond: 'Driver Conditions',
+    hoursOfDay: 'Hours of the Day',
+    initdir: 'Initial Direction of Travel',
+    impactype: 'Initial Impact Type',
+    rdsfcond: 'Weather',
+    vehtype: 'Vehicle Type',
+    manoeuver: 'Manoeuvre',
+  };
+
+  const formattedFilters = filters.map(item => (
+    `${filtersMap[item.filter]}: ${item.label}`));
+  return formattedFilters;
+}
+
+export {
+  generateCollisionFilters,
+  formatFilters,
+  generateDateRange,
+};

--- a/lib/filters/prettyCollisionFilters.js
+++ b/lib/filters/prettyCollisionFilters.js
@@ -5,8 +5,8 @@ import CollisionFactorDAO from '../db/CollisionFactorDAO';
 
 function generateDateRange(filters) {
   const { dateRangeStart, dateRangeEnd } = filters;
-  if (dateRangeStart !== null || dateRangeEnd !== null) {
-    const label = `${dateRangeStart.slice(0, 10)} to ${dateRangeEnd.slice(0, 10)}`;
+  if (dateRangeStart !== null && dateRangeEnd !== null) {
+    const label = `${dateRangeStart.toString().slice(0, 10)} to ${dateRangeEnd.toString().slice(0, 10)}`;
     return label;
   }
   return '1985 to Present';

--- a/lib/jobs/JobRunnerGenerateReports.js
+++ b/lib/jobs/JobRunnerGenerateReports.js
@@ -40,7 +40,7 @@ class JobRunnerGenerateReports extends JobRunnerBase {
   static async fetchReportStream(report) {
     const options = {
       method: 'GET',
-      data: { ...report, single: false },
+      data: { ...report, singleFile: false },
       responseType: 'stream',
     };
     return reporterClient.fetch('/reports', options);

--- a/lib/jobs/JobRunnerGenerateReports.js
+++ b/lib/jobs/JobRunnerGenerateReports.js
@@ -90,7 +90,7 @@ class JobRunnerGenerateReports extends JobRunnerBase {
           .on('error', reject);
         archive.append(valueStreamReport, { name: keyReport });
       });
-      if (format.extension === 'csv') {
+      if (format.extension === 'csv' && collisionFilters.length > 1) {
         const filters = formatFilters(collisionFilters);
         archive.append(filters.join('\n'), { name: 'filters.txt' });
       }

--- a/lib/jobs/JobRunnerGenerateReports.js
+++ b/lib/jobs/JobRunnerGenerateReports.js
@@ -40,7 +40,7 @@ class JobRunnerGenerateReports extends JobRunnerBase {
   static async fetchReportStream(report) {
     const options = {
       method: 'GET',
-      data: report,
+      data: { ...report, single: false },
       responseType: 'stream',
     };
     return reporterClient.fetch('/reports', options);

--- a/lib/jobs/JobRunnerGenerateReports.js
+++ b/lib/jobs/JobRunnerGenerateReports.js
@@ -82,6 +82,7 @@ class JobRunnerGenerateReports extends JobRunnerBase {
           .on('error', reject);
         archive.append(valueStreamReport, { name: keyReport });
       });
+      archive.append('Hello there', { name: 'filters.txt' });
       archive.finalize();
 
       storageStrategy.putStream(namespace, key, valueStream);

--- a/lib/jobs/JobRunnerGenerateReports.js
+++ b/lib/jobs/JobRunnerGenerateReports.js
@@ -66,8 +66,10 @@ class JobRunnerGenerateReports extends JobRunnerBase {
     const {
       id, type, format, ...rest
     } = data.reports[0];
-    const collisionFilters = await generateCollisionFilters(rest);
-    const filters = formatFilters(collisionFilters);
+    let collisionFilters = [];
+    if (format.extension === 'csv') {
+      collisionFilters = await generateCollisionFilters(rest);
+    }
     const { namespace, key } = await StoragePath.forReportZip(data, storagePaths);
     const reportZipExists = await storageStrategy.has(namespace, key);
     if (reportZipExists) {
@@ -89,6 +91,7 @@ class JobRunnerGenerateReports extends JobRunnerBase {
         archive.append(valueStreamReport, { name: keyReport });
       });
       if (format.extension === 'csv') {
+        const filters = formatFilters(collisionFilters);
         archive.append(filters.join('\n'), { name: 'filters.txt' });
       }
       archive.finalize();

--- a/lib/jobs/JobRunnerGenerateReports.js
+++ b/lib/jobs/JobRunnerGenerateReports.js
@@ -11,6 +11,7 @@ import JobRunnerBase from '@/lib/jobs/JobRunnerBase';
 import StoragePath from '@/lib/io/storage/StoragePath';
 import storageStrategy from '@/lib/io/storage/StorageStrategy';
 import { writableStreamFinish } from '../io/StreamUtils';
+import { generateCollisionFilters, formatFilters } from '../filters/prettyCollisionFilters';
 
 const reporterClientOptions = {};
 if (config.https !== null) {
@@ -62,6 +63,11 @@ class JobRunnerGenerateReports extends JobRunnerBase {
   }
 
   async zipReports(data, storagePaths) {
+    const {
+      id, type, format, ...rest
+    } = data.reports[0];
+    const collisionFilters = await generateCollisionFilters(rest);
+    const filters = formatFilters(collisionFilters);
     const { namespace, key } = await StoragePath.forReportZip(data, storagePaths);
     const reportZipExists = await storageStrategy.has(namespace, key);
     if (reportZipExists) {
@@ -82,7 +88,9 @@ class JobRunnerGenerateReports extends JobRunnerBase {
           .on('error', reject);
         archive.append(valueStreamReport, { name: keyReport });
       });
-      archive.append('Hello there', { name: 'filters.txt' });
+      if (format.extension === 'csv') {
+        archive.append(filters.join('\n'), { name: 'filters.txt' });
+      }
       archive.finalize();
 
       storageStrategy.putStream(namespace, key, valueStream);

--- a/lib/time/TimeFormatters.js
+++ b/lib/time/TimeFormatters.js
@@ -119,13 +119,13 @@ class TimeFormatters {
       bitMask |= 1 << d;
     });
     if (bitMask === 0x7f) { // 1111111
-      return 'any day';
+      return 'Any Day';
     }
     if (bitMask === 0x3e) { // 0111110
-      return 'weekdays';
+      return 'Weekdays';
     }
     if (bitMask === 0x41) { // 1000001
-      return 'weekends';
+      return 'Weekends';
     }
     return ArrayUtils
       .sortBy(daysOfWeek, i => i)

--- a/tests/jest/unit/time/TimeFormatters.spec.js
+++ b/tests/jest/unit/time/TimeFormatters.spec.js
@@ -61,13 +61,13 @@ test('TimeFormatters.formatDaysOfWeek()', () => {
   expect(TimeFormatters.formatDaysOfWeek(daysOfWeek)).toEqual('Sun');
 
   daysOfWeek = [0, 1, 2, 3, 4, 5, 6];
-  expect(TimeFormatters.formatDaysOfWeek(daysOfWeek)).toEqual('any day');
+  expect(TimeFormatters.formatDaysOfWeek(daysOfWeek)).toEqual('Any Day');
 
   daysOfWeek = [1, 2, 3, 4, 5];
-  expect(TimeFormatters.formatDaysOfWeek(daysOfWeek)).toEqual('weekdays');
+  expect(TimeFormatters.formatDaysOfWeek(daysOfWeek)).toEqual('Weekdays');
 
   daysOfWeek = [0, 6];
-  expect(TimeFormatters.formatDaysOfWeek(daysOfWeek)).toEqual('weekends');
+  expect(TimeFormatters.formatDaysOfWeek(daysOfWeek)).toEqual('Weekends');
 
   daysOfWeek = [2, 3, 4];
   expect(TimeFormatters.formatDaysOfWeek(daysOfWeek)).toEqual('Tue, Wed, Thu');


### PR DESCRIPTION
# Issue Addressed
This issue closes MOVE-1195

# Description
When filters have been applied, a text file with filters will be packaged alongside the report CSVs. A new boolean value called `singleFile` will now be sent to '/reports' to help the endpoint distinguish between single and bulk CSV downloads. Also, `prettyCollisionFilters.js` has been created to help with the generation and formatting of filters.

# Tests
Tested in MOVE local v1.12.0 using Firefox. Downloaded a variety of report types, with various filters.
