### PR TITLE
Update emails

### DIFF
--- a/lib/email/EmailStudyRequestBulkCancelled.js
+++ b/lib/email/EmailStudyRequestBulkCancelled.js
@@ -30,7 +30,7 @@ class EmailStudyRequestBulkCancelled extends EmailBaseStudyRequestBulk {
       </p>
       ${EmailBaseStudyRequestBulk.TEMPLATE_LIST_STUDY_REQUESTS}
       <p>
-        If you believe this is a mistake, please email Data Collection at
+        If you believe this was a mistake, please email Data Collection at
         <a href="mailto:trafficdata@toronto.ca">TrafficData@toronto.ca</a>.
       </p>
       <p>

--- a/lib/email/EmailStudyRequestBulkCancelled.js
+++ b/lib/email/EmailStudyRequestBulkCancelled.js
@@ -1,8 +1,9 @@
 import EmailBaseStudyRequestBulk from '@/lib/email/EmailBaseStudyRequestBulk';
 
 /**
- * Notifies the requester that a project (bulk study request) has been cancelled.  This is sent immediately
- * when the whole project is marked as cancelled, either by Data Collection or by the requester.
+ * Notifies the requester that a project (bulk study request) has been cancelled.  This is sent
+ * immediately when the whole project is marked as cancelled, either by Data Collection or by
+ * the requester.
  */
 class EmailStudyRequestBulkCancelled extends EmailBaseStudyRequestBulk {
   getRecipients() {

--- a/lib/email/EmailStudyRequestBulkCancelled.js
+++ b/lib/email/EmailStudyRequestBulkCancelled.js
@@ -26,12 +26,12 @@ class EmailStudyRequestBulkCancelled extends EmailBaseStudyRequestBulk {
     return `
     <div>
       <p>
-        Your project for the following studies has been cancelled:
+        Your project for the following studies was cancelled:
       </p>
       ${EmailBaseStudyRequestBulk.TEMPLATE_LIST_STUDY_REQUESTS}
       <p>
-        If you believe this is a mistake, please reach out to the data collection team at
-        <a href="mailto:trafficdata@toronto.ca">trafficdata@toronto.ca</a>.
+        If you believe this is a mistake, please email Data Collection at
+        <a href="mailto:trafficdata@toronto.ca">TrafficData@toronto.ca</a>.
       </p>
       <p>
         <a href="{{{hrefStudyRequestBulk}}}">View your cancelled project</a>

--- a/lib/email/EmailStudyRequestBulkCancelled.js
+++ b/lib/email/EmailStudyRequestBulkCancelled.js
@@ -1,8 +1,8 @@
 import EmailBaseStudyRequestBulk from '@/lib/email/EmailBaseStudyRequestBulk';
 
 /**
- * Notifies the requester that a bulk study request has been cancelled.  This is sent immediately
- * when the request is marked as cancelled, either by Data Collection or by the requester.
+ * Notifies the requester that a project (bulk study request) has been cancelled.  This is sent immediately
+ * when the whole project is marked as cancelled, either by Data Collection or by the requester.
  */
 class EmailStudyRequestBulkCancelled extends EmailBaseStudyRequestBulk {
   getRecipients() {

--- a/lib/email/EmailStudyRequestBulkCancelledAdmin.js
+++ b/lib/email/EmailStudyRequestBulkCancelledAdmin.js
@@ -2,7 +2,7 @@ import EmailBase from '@/lib/email/EmailBase';
 import EmailBaseStudyRequestBulk from '@/lib/email/EmailBaseStudyRequestBulk';
 
 /**
- * Notifies the Data supervisors that a bulk study request has been cancelled. This is sent
+ * Notifies the Data Supervisors that a project (bulk study request) has been cancelled. This is sent
  * immediately when the request is marked as cancelled, either by Data Collection or by the
  * requester.
  */

--- a/lib/email/EmailStudyRequestBulkCancelledAdmin.js
+++ b/lib/email/EmailStudyRequestBulkCancelledAdmin.js
@@ -16,7 +16,7 @@ class EmailStudyRequestBulkCancelledAdmin extends EmailBaseStudyRequestBulk {
 
   getSubject() {
     const { name } = this.studyRequestBulk;
-    return `[MOVE] Project request cancelled: ${name}`;
+    return `[MOVE] Project cancelled: ${name}`;
   }
 
   /* eslint-disable-next-line class-methods-use-this */
@@ -24,7 +24,7 @@ class EmailStudyRequestBulkCancelledAdmin extends EmailBaseStudyRequestBulk {
     return `
     <div>
       <p>
-        The project for the following studies has been cancelled:
+        The project for the following studies was cancelled:
       </p>
       ${EmailBaseStudyRequestBulk.TEMPLATE_LIST_STUDY_REQUESTS}
       <p>

--- a/lib/email/EmailStudyRequestBulkCancelledAdmin.js
+++ b/lib/email/EmailStudyRequestBulkCancelledAdmin.js
@@ -2,8 +2,8 @@ import EmailBase from '@/lib/email/EmailBase';
 import EmailBaseStudyRequestBulk from '@/lib/email/EmailBaseStudyRequestBulk';
 
 /**
- * Notifies the Data Supervisors that a project (bulk study request) has been cancelled. This is sent
- * immediately when the request is marked as cancelled, either by Data Collection or by the
+ * Notifies the Data Supervisors that a project (bulk study request) has been cancelled.  This is
+ * sent immediately when the request is marked as cancelled, either by Data Collection or by the
  * requester.
  */
 class EmailStudyRequestBulkCancelledAdmin extends EmailBaseStudyRequestBulk {

--- a/lib/email/EmailStudyRequestBulkChangesNeeded.js
+++ b/lib/email/EmailStudyRequestBulkChangesNeeded.js
@@ -28,7 +28,7 @@ class EmailStudyRequestBulkChangesNeeded extends EmailBaseStudyRequestBulk {
         <p>Before we can send your request out for collection, we need more information, or we need you to make changes.</p>
         ${EmailBaseStudyRequestBulk.TEMPLATE_LIST_STUDY_REQUESTS}
         <p><a href="{{{hrefStudyRequest}}}">Update your request here</a></p>
-        <p>If you need additional clarification on what information is needed, please check the comment section in MOVE, or email the Data Collection team (<a href="mailto:TrafficData@toronto.ca>TrafficData@toronto.ca</a>).</p>
+        <p>If you need additional clarification on what information is needed, please check the comment section in MOVE, or email Data Collection at (<a href="mailto:TrafficData@toronto.ca>TrafficData@toronto.ca</a>).</p>
     </div>`;
   }
 }

--- a/lib/email/EmailStudyRequestBulkChangesNeeded.js
+++ b/lib/email/EmailStudyRequestBulkChangesNeeded.js
@@ -18,16 +18,16 @@ class EmailStudyRequestBulkChangesNeeded extends EmailBaseStudyRequestBulk {
 
   getSubject() {
     const { name } = this.studyRequestBulk;
-    return `[MOVE] Changes Needed: ${name}`;
+    return `[MOVE] Changes needed: ${name}`;
   }
 
   /* eslint-disable-next-line class-methods-use-this */
   getBodyTemplate() {
     return `
     <div>
-        <p>Before we can send your request out for collection, we need more information, or we need you to make changes.</p>
+        <p>Before we can send your project out for collection, we need more information, or we need you to make changes.</p>
         ${EmailBaseStudyRequestBulk.TEMPLATE_LIST_STUDY_REQUESTS}
-        <p><a href="{{{hrefStudyRequest}}}">Update your request here</a></p>
+        <p><a href="{{{hrefStudyRequest}}}">Update your requests here</a></p>
         <p>If you need additional clarification on what information is needed, please check the comment section in MOVE, or email Data Collection at (<a href="mailto:TrafficData@toronto.ca>TrafficData@toronto.ca</a>).</p>
     </div>`;
   }

--- a/lib/email/EmailStudyRequestBulkChangesNeeded.js
+++ b/lib/email/EmailStudyRequestBulkChangesNeeded.js
@@ -1,8 +1,8 @@
 import EmailBaseStudyRequestBulk from '@/lib/email/EmailBaseStudyRequestBulk';
 
 /**
- * Notifies the requester that a bulk study request requires changes.  This is sent immediately
- * when Data Collection marks the request as needs clairification.
+ * Notifies the requester that a project (bulk study request) requires changes.  This is sent immediately
+ * when Data Collection marks the request as Needs Clarification.
  */
 class EmailStudyRequestBulkChangesNeeded extends EmailBaseStudyRequestBulk {
   getRecipients() {

--- a/lib/email/EmailStudyRequestBulkChangesNeeded.js
+++ b/lib/email/EmailStudyRequestBulkChangesNeeded.js
@@ -1,8 +1,8 @@
 import EmailBaseStudyRequestBulk from '@/lib/email/EmailBaseStudyRequestBulk';
 
 /**
- * Notifies the requester that a project (bulk study request) requires changes.  This is sent immediately
- * when Data Collection marks the request as Needs Clarification.
+ * Notifies the requester that a project (bulk study request) requires changes.  This is sent
+ * immediately when Data Collection marks the request as Needs Clarification.
  */
 class EmailStudyRequestBulkChangesNeeded extends EmailBaseStudyRequestBulk {
   getRecipients() {

--- a/lib/email/EmailStudyRequestBulkCompleted.js
+++ b/lib/email/EmailStudyRequestBulkCompleted.js
@@ -34,8 +34,9 @@ class EmailStudyRequestBulkCompleted extends EmailBaseStudyRequestBulk {
       </p>
       <p><strong>How to get your data</strong></p>
       <ul>
-        <li>TMC, Speed / Volume ATR, and Volume ATR studies will be available in MOVE within 24 hours.</li>
-        <li>For all other studies, or if we are unable to load your data into MOVE, a member of the Data Collection team will email the data to you directly.</li>
+        <li>TMC and Speed / Volume ATR studies will be available in MOVE within 24 hours.</li>
+        <li>If there is a problem loading your data, the Data Collection team will be in touch.</li>
+        <li>For all other studies, you will receive the data directly via email.</li>
         <li>If you still haven't received your requested data within 1-2 business days, please forward this email to move-team@toronto.ca.</li>
       </ul>
     </div>`;

--- a/lib/email/EmailStudyRequestBulkCompleted.js
+++ b/lib/email/EmailStudyRequestBulkCompleted.js
@@ -1,7 +1,7 @@
 import EmailBaseStudyRequestBulk from '@/lib/email/EmailBaseStudyRequestBulk';
 
 /**
- * Notifies the requester that a bulk study request has been completed.  This is sent immediately
+ * Notifies the requester that a project (bulk study request) has been completed.  This is sent immediately
  * when Data Collection marks the request as completed.
  */
 class EmailStudyRequestBulkCompleted extends EmailBaseStudyRequestBulk {

--- a/lib/email/EmailStudyRequestBulkCompleted.js
+++ b/lib/email/EmailStudyRequestBulkCompleted.js
@@ -1,8 +1,8 @@
 import EmailBaseStudyRequestBulk from '@/lib/email/EmailBaseStudyRequestBulk';
 
 /**
- * Notifies the requester that a project (bulk study request) has been completed.  This is sent immediately
- * when Data Collection marks the request as completed.
+ * Notifies the requester that a project (bulk study request) has been completed.  This is sent
+ * immediately when Data Collection marks the request as completed.
  */
 class EmailStudyRequestBulkCompleted extends EmailBaseStudyRequestBulk {
   getRecipients() {

--- a/lib/email/EmailStudyRequestBulkRequested.js
+++ b/lib/email/EmailStudyRequestBulkRequested.js
@@ -1,7 +1,7 @@
 import EmailBaseStudyRequestBulk from '@/lib/email/EmailBaseStudyRequestBulk';
 
 /**
- * Confirms to the requester that a bulk study request has been requested.  This is sent
+ * Confirms to the requester that a project (bulk study request) was requested.  This is sent
  * immediately upon completion of the multi-location Request Study user flow in the frontend.
  */
 class EmailStudyRequestBulkRequested extends EmailBaseStudyRequestBulk {

--- a/lib/email/EmailStudyRequestCancelled.js
+++ b/lib/email/EmailStudyRequestCancelled.js
@@ -1,8 +1,8 @@
 import EmailBaseStudyRequest from '@/lib/email/EmailBaseStudyRequest';
 
 /**
- * Notifies the requester that a study request has been completed.  This is sent immediately when
- * Data Collection marks the request as completed.
+ * Notifies the requester that a study request has been cancelled.  This is sent immediately when
+ * Data Collection marks the request as cancelled.
  */
 class EmailStudyRequestCancelled extends EmailBaseStudyRequest {
   getRecipients() {

--- a/lib/email/EmailStudyRequestCancelledAdmin.js
+++ b/lib/email/EmailStudyRequestCancelledAdmin.js
@@ -2,8 +2,8 @@ import EmailBase from '@/lib/email/EmailBase';
 import EmailBaseStudyRequest from '@/lib/email/EmailBaseStudyRequest';
 
 /**
- * Notifies the Data supervisors that a study request has been canceled. This is sent
- * immediately upon study cancelation user flow in the frontend.
+ * Notifies the Data Supervisors that a study request has been cancelled. This is sent
+ * immediately upon study cancellation user flow in the frontend.
  */
 class EmailStudyRequestCancelledAdmin extends EmailBaseStudyRequest {
   /* eslint-disable-next-line class-methods-use-this */

--- a/lib/email/EmailStudyRequestChangedAdmin.js
+++ b/lib/email/EmailStudyRequestChangedAdmin.js
@@ -2,8 +2,8 @@ import EmailBase from '@/lib/email/EmailBase';
 import EmailBaseStudyRequestChanged from '@/lib/email/EmailBaseStudyRequestChanged';
 
 /**
- * Notifies the requester that a study request has been completed.  This is sent immediately when
- * Data Collection marks the request as completed.
+ * Notifies the Data Supervisors that a study request has been edited.  This is sent immediately
+ * after a the study request is edited via the edit user flow.
  */
 class EmailStudyRequestChanged extends EmailBaseStudyRequestChanged {
   /* eslint-disable-next-line class-methods-use-this */

--- a/lib/email/EmailStudyRequestChangedAdmin.js
+++ b/lib/email/EmailStudyRequestChangedAdmin.js
@@ -31,11 +31,11 @@ class EmailStudyRequestChanged extends EmailBaseStudyRequestChanged {
         {{#locationOld}}
           at <strong>{{locationOld}}</strong>
         {{/locationOld}}
-        has had the following changes:
+        was edited:
       </p>
       ${EmailBaseStudyRequestChanged.TEMPLATE_CHANGES_LIST}
       <p>
-        <a href="{{{hrefStudyRequest}}}">View changed request</a>
+        <a href="{{{hrefStudyRequest}}}">View request</a>
       </p>
     </div>`;
   }

--- a/lib/email/EmailStudyRequestChangedAdmin.js
+++ b/lib/email/EmailStudyRequestChangedAdmin.js
@@ -5,7 +5,7 @@ import EmailBaseStudyRequestChanged from '@/lib/email/EmailBaseStudyRequestChang
  * Notifies the Data Supervisors that a study request has been edited.  This is sent immediately
  * after a the study request is edited via the edit user flow.
  */
-class EmailStudyRequestChanged extends EmailBaseStudyRequestChanged {
+class EmailStudyRequestChangedAdmin extends EmailBaseStudyRequestChanged {
   /* eslint-disable-next-line class-methods-use-this */
   getRecipients() {
     return [
@@ -41,4 +41,4 @@ class EmailStudyRequestChanged extends EmailBaseStudyRequestChanged {
   }
 }
 
-export default EmailStudyRequestChanged;
+export default EmailStudyRequestChangedAdmin;

--- a/lib/email/EmailStudyRequestChangesNeeded.js
+++ b/lib/email/EmailStudyRequestChangesNeeded.js
@@ -19,10 +19,10 @@ class EmailStudyRequestChangesNeeded extends EmailBaseStudyRequest {
   getSubject() {
     const { id } = this.studyRequest;
     if (this.location === null) {
-      return `[MOVE] Changes Needed: #${id}`;
+      return `[MOVE] Changes needed: #${id}`;
     }
     const { description } = this.location;
-    return `[MOVE] Changes Needed: #${id} - ${description}`;
+    return `[MOVE] Changes needed: #${id} - ${description}`;
   }
 
   /* eslint-disable-next-line class-methods-use-this */

--- a/lib/email/EmailStudyRequestChangesNeeded.js
+++ b/lib/email/EmailStudyRequestChangesNeeded.js
@@ -1,8 +1,8 @@
 import EmailBaseStudyRequest from '@/lib/email/EmailBaseStudyRequest';
 
 /**
- * Notifies the requester that a study request needs clairification.  This is sent immediately when
- * Data Collection marks the request as needs clairification.
+ * Notifies the requester that a study request needs additional clarification.  This is sent immediately when
+ * Data Collection marks the request as Needs Clarification.
  */
 class EmailStudyRequestChangesNeeded extends EmailBaseStudyRequest {
   getRecipients() {

--- a/lib/email/EmailStudyRequestChangesNeeded.js
+++ b/lib/email/EmailStudyRequestChangesNeeded.js
@@ -1,8 +1,8 @@
 import EmailBaseStudyRequest from '@/lib/email/EmailBaseStudyRequest';
 
 /**
- * Notifies the requester that a study request needs additional clarification.  This is sent immediately when
- * Data Collection marks the request as Needs Clarification.
+ * Notifies the requester that a study request needs additional clarification.  This is sent
+ * immediately when Data Collection marks the request as Needs Clarification.
  */
 class EmailStudyRequestChangesNeeded extends EmailBaseStudyRequest {
   getRecipients() {

--- a/lib/email/EmailStudyRequestChangesNeeded.js
+++ b/lib/email/EmailStudyRequestChangesNeeded.js
@@ -32,7 +32,7 @@ class EmailStudyRequestChangesNeeded extends EmailBaseStudyRequest {
         <p>Before we can send your request out for collection, we need more information, or we need you to make changes.</p>
         <p><strong>{{studyType}}</strong> &mdash; {{hours}} &mdash; {{days}}</p>
         <p><a href="{{{hrefStudyRequest}}}">Update your request here</a></p>
-        <p>If you need additional clarification on what information is needed, please check the comment section in MOVE, or email the Data Collection team at <a href="mailto:trafficdata@toronto.ca">trafficdata@toronto.ca</a>.</p>
+        <p>If you need additional clarification on what information is needed, please check the comment section in MOVE, or email Data Collection at <a href="mailto:trafficdata@toronto.ca">TrafficData@toronto.ca</a>.</p>
     </div>`;
   }
 }

--- a/lib/email/EmailStudyRequestCompleted.js
+++ b/lib/email/EmailStudyRequestCompleted.js
@@ -17,11 +17,12 @@ class EmailStudyRequestCompleted extends EmailBaseStudyRequest {
   }
 
   getSubject() {
+    const { id } = this.studyRequest;
     if (this.location === null) {
-      return '[MOVE] Your request is complete!';
+      return `[MOVE] Your request is complete! (#${id})`;
     }
     const { description } = this.location;
-    return `[MOVE] Your request is complete! (${description})`;
+    return `[MOVE] Your request is complete! (#${id} - ${description})`;
   }
 
   /* eslint-disable-next-line class-methods-use-this */
@@ -44,8 +45,8 @@ class EmailStudyRequestCompleted extends EmailBaseStudyRequest {
       <p><strong>How to get your data</strong></p>
       <ul>
         <li>TMC and Speed / Volume ATR studies will be available in MOVE within 24 hours.</li>
-        <li>For all other studies, you will receive the data directly via email.</li>
         <li>If there is a problem loading your data, the Data Collection team will be in touch.</li>
+        <li>For all other studies, you will receive the data directly via email.</li>
         <li>If you still haven't received your requested data within 1-2 business days, please forward this email to move-team@toronto.ca.</li>
       </ul>
     </div>`;

--- a/lib/email/EmailStudyRequestCompleted.js
+++ b/lib/email/EmailStudyRequestCompleted.js
@@ -43,8 +43,9 @@ class EmailStudyRequestCompleted extends EmailBaseStudyRequest {
       </p>
       <p><strong>How to get your data</strong></p>
       <ul>
-        <li>TMC, Speed / Volume ATR, and Volume ATR studies will be available in MOVE within 24 hours.</li>
-        <li>For all other studies, or if we are unable to load your data into MOVE, a member of the Data Collection team will email the data to you directly.</li>
+        <li>TMC and Speed / Volume ATR studies will be available in MOVE within 24 hours.</li>
+        <li>For all other studies, you will receive the data directly via email.</li>
+        <li>If there is a problem loading your data, the Data Collection team will be in touch.</li>
         <li>If you still haven't received your requested data within 1-2 business days, please forward this email to move-team@toronto.ca.</li>
       </ul>
     </div>`;

--- a/lib/email/EmailStudyRequestNewComment.js
+++ b/lib/email/EmailStudyRequestNewComment.js
@@ -52,13 +52,13 @@ class EmailStudyRequestNewComment extends EmailBaseStudyRequest {
     return `
     <div>
       <p>
-        A comment has been added to the {{studyType}} request
-        {{#location}}
-          for {{location}}
-        {{/location}}
         {{#usernameCommenter}}
-          by {{usernameCommenter}}
-        {{/usernameCommenter}}:
+          {{usernameCommenter}} 
+        {{/usernameCommenter}}
+        added a comment to the {{studyType}} request 
+        {{#location}}
+          at {{location}}
+        {{/location}}:
       </p>
       <p>
         <i>{{comment}}</i>

--- a/lib/email/EmailStudyRequestNewComment.js
+++ b/lib/email/EmailStudyRequestNewComment.js
@@ -3,6 +3,11 @@ import UserDAO from '@/lib/db/UserDAO';
 import EmailBase from '@/lib/email/EmailBase';
 import EmailBaseStudyRequest from '@/lib/email/EmailBaseStudyRequest';
 
+/**
+ * Notifies request watchers that a study request has a new comment.  This is sent immediately when
+ * a comment is added to the study request page.
+ */
+
 class EmailStudyRequestNewComment extends EmailBaseStudyRequest {
   constructor(studyRequest, studyRequestComment) {
     super(studyRequest);

--- a/lib/email/EmailStudyRequestNewComment.js
+++ b/lib/email/EmailStudyRequestNewComment.js
@@ -44,7 +44,7 @@ class EmailStudyRequestNewComment extends EmailBaseStudyRequest {
       return `[MOVE] New comment on request #${id}`;
     }
     const { description } = this.location;
-    return `[MOVE] New comment on request #${id} for ${description}`;
+    return `[MOVE] New comment on request #${id} at ${description}`;
   }
 
   /* eslint-disable-next-line class-methods-use-this */

--- a/lib/email/MailUtils.js
+++ b/lib/email/MailUtils.js
@@ -8,7 +8,7 @@ import EmailStudyRequestCancelled from '@/lib/email/EmailStudyRequestCancelled';
 import EmailStudyRequestCompleted from '@/lib/email/EmailStudyRequestCompleted';
 import EmailStudyRequestChangesNeeded from '@/lib/email/EmailStudyRequestChangesNeeded';
 import EmailStudyRequestCancelledAdmin from '@/lib/email/EmailStudyRequestCancelledAdmin';
-import EmailStudyRequestChanged from '@/lib/email/EmailStudyRequestChanged';
+import EmailStudyRequestChangedAdmin from '@/lib/email/EmailStudyRequestChangedAdmin';
 import EmailStudyRequestUtils from '@/lib/email/EmailStudyRequestUtils';
 
 import Mailer from '@/lib/email/Mailer';
@@ -97,7 +97,7 @@ function getStudyRequestUpdateEmails(studyRequestNew, studyRequestOld) {
     const requestChanges = {
       studyRequestChanges, featureOld, featureNew, id, userId,
     };
-    const emailRequestChanged = new EmailStudyRequestChanged(requestChanges);
+    const emailRequestChanged = new EmailStudyRequestChangedAdmin(requestChanges);
     emails.push(emailRequestChanged);
   }
 

--- a/tests/jest/unit/email/EmailStudyRequestChanged.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestChanged.spec.js
@@ -1,7 +1,7 @@
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
 import UserDAO from '@/lib/db/UserDAO';
 import EmailBase from '@/lib/email/EmailBase';
-import EmailStudyRequestChanged from '@/lib/email/EmailStudyRequestChanged';
+import EmailStudyRequestChangedAdmin from '@/lib/email/EmailStudyRequestChangedAdmin';
 import { getRequestChanges } from '@/lib/email/MailUtils';
 import { generateStudyRequest, generateStudyTypeChange } from '@/lib/test/random/StudyRequestGenerator';
 import { generateUser } from '@/lib/test/random/UserGenerator';
@@ -37,7 +37,7 @@ test('EmailStudyRequestChanged', async () => {
   const requestChanges = {
     studyRequestChanges, featureOld, featureNew, id, userId,
   };
-  const email = new EmailStudyRequestChanged(requestChanges);
+  const email = new EmailStudyRequestChangedAdmin(requestChanges);
 
   await email.init();
 

--- a/tests/jest/unit/email/EmailStudyRequestChanged.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestChanged.spec.js
@@ -9,7 +9,7 @@ import { generateUser } from '@/lib/test/random/UserGenerator';
 jest.mock('@/lib/db/CentrelineDAO');
 jest.mock('@/lib/db/UserDAO');
 
-test('EmailStudyRequestChanged', async () => {
+test('EmailStudyRequestChangedAdmin', async () => {
   const requester = generateUser();
   const studyRequestOld = generateStudyRequest();
   studyRequestOld.id = 42;

--- a/tests/jest/unit/email/EmailStudyRequestCompleted.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestCompleted.spec.js
@@ -27,7 +27,7 @@ test('EmailStudyRequestCompleted', async () => {
   expect(recipients).toEqual([requester.email, ...studyRequest.ccEmails]);
 
   const subject = email.getSubject();
-  expect(subject).toEqual('[MOVE] Your request is complete! (Test location)');
+  expect(subject).toEqual('[MOVE] Your request is complete! (#42 - Test location)');
 
   const params = email.getBodyParams();
   expect(params.hrefStudyRequest).toEqual('https://localhost:8080/requests/study/42');

--- a/tests/jest/unit/email/EmailStudyRequestNewComment.spec.js
+++ b/tests/jest/unit/email/EmailStudyRequestNewComment.spec.js
@@ -31,7 +31,7 @@ test('EmailStudyRequestNewComment', async () => {
   expect(recipients).toEqual([EmailBase.getRecipientStudyRequestAdmin(), ...studyRequest.ccEmails]);
 
   const subject = email.getSubject();
-  expect(subject).toEqual('[MOVE] New comment on request #42 for Test location');
+  expect(subject).toEqual('[MOVE] New comment on request #42 at Test location');
 
   const params = email.getBodyParams();
   expect(params.comment).toEqual('Test comment');


### PR DESCRIPTION
# Issue Addressed
This PR addresses MOVE-1133, cleanup email language.

# Description
Updates to email language. Mostly cleaning up my old sloppy copy. Updated comments on each file. And, found one place where the email wasn't named per the convention (`EmailStudyRequestChanged` --> `EmailStudyRequestChangedAdmin`, because it gets sent to data supervisor/admins)... hopefully I didn't break anything.

# Tests
Not tested yet 🙃 Hoping to get some help with this tomorrow (Thursday).