### PR TITLE
correctly filtering out reports that have zero collisions

### DIFF
--- a/web/components/data/FcViewDataAggregate.vue
+++ b/web/components/data/FcViewDataAggregate.vue
@@ -222,16 +222,16 @@ export default {
         JSON.stringify(this.locationsSelection),
       );
 
-      const indexesToIgnore = await getCollisionsByCentrelineSummaryPerLocation(
+      const collisionMetaDataForLocations = await getCollisionsByCentrelineSummaryPerLocation(
         this.locations, this.filterParamsCollision,
       );
-      const indexes = indexesToIgnore.map((element, index) => {
+      const indexesToRetrieve = collisionMetaDataForLocations.map((element, index) => {
         if (element.amount !== 0) return index;
         return null;
       }).filter(element => element !== null);
       this.locationsSelectionForReport.locations = this.locations
         .map((element, index) => {
-          if (indexes.includes(index)) return element;
+          if (indexesToRetrieve.includes(index)) return element;
           return null;
         }).filter(element => element !== null);
     },


### PR DESCRIPTION
# Issue Addressed
This PR addresses [MOVE-59](https://move-toronto.atlassian.net/browse/MOVE-59)

# Description
The report export function on the data aggregate drawer was downloading reports even if they were empty (i.e. zero collisions at the location). This is obviously not what we want. This change filters out locations where the metadata shows zero collisions and only requests reports for the rest.

# Tests
Manually tested running reports at multi location selections (both with and without corridors)
