### PR TITLE
Remove export-mode

### DIFF
--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -23,7 +23,8 @@
             </div>
           </div>
 
-          <FcGlobalFilters class="fc-filter-section px-5 py-3" header-tag="h3" />
+          <FcGlobalFilters class="px-5 py-3" header-tag="h3"
+            :class="{'fc-filter-section-border':locationMode === LocationMode.SINGLE}"/>
 
           <v-divider></v-divider>
 
@@ -186,7 +187,7 @@ export default {
   & .fc-view-data-section {
     max-height: calc(100vh - 215px);
   }
-  & .fc-filter-section {
+  & .fc-filter-section-border {
     border-top: 1px solid lightgrey;
   }
   & .add-location-btn {

--- a/web/components/data/FcAggregateCollisions.vue
+++ b/web/components/data/FcAggregateCollisions.vue
@@ -46,7 +46,7 @@
         </div>
       </dl>
 
-      <div class="fc-collision-detail-box ml-1 mr-3 body-1">
+      <div class="fc-collision-detail-box ml-1 mr-4 body-1">
         <div class="d-flex fc-collision-detail-title ml-2 justify-space-apart">
           <FcButton
             type="tertiary"

--- a/web/components/data/FcAggregateCollisions.vue
+++ b/web/components/data/FcAggregateCollisions.vue
@@ -58,7 +58,7 @@
           </FcButton>
           <slot name="second"></slot>
         </div>
-        <table v-if="showDetails" class="fc-collision-detail-table pa-2">
+        <table v-if="showDetails" class="fc-collision-detail-table pa-2 mb-2 elevation-1">
           <th class="fc-detail-row fc-detail-header">
             <td class="fc-detail-desc"></td>
             <td class="fc-detail-num">Total</td>

--- a/web/components/data/FcAggregateCollisions.vue
+++ b/web/components/data/FcAggregateCollisions.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fc-aggregate-collisions mb-5 ml-5">
+  <div class="fc-aggregate-collisions mb-0 ml-5">
     <FcProgressLinear
       v-if="loading"
       aria-label="Loading Aggregate View collisions data" />
@@ -57,7 +57,7 @@
               Details
           </FcButton>
         </div>
-        <table v-if="showDetails" class="fc-collision-detail-table elevation-1 pa-2">
+        <table v-if="showDetails" class="fc-collision-detail-table pa-2">
           <th class="fc-detail-row fc-detail-header">
             <td class="fc-detail-desc"></td>
             <td class="fc-detail-num">Total</td>
@@ -172,7 +172,7 @@ export default {
   }
   & .fc-details-btn {
     text-transform: none !important;
-    color: var(--v-default-base);
+    color: var(--v-secondary-base) !important
   }
   & .fc-collision-detail-table {
     width: 100%;

--- a/web/components/data/FcAggregateCollisions.vue
+++ b/web/components/data/FcAggregateCollisions.vue
@@ -47,7 +47,7 @@
       </dl>
 
       <div class="fc-collision-detail-box ml-1 mr-3 body-1">
-        <div class="d-flex fc-collision-detail-title ml-2">
+        <div class="d-flex fc-collision-detail-title ml-2 justify-space-apart">
           <FcButton
             type="tertiary"
             class="fc-details-btn"
@@ -56,6 +56,7 @@
               <v-icon v-else>mdi mdi-chevron-down</v-icon>
               Details
           </FcButton>
+          <slot name="second"></slot>
         </div>
         <table v-if="showDetails" class="fc-collision-detail-table pa-2">
           <th class="fc-detail-row fc-detail-header">
@@ -173,6 +174,10 @@ export default {
   & .fc-details-btn {
     text-transform: none !important;
     color: var(--v-secondary-base) !important
+  }
+  & .fc-collision-detail-title {
+    display: flex;
+    justify-content: space-between;
   }
   & .fc-collision-detail-table {
     width: 100%;

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -16,7 +16,7 @@
           class="fc-studies-summary-per-location"
           :disabled="item.n === 0">
           <v-expansion-panel-header class="pa-1 pr-4 fc-study-expansion-header" ripple>
-            <v-icon small color="primary" class="fc-study-header-icon">mdi-briefcase</v-icon>
+            <v-icon small color="primary" class="fc-study-header-icon mx-1">mdi-briefcase</v-icon>
             <div class="body-1 fc-study-summary-header">
               {{item.studyType.label}}
               <FcTextStudyTypeBeta

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fc-aggregate-studies mb-9 ml-5">
+  <div class="fc-aggregate-studies mb-5 ml-5">
     <FcProgressLinear
       v-if="loading"
       aria-label="Loading Aggregate View studies data" />

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -33,7 +33,7 @@
               <span>View Report</span>
             </v-tooltip>
             <template v-slot:second v-if="collisionSummary.amount > 0">
-              <div class=" d-flex flex-column align-end mr-1 mb-4">
+              <div class="d-flex flex-column align-end mr-1 mb-2">
                 <FcMenuDownloadReportFormat
                   :require-auth="true"
                   type="secondary"

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -60,7 +60,7 @@
           @show-reports="actionShowReportsStudy"
           />
 
-          <div class="fc-study-buttons d-flex justify-end align-end mr-5 mb-3 mt-1">
+          <div class="fc-study-buttons d-flex justify-end align-end mr-3 mb-3 mt-1">
 
             <FcButton
               type="secondary"

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -21,6 +21,7 @@
               <FcButton
                 v-on="on"
                 width="50px"
+                class="fc-view-collision-report"
                 :disabled="collisionSummary.amount === 0"
                 type="secondary"
                 @click="actionShowReportsCollision">
@@ -338,3 +339,9 @@ export default {
   },
 };
 </script>
+
+<style lang="scss">
+.fc-view-collision-report {
+  align-self: center;
+}
+</style>

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -60,7 +60,7 @@
           @show-reports="actionShowReportsStudy"
           />
 
-          <div class="fc-study-buttons d-flex flex-col justify-end align-end mr-5 mb-3 mt-1">
+          <div class="fc-study-buttons d-flex flex-column justify-end align-end mr-5 mb-3 mt-1">
 
             <template v-if="studySummary.length > 0">
               <FcMenuDownloadReportFormat

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -21,6 +21,7 @@
               <FcButton
                 v-on="on"
                 width="50px"
+                height="40px"
                 class="fc-view-collision-report"
                 :disabled="collisionSummary.amount === 0"
                 type="secondary"
@@ -34,7 +35,7 @@
         </FcAggregateCollisions>
 
         <template v-if="collisionSummary.amount > 0">
-          <div class="fc-study-buttons d-flex flex-column align-end mr-5 mb-2">
+          <div class="fc-study-buttons d-flex flex-column align-end mr-5 mb-2 mt-3">
             <FcMenuDownloadReportFormat
               :require-auth="true"
               type="secondary"
@@ -343,5 +344,8 @@ export default {
 <style lang="scss">
 .fc-view-collision-report {
   align-self: center;
+  box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2),
+    0 2px 2px 0 rgba(0, 0, 0, 0.14),
+    0 1px 5px 0 rgba(0, 0, 0, 0.12);
 }
 </style>

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -36,7 +36,7 @@
               <div class=" d-flex flex-column align-end mr-5 mb-4">
                 <FcMenuDownloadReportFormat
                   :require-auth="true"
-                  type="tertiary"
+                  type="secondary"
                   text-screen-reader="Collision Reports"
                   @download-report-format="actionDownloadReportFormatCollisions" />
                 </div>
@@ -60,25 +60,26 @@
           @show-reports="actionShowReportsStudy"
           />
 
-          <div class="fc-study-buttons d-flex flex-column justify-end align-end mr-5 mb-3 mt-1">
-
-            <template v-if="studySummary.length > 0">
-              <FcMenuDownloadReportFormat
-                :require-auth="true"
-                type="tertiary"
-                text-screen-reader="Study Reports"
-                @download-report-format="actionDownloadReportFormatStudies" />
-            </template>
+          <div class="fc-study-buttons d-flex justify-end align-end mr-5 mb-3 mt-1">
 
             <FcButton
               type="secondary"
               color="primary"
-              class="ml-2 mt-1"
+              class="mr-1 mt-1"
               @click="actionRequestStudy">
               Request&nbsp;
               <span class="sr-only">New Study</span>
               <v-icon >mdi-briefcase-plus</v-icon>
             </FcButton>
+
+            <template v-if="studySummary.length > 0">
+              <FcMenuDownloadReportFormat
+                :require-auth="true"
+                type="secondary"
+                text-screen-reader="Study Reports"
+                @download-report-format="actionDownloadReportFormatStudies" />
+            </template>
+
           </div>
       </section>
     </template>

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -5,17 +5,7 @@
       aria-label="Loading Aggregate View for View Data" />
     <template v-else>
       <section class="d-flex flex-column">
-        <FcHeaderCollisions
-          :collision-total="collisionTotal"
-          :disabled="reportExportMode === ReportExportMode.STUDIES">
-          <template v-slot:action v-if="collisionSummary.amount > 0">
-            <FcMenuDownloadReportFormat
-              v-if="reportExportMode === ReportExportMode.COLLISIONS"
-              :require-auth="true"
-              text-screen-reader="Collision Reports"
-              @download-report-format="actionDownloadReportFormatCollisions" />
-          </template>
-        </FcHeaderCollisions>
+        <FcHeaderCollisions :collision-total="collisionTotal"/>
 
         <FcAggregateCollisions
           :collision-summary="collisionSummary"
@@ -41,42 +31,22 @@
               <span>View Report</span>
             </v-tooltip>
         </FcAggregateCollisions>
-          <div v-if="collisionSummary.amount > 0" class="mr-5 align-self-end mb-2">
-            <FcButton
-              class="ma-1"
-              :scope="[]"
+
+        <template v-if="collisionSummary.amount > 0">
+          <div class="fc-study-buttons d-flex flex-column align-end mr-5 mb-2">
+            <FcMenuDownloadReportFormat
+              :require-auth="true"
               type="secondary"
-              color="primary"
-              @click="actionToggleReportExportMode(ReportExportMode.COLLISIONS)">
-              <template v-if="reportExportMode === ReportExportMode.COLLISIONS">
-                Cancel&nbsp;<v-icon color="primary">mdi-cloud-check</v-icon>
-                <span class="sr-only">Cancel Export of Collision Reports</span>
-              </template>
-              <template v-else>
-                Export&nbsp;
-                <v-icon color="primary">mdi-cloud-download</v-icon>
-                <span class="sr-only">Export Collision Reports</span>
-              </template>
-            </FcButton>
-          </div>
+              text-screen-reader="Collision Reports"
+              @download-report-format="actionDownloadReportFormatCollisions" />
+            </div>
+        </template>
       </section>
 
       <v-divider></v-divider>
 
       <section>
-        <FcHeaderStudies
-          :disabled="reportExportMode === ReportExportMode.COLLISIONS"
-          :study-total="studyTotal">
-          <template v-slot:action>
-            <div v-if="reportExportMode !== ReportExportMode.STUDIES"></div>
-            <FcMenuDownloadReportFormat
-              v-else
-              :require-auth="true"
-              text-screen-reader="Study Reports"
-              @download-report-format="actionDownloadReportFormatStudies" />
-          </template>
-        </FcHeaderStudies>
-
+        <FcHeaderStudies :study-total="studyTotal" />
         <FcAggregateStudies
           :study-summary="studySummary"
           :study-summary-unfiltered="studySummaryUnfiltered"
@@ -89,29 +59,19 @@
           />
 
           <div class="fc-study-buttons d-flex flex-column align-end mr-5">
-            <FcButton
-              class="mb-1"
-              v-if="studySummary.length > 0"
-              :scope="[]"
-              type="secondary"
-              color="primary"
-              @click="actionToggleReportExportMode(ReportExportMode.STUDIES)">
-              <template v-if="reportExportMode === ReportExportMode.STUDIES">
-                Cancel&nbsp;<v-icon color="primary">mdi-cloud-check</v-icon>
-                <span class="sr-only">Cancel Export of Study Reports</span>
-              </template>
-              <template v-else>
-                Export&nbsp;
-                <v-icon color="primary">mdi-cloud-download</v-icon>
-                <span class="sr-only">Export Study Reports</span>
-              </template>
-            </FcButton>
+
+            <template v-if="studySummary.length > 0">
+              <FcMenuDownloadReportFormat
+                :require-auth="true"
+                type="secondary"
+                text-screen-reader="Study Reports"
+                @download-report-format="actionDownloadReportFormatStudies" />
+            </template>
 
             <FcButton
-              v-if="reportExportMode !== ReportExportMode.STUDIES"
               type="secondary"
               color="primary"
-              class="mb-3"
+              class="mb-3 mt-1"
               @click="actionRequestStudy">
               Request&nbsp;
               <span class="sr-only">New Study</span>
@@ -126,7 +86,7 @@
 <script>
 import { mapGetters, mapMutations, mapState } from 'vuex';
 
-import { ReportExportMode, LocationSelectionType } from '@/lib/Constants';
+import { LocationSelectionType } from '@/lib/Constants';
 import {
   getCollisionsByCentrelineSummary,
   getCollisionsByCentrelineSummaryPerLocation,
@@ -190,8 +150,6 @@ export default {
       collisionSummaryPerLocation,
       collisionSummaryPerLocationUnfiltered,
       collisionTotal: 0,
-      reportExportMode: null,
-      ReportExportMode,
       loading: false,
       loadingCollisions: false,
       loadingStudies: false,
@@ -282,8 +240,6 @@ export default {
         toast: 'Job',
         toastData: { job },
       });
-
-      this.reportExportMode = null;
     },
     async actionDownloadReportFormatStudies(reportFormat) {
       const job = await postJobGenerateStudyReports(
@@ -297,8 +253,6 @@ export default {
         toast: 'Job',
         toastData: { job },
       });
-
-      this.reportExportMode = null;
     },
     actionRequestStudy() {
       const params = this.locationsRouteParams;
@@ -375,15 +329,6 @@ export default {
       this.studyTotal = studyTotal;
 
       this.loading = false;
-    },
-    actionToggleReportExportMode(reportExportMode) {
-      if (this.reportExportMode === reportExportMode) {
-        this.reportExportMode = null;
-        this.setToastInfo('You\'re no longer in Export Report Mode.');
-      } else {
-        this.reportExportMode = reportExportMode;
-        this.setToastInfo('You\'re currently in Export Report Mode.');
-      }
     },
     ...mapMutations([
       'setLocationsIndex',

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -32,17 +32,17 @@
               </template>
               <span>View Report</span>
             </v-tooltip>
+            <template v-slot:second v-if="collisionSummary.amount > 0">
+              <div class=" d-flex flex-column align-end mr-5 mb-4">
+                <FcMenuDownloadReportFormat
+                  :require-auth="true"
+                  type="tertiary"
+                  text-screen-reader="Collision Reports"
+                  @download-report-format="actionDownloadReportFormatCollisions" />
+                </div>
+            </template>
         </FcAggregateCollisions>
 
-        <template v-if="collisionSummary.amount > 0">
-          <div class="fc-study-buttons d-flex flex-column align-end mr-5 mb-2 mt-3">
-            <FcMenuDownloadReportFormat
-              :require-auth="true"
-              type="secondary"
-              text-screen-reader="Collision Reports"
-              @download-report-format="actionDownloadReportFormatCollisions" />
-            </div>
-        </template>
       </section>
 
       <v-divider></v-divider>
@@ -60,12 +60,12 @@
           @show-reports="actionShowReportsStudy"
           />
 
-          <div class="fc-study-buttons d-flex justify-end align-center mr-5 mb-3 mt-1">
+          <div class="fc-study-buttons d-flex flex-col justify-end align-end mr-5 mb-3 mt-1">
 
             <template v-if="studySummary.length > 0">
               <FcMenuDownloadReportFormat
                 :require-auth="true"
-                type="secondary"
+                type="tertiary"
                 text-screen-reader="Study Reports"
                 @download-report-format="actionDownloadReportFormatStudies" />
             </template>
@@ -73,7 +73,7 @@
             <FcButton
               type="secondary"
               color="primary"
-              class="ml-2"
+              class="ml-2 mt-1"
               @click="actionRequestStudy">
               Request&nbsp;
               <span class="sr-only">New Study</span>

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -33,7 +33,7 @@
               <span>View Report</span>
             </v-tooltip>
             <template v-slot:second v-if="collisionSummary.amount > 0">
-              <div class=" d-flex flex-column align-end mr-5 mb-4">
+              <div class=" d-flex flex-column align-end mr-1 mb-4">
                 <FcMenuDownloadReportFormat
                   :require-auth="true"
                   type="secondary"
@@ -60,12 +60,12 @@
           @show-reports="actionShowReportsStudy"
           />
 
-          <div class="fc-study-buttons d-flex justify-end align-end mr-5 mb-3 mt-1">
+          <div class="fc-study-buttons d-flex justify-end align-end mr-4 mb-3 mt-1">
 
             <FcButton
               type="secondary"
               color="primary"
-              class="mr-1 mt-1"
+              class="mr-2 mt-1"
               @click="actionRequestStudy">
               Request&nbsp;
               <span class="sr-only">New Study</span>

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -30,11 +30,8 @@
             <template v-slot:activator="{ on }">
               <FcButton
                 v-on="on"
-                v-if="reportExportMode !== ReportExportMode.COLLISIONS"
                 width="50px"
-                :disabled="
-                  collisionSummary.amount === 0
-                  || reportExportMode === ReportExportMode.STUDIES"
+                :disabled="collisionSummary.amount === 0"
                 type="secondary"
                 @click="actionShowReportsCollision">
                 <v-icon color="primary" x-large>mdi-chevron-right</v-icon>

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -60,7 +60,7 @@
           @show-reports="actionShowReportsStudy"
           />
 
-          <div class="fc-study-buttons d-flex justify-end align-end mr-4 mb-3 mt-1">
+          <div class="fc-study-buttons d-flex justify-end align-end mr-5 mb-3 mt-1">
 
             <FcButton
               type="secondary"

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -58,7 +58,7 @@
           @show-reports="actionShowReportsStudy"
           />
 
-          <div class="fc-study-buttons d-flex flex-column align-end mr-5">
+          <div class="fc-study-buttons d-flex justify-end align-center mr-5 mb-3 mt-1">
 
             <template v-if="studySummary.length > 0">
               <FcMenuDownloadReportFormat
@@ -71,7 +71,7 @@
             <FcButton
               type="secondary"
               color="primary"
-              class="mb-3 mt-1"
+              class="ml-2"
               @click="actionRequestStudy">
               Request&nbsp;
               <span class="sr-only">New Study</span>

--- a/web/components/geo/map/FcMapPopup.vue
+++ b/web/components/geo/map/FcMapPopup.vue
@@ -57,13 +57,14 @@ const SELECTABLE_LAYERS = [
   'midblocks',
 ];
 
+// some commented-out for being too frequent
 const VEHTYPE_ICONS = {
-  1: 'mdi-car', // Automobile
+  // 1: 'mdi-car', // Automobile
   2: 'mdi-motorbike', // Motorcycle
   3: 'mdi-moped', // Moped
-  4: 'mdi-van-utility', // Passenger Van
-  5: 'mdi-car-lifted-pickup', // Pick Up Truck
-  6: 'mdi-van-utility', // delivery van
+  // 4: 'mdi-van-utility', // Passenger Van
+  // 5: 'mdi-car-lifted-pickup', // Pick Up Truck
+  // 6: 'mdi-van-utility', // delivery van
   7: 'mdi-tow-truck', // tow truck
   8: 'mdi-truck', // open truck
   9: 'mdi-truck', // closed truck
@@ -82,9 +83,10 @@ const VEHTYPE_ICONS = {
   30: 'mdi-tram', // Street Car
   32: 'mdi-ambulance', // Ambulance
   33: 'mdi-fire-truck', //  Fire Vehicle
+  34: 'mdi-car-emergency', //  Police
   36: 'mdi-bicycle', // Bicycle
-  39: 'mdi-taxi', // Taxi
-  98: 'mdi-truck', // Truck (other)
+  // 39: 'mdi-taxi', // Taxi
+  // 98: 'mdi-truck', // Truck (other)
 };
 
 export default {
@@ -135,8 +137,6 @@ export default {
     icon() {
       if (this.layerId === 'collisionsLevel2' || this.layerId === 'collisionsLevel1') {
         const props = this.feature.properties || {};
-        console.log(props);//eslint-disable-line
-        console.log(props.vehtype);//eslint-disable-line
         if (props.pedestrian && props.older_adult) {
           return 'mdi-human-cane';
         }
@@ -151,9 +151,7 @@ export default {
         }
         if (props.vehtype) {
           const types = props.vehtype.split('|');
-          console.log(types);//eslint-disable-line
           for (let i = 0; i <= types.length; i += 1) {
-            console.log(types[i], VEHTYPE_ICONS[types[i]]);//eslint-disable-line
             if (types[i] && VEHTYPE_ICONS[types[i]]) {
               return VEHTYPE_ICONS[types[i]];
             }

--- a/web/components/geo/map/FcMapPopup.vue
+++ b/web/components/geo/map/FcMapPopup.vue
@@ -2,7 +2,10 @@
   <div class="d-none">
     <v-card ref="content" min-width="220">
       <v-card-title class="shading flex-column d-flex align-start">
-        <h2 class="display-1">{{title}}</h2>
+        <h2 class="display-1 fc-popup-title">
+          <span>{{title}}</span>
+          <v-icon v-if="icon !== null">{{ icon }}</v-icon>
+        </h2>
         <h4 v-if="this.feature.properties.studyRequests"
         class="display-2 body-2 text-subtitle-2
         mt-1">{{ this.feature.properties.description }}</h4>
@@ -54,6 +57,36 @@ const SELECTABLE_LAYERS = [
   'midblocks',
 ];
 
+const VEHTYPE_ICONS = {
+  1: 'mdi-car', // Automobile
+  2: 'mdi-motorbike', // Motorcycle
+  3: 'mdi-moped', // Moped
+  4: 'mdi-van-utility', // Passenger Van
+  5: 'mdi-car-lifted-pickup', // Pick Up Truck
+  6: 'mdi-van-utility', // delivery van
+  7: 'mdi-tow-truck', // tow truck
+  8: 'mdi-truck', // open truck
+  9: 'mdi-truck', // closed truck
+  10: 'mdi-tanker-truck', // tank truck
+  11: 'mdi-dump-truck', // dump truck
+  12: 'mdi-truck', // car-carrier
+  13: 'mdi-truck-flatbed', // truck-tractor
+  14: 'mdi-bus', // ttc bus
+  15: 'mdi-bus', // intercity bus
+  16: 'mdi-bus', // coach bus
+  17: 'mdi-bus', // school bus
+  18: 'mdi-van-utility', // school van
+  20: 'mdi-rv-truck', // motor home
+  26: 'mdi-tractor-variant', // farm tractor
+  29: 'mdi-train-car-hopper', // Railway Train
+  30: 'mdi-tram', // Street Car
+  32: 'mdi-ambulance', // Ambulance
+  33: 'mdi-fire-truck', //  Fire Vehicle
+  36: 'mdi-bicycle', // Bicycle
+  39: 'mdi-taxi', // Taxi
+  98: 'mdi-truck', // Truck (other)
+};
+
 export default {
   name: 'FcMapPopup',
   components: {
@@ -98,6 +131,36 @@ export default {
     },
     layerId() {
       return this.feature.layer.id;
+    },
+    icon() {
+      if (this.layerId === 'collisionsLevel2' || this.layerId === 'collisionsLevel1') {
+        const props = this.feature.properties || {};
+        console.log(props);//eslint-disable-line
+        console.log(props.vehtype);//eslint-disable-line
+        if (props.pedestrian && props.older_adult) {
+          return 'mdi-human-cane';
+        }
+        if (props.motorcyclist) {
+          return 'mdi-motorbike';
+        }
+        if (props.cyclist) {
+          return 'mdi-bicycle';
+        }
+        if (props.pedestrian) {
+          return 'mdi-walk';
+        }
+        if (props.vehtype) {
+          const types = props.vehtype.split('|');
+          console.log(types);//eslint-disable-line
+          for (let i = 0; i <= types.length; i += 1) {
+            console.log(types[i], VEHTYPE_ICONS[types[i]]);//eslint-disable-line
+            if (types[i] && VEHTYPE_ICONS[types[i]]) {
+              return VEHTYPE_ICONS[types[i]];
+            }
+          }
+        }
+      }
+      return null;
     },
     title() {
       if (this.layerId === 'collisionsLevel2' || this.layerId === 'collisionsLevel1') {
@@ -193,6 +256,13 @@ export default {
 <style lang="scss">
 .fc-map-popup {
   z-index: calc(var(--z-index-controls) - 1);
+  & .fc-popup-title {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    flex-flow: row nowrap;
+  }
   &.hovered {
     z-index: calc(var(--z-index-controls) - 2);
   }

--- a/web/components/inputs/FcMenuDownloadReportFormat.vue
+++ b/web/components/inputs/FcMenuDownloadReportFormat.vue
@@ -5,6 +5,7 @@
         v-bind="attrs"
         v-on="on"
         :disabled="disabled"
+        width="50px"
         title="Export Reports"
         :loading="loading"
         color="primary"
@@ -25,7 +26,7 @@
         @click="$emit('download-report-format', value)">
         <v-list-item-title>
           <v-icon color="primary">mdi-download</v-icon>
-          {{label}} files
+          Zipped {{label}} files
         </v-list-item-title>
       </v-list-item>
     </v-list>

--- a/web/components/inputs/FcMenuDownloadReportFormat.vue
+++ b/web/components/inputs/FcMenuDownloadReportFormat.vue
@@ -10,7 +10,7 @@
         :loading="loading"
         color="primary"
         :scope="requireAuth ? [] : null"
-        type="tertiary">
+        :type="type">
           <span  v-if="textScreenReader !== null" class="sr-only">
             {{textScreenReader}}
           </span>

--- a/web/components/inputs/FcMenuDownloadReportFormat.vue
+++ b/web/components/inputs/FcMenuDownloadReportFormat.vue
@@ -11,12 +11,11 @@
         :loading="loading"
         :scope="requireAuth ? [] : null"
         :type="type">
-          <v-icon left>mdi-cloud-download</v-icon>
-          <span class="fc-download-label">Export</span>
+        <span class="fc-download-label">Export</span>
           <span  v-if="textScreenReader !== null" class="sr-only">
             {{textScreenReader}}
           </span>
-          <v-icon right>mdi-menu-down</v-icon>
+          <v-icon right>mdi-share-all</v-icon>
       </FcButton>
     </template>
     <v-list>

--- a/web/components/inputs/FcMenuDownloadReportFormat.vue
+++ b/web/components/inputs/FcMenuDownloadReportFormat.vue
@@ -15,7 +15,7 @@
           <span  v-if="textScreenReader !== null" class="sr-only">
             {{textScreenReader}}
           </span>
-          <v-icon right>mdi-share-all</v-icon>
+          <v-icon right>mdi-arrow-top-right</v-icon>
       </FcButton>
     </template>
     <v-list>

--- a/web/components/inputs/FcMenuDownloadReportFormat.vue
+++ b/web/components/inputs/FcMenuDownloadReportFormat.vue
@@ -4,18 +4,17 @@
       <FcButton
         v-bind="attrs"
         v-on="on"
-        class="ml-2"
         :disabled="disabled"
         title="Export Reports"
-        color="primary"
         :loading="loading"
+        color="primary"
         :scope="requireAuth ? [] : null"
         :type="type">
-        <span class="fc-download-label">Export</span>
           <span  v-if="textScreenReader !== null" class="sr-only">
             {{textScreenReader}}
           </span>
-          <v-icon right>mdi-arrow-top-right</v-icon>
+          <v-icon>mdi-cloud-download</v-icon>
+          <v-icon right>mdi-menu-down</v-icon>
       </FcButton>
     </template>
     <v-list>

--- a/web/components/inputs/FcMenuDownloadReportFormat.vue
+++ b/web/components/inputs/FcMenuDownloadReportFormat.vue
@@ -6,21 +6,17 @@
         v-on="on"
         class="ml-2"
         :disabled="disabled"
-        title="Download Report"
+        title="Export Reports"
+        color="primary"
         :loading="loading"
         :scope="requireAuth ? [] : null"
         :type="type">
-        <v-icon
-          left
-          :color="type === 'secondary' ? 'primary' : 'white'">
-          mdi-cloud-download
-        </v-icon>
-        <span
-          v-if="textScreenReader !== null"
-          class="sr-only">
-          {{textScreenReader}}
-        </span>
-        <v-icon right>mdi-menu-down</v-icon>
+          <v-icon left>mdi-cloud-download</v-icon>
+          <span class="fc-download-label">Export</span>
+          <span  v-if="textScreenReader !== null" class="sr-only">
+            {{textScreenReader}}
+          </span>
+          <v-icon right>mdi-menu-down</v-icon>
       </FcButton>
     </template>
     <v-list>
@@ -90,3 +86,8 @@ export default {
   },
 };
 </script>
+<style lang="scss">
+.fc-download-label {
+  text-transform: none;
+}
+</style>

--- a/web/components/inputs/FcMenuDownloadReportFormat.vue
+++ b/web/components/inputs/FcMenuDownloadReportFormat.vue
@@ -9,7 +9,7 @@
         :loading="loading"
         color="primary"
         :scope="requireAuth ? [] : null"
-        :type="type">
+        type="tertiary">
           <span  v-if="textScreenReader !== null" class="sr-only">
             {{textScreenReader}}
           </span>
@@ -17,13 +17,15 @@
           <v-icon right>mdi-menu-down</v-icon>
       </FcButton>
     </template>
-    <v-list>
+    <v-list shaped>
+      <v-subheader>Export Formats:</v-subheader>
       <v-list-item
         v-for="{ label, value } in items"
         :key="value"
         @click="$emit('download-report-format', value)">
         <v-list-item-title>
-          {{label}}
+          <v-icon color="primary">mdi-download</v-icon>
+          {{label}} files
         </v-list-item-title>
       </v-list-item>
     </v-list>

--- a/web/components/inputs/FcMenuDownloadReportFormat.vue
+++ b/web/components/inputs/FcMenuDownloadReportFormat.vue
@@ -8,6 +8,7 @@
         width="50px"
         title="Export Reports"
         :loading="loading"
+        height="35px"
         color="primary"
         :scope="requireAuth ? [] : null"
         :type="type">

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -87,17 +87,16 @@
         :locations-selection="locationsSelection" />
 
       <div v-if="textLocationsSelectionIncludes !== null"
-        class="pr-2 secondary--text text-left mt-2">
-        {{textLocationsSelectionIncludes}}
+        class="pr-2 secondary--text text-left mt-1 d-flex justify-space-between align-center">
+        <div>{{textLocationsSelectionIncludes}}</div>
+        <FcButton
+          class="ml-3 edit-location-btn"
+          type="tertiary"
+          @click="setLocationMode(LocationMode.MULTI_EDIT)">
+          <v-icon color="primary" left>mdi-pencil</v-icon>
+          Edit
+        </FcButton>
       </div>
-
-      <FcButton
-        class="ml-3 edit-location-btn"
-        type="tertiary"
-        @click="setLocationMode(LocationMode.MULTI_EDIT)">
-        <v-icon color="primary" left>mdi-pencil</v-icon>
-        Edit Locations
-      </FcButton>
 
     </div>
     <div class="flex-grow-0 flex-shrink-0">

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     aria-label="Search for multiple locations in the map"
-    class="fc-selector-multi-location d-flex flex-column px-4 pt-3"
+    class="fc-selector-multi-location d-flex flex-column px-4 py-3"
     role="search">
     <FcDialogConfirmMultiLocationLeave
       v-model="showConfirmMultiLocationLeave" />
@@ -420,7 +420,7 @@ export default {
 <style lang="scss">
 .fc-selector-multi-location {
   position: relative;
-  border: 1px solid lightgrey;
+  border-bottom: 1px solid lightgrey;
 
   & .fc-input-location-search-wrapper {
     display: flex;

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -470,6 +470,6 @@ export default {
 }
 .edit-location-btn {
   text-transform: none !important;
-  margin-right: -5px;
+  margin-right: -8px;
 }
 </style>

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -20,7 +20,7 @@
                 v-if="i < 4"
               ></div>
             </div>
-            <div class="fc-input-location-search-wrapper" >
+            <div class="fc-input-location-search-wrapper align-center" >
               <FcInputLocationSearch
               v-model="locationsEditSelection.locations[i]"
               :location-index="i"
@@ -86,9 +86,8 @@
         :locations-index="locationsIndex"
         :locations-selection="locationsSelection" />
 
-      <div v-if="textLocationsSelectionIncludes !== null"
-        class="pr-2 secondary--text text-left mt-1 d-flex justify-space-between align-center">
-        <div>{{textLocationsSelectionIncludes}}</div>
+      <div class="pr-2 secondary--text text-left mt-1 d-flex justify-space-between align-center">
+        <div v-if="textLocationsSelectionIncludes !== null">{{textLocationsSelectionIncludes}}</div>
         <FcButton
           class="ml-3 edit-location-btn"
           type="tertiary"
@@ -145,9 +144,9 @@
             hide-details
             label="Include corridor between locations" />
 
-      <div class="d-flex mt-2 mr-2 justify-end">
+      <div class="d-flex mr-2 justify-end">
         <template v-if="locationMode === LocationMode.MULTI_EDIT">
-          <div class="mb-3">
+          <div class="mb-3 mt-2">
             <FcButton
               type="tertiary"
               @click="leaveLocationMode">
@@ -444,8 +443,8 @@ export default {
   }
   & .fc-close-top-right {
     position: absolute;
-    right: 8px;
-    top: 4px;
+    right: 10px;
+    top: 6px;
   }
   & .fc-multi-line {
     display: flex;

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -420,6 +420,7 @@ export default {
 <style lang="scss">
 .fc-selector-multi-location {
   position: relative;
+  border: 1px solid lightgrey;
 
   & .fc-input-location-search-wrapper {
     display: flex;

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -86,7 +86,7 @@
         :locations-index="locationsIndex"
         :locations-selection="locationsSelection" />
 
-      <div class="pr-2 secondary--text text-left mt-1 d-flex justify-space-between align-center">
+      <div class="secondary--text text-left mt-1 d-flex justify-space-between align-center">
         <div v-if="textLocationsSelectionIncludes !== null">{{textLocationsSelectionIncludes}}</div>
         <FcButton
           class="ml-3 edit-location-btn"
@@ -443,8 +443,8 @@ export default {
   }
   & .fc-close-top-right {
     position: absolute;
-    right: 10px;
-    top: 6px;
+    right: 12px;
+    top: 8px;
   }
   & .fc-multi-line {
     display: flex;
@@ -470,5 +470,6 @@ export default {
 }
 .edit-location-btn {
   text-transform: none !important;
+  margin-right: -5px;
 }
 </style>

--- a/web/components/nav/FcDashboardNav.vue
+++ b/web/components/nav/FcDashboardNav.vue
@@ -17,12 +17,12 @@
         'requestStudyEdit',
         'requestStudyNew',
       ]"
-      icon="clipboard-list"
+      icon="clipboard-list-outline"
       label="Track Requests"
       :to="{ name: 'requestsTrack' }" />
 
     <FcDashboardNavItem
-      icon="download"
+      icon="cloud-download"
       label="Manage Exports"
       :to="{ name: 'downloadsManage' }">
       <div class="fc-badge-wrapper">
@@ -43,12 +43,12 @@
 
     <FcDashboardNavItem
       external
-      icon="help-circle-outline"
+      icon="information-outline"
       label="MOVE Help Centre"
       href="https://notion.so/MOVE-Help-Centre-8a345a510b1a4119a1ddef5aa03e1bdc" />
 
     <FcDashboardNavItem
-      icon="bug"
+      icon="room-service-outline"
       label="Report an Issue"
       :href="urlReportIssue" />
   </v-list>

--- a/web/components/nav/FcDashboardNavUser.vue
+++ b/web/components/nav/FcDashboardNavUser.vue
@@ -54,7 +54,7 @@
           type="fab-icon"
           @click="$refs.login.actionSignIn()"
           v-on="on">
-          <v-icon>mdi-login</v-icon>
+          <v-icon>mdi-account-plus</v-icon>
         </FcButton>
       </template>
       <span>Sign In</span>


### PR DESCRIPTION
# Issue Addressed
This PR removes the **'Export Mode'** UI, and restyles the export button to be always-on. It also adds icons to some collision tooltips, and changes some of the left nav-bar icons.

# Description
* margin-tweaks for the sidebar
* show a top border in view-data scroll, only sometimes
* add shadow to view collision reports btn

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/399657/10286199-ccce-4600-ae48-ee6505a897ec)

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/399657/500c027c-1071-456b-a7cf-4f540c927378)
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/399657/7ca9960e-3f72-4f83-942a-72b13e365119)
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/399657/f39a9f05-9ad6-4c5b-9548-5e1b318d5326)
