### PR TITLE
MOVE-1189   After editing the location of a request, other study values switch to defaults

### DIFF
--- a/web/components/geo/map/EditStudyLocationPopUp.vue
+++ b/web/components/geo/map/EditStudyLocationPopUp.vue
@@ -8,8 +8,8 @@
       textOk="OK" title="Invalid location for Study Type" okButtonType="primary">
       <span class="body-1">
         We cannot conduct your study at this location.<br />
-        The Study Type will need to be saved as one that is
-        valid for this location before selecting this location.
+        Ensure that the Study Type selected for this location is valid before proceeding with the
+        selection.
       </span>
     </FcDialogAlert>
   </div>

--- a/web/components/geo/map/EditStudyLocationPopUp.vue
+++ b/web/components/geo/map/EditStudyLocationPopUp.vue
@@ -3,15 +3,15 @@
     <FcButton type="tertiary" @click="actionSelected">
       Set Location
     </FcButton>
-    <FcDialogConfirm
-      v-model="showIncompatableDialog" textCancel="Cancel"
-      textOk="Change Location" title="Invalid location for Study Type" okButtonType="primary"
-      @action-ok="actionForceStudyLocation">
+    <FcDialogAlert
+      v-model="showIncompatableDialog"
+      textOk="OK" title="Invalid location for Study Type" okButtonType="primary">
       <span class="body-1">
-        The location you have selected is not valid for this Study Type.<br />
-        Changing to this location will require the Study Request details to be manually updated.
+        We cannot conduct your study at this location.<br />
+        The Study Type will need to be saved as one that is
+        valid for this location before selecting this location.
       </span>
-    </FcDialogConfirm>
+    </FcDialogAlert>
   </div>
 
 </template>
@@ -19,7 +19,7 @@
 <script>
 import { mapActions, mapMutations, mapState } from 'vuex';
 import { getLocationByCentreline, getStudyRequest } from '@/lib/api/WebApi';
-import FcDialogConfirm from '@/web/components/dialogs/FcDialogConfirm.vue';
+import FcDialogAlert from '@/web/components/dialogs/FcDialogAlert.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import { getLocationStudyTypes } from '@/lib/geo/CentrelineUtils';
 
@@ -27,12 +27,11 @@ export default {
   name: 'EditStudyLocationPopUp',
   components: {
     FcButton,
-    FcDialogConfirm,
+    FcDialogAlert,
   },
   data() {
     return {
       showIncompatableDialog: false,
-      forcedLocation: null,
     };
   },
   props: {
@@ -54,9 +53,6 @@ export default {
       this.setToastInfo(`Set study location to ${description}.`);
       await this.setSelectedStudyRequestsLocation(location);
     },
-    async actionForceStudyLocation() {
-      await this.setSelectedStudyRequestsLocation(this.forcedLocation);
-    },
     async actionSelected() {
       const { centrelineId, centrelineType } = this.feature.properties;
       const feature = { centrelineId, centrelineType };
@@ -65,7 +61,6 @@ export default {
         await this.actionSetStudyLocation(location);
       } else {
         this.showIncompatableDialog = true;
-        this.forcedLocation = location;
       }
     },
     ...mapMutations(['setToastInfo']),

--- a/web/components/geo/map/EditStudyLocationPopUp.vue
+++ b/web/components/geo/map/EditStudyLocationPopUp.vue
@@ -1,14 +1,25 @@
 <template>
-  <FcButton
-    type="tertiary"
-    @click="actionSelected">
-    Set Location
-  </FcButton>
+  <div>
+    <FcButton type="tertiary" @click="actionSelected">
+      Set Location
+    </FcButton>
+    <FcDialogConfirm
+      v-model="showIncompatableDialog" textCancel="Cancel"
+      textOk="Change Location" title="Invalid location for Study Type" okButtonType="primary"
+      @action-ok="actionForceStudyLocation">
+      <span class="body-1">
+        The location you have selected is not valid for this Study Type.<br />
+        Changing to this location will require you to update the Study Type.
+      </span>
+    </FcDialogConfirm>
+  </div>
+
 </template>
 
 <script>
 import { mapActions, mapMutations, mapState } from 'vuex';
 import { getLocationByCentreline, getStudyRequest } from '@/lib/api/WebApi';
+import FcDialogConfirm from '@/web/components/dialogs/FcDialogConfirm.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import { getLocationStudyTypes } from '@/lib/geo/CentrelineUtils';
 
@@ -16,6 +27,13 @@ export default {
   name: 'EditStudyLocationPopUp',
   components: {
     FcButton,
+    FcDialogConfirm,
+  },
+  data() {
+    return {
+      showIncompatableDialog: false,
+      forcedLocation: null,
+    };
   },
   props: {
     feature: Object,
@@ -36,6 +54,9 @@ export default {
       this.setToastInfo(`Set study location to ${description}.`);
       await this.setSelectedStudyRequestsLocation(location);
     },
+    async actionForceStudyLocation() {
+      await this.setSelectedStudyRequestsLocation(this.forcedLocation);
+    },
     async actionSelected() {
       const { centrelineId, centrelineType } = this.feature.properties;
       const feature = { centrelineId, centrelineType };
@@ -45,6 +66,8 @@ export default {
       } else {
         // eslint-disable-next-line no-console
         console.log('Invalid');
+        this.showIncompatableDialog = true;
+        this.forcedLocation = location;
       }
     },
     ...mapMutations(['setToastInfo']),

--- a/web/components/geo/map/EditStudyLocationPopUp.vue
+++ b/web/components/geo/map/EditStudyLocationPopUp.vue
@@ -9,7 +9,7 @@
       @action-ok="actionForceStudyLocation">
       <span class="body-1">
         The location you have selected is not valid for this Study Type.<br />
-        Changing to this location will require you to update the Study Request details.
+        Changing to this location will require the Study Request details to be manually updated.
       </span>
     </FcDialogConfirm>
   </div>

--- a/web/components/geo/map/EditStudyLocationPopUp.vue
+++ b/web/components/geo/map/EditStudyLocationPopUp.vue
@@ -9,7 +9,7 @@
       @action-ok="actionForceStudyLocation">
       <span class="body-1">
         The location you have selected is not valid for this Study Type.<br />
-        Changing to this location will require you to update the Study Type.
+        Changing to this location will require you to update the Study Request details.
       </span>
     </FcDialogConfirm>
   </div>
@@ -64,8 +64,6 @@ export default {
       if (await this.isCompatibleLocationChange(location)) {
         await this.actionSetStudyLocation(location);
       } else {
-        // eslint-disable-next-line no-console
-        console.log('Invalid');
         this.showIncompatableDialog = true;
         this.forcedLocation = location;
       }


### PR DESCRIPTION
# Issue Addressed
"This PR closes [MOVE-1189](https://move-toronto.atlassian.net/browse/MOVE-1189) - After editing the location of a request, other study values switch to defaults

# Description
If the new location is 'compatible' with the current study request, all that will change is the location.
If not, a modal will appear informing the user of this:
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/5003768/4f72247d-bbe5-462a-9181-34836d485158)


# Tests
All tests are passing.
