### PR TITLE
MOVE-63-v2

### DIFF
--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -1,17 +1,5 @@
 <template>
   <div class="fc-drawer-view-collision-reports d-flex flex-column">
-    <FcDialogConfirm
-      v-model="showConfirmLeave"
-      textCancel="Stay on this page"
-      textOk="Leave"
-      title="Leave Reports?"
-      okButtonType="primary"
-      @action-ok="actionLeave">
-      <span class="body-1">
-        Leaving this page will cause you to switch to another location.<br/>
-        Are you sure you want to leave?
-      </span>
-    </FcDialogConfirm>
     <div class="fc-report-loading" v-if="loading">
       <div class="align-center d-flex flex-grow-0 flex-shrink-0 px-3 py-2">
         <v-icon @click="actionNavigateBack" large>mdi-chevron-left</v-icon>
@@ -188,7 +176,6 @@ import {
 import { defaultCollisionFilters, defaultCommonFilters } from '@/lib/filters/DefaultFilters';
 import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
 import CompositeId from '@/lib/io/CompositeId';
-import FcDialogConfirm from '@/web/components/dialogs/FcDialogConfirm.vue';
 import FcProgressCircular from '@/web/components/dialogs/FcProgressCircular.vue';
 import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
@@ -205,7 +192,6 @@ export default {
   components: {
     FcButton,
     FcCallout,
-    FcDialogConfirm,
     FcListLocationDropdown,
     FcMenuDownloadReportFormat,
     FcProgressCircular,
@@ -230,7 +216,6 @@ export default {
         ReportType.COLLISION_DIRECTORY,
         ReportType.COLLISION_TABULATION,
       ],
-      showConfirmLeave: false,
       collapseReport: false,
     };
   },
@@ -338,8 +323,8 @@ export default {
       }
     }
     this.nextRoute = to;
