### PR TITLE
MOVE-1189 - After editing the location of a request, other study values switch to defaults

### DIFF
--- a/web/components/dialogs/FcDialogAlertIncompatibleStudy.vue
+++ b/web/components/dialogs/FcDialogAlertIncompatibleStudy.vue
@@ -1,0 +1,47 @@
+<template>
+  <v-dialog v-model="internalValue" max-width="560" z-index="301">
+    <v-card aria-labelledby="heading_dialog_alert" role="dialog">
+      <v-card-title class="shading">
+        <h2 class="display-1" id="heading_dialog_alert">{{ title }}</h2>
+      </v-card-title>
+
+      <v-divider></v-divider>
+
+      <v-card-text class="pt-4">
+        <slot></slot>
+      </v-card-text>
+
+      <v-divider></v-divider>
+
+      <v-card-actions class="shading">
+        <v-spacer></v-spacer>
+        <FcButton type="primary" @click="internalValue = false">
+          {{ textOk }}
+        </FcButton>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import FcButton from '@/web/components/inputs/FcButton.vue';
+import FcMixinVModelProxy from '@/web/mixins/FcMixinVModelProxy';
+
+export default {
+  name: 'FcDialogAlertIncompatibleStudy',
+  mixins: [FcMixinVModelProxy(Boolean)],
+  components: {
+    FcButton,
+  },
+  props: {
+    textOk: {
+      type: String,
+      default: 'OK',
+    },
+    title: {
+      type: String,
+      default: 'Alert',
+    },
+  },
+};
+</script>

--- a/web/components/geo/map/EditStudyLocationPopUp.vue
+++ b/web/components/geo/map/EditStudyLocationPopUp.vue
@@ -50,7 +50,7 @@ export default {
       const { studyType } = studyRequest;
       this.currentStudyTypeString = studyType.label;
       const validStudiesArray = await getLocationStudyTypes(location);
-      return validStudiesArray.includes(studyType);
+      return validStudiesArray.includes(studyType) || studyType.other;
     },
     async actionSetStudyLocation(location) {
       const { description } = location;

--- a/web/components/geo/map/EditStudyLocationPopUp.vue
+++ b/web/components/geo/map/EditStudyLocationPopUp.vue
@@ -5,11 +5,13 @@
     </FcButton>
     <FcDialogAlert
       v-model="showIncompatableDialog"
-      textOk="OK" title="Invalid location for Study Type" okButtonType="primary">
+      textOk="OK" title="Cannot change location" okButtonType="primary">
       <span class="body-1">
-        We cannot conduct your study at this location.<br />
-        Ensure that the Study Type selected for this location is valid before proceeding with the
-        selection.
+        We cannot conduct a {{this.currentStudyTypeString}} at this location.
+        To learn more about studies and the limitations of where they can be
+        conducted, email Data Collection at TrafficData@toronto.ca. <br />
+        Alternatively, cancel this request and submit a new one. This will
+        not affect the turnaround time of your request.
       </span>
     </FcDialogAlert>
   </div>
@@ -32,6 +34,7 @@ export default {
   data() {
     return {
       showIncompatableDialog: false,
+      currentStudyTypeString: null,
     };
   },
   props: {
@@ -45,6 +48,7 @@ export default {
       const requestId = this.$route.params.id;
       const { studyRequest } = await getStudyRequest(requestId);
       const { studyType } = studyRequest;
+      this.currentStudyTypeString = studyType.label;
       const validStudiesArray = await getLocationStudyTypes(location);
       return validStudiesArray.includes(studyType);
     },

--- a/web/components/geo/map/EditStudyLocationPopUp.vue
+++ b/web/components/geo/map/EditStudyLocationPopUp.vue
@@ -3,7 +3,7 @@
     <FcButton type="tertiary" @click="actionSelected">
       Set Location
     </FcButton>
-    <FcDialogAlert
+    <FcDialogAlertIncompatibleStudy
       v-model="showIncompatableDialog"
       textOk="OK" title="Cannot change location" okButtonType="primary">
       <span class="body-1">
@@ -13,7 +13,7 @@
         Alternatively, cancel this request and submit a new one. This will
         not affect the turnaround time of your request.
       </span>
-    </FcDialogAlert>
+    </FcDialogAlertIncompatibleStudy>
   </div>
 
 </template>
@@ -21,7 +21,7 @@
 <script>
 import { mapActions, mapMutations, mapState } from 'vuex';
 import { getLocationByCentreline, getStudyRequest } from '@/lib/api/WebApi';
-import FcDialogAlert from '@/web/components/dialogs/FcDialogAlert.vue';
+import FcDialogAlertIncompatibleStudy from '@/web/components/dialogs/FcDialogAlertIncompatibleStudy.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import { getLocationStudyTypes } from '@/lib/geo/CentrelineUtils';
 
@@ -29,7 +29,7 @@ export default {
   name: 'EditStudyLocationPopUp',
   components: {
     FcButton,
-    FcDialogAlert,
+    FcDialogAlertIncompatibleStudy,
   },
   data() {
     return {


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-1189](https://move-toronto.atlassian.net/browse/MOVE-1189)

# Description
Changes:
- Updates to copy as requested by Maddy
- Allow users to change the location if the StudyType is `Other`
- Made a custom dialog alert based on `FcDialogAlert`, but with a primary OK button, and a higher z-index so that it doesn't auto dismiss.

# Tests
All tests are passing.
