### PR TITLE
MOVE-7: Staff need to see the filters applied to a collision directory report, so they can see the context

### DIFF
--- a/lib/controller/ReportController.js
+++ b/lib/controller/ReportController.js
@@ -163,7 +163,7 @@ ReportController.push({
           const duplexStream = new stream.PassThrough();
           archive.pipe(duplexStream);
           archive.append(reportStream, { name: key });
-          archive.append(prettyFilters.join('\n'), { name: 'filters.txt' });
+          archive.append(prettyFilters.join('\n'), { name: `${key.replace('.csv', '_f.txt')}` });
           archive.finalize();
           response = h.response(duplexStream).type(reportFormat.mimeType);
           response.header('Content-Disposition', `attachment; filename="${key.replace('.csv', '.zip')}"`);

--- a/lib/controller/ReportController.js
+++ b/lib/controller/ReportController.js
@@ -15,7 +15,7 @@ import StudyRequestFilters from '@/lib/model/StudyRequestFilters';
 import ReportFactory from '@/lib/reports/ReportFactory';
 import archiver from 'archiver';
 import stream from 'stream';
-import { generateCollisionFilters, formatFilters } from '@/lib/filters/PrettyCollisionFilters';
+import { generateCollisionFilters, formatFilters, generateFilterFile } from '@/lib/filters/PrettyCollisionFilters';
 
 /**
  * Reporting-related routes.  Note that routes in this controller are handled by `reporter`.
@@ -149,7 +149,7 @@ ReportController.push({
         ...reportOptions,
       };
 
-      const { key } = await StoragePath.forReport(report);
+      const { key, partReportType, partLocationsSelection } = await StoragePath.forReport(report);
 
       response.header('Content-Disposition', `attachment; filename="${key}"`);
 
@@ -161,9 +161,10 @@ ReportController.push({
           const prettyFilters = formatFilters(filters);
           const archive = archiver('zip');
           const duplexStream = new stream.PassThrough();
+          const filterFileContent = await generateFilterFile(prettyFilters, id);
           archive.pipe(duplexStream);
           archive.append(reportStream, { name: key });
-          archive.append(prettyFilters.join('\n'), { name: `${key.replace('.csv', '_f.txt')}` });
+          archive.append(filterFileContent.join('\n'), { name: `${partReportType}_${partLocationsSelection}_DATA_SUMMARY.txt` });
           archive.finalize();
           response = h.response(duplexStream).type(reportFormat.mimeType);
           response.header('Content-Disposition', `attachment; filename="${key.replace('.csv', '.zip')}"`);

--- a/lib/filters/PrettyCollisionFilters.js
+++ b/lib/filters/PrettyCollisionFilters.js
@@ -2,6 +2,8 @@ import DateTime from '@/lib/time/DateTime';
 import TimeFormatters from '@/lib/time/TimeFormatters';
 import CollisionFactorDAO from '@/lib/db/CollisionFactorDAO';
 import { getCollisionFilterChip } from '@/web/store/modules/viewData';
+import { parseCollisionReportId } from '@/lib/reports/ReportIdParser';
+import { getLocationsSelectionDescription } from '@/lib/geo/CentrelineUtils';
 
 function generateDateRange(filters) {
   const { dateRangeStart, dateRangeEnd } = filters;
@@ -141,10 +143,10 @@ function formatFilters(filters) {
   return formattedFilters;
 }
 
-async function generateFilterFile(filters, location) {
-  const freshFilters = await generateCollisionFilters(filters);
-  const formattedFilters = formatFilters(freshFilters);
-  return ['Collision Directory Report', location, '', 'The attached CSV file contains collision records that match the following criteria:', '', formattedFilters];
+async function generateFilterFile(filters, id) {
+  const { locationsSelection } = await parseCollisionReportId(id);
+  const locationDescription = getLocationsSelectionDescription(locationsSelection);
+  return ['Collision Directory Report', locationDescription, '', 'The attached CSV file contains collision records that match the following criteria:', '', ...filters];
 }
 
 export {

--- a/lib/filters/PrettyCollisionFilters.js
+++ b/lib/filters/PrettyCollisionFilters.js
@@ -141,8 +141,15 @@ function formatFilters(filters) {
   return formattedFilters;
 }
 
+async function generateFilterFile(filters, location) {
+  const freshFilters = await generateCollisionFilters(filters);
+  const formattedFilters = formatFilters(freshFilters);
+  return ['Collision Directory Report', location, '', 'The attached CSV file contains collision records that match the following criteria:', '', formattedFilters];
+}
+
 export {
   generateCollisionFilters,
   formatFilters,
   generateDateRange,
+  generateFilterFile,
 };

--- a/lib/io/storage/StoragePath.js
+++ b/lib/io/storage/StoragePath.js
@@ -261,7 +261,12 @@ class StoragePath {
     const partOptionsHash = StoragePath.getOptionsHash(options);
     const { extension } = format;
     const key = `${partReportType}_${partLocationsSelection}_${partId}${partOptionsHash}.${extension}`;
-    return { namespace: StoragePath.NAMESPACE_REPORTS_COLLISION, key };
+    return {
+      namespace: StoragePath.NAMESPACE_REPORTS_COLLISION,
+      partReportType,
+      partLocationsSelection,
+      key,
+    };
   }
 
   /**

--- a/lib/jobs/JobRunnerGenerateReports.js
+++ b/lib/jobs/JobRunnerGenerateReports.js
@@ -11,7 +11,7 @@ import JobRunnerBase from '@/lib/jobs/JobRunnerBase';
 import StoragePath from '@/lib/io/storage/StoragePath';
 import storageStrategy from '@/lib/io/storage/StorageStrategy';
 import { ReportType } from '@/lib/Constants';
-import { generateCollisionFilters, formatFilters } from '@/lib/filters/PrettyCollisionFilters';
+import { generateCollisionFilters, formatFilters, generateFilterFile } from '@/lib/filters/PrettyCollisionFilters';
 import { writableStreamFinish } from '@/lib/io/StreamUtils';
 
 const reporterClientOptions = {};
@@ -64,12 +64,19 @@ class JobRunnerGenerateReports extends JobRunnerBase {
   }
 
   async zipReports(data, storagePaths) {
+    const { s1, selectionType } = data;
     const {
       id, type, format, ...rest
     } = data.reports[0];
+
     let collisionFilters = [];
+    let filterFileContent = [];
     if (format.extension === 'csv' && type === ReportType.COLLISION_DIRECTORY) {
       collisionFilters = await generateCollisionFilters(rest);
+      if (collisionFilters.length > 1) {
+        const filters = formatFilters(collisionFilters);
+        filterFileContent = await generateFilterFile(filters, `${s1}/${selectionType.name}`);
+      }
     }
     const { namespace, key } = await StoragePath.forReportZip(data, storagePaths);
     const reportZipExists = await storageStrategy.has(namespace, key);
@@ -92,8 +99,7 @@ class JobRunnerGenerateReports extends JobRunnerBase {
         archive.append(valueStreamReport, { name: keyReport });
       });
       if (format.extension === 'csv' && collisionFilters.length > 1 && type === ReportType.COLLISION_DIRECTORY) {
-        const filters = formatFilters(collisionFilters);
-        archive.append(filters.join('\n'), { name: 'filters.txt' });
+        archive.append(filterFileContent.join('\n'), { name: 'COLLISION_DATA_SUMMARY.txt' });
       }
       archive.finalize();
 

--- a/lib/reports/format/MovePdfGenerator.js
+++ b/lib/reports/format/MovePdfGenerator.js
@@ -653,7 +653,10 @@ class MovePdfGenerator {
           pageBreak: 'after',
           text: '',
         },
-        { text: 'Collision Filters:', bold: true, fontSize: 15 },
+        {
+          text: 'Collision Filters', bold: true, fontSize: 15, margin: [0, 0, 0, 2],
+        },
+        { text: 'This report contains collision events that match the following filters.', margin: [0, 0, 0, 3] },
         {
           ul: this.filters,
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "module-alias": "^2.2.3",
         "mustache": "^4.2.0",
         "openid-client": "^4.9.1",
-        "pdfmake": "^0.2.7",
+        "pdfmake": "^0.2.10",
         "pg-boss": "^6.2.2",
         "pg-promise": "^10.15.4",
         "underscore": "^1.13.6",
@@ -5272,14 +5272,12 @@
       }
     },
     "node_modules/@foliojs-fork/fontkit": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@foliojs-fork/fontkit/-/fontkit-1.9.1.tgz",
-      "integrity": "sha512-U589voc2/ROnvx1CyH9aNzOQWJp127JGU1QAylXGQ7LoEAF6hMmahZLQ4eqAcgHUw+uyW4PjtCItq9qudPkK3A==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@foliojs-fork/fontkit/-/fontkit-1.9.2.tgz",
+      "integrity": "sha512-IfB5EiIb+GZk+77TRB86AHroVaqfq8JRFlUbz0WEwsInyCG0epX2tCPOy+UfaWPju30DeVoUAXfzWXmhn753KA==",
       "dependencies": {
         "@foliojs-fork/restructure": "^2.0.2",
-        "brfs": "^2.0.0",
         "brotli": "^1.2.0",
-        "browserify-optional": "^1.0.1",
         "clone": "^1.0.4",
         "deep-equal": "^1.0.0",
         "dfa": "^1.2.0",
@@ -5289,23 +5287,22 @@
       }
     },
     "node_modules/@foliojs-fork/linebreak": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@foliojs-fork/linebreak/-/linebreak-1.1.1.tgz",
-      "integrity": "sha512-pgY/+53GqGQI+mvDiyprvPWgkTlVBS8cxqee03ejm6gKAQNsR1tCYCIvN9FHy7otZajzMqCgPOgC4cHdt4JPig==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@foliojs-fork/linebreak/-/linebreak-1.1.2.tgz",
+      "integrity": "sha512-ZPohpxxbuKNE0l/5iBJnOAfUaMACwvUIKCvqtWGKIMv1lPYoNjYXRfhi9FeeV9McBkBLxsMFWTVVhHJA8cyzvg==",
       "dependencies": {
         "base64-js": "1.3.1",
-        "brfs": "^2.0.2",
         "unicode-trie": "^2.0.0"
       }
     },
     "node_modules/@foliojs-fork/pdfkit": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@foliojs-fork/pdfkit/-/pdfkit-0.13.0.tgz",
-      "integrity": "sha512-YXeG1fml9k97YNC9K8e292Pj2JzGt9uOIiBFuQFxHsdQ45BlxW+JU3RQK6JAvXU7kjhjP8rCcYvpk36JLD33sQ==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@foliojs-fork/pdfkit/-/pdfkit-0.14.0.tgz",
+      "integrity": "sha512-nMOiQAv6id89MT3tVTCgc7HxD5ZMANwio2o5yvs5sexQkC0KI3BLaLakpsrHmFfeGFAhqPmZATZGbJGXTUebpg==",
       "dependencies": {
         "@foliojs-fork/fontkit": "^1.9.1",
         "@foliojs-fork/linebreak": "^1.1.1",
-        "crypto-js": "^4.0.0",
+        "crypto-js": "^4.2.0",
         "png-js": "^1.0.0"
       }
     },
@@ -10770,27 +10767,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/acorn-node": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
-      "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
-      "dependencies": {
-        "acorn": "^7.0.0",
-        "acorn-walk": "^7.0.0",
-        "xtend": "^4.0.2"
-      }
-    },
-    "node_modules/acorn-node/node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/acorn-walk": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.1.1.tgz",
@@ -10884,15 +10860,6 @@
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha512-0FcBfdcmaumGPQ0qPn7Q5qTgz/ooXgIyp1rf8ik5bGX8mpE2YHjC0P/eyQvxu1GURYQgq9ozf2mteQ5ZD9YiyQ==",
       "dev": true
-    },
-    "node_modules/amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.4.2"
-      }
     },
     "node_modules/ansi-align": {
       "version": "3.0.1",
@@ -11445,11 +11412,6 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "dev": true
-    },
-    "node_modules/array-from": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-      "integrity": "sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg=="
     },
     "node_modules/array-includes": {
       "version": "3.1.6",
@@ -12657,76 +12619,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ast-transform": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/ast-transform/-/ast-transform-0.0.0.tgz",
-      "integrity": "sha512-e/JfLiSoakfmL4wmTGPjv0HpTICVmxwXgYOB8x+mzozHL8v+dSfCbrJ8J8hJ0YBP0XcYu1aLZ6b/3TnxNK3P2A==",
-      "dependencies": {
-        "escodegen": "~1.2.0",
-        "esprima": "~1.0.4",
-        "through": "~2.3.4"
-      }
-    },
-    "node_modules/ast-transform/node_modules/escodegen": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.2.0.tgz",
-      "integrity": "sha512-yLy3Cc+zAC0WSmoT2fig3J87TpQ8UaZGx8ahCAs9FL8qNbyV7CVyPKS74DG4bsHiL5ew9sxdYx131OkBQMFnvA==",
-      "dependencies": {
-        "esprima": "~1.0.4",
-        "estraverse": "~1.5.0",
-        "esutils": "~1.0.0"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.1.30"
-      }
-    },
-    "node_modules/ast-transform/node_modules/esprima": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-      "integrity": "sha512-rp5dMKN8zEs9dfi9g0X1ClLmV//WRyk/R15mppFNICIFRG5P92VP7Z04p8pk++gABo9W2tY+kHyu6P1mEHgmTA==",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/ast-transform/node_modules/estraverse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
-      "integrity": "sha512-FpCjJDfmo3vsc/1zKSeqR5k42tcIhxFIlvq+h9j0fO2q/h2uLKyweq7rYJ+0CoVvrGQOxIS5wyBrW/+vF58BUQ==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/ast-transform/node_modules/esutils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
-      "integrity": "sha512-x/iYH53X3quDwfHRz4y8rn4XcEwwCJeWsul9pF1zldMbGtgOtMNBEOuYWwB1EQlK2LRa1fev3YAgym/RElp5Cg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ast-transform/node_modules/source-map": {
-      "version": "0.1.43",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-      "integrity": "sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==",
-      "optional": true,
-      "dependencies": {
-        "amdefine": ">=0.0.4"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/ast-types": {
@@ -14138,20 +14030,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/brfs": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brfs/-/brfs-2.0.2.tgz",
-      "integrity": "sha512-IrFjVtwu4eTJZyu8w/V2gxU7iLTtcHih67sgEdzrhjLBMHp2uYefUBfdM4k2UvcuWMgV7PQDZHSLeNWnLFKWVQ==",
-      "dependencies": {
-        "quote-stream": "^1.0.1",
-        "resolve": "^1.1.5",
-        "static-module": "^3.0.2",
-        "through2": "^2.0.0"
-      },
-      "bin": {
-        "brfs": "bin/cmd.js"
-      }
-    },
     "node_modules/brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -14170,19 +14048,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
-    },
-    "node_modules/browser-resolve": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
-      "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
-      "dependencies": {
-        "resolve": "1.1.7"
-      }
-    },
-    "node_modules/browser-resolve/node_modules/resolve": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
     },
     "node_modules/browserify-aes": {
       "version": "1.2.0",
@@ -14219,24 +14084,6 @@
         "des.js": "^1.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
-      }
-    },
-    "node_modules/browserify-optional": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-optional/-/browserify-optional-1.0.1.tgz",
-      "integrity": "sha512-VrhjbZ+Ba5mDiSYEuPelekQMfTbhcA2DhLk2VQWqdcCROWeFqlTcXZ7yfRkXCIl8E+g4gINJYJiRB7WEtfomAQ==",
-      "dependencies": {
-        "ast-transform": "0.0.0",
-        "ast-types": "^0.7.0",
-        "browser-resolve": "^1.8.1"
-      }
-    },
-    "node_modules/browserify-optional/node_modules/ast-types": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
-      "integrity": "sha512-RIOpVnVlltB6PcBJ5BMLx+H+6JJ/zjDGU0t7f0L6c2M1dqcK92VQopLBlPQ9R80AVXelfqYgjcPLtHtDbNFg0Q==",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/browserify-rsa": {
@@ -14403,7 +14250,8 @@
     "node_modules/buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "node_modules/buffer-indexof": {
       "version": "1.1.1",
@@ -15993,6 +15841,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
       "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.1"
       }
@@ -16376,9 +16225,9 @@
       }
     },
     "node_modules/crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
@@ -16897,15 +16746,6 @@
       "integrity": "sha512-NJGVKPS81XejHcLhaLJS7plab0fK3slPh11mESeeDq2W4ZI5kUKK/LRRdVDvjJseojbPB7ZwjnyOybg3Igea/A==",
       "dev": true
     },
-    "node_modules/d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "dependencies": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
-    },
     "node_modules/d3-array": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
@@ -16969,11 +16809,6 @@
       "dependencies": {
         "d3-time": "1 - 2"
       }
-    },
-    "node_modules/dash-ast": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-2.0.1.tgz",
-      "integrity": "sha512-5TXltWJGc+RdnabUGzhRae1TRq6m4gr+3K2wQX0is5/F2yS6MJXJvLyI3ErAnsAXuJoGqvfVD5icRgim07DrxQ=="
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
@@ -18722,14 +18557,6 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
     },
-    "node_modules/duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-      "dependencies": {
-        "readable-stream": "^2.0.2"
-      }
-    },
     "node_modules/duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -19108,73 +18935,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "node_modules/es6-map": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-      "integrity": "sha512-mz3UqCh0uPCIqsw1SSAkB/p0rOzF/M0V++vyN7JqlPtSW/VsYgQBvVvqMLmfBuyMzTpLnNqi6JmcSizs4jy19A==",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
-        "es6-set": "~0.1.5",
-        "es6-symbol": "~3.1.1",
-        "event-emitter": "~0.3.5"
-      }
-    },
-    "node_modules/es6-set": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.6.tgz",
-      "integrity": "sha512-TE3LgGLDIBX332jq3ypv6bcOpkLO0AslAQo7p2VqX/1N46YNsvIWgvjojjSEnWEGWMhr1qUbYeTSir5J6mFHOw==",
-      "dependencies": {
-        "d": "^1.0.1",
-        "es5-ext": "^0.10.62",
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "^3.1.3",
-        "event-emitter": "^0.3.5",
-        "type": "^2.7.2"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "node_modules/es6-set/node_modules/type": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
-    },
-    "node_modules/es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "dependencies": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
       }
     },
     "node_modules/escalade": {
@@ -20409,14 +20169,10 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/estree-is-function": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/estree-is-function/-/estree-is-function-1.0.0.tgz",
-      "integrity": "sha512-nSCWn1jkSq2QAtkaVLJZY2ezwcFO161HVc174zL1KPW3RJ+O6C3eJb8Nx7OXzvhoEv+nLgSR1g71oWUHUDTrJA=="
     },
     "node_modules/estree-walker": {
       "version": "2.0.2",
@@ -20439,15 +20195,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
       }
     },
     "node_modules/event-pubsub": {
@@ -20724,14 +20471,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/ext": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
-      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-      "dependencies": {
-        "type": "^2.7.2"
-      }
-    },
     "node_modules/ext-list": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
@@ -20756,11 +20495,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/ext/node_modules/type": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -22104,11 +21838,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
       "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
-    },
-    "node_modules/get-assigned-identifiers": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
-      "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ=="
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -24589,6 +24318,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
       "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+      "dev": true,
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -29529,14 +29259,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/magic-string": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.1.tgz",
-      "integrity": "sha512-sCuTz6pYom8Rlt4ISPFn6wuFodbKMIHUMv4Qko9P17dpxb7s52KJTmRuZZqHdGmLCK9AOcDare039nRIcfdkEg==",
-      "dependencies": {
-        "sourcemap-codec": "^1.4.1"
-      }
-    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -31974,11 +31696,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
-    "node_modules/next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-    },
     "node_modules/nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -33341,6 +33058,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
       "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -35174,7 +34892,8 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "node_modules/path-root": {
       "version": "0.1.1",
@@ -35244,12 +34963,12 @@
       }
     },
     "node_modules/pdfmake": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.2.7.tgz",
-      "integrity": "sha512-ClLpgx30H5G3EDvRW1MrA1Xih6YxEaSgIVFrOyBMgAAt62V+hxsyWAi6JNP7u1Fc5JKYAbpb4RRVw8Rhvmz5cQ==",
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.2.10.tgz",
+      "integrity": "sha512-doipFnmE1UHSk+Z3wfQuVweVQqx2pE/Ns2G5gCqZmWwqjDj+mZHnZYH/ryXWoIfD+iVdZUAutgI/VHkTCN+Xrw==",
       "dependencies": {
         "@foliojs-fork/linebreak": "^1.1.1",
-        "@foliojs-fork/pdfkit": "^0.13.0",
+        "@foliojs-fork/pdfkit": "^0.14.0",
         "iconv-lite": "^0.6.3",
         "xmldoc": "^1.1.2"
       },
@@ -38219,27 +37938,6 @@
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
     },
-    "node_modules/quote-stream": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
-      "integrity": "sha512-kKr2uQ2AokadPjvTyKJQad9xELbZwYzWlNfI3Uz2j/ib5u6H9lDP7fUUR//rMycd0gv4Z5P1qXMfXR8YpIxrjQ==",
-      "dependencies": {
-        "buffer-equal": "0.0.1",
-        "minimist": "^1.1.3",
-        "through2": "^2.0.0"
-      },
-      "bin": {
-        "quote-stream": "bin/cmd.js"
-      }
-    },
-    "node_modules/quote-stream/node_modules/buffer-equal": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-      "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -39786,6 +39484,7 @@
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
       "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dev": true,
       "dependencies": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
@@ -40262,20 +39961,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/scope-analyzer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/scope-analyzer/-/scope-analyzer-2.1.2.tgz",
-      "integrity": "sha512-5cfCmsTYV/wPaRIItNxatw02ua/MThdIUNnUOCYp+3LSEJvnG804ANw2VLaavNILIfWXF1D1G2KNANkBBvInwQ==",
-      "dependencies": {
-        "array-from": "^2.1.1",
-        "dash-ast": "^2.0.1",
-        "es6-map": "^0.1.5",
-        "es6-set": "^0.1.5",
-        "es6-symbol": "^3.1.1",
-        "estree-is-function": "^1.0.0",
-        "get-assigned-identifiers": "^1.1.0"
-      }
-    },
     "node_modules/seek-bzip": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
@@ -40578,11 +40263,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/shallow-copy": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
-      "integrity": "sha512-b6i4ZpVuUxB9h5gfCxPiusKYkqTMOjEbBs4wMaFbkfia4yFv92UKZ6Df8WXcKbn08JNL/abvg3FnMAOfakDvUw=="
     },
     "node_modules/shebang-command": {
       "version": "1.2.0",
@@ -41225,12 +40905,6 @@
       "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
       "dev": true
     },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "deprecated": "Please use @jridgewell/sourcemap-codec instead"
-    },
     "node_modules/space-separated-tokens": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
@@ -41439,44 +41113,6 @@
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "dev": true
     },
-    "node_modules/static-eval": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.1.0.tgz",
-      "integrity": "sha512-agtxZ/kWSsCkI5E4QifRwsaPs0P0JmZV6dkLz6ILYfFYQGn+5plctanRN+IC8dJRiFkyXHrwEE3W9Wmx67uDbw==",
-      "dependencies": {
-        "escodegen": "^1.11.1"
-      }
-    },
-    "node_modules/static-eval/node_modules/escodegen": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/static-eval/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -41498,87 +41134,6 @@
       "dependencies": {
         "is-descriptor": "^0.1.0"
       },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/static-module": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/static-module/-/static-module-3.0.4.tgz",
-      "integrity": "sha512-gb0v0rrgpBkifXCa3yZXxqVmXDVE+ETXj6YlC/jt5VzOnGXR2C15+++eXuMDUYsePnbhf+lwW0pE1UXyOLtGCw==",
-      "dependencies": {
-        "acorn-node": "^1.3.0",
-        "concat-stream": "~1.6.0",
-        "convert-source-map": "^1.5.1",
-        "duplexer2": "~0.1.4",
-        "escodegen": "^1.11.1",
-        "has": "^1.0.1",
-        "magic-string": "0.25.1",
-        "merge-source-map": "1.0.4",
-        "object-inspect": "^1.6.0",
-        "readable-stream": "~2.3.3",
-        "scope-analyzer": "^2.0.1",
-        "shallow-copy": "~0.0.1",
-        "static-eval": "^2.0.5",
-        "through2": "~2.0.3"
-      }
-    },
-    "node_modules/static-module/node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "engines": [
-        "node >= 0.8"
-      ],
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
-    "node_modules/static-module/node_modules/escodegen": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/static-module/node_modules/merge-source-map": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
-      "integrity": "sha512-PGSmS0kfnTnMJCzJ16BLLCEe6oeYCamKFFdQKshi4BmM6FUwipjVOcBFGxqtQtirtAG4iZvHlqST9CpZKqlRjA==",
-      "dependencies": {
-        "source-map": "^0.5.6"
-      }
-    },
-    "node_modules/static-module/node_modules/merge-source-map/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/static-module/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -43858,12 +43413,14 @@
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "node_modules/through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
       "dependencies": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
@@ -44216,11 +43773,6 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
-    "node_modules/type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
-    },
     "node_modules/type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -44320,7 +43872,8 @@
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
@@ -48574,8 +48127,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.dropunuseddefinitions/-/utils.dropunuseddefinitions-1.1.0.tgz",
       "integrity": "sha512-jU1XjMr6ec9pPoL+BFWzEPW7VHHulVdGKMkPAMiCigpVIT11VmCbnij0bWob8uS3ODJ65tZLYKAh/55vLw2rbg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@apollo/utils.keyvaluecache": {
       "version": "1.0.1",
@@ -48605,15 +48157,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.printwithreducedwhitespace/-/utils.printwithreducedwhitespace-1.1.0.tgz",
       "integrity": "sha512-GfFSkAv3n1toDZ4V6u2d7L4xMwLA+lv+6hqXicMN9KELSJ9yy9RzuEXaX73c/Ry+GzRsBy/fdSUGayGqdHfT2Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@apollo/utils.removealiases": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.removealiases/-/utils.removealiases-1.0.0.tgz",
       "integrity": "sha512-6cM8sEOJW2LaGjL/0vHV0GtRaSekrPQR4DiywaApQlL9EdROASZU5PsQibe2MWeZCOhNrPRuHh4wDMwPsWTn8A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@apollo/utils.sortast": {
       "version": "1.1.0",
@@ -48628,8 +48178,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.stripsensitiveliterals/-/utils.stripsensitiveliterals-1.2.0.tgz",
       "integrity": "sha512-E41rDUzkz/cdikM5147d8nfCFVKovXxKBcjvLEQ7bjZm/cg9zEcXvS6vFY8ugTubI3fn6zoqo0CyU8zT+BGP9w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@apollo/utils.usagereporting": {
       "version": "1.0.0",
@@ -48649,8 +48198,7 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.5.4.tgz",
       "integrity": "sha512-shM3q7rUbNyXVVRkQJQseXv6bnYM3BUma/eZhwXR4xsuM+bqWnJKvW7SAfRjP7LuSCocrexa5AXhjjawNHrIlw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@apollographql/graphql-playground-html": {
       "version": "1.6.29",
@@ -52188,8 +51736,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.6.1.tgz",
       "integrity": "sha512-ubEkAaTfVZa+WwGhs5jbo5Xfqpeaybr/RvWzvFxRs4jfq16wH8l8Ty/QEEpINxll4xhuGfdMbipRyz5QZh9+FA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@csstools/css-tokenizer": {
       "version": "2.2.4",
@@ -52201,15 +51748,13 @@
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.9.tgz",
       "integrity": "sha512-qqGuFfbn4rUmyOB0u8CVISIp5FfJ5GAR3mBrZ9/TKndHakdnm6pY0L/fbLcpPnrzwCyyTEZl1nUcXAYHEWneTA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@csstools/selector-specificity": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.3.tgz",
       "integrity": "sha512-KEPNw4+WW5AVEIyzC80rTbWEUatTW2lXpN8+8ILC8PiPeWPjwUzrPZDIOZ2wwqDmeqOYTdSGyL3+vE5GC3FB3Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -53649,8 +53194,7 @@
     "@mapbox/mapbox-gl-supported": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
-      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
-      "requires": {}
+      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg=="
     },
     "@mapbox/node-pre-gyp": {
       "version": "1.0.10",
@@ -55630,8 +55174,7 @@
       "version": "4.5.19",
       "resolved": "https://registry.npmjs.org/@vue/cli-plugin-vuex/-/cli-plugin-vuex-4.5.19.tgz",
       "integrity": "sha512-DUmfdkG3pCdkP7Iznd87RfE9Qm42mgp2hcrNcYQYSru1W1gX2dG/JcW8bxmeGSa06lsxi9LEIc/QD1yPajSCZw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@vue/cli-service": {
       "version": "4.5.19",
@@ -56469,8 +56012,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@vue/preload-webpack-plugin/-/preload-webpack-plugin-1.1.2.tgz",
       "integrity": "sha512-LIZMuJk38pk9U9Ur4YzHjlIyMuxPlACdBIHH9/nGYVTsaGKOSnSuELiE8vS9wa+dJpIYspYUOqk+L1Q4pgHQHQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@vue/reactivity-transform": {
       "version": "3.3.4",
@@ -56784,8 +56326,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.1.1",
@@ -56842,15 +56383,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -57022,8 +56561,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-3.3.1.tgz",
       "integrity": "sha512-xnZJ5QWs6FixHICXHxUfm+ZWqqxrNuPlQ+kj5m6RtEgIpekOPssH/SD9gf2B4HuWV0QozorrygwZnux8POvyPA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "apollo-server-express": {
       "version": "3.10.2",
@@ -58488,8 +58026,7 @@
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
       "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "babel-eslint": {
       "version": "10.1.0",
@@ -63551,8 +63088,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz",
       "integrity": "sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.4",
@@ -65760,8 +65296,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.2.tgz",
       "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "grid-index": {
       "version": "1.1.0",
@@ -69142,8 +68677,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -70051,8 +69585,7 @@
         "ws": {
           "version": "8.2.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.0.tgz",
-          "integrity": "sha512-uYhVJ/m9oXwEI04iIVmgLmugh2qrZihkywG9y5FfZV2ATeLIzHf93qs+tUNqlttbQK957/VX3mtwAS+UfIwA4g==",
-          "requires": {}
+          "integrity": "sha512-uYhVJ/m9oXwEI04iIVmgLmugh2qrZihkywG9y5FfZV2ATeLIzHf93qs+tUNqlttbQK957/VX3mtwAS+UfIwA4g=="
         }
       }
     },
@@ -75294,8 +74827,7 @@
     "pg-pool": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.4.1.tgz",
-      "integrity": "sha512-TVHxR/gf3MeJRvchgNHxsYsTCHQ+4wm3VIHSS19z8NC0+gioEhq1okDY1sm/TYbfoP6JLFx01s0ShvZ3puP/iQ==",
-      "requires": {}
+      "integrity": "sha512-TVHxR/gf3MeJRvchgNHxsYsTCHQ+4wm3VIHSS19z8NC0+gioEhq1okDY1sm/TYbfoP6JLFx01s0ShvZ3puP/iQ=="
     },
     "pg-promise": {
       "version": "10.15.4",
@@ -75325,8 +74857,7 @@
         "pg-pool": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.0.tgz",
-          "integrity": "sha512-clFRf2ksqd+F497kWFyM21tMjeikn60oGDmqMT8UBrynEwVEX/5R5xd2sdvdo1cZCFlguORNpVuqxIj+aK4cfQ==",
-          "requires": {}
+          "integrity": "sha512-clFRf2ksqd+F497kWFyM21tMjeikn60oGDmqMT8UBrynEwVEX/5R5xd2sdvdo1cZCFlguORNpVuqxIj+aK4cfQ=="
         }
       }
     },
@@ -76007,8 +75538,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
           "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "source-map-js": {
           "version": "1.2.0",
@@ -76980,15 +76510,13 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
       "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-scss": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
       "integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-selector-parser": {
       "version": "6.0.4",
@@ -80909,15 +80437,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-html/-/stylelint-config-html-1.1.0.tgz",
       "integrity": "sha512-IZv4IVESjKLumUGi+HWeb7skgO6/g4VMuAYrJdlqQFndgbj6WJAXPhaysvBiXefX79upBdQVumgYcdd17gCpjQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "stylelint-config-recommended": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.0.tgz",
       "integrity": "sha512-jSkx290CglS8StmrLp2TxAppIajzIBZKYm3IxT89Kg6fGlxbPiTiyH9PS5YUuVAFwaJLl1ikiXX0QWjI0jmgZQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "stylelint-config-recommended-scss": {
       "version": "14.0.0",
@@ -80963,8 +80489,7 @@
           "version": "14.0.0",
           "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.0.tgz",
           "integrity": "sha512-jSkx290CglS8StmrLp2TxAppIajzIBZKYm3IxT89Kg6fGlxbPiTiyH9PS5YUuVAFwaJLl1ikiXX0QWjI0jmgZQ==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "yallist": {
           "version": "4.0.0",
@@ -80987,8 +80512,7 @@
           "version": "12.0.0",
           "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-12.0.0.tgz",
           "integrity": "sha512-x6x8QNARrGO2sG6iURkzqL+Dp+4bJorPMMRNPScdvaUK8PsynriOcMW7AFDKqkWAS5wbue/u8fUT/4ynzcmqdQ==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -81007,8 +80531,7 @@
           "version": "14.0.0",
           "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.0.tgz",
           "integrity": "sha512-jSkx290CglS8StmrLp2TxAppIajzIBZKYm3IxT89Kg6fGlxbPiTiyH9PS5YUuVAFwaJLl1ikiXX0QWjI0jmgZQ==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "stylelint-config-standard": {
           "version": "36.0.0",
@@ -81919,6 +81442,7 @@
       "version": "3.4.10",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",
       "integrity": "sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==",
+      "devOptional": true,
       "requires": {
         "commander": "~2.19.0",
         "source-map": "~0.6.1"
@@ -81927,12 +81451,14 @@
         "commander": {
           "version": "2.19.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+          "devOptional": true
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "devOptional": true
         }
       }
     },
@@ -83645,8 +83171,7 @@
     "vuetify": {
       "version": "2.6.15",
       "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.6.15.tgz",
-      "integrity": "sha512-2a6sBSHzivXgi9pZMyHuzTgMyInCkj/BrVwTnoCa1Y/Dnfwj7lkWzgKQDScbGVK0q4vJ+YHoBBrLOmnhz1R0YA==",
-      "requires": {}
+      "integrity": "sha512-2a6sBSHzivXgi9pZMyHuzTgMyInCkj/BrVwTnoCa1Y/Dnfwj7lkWzgKQDScbGVK0q4vJ+YHoBBrLOmnhz1R0YA=="
     },
     "vuetify-loader": {
       "version": "1.9.2",
@@ -83716,8 +83241,7 @@
     "vuex": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.2.tgz",
-      "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==",
-      "requires": {}
+      "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw=="
     },
     "w3c-hr-time": {
       "version": "1.0.2",
@@ -84588,8 +84112,7 @@
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
       "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/tests/jest/unit/io/storage/StoragePath.spec.js
+++ b/tests/jest/unit/io/storage/StoragePath.spec.js
@@ -59,6 +59,8 @@ test('StoragePath.forReport [collision]', async () => {
   await expect(StoragePath.forReport(report)).resolves.toEqual({
     namespace: StoragePath.NAMESPACE_REPORTS_COLLISION,
     key: 'COLLISION_DIRECTORY_ST_CLAIR_AVE_W_HOUNSLOW_HEATH_RD_SILVERTHORN_AVE_PLUS_1_LOCATION_s1_AkttmBoXtmB_POINTS_204c1293.pdf',
+    partLocationsSelection: 'ST_CLAIR_AVE_W_HOUNSLOW_HEATH_RD_SILVERTHORN_AVE_PLUS_1_LOCATION',
+    partReportType: 'COLLISION_DIRECTORY',
   });
 });
 

--- a/web/components/reports/FcReportMetadata.vue
+++ b/web/components/reports/FcReportMetadata.vue
@@ -22,14 +22,15 @@
 
     <div v-if="numFilters > 0 && this.type.label.startsWith('Collision')" class="px-0">
       <v-row class="align-center mx-0 px-1">
-        <h3 class="flex-1">{{ numFilters }} Filter{{ this.numFilters > 1 ? 's' : '' }}</h3>
-        <FcButton @click="isExpanded = !isExpanded" type="icon" class="flex-1">
+        <h3 class="flex-1 pr-1">{{ numFilters }}
+          Active Filter{{ this.numFilters > 1 ? 's' : '' }}</h3>
+        <FcButton @click="isExpanded = !isExpanded" type="icon" class="flex-1" small>
           <v-icon v-if="isExpanded">mdi-menu-up</v-icon>
           <v-icon v-else>mdi-menu-down</v-icon>
         </FcButton>
       </v-row>
       <v-expand-transition>
-        <ul v-show="isExpanded" class="pt-1">
+        <ul v-show="isExpanded" class="pt-3">
           <li v-for="(item, i) in collisionFilters" :key="i">
             <b>{{ item.filter }}: </b> {{ item.label }}
           </li>


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-7.

# Description
Implemented feedback on the subtasks of MOVE-7.

The filters section on the web report has been renamed to "# Active Filters". The dropdown button has been shrunk and padding has been introduced to prevent overlap between the filters list and the dropdown button.

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/64811136/9ae69f06-ef88-4390-9002-0a7fdeb7432b)

Filters section on the PDF report now has more spacing between elements, and a line describing the data.

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/64811136/87b081e3-d3da-4599-a55a-729720fbf2e3)

The text file containing filters now follows the naming scheme of the collision directory report CSV files, with 'DATA_SUMMARY' appended. The file contains more information describing the data it is packaged with.

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/64811136/71670767-fde5-41f4-bcb3-17619b37470f)

# Tests
Tested in MOVE local v1.12.0 using Firefox, by downloading both CSV and PDF reports, with and without filters.
