### PR TITLE
MOVE-1229: Map / Table interactions gone after request status change

### DIFF
--- a/web/components/FcDataTable.vue
+++ b/web/components/FcDataTable.vue
@@ -40,7 +40,6 @@
 </template>
 
 <script>
-import { mapMutations } from 'vuex';
 import { Ripple } from 'vuetify/lib/directives';
 
 import { KeyCode } from '@/lib/Constants';
@@ -183,18 +182,6 @@ export default {
         }
       });
     });
-
-    // Adds hover event listeners to table rows
-    const $tableRows = this.$el.querySelectorAll('tbody tr');
-    $tableRows.forEach(($tr) => {
-      $tr.addEventListener('mouseover', () => {
-        const requestId = parseInt($tr.children[1].innerText.trim(), 10);
-        this.setHoveredStudyRequest(requestId);
-      });
-      $tr.addEventListener('mouseleave', () => {
-        this.setHoveredStudyRequest(null);
-      });
-    });
   },
   methods: {
     customSort(items, sortBy, sortDesc) {
@@ -209,7 +196,6 @@ export default {
         return compareKeys(ka, kb, kf);
       });
     },
-    ...mapMutations('trackRequests', ['setHoveredStudyRequest']),
   },
 };
 </script>

--- a/web/views/FcRequestStudyBulkView.vue
+++ b/web/views/FcRequestStudyBulkView.vue
@@ -289,6 +289,22 @@ export default {
       return ids;
     },
   },
+  mounted() {
+    // Adds hover event listeners to table rows
+    document.body.addEventListener('mouseover', (element) => {
+      const targetParent = element.target.parentNode;
+      if (targetParent.tagName === 'TR') {
+        const requestId = parseInt(targetParent.children[1].innerText.trim(), 10);
+        this.setHoveredStudyRequest(requestId);
+      }
+    });
+    document.body.addEventListener('mouseleave', (element) => {
+      const targetParent = element.target.parentNode;
+      if (targetParent.tagName === 'TR') {
+        this.setHoveredStudyRequest(null);
+      }
+    });
+  },
   methods: {
     actionEdit() {
       const { id } = this.studyRequestBulk;
@@ -375,6 +391,7 @@ export default {
     },
     ...mapActions(['saveStudyRequest', 'saveStudyRequestBulk']),
     ...mapActions('editRequests', ['updateStudyRequestsBulkRequests']),
+    ...mapMutations('trackRequests', ['setHoveredStudyRequest']),
     ...mapMutations(['setToastInfo', 'setDialog']),
   },
 };


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-1229.

# Description
MouseEvent Listeners on table rows are now being added to the whole document body, instead of the rows themselves. This keeps the listeners "attached" to the table row, even if row data gets altered. The code for adding these listeners is now housed in `FcRequestStudyBulk.vue` instead of `FcDataTable.vue`, to ensure that the listeners only activate on the Project View page, and not on every page that contains an FcDataTable.

# Tests
Tested in MOVE local v1.12.0 using Firefox.
