### PR TITLE
MOVE-1229: Map / Table interactions gone after request status change

### DIFF
--- a/web/components/FcDataTable.vue
+++ b/web/components/FcDataTable.vue
@@ -185,15 +185,20 @@ export default {
     });
 
     // Adds hover event listeners to table rows
-    const $tableRows = this.$el.querySelectorAll('tbody tr');
-    $tableRows.forEach(($tr) => {
-      $tr.addEventListener('mouseover', () => {
-        const requestId = parseInt($tr.children[1].innerText.trim(), 10);
+    const table = document.getElementsByTagName('tbody')[0];
+
+    table.addEventListener('mouseover', (e) => {
+      const target = e.target.closest('tr');
+      if (target) {
+        const requestId = parseInt(target.children[1].innerText.trim(), 10);
         this.setHoveredStudyRequest(requestId);
-      });
-      $tr.addEventListener('mouseleave', () => {
+      }
+    });
+    table.addEventListener('mouseleave', (e) => {
+      const target = e.target.closest('tbody');
+      if (target) {
         this.setHoveredStudyRequest(null);
-      });
+      }
     });
   },
   methods: {


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-1229.

# Description
MouseEvent Listeners on table rows are now being added to the table body, instead of the rows themselves. This keeps the listeners "attached" to the table row, even if row data gets altered. 

# Tests
Tested in MOVE local v1.12.0 using Firefox.