-    this.showConfirmLeave = true;
-    next(false);
+    this.leaveConfirmed = true;
+    this.$router.push(this.nextRoute);
   },
   methods: {
     changeLocation(num) {

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -52,7 +52,12 @@
                 v-on="on"
                 class="flex-grow-0 mt-0 ml-2"
                 type="secondary">
-                <v-icon class="fc-icon-dim" size="20">mdi-map-marker</v-icon>
+                <span class="pr-1">
+                  <img v-if="locationActive.centrelineType == 1" title="Midblock"
+                  src="/icons/map/location-multi-midblock.svg" alt="Midblock icon" width="14"/>
+                  <img v-else title="Intersection"
+                  src="/icons/map/location-multi-intersection.svg" alt="Midblock icon" width="14"/>
+                </span>
                 <span class="pl-2 fc-collision-btn-location">{{locationActive.description}}</span>
                 <v-icon right>mdi-menu-down</v-icon>
               </FcButton>

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -119,6 +119,7 @@
               :disabled="reportRetrievalError"
               :loading="loadingDownload"
               :report-type="activeReportType"
+              :singleFile="true"
               text-screen-reader="Collision Report"
               type="tertiary"
               @download-report-format="actionDownload" />

--- a/web/components/FcDrawerViewCollisionReports.vue
+++ b/web/components/FcDrawerViewCollisionReports.vue
@@ -106,9 +106,9 @@
           <template v-if="!loadingReportLayout && !reportRetrievalError">
             <div v-if="isDirectoryReport && userLoggedIn
               && userHasMvcrReadPermission && mvcrIds.length > 0">
-              <FcButton
+              <FcButton small
                 @click="downloadAllMvcrs"
-                class="ml-2"
+                class="mx-2"
                 :type="'secondary'">
                   <span>Export {{ mvcrIds.length }} MVCR</span>
               </FcButton>
@@ -120,7 +120,7 @@
               :loading="loadingDownload"
               :report-type="activeReportType"
               text-screen-reader="Collision Report"
-              type="secondary"
+              type="tertiary"
               @download-report-format="actionDownload" />
           </div>
         </div>

--- a/web/components/FcDrawerViewData.vue
+++ b/web/components/FcDrawerViewData.vue
@@ -23,7 +23,7 @@
             </div>
           </div>
 
-          <FcGlobalFilters class="px-5 py-3" header-tag="h3"
+          <FcGlobalFilters class="pl-5 pr-3 py-1" header-tag="h3"
             :class="{'fc-filter-section-border':locationMode === LocationMode.SINGLE}"/>
 
           <v-divider></v-divider>

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -147,8 +147,9 @@
               :disabled="reportBodyEmpty || studyRetrievalError"
               :loading="loadingDownload"
               :report-type="activeReportType"
+              :singleFile="true"
               text-screen-reader="Study Report"
-              type="secondary"
+              type="tertiary"
               @download-report-format="actionDownload" />
           </div>
         </div>

--- a/web/components/FcDrawerViewStudyReports.vue
+++ b/web/components/FcDrawerViewStudyReports.vue
@@ -1,17 +1,5 @@
 <template>
   <div class="fc-drawer-view-study-reports d-flex flex-column">
-    <FcDialogConfirm
-      v-model="showConfirmLeave"
-      textCancel="Stay on this page"
-      textOk="Leave"
-      title="Leave Reports?"
-      okButtonType="primary"
-      @action-ok="actionLeave">
-      <span class="body-1">
-        Leaving this page will cause you to switch to another location.<br/>
-        Are you sure you want to leave?
-      </span>
-    </FcDialogConfirm>
     <div class="fc-report-loading" v-if="loading">
       <div class="align-center d-flex flex-grow-0 flex-shrink-0 px-3 py-2">
         <v-icon @click="actionNavigateBack" large>mdi-chevron-left</v-icon>
@@ -222,7 +210,6 @@ import {
 import { getLocationsIconProps } from '@/lib/geo/CentrelineUtils';
 import CompositeId from '@/lib/io/CompositeId';
 import TimeFormatters from '@/lib/time/TimeFormatters';
-import FcDialogConfirm from '@/web/components/dialogs/FcDialogConfirm.vue';
 import FcProgressCircular from '@/web/components/dialogs/FcProgressCircular.vue';
 import FcProgressLinear from '@/web/components/dialogs/FcProgressLinear.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
@@ -239,7 +226,6 @@ export default {
   components: {
     FcButton,
     FcCallout,
-    FcDialogConfirm,
     FcListLocationDropdown,
     FcMenuDownloadReportFormat,
     FcProgressCircular,
@@ -268,7 +254,6 @@ export default {
       reportBodyEmpty: false,
       reportLayout: null,
       reportUserParameters,
-      showConfirmLeave: false,
       showReportParameters: false,
       studies: [],
       studyRetrievalError: false,
@@ -431,8 +416,8 @@ export default {
       }
     }
     this.nextRoute = to;
-    this.showConfirmLeave = true;
-    next(false);
+    this.leaveConfirmed = true;
+    this.$router.push(this.nextRoute);
   },
   methods: {
     async actionDownload(format) {

--- a/web/components/data/FcAggregateCollisions.vue
+++ b/web/components/data/FcAggregateCollisions.vue
@@ -46,7 +46,7 @@
         </div>
       </dl>
 
-      <div class="fc-collision-detail-box ml-1 mr-4 body-1 mb-2">
+      <div class="fc-collision-detail-box ml-2 mr-4 body-1 mb-4">
         <div class="d-flex fc-collision-detail-title ml-2 justify-space-apart">
           <FcButton
             type="tertiary"

--- a/web/components/data/FcAggregateCollisions.vue
+++ b/web/components/data/FcAggregateCollisions.vue
@@ -46,11 +46,13 @@
         </div>
       </dl>
 
-      <div class="fc-collision-detail-box ml-1 mr-4 body-1">
+      <div class="fc-collision-detail-box ml-1 mr-4 body-1 mb-2">
         <div class="d-flex fc-collision-detail-title ml-2 justify-space-apart">
           <FcButton
             type="tertiary"
             class="fc-details-btn"
+            width="85px"
+            height="30px"
             @click="showDetails= !showDetails">
               <v-icon v-if="showDetails">mdi mdi-chevron-up</v-icon>
               <v-icon v-else>mdi mdi-chevron-down</v-icon>

--- a/web/components/data/FcAggregateStudies.vue
+++ b/web/components/data/FcAggregateStudies.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fc-aggregate-studies mb-5 ml-5">
+  <div class="fc-aggregate-studies mb-5 ml-5 mr-3">
     <FcProgressLinear
       v-if="loading"
       aria-label="Loading Aggregate View studies data" />
@@ -53,8 +53,9 @@
                           v-on="on"
                           v-if="itemsPerLocation[i][j].n !== 0"
                           class="pa-0"
-                          max-width="50px"
-                          min-width="50px"
+                          width="40px"
+                          max-width="40px"
+                          min-width="40px"
                           type="tertiary"
                           :disabled="itemsPerLocation[i][j].n === 0"
                           @click="$emit('show-reports', { item, locationsIndex: j })">

--- a/web/components/data/FcDetailCollisions.vue
+++ b/web/components/data/FcDetailCollisions.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fc-detail-collisions  mb-5">
+  <div class="fc-detail-collisions mb-4">
     <FcProgressLinear
       v-if="loading"
       aria-label="Loading Detail View collisions data" />
@@ -101,6 +101,7 @@ export default {
 }
 .fc-collision-detail-row {
   border-radius: 5px;
+  align-content: center;
 }
 
 @media only screen and (max-width: 600px) {

--- a/web/components/data/FcHeaderCollisions.vue
+++ b/web/components/data/FcHeaderCollisions.vue
@@ -1,5 +1,5 @@
 <template>
-  <header class="pa-3 pl-5">
+  <header class="pa-3 pl-5 pb-1">
     <div class="align-center d-flex flex-wrap justify-end">
       <h3 class="headline">
         <span>Collisions</span>

--- a/web/components/data/FcHeaderCollisions.vue
+++ b/web/components/data/FcHeaderCollisions.vue
@@ -1,5 +1,5 @@
 <template>
-  <header class="pa-3 pl-5 pb-1">
+  <header class="px-5 pt-3">
     <div class="align-center d-flex flex-wrap justify-end">
       <h3 class="headline">
         <span>Collisions</span>

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -48,7 +48,15 @@
       <v-divider></v-divider>
 
       <section>
-        <FcHeaderStudies :study-total="studyTotal" />
+        <FcHeaderStudies :study-total="studyTotal" >
+          <template v-if="studySummary.length > 0" v-slot:action>
+              <FcMenuDownloadReportFormat
+                :require-auth="true"
+                type="tertiary"
+                text-screen-reader="Study Reports"
+                @download-report-format="actionDownloadReportFormatStudies" />
+            </template>
+        </FcHeaderStudies>
         <FcAggregateStudies
           :study-summary="studySummary"
           :study-summary-unfiltered="studySummaryUnfiltered"
@@ -71,14 +79,6 @@
               <span class="sr-only">New Study</span>
               <v-icon >mdi-briefcase-plus</v-icon>
             </FcButton>
-
-            <template v-if="studySummary.length > 0">
-              <FcMenuDownloadReportFormat
-                :require-auth="true"
-                type="secondary"
-                text-screen-reader="Study Reports"
-                @download-report-format="actionDownloadReportFormatStudies" />
-            </template>
 
           </div>
       </section>

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -7,7 +7,7 @@
       <section class="d-flex flex-column">
         <FcHeaderCollisions :collision-total="collisionTotal">
           <template v-slot:action v-if="collisionSummary.amount > 0">
-            <div class="d-flex flex-column align-end mr-1 mb-2">
+            <div class="d-flex flex-column align-end mb-2">
               <FcMenuDownloadReportFormat
                 :require-auth="true"
                 type="tertiary"

--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -5,7 +5,17 @@
       aria-label="Loading Aggregate View for View Data" />
     <template v-else>
       <section class="d-flex flex-column">
-        <FcHeaderCollisions :collision-total="collisionTotal"/>
+        <FcHeaderCollisions :collision-total="collisionTotal">
+          <template v-slot:action v-if="collisionSummary.amount > 0">
+            <div class="d-flex flex-column align-end mr-1 mb-2">
+              <FcMenuDownloadReportFormat
+                :require-auth="true"
+                type="tertiary"
+                text-screen-reader="Collision Reports"
+                @download-report-format="actionDownloadReportFormatCollisions" />
+              </div>
+          </template>
+        </FcHeaderCollisions>
 
         <FcAggregateCollisions
           :collision-summary="collisionSummary"
@@ -32,15 +42,6 @@
               </template>
               <span>View Report</span>
             </v-tooltip>
-            <template v-slot:second v-if="collisionSummary.amount > 0">
-              <div class="d-flex flex-column align-end mr-1 mb-2">
-                <FcMenuDownloadReportFormat
-                  :require-auth="true"
-                  type="secondary"
-                  text-screen-reader="Collision Reports"
-                  @download-report-format="actionDownloadReportFormatCollisions" />
-                </div>
-            </template>
         </FcAggregateCollisions>
 
       </section>

--- a/web/components/filters/FcGlobalFilters.vue
+++ b/web/components/filters/FcGlobalFilters.vue
@@ -14,6 +14,8 @@
         <template v-slot:activator="{ on, attrs }">
           <FcButton
             v-if="!readonly"
+            width="40px"
+            min-width="40px"
             type="tertiary" v-bind="attrs" v-on="on"
             @click="setFiltersOpen(true)">
             <v-icon>mdi-plus</v-icon>

--- a/web/components/geo/map/FcMap.vue
+++ b/web/components/geo/map/FcMap.vue
@@ -9,8 +9,11 @@
         silent />
     </div>
 
-    <div class="fc-map-controls fc-map-top-left fc-half-width">
+    <div class="fc-map-controls fc-half-width">
       <slot name="top-left" />
+    </div>
+    <div class="fc-map-controls top-left-two">
+      <slot name="top-left-two" />
     </div>
 
     <div class="fc-map-controls fc-map-mode">
@@ -741,6 +744,9 @@ export default {
   }
   & > .fc-half-width {
     width: 50%;
+  }
+  & .top-left-two {
+    margin-top: 50px;
   }
 
   /*

--- a/web/components/inputs/FcMenuDownloadReportFormat.vue
+++ b/web/components/inputs/FcMenuDownloadReportFormat.vue
@@ -5,7 +5,9 @@
         v-bind="attrs"
         v-on="on"
         :disabled="disabled"
-        width="50px"
+        width="55px"
+        max-width="55px"
+        min-width="55px"
         title="Export Reports"
         :loading="loading"
         height="25px"
@@ -91,7 +93,7 @@ export default {
 </script>
 <style lang="scss">
 .fc-download-button {
-  opacity: 0.9;
+  opacity: 0.8;
   margin-top: 5px;
 }
 </style>

--- a/web/components/inputs/FcMenuDownloadReportFormat.vue
+++ b/web/components/inputs/FcMenuDownloadReportFormat.vue
@@ -30,7 +30,8 @@
         @click="$emit('download-report-format', value)">
         <v-list-item-title>
           <v-icon color="primary">mdi-download</v-icon>
-          Zipped {{label}} files
+          <span v-if="singleFile === true"> {{label}}</span>
+          <span v-else>Zipped {{label}} files</span>
         </v-list-item-title>
       </v-list-item>
     </v-list>
@@ -76,6 +77,10 @@ export default {
       type: String,
       default: 'primary',
     },
+    singleFile: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
     items() {
@@ -93,7 +98,7 @@ export default {
 </script>
 <style lang="scss">
 .fc-download-button {
-  opacity: 0.8;
+  opacity: 0.7;
   margin-top: 5px;
 }
 </style>

--- a/web/components/inputs/FcMenuDownloadReportFormat.vue
+++ b/web/components/inputs/FcMenuDownloadReportFormat.vue
@@ -8,8 +8,9 @@
         width="50px"
         title="Export Reports"
         :loading="loading"
-        height="35px"
+        height="25px"
         color="primary"
+        class="fc-download-button"
         :scope="requireAuth ? [] : null"
         :type="type">
           <span  v-if="textScreenReader !== null" class="sr-only">
@@ -89,7 +90,8 @@ export default {
 };
 </script>
 <style lang="scss">
-.fc-download-label {
-  text-transform: none;
+.fc-download-button {
+  opacity: 0.9;
+  margin-top: 5px;
 }
 </style>

--- a/web/components/inputs/FcSelectorMultiLocation.vue
+++ b/web/components/inputs/FcSelectorMultiLocation.vue
@@ -87,7 +87,11 @@
         :locations-selection="locationsSelection" />
 
       <div class="secondary--text text-left mt-1 d-flex justify-space-between align-center">
-        <div v-if="textLocationsSelectionIncludes !== null">{{textLocationsSelectionIncludes}}</div>
+        <div>
+          <span v-if="textLocationsSelectionIncludes !== null">
+            {{textLocationsSelectionIncludes}}
+          </span>
+        </div>
         <FcButton
           class="ml-3 edit-location-btn"
           type="tertiary"

--- a/web/components/nav/FcAppbar.vue
+++ b/web/components/nav/FcAppbar.vue
@@ -7,35 +7,17 @@
     dense>
     <FcDashboardNavBrand />
     <h1 class="headline ml-2 no-select">{{textH1}}</h1>
-    <v-chip
-      class="ml-2"
-      :color="frontendEnv.colorClass + ' darken-4'"
-      dark
-      small>
+    <v-spacer></v-spacer>
+    <v-chip class="ml-2" small>
       {{frontendEnv.name.toLowerCase()}} v{{frontendMeta.version}}
     </v-chip>
 
-    <v-spacer></v-spacer>
-
-    <FcButton
-      v-if="frontendEnv !== FrontendEnv.PROD"
-      type="secondary"
-      @click="actionProd">
-      <v-icon
-        :aria-hidden="false"
-        aria-label="Opens in a new window"
-        left>
-        mdi-open-in-new
-      </v-icon>
-      Open in release version
-    </FcButton>
   </v-app-bar>
 </template>
 
 <script>
 import { mapState } from 'vuex';
 
-import FcButton from '@/web/components/inputs/FcButton.vue';
 import FcDashboardNavBrand from '@/web/components/nav/FcDashboardNavBrand.vue';
 import FrontendEnv from '@/web/config/FrontendEnv';
 import FrontendMeta from '@/web/config/FrontendMeta';
@@ -43,7 +25,6 @@ import FrontendMeta from '@/web/config/FrontendMeta';
 export default {
   name: 'FcAppbar',
   components: {
-    FcButton,
     FcDashboardNavBrand,
   },
   data() {

--- a/web/components/nav/FcDashboardNav.vue
+++ b/web/components/nav/FcDashboardNav.vue
@@ -22,7 +22,7 @@
       :to="{ name: 'requestsTrack' }" />
 
     <FcDashboardNavItem
-      icon="cloud-download"
+      icon="cloud-download-outline"
       label="Manage Exports"
       :to="{ name: 'downloadsManage' }">
       <div class="fc-badge-wrapper">

--- a/web/components/reports/FcReport.vue
+++ b/web/components/reports/FcReport.vue
@@ -14,6 +14,7 @@
             :key="'content_' + i + '_' + j">
             <component
               :is="'FcReport' + blockType.suffix"
+              :type="type"
               v-bind="options"
               class="pt-4" />
           </v-col>

--- a/web/components/reports/FcReportTable.vue
+++ b/web/components/reports/FcReportTable.vue
@@ -89,7 +89,11 @@ import MvcrLink from './cells/MvcrLink.vue';
 
 const USE_STICKY_HEADER = {
   COLLISION_DIRECTORY: true,
+  COUNT_SUMMARY_TURNING_MOVEMENT: true,
   COUNT_SUMMARY_TURNING_MOVEMENT_DETAILED: true,
+  SPEED_PERCENTILE: true,
+  COUNT_SUMMARY_24H: true,
+  COUNT_SUMMARY_24H_DETAILED: true,
 };
 
 function getClassListForStyle(style) {

--- a/web/components/reports/FcReportTable.vue
+++ b/web/components/reports/FcReportTable.vue
@@ -25,7 +25,7 @@
           :key="'col_' + c"
           v-bind="attrs" />
       </colgroup>
-      <thead class="fc-report-table-header" v-if="header.length > 0">
+      <thead v-if="header.length > 0" :class="{'fc-table-sticky-header': useStickyHeader}">
         <tr
           v-for="(row, r) in headerNormalized"
           :key="'row_header_' + r">
@@ -86,6 +86,11 @@ import MvcrNotFoundAlert from '@/web/components/dialogs/MvcrNotFoundAlert.vue';
 import FcMixinAuthScope from '@/web/mixins/FcMixinAuthScope';
 import { AuthScope } from '@/lib/Constants';
 import MvcrLink from './cells/MvcrLink.vue';
+
+const USE_STICKY_HEADER = {
+  COLLISION_DIRECTORY: true,
+  COUNT_SUMMARY_TURNING_MOVEMENT_DETAILED: true,
+};
 
 function getClassListForStyle(style) {
   const {
@@ -246,6 +251,10 @@ export default {
       type: Array,
       default() { return []; },
     },
+    type: {
+      type: Object,
+      default() { return {}; },
+    },
     body: Array,
     footer: {
       type: Array,
@@ -280,6 +289,9 @@ export default {
     userHasMvcrReadPermission() {
       return this.hasAuthScope(AuthScope.MVCR_READ);
     },
+    useStickyHeader() {
+      return USE_STICKY_HEADER[this.type.name] === true;
+    },
   },
   mounted() {
     const routeParams = this.$route.params;
@@ -313,11 +325,11 @@ export default {
       background-color: var(--base-lighter);
     }
   }
-  & .fc-report-table-header {
-    position: sticky;
-    top: 0;
+  & .fc-table-sticky-header {
     background-color: #ACACAC !important;
+    position: sticky;
     z-index: 2;
+    top: 0;
   }
 }
 </style>

--- a/web/views/FcLayoutViewData.vue
+++ b/web/views/FcLayoutViewData.vue
@@ -19,17 +19,15 @@
           :layers.sync="internalLayers"
           :location-active="locationActive"
           :locations-state="locationsState">
-          <template
-            v-if="!drawerOpen"
-            v-slot:top-left>
+          <template v-if="!drawerOpen" v-slot:top-left>
             <FcSelectorCollapsedLocation
               v-if="!showLocationSelection"
               class="mt-3 ml-5" />
             <FcSelectorSingleLocation
-              v-else
-              v-model="internalLocationsSelection"
+              v-else v-model="internalLocationsSelection"
               class="mt-3 ml-5" />
-
+          </template>
+          <template v-if="!drawerOpen" v-slot:top-left-two>
             <FcGlobalFilterBox
               class="mt-3 ml-5"
               :readonly="filtersReadonly" />


### PR DESCRIPTION
# Issue Addressed
This PR addresses issues for: 
* [MOVE-63](https://move-toronto.atlassian.net/browse/MOVE-63) - sticky headers
* [MOVE-1177](https://move-toronto.atlassian.net/browse/MOVE-1177) - consistent map pins
* [MOVE-1173](https://move-toronto.atlassian.net/browse/MOVE-1173) - map peek ability
* [MOVE-1234](https://move-toronto.atlassian.net/browse/MOVE-1234) - Invisible box kills tooltips

# Description
Fixes to issues, hopefully making us ready for v1.13:
* **sticky-headers** now whitelisted to certain studies only
* remove **[Open in release version]** button
* * lighten + move version chip to right-side
* replace final grey **map pins** w/ svg ones
* final design-pass at **export button**
* * support single-file property for dropdown copy
* margin+padding tweaks for view-data sidebar
* remove confirm dialog for closing studies

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/399657/6282f1d7-0aed-4603-8e8e-6c94a9697114)

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/399657/2661211c-8ef9-42c8-909d-72c13412d4cc)

