### PR TITLE
MOVE-7: Copy changes

### DIFF
--- a/lib/filters/PrettyCollisionFilters.js
+++ b/lib/filters/PrettyCollisionFilters.js
@@ -146,7 +146,7 @@ function formatFilters(filters) {
 async function generateFilterFile(filters, id) {
   const { locationsSelection } = await parseCollisionReportId(id);
   const locationDescription = getLocationsSelectionDescription(locationsSelection);
-  return ['Collision Directory Report', locationDescription, '', 'The attached CSV file contains collision records that match the following criteria:', '', ...filters];
+  return ['Collision Directory Report', locationDescription, '', 'The attached CSV file contains collision events that match the following criteria:', '', ...filters];
 }
 
 export {

--- a/lib/reports/format/MovePdfGenerator.js
+++ b/lib/reports/format/MovePdfGenerator.js
@@ -656,7 +656,7 @@ class MovePdfGenerator {
         {
           text: 'Collision Filters', bold: true, fontSize: 15, margin: [0, 0, 0, 2],
         },
-        { text: 'This report contains collision events that match the following filters.', margin: [0, 0, 0, 3] },
+        { text: 'This report contains collision events that match the following criteria.', margin: [0, 0, 0, 3] },
         {
           ul: this.filters,
         },


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-7

# Description
Some copy changes in the filters section of the PDF and CSV exports of collision directory reports.

# Tests
Tested in MOVE local v1.12 in Firefox, by downloading various CSV and PDF exports of collision directory reports.
