### PR TITLE
MOVE-1230: UI issues when adding request to new project

### DIFF
--- a/web/components/FcDrawerRequestStudyBulkEdit.vue
+++ b/web/components/FcDrawerRequestStudyBulkEdit.vue
@@ -63,7 +63,6 @@ import FcStudyRequestBulkDetails
 import FcNavStudyRequest from '@/web/components/requests/nav/FcNavStudyRequest.vue';
 import FcMixinLeaveGuard from '@/web/mixins/FcMixinLeaveGuard';
 import FcMixinRouteAsync from '@/web/mixins/FcMixinRouteAsync';
-import { getFirstErrorText, scrollToFirstError } from '@/web/ui/FormUtils';
 
 export default {
   name: 'FcDrawerRequestStudyBulkEdit',
@@ -104,18 +103,15 @@ export default {
   },
   methods: {
     actionSave() {
-      if (!this.formValid) {
-        this.errorOnSubmit = true;
-        const $form = this.$refs.formWrapper;
-        scrollToFirstError($form, '.v-input');
+      setTimeout(() => {
+        if (!this.formValid) {
+          this.errorOnSubmit = true;
+          return;
+        }
 
-        const errorText = getFirstErrorText($form);
-        this.setToastError(errorText);
-        return;
-      }
-
-      this.updateStudyRequestBulk(this.studyRequestBulk);
-      this.actionNavigateBack(true);
+        this.updateStudyRequestBulk(this.studyRequestBulk);
+        this.actionNavigateBack(true);
+      });
     },
     async loadAsyncForRoute(to) {
       const { id } = to.params;

--- a/web/components/FcDrawerRequestStudyBulkEdit.vue
+++ b/web/components/FcDrawerRequestStudyBulkEdit.vue
@@ -22,7 +22,8 @@
           class="px-5"
           :is-create="false"
           :v="$v.studyRequestBulk"
-          :errorOnSubmit="errorOnSubmit" />
+          :errorOnSubmit="errorOnSubmit"
+          ref="projectDetails" />
       </div>
 
       <footer class="flex-grow-0 flex-shrink-0 shading">
@@ -103,7 +104,8 @@ export default {
   },
   methods: {
     actionSave() {
-      setTimeout(() => {
+      this.$refs.projectDetails.$refs.inputTextArray.$refs.comboInput.blur();
+      this.$nextTick(() => {
         if (!this.formValid) {
           this.errorOnSubmit = true;
           return;

--- a/web/components/FcDrawerRequestStudyBulkEdit.vue
+++ b/web/components/FcDrawerRequestStudyBulkEdit.vue
@@ -21,7 +21,8 @@
           v-model="studyRequestBulk"
           class="px-5"
           :is-create="false"
-          :v="$v.studyRequestBulk" />
+          :v="$v.studyRequestBulk"
+          :errorOnSubmit="errorOnSubmit" />
       </div>
 
       <footer class="flex-grow-0 flex-shrink-0 shading">
@@ -81,6 +82,7 @@ export default {
     return {
       loadingSave: false,
       studyRequestBulk: null,
+      errorOnSubmit: false,
     };
   },
   computed: {
@@ -103,6 +105,7 @@ export default {
   methods: {
     actionSave() {
       if (!this.formValid) {
+        this.errorOnSubmit = true;
         const $form = this.$refs.formWrapper;
         scrollToFirstError($form, '.v-input');
 

--- a/web/components/dialogs/FcDialogProjectMode.vue
+++ b/web/components/dialogs/FcDialogProjectMode.vue
@@ -18,6 +18,7 @@
       <v-card-text class="default--text">
         <FcStudyRequestBulkDetails
           v-if="projectMode === ProjectMode.CREATE_NEW"
+          ref="projectDetails"
           v-model="studyRequestBulk"
           :is-create="true"
           :v="$v.studyRequestBulk"
@@ -105,7 +106,8 @@ export default {
       this.errorOnSubmit = false;
     },
     actionSave() {
-      setTimeout(() => {
+      this.$refs.projectDetails.$refs.inputTextArray.$refs.comboInput.blur();
+      this.$nextTick(() => {
         if (!this.$v.$invalid) {
           this.$emit('action-save', this.studyRequestBulk);
           this.studyRequestBulk = makeStudyRequestBulk();

--- a/web/components/dialogs/FcDialogProjectMode.vue
+++ b/web/components/dialogs/FcDialogProjectMode.vue
@@ -20,11 +20,12 @@
           v-if="projectMode === ProjectMode.CREATE_NEW"
           v-model="studyRequestBulk"
           :is-create="true"
-          :v="$v.studyRequestBulk" />
+          :v="$v.studyRequestBulk"
+          :errorOnSubmit="errorOnSubmit" />
         <div v-else-if="projectMode === ProjectMode.ADD_TO_EXISTING">
           <FcInputProjectSearch
             v-model="studyRequestBulk"
-            :error-messages="errorMessagesAddToProject"
+            :error-messages="errorOnSubmit ? errorMessagesAddToProject : []"
             class="mt-6" />
         </div>
       </v-card-text>
@@ -39,7 +40,6 @@
           Cancel
         </FcButton>
         <FcButton
-          :disabled="$v.$invalid"
           type="tertiary"
           @click="actionSave">
           Save
@@ -75,6 +75,7 @@ export default {
     return {
       ProjectMode,
       studyRequestBulk: makeStudyRequestBulk(),
+      errorOnSubmit: false,
     };
   },
   validations: {
@@ -101,11 +102,16 @@ export default {
     actionCancel() {
       this.$emit('action-cancel');
       this.internalValue = false;
+      this.errorOnSubmit = false;
     },
     actionSave() {
-      this.$emit('action-save', this.studyRequestBulk);
-      this.studyRequestBulk = makeStudyRequestBulk();
-      this.internalValue = false;
+      if (!this.$v.$invalid) {
+        this.$emit('action-save', this.studyRequestBulk);
+        this.studyRequestBulk = makeStudyRequestBulk();
+        this.internalValue = false;
+      } else {
+        this.errorOnSubmit = true;
+      }
     },
   },
 };

--- a/web/components/dialogs/FcDialogProjectMode.vue
+++ b/web/components/dialogs/FcDialogProjectMode.vue
@@ -105,13 +105,15 @@ export default {
       this.errorOnSubmit = false;
     },
     actionSave() {
-      if (!this.$v.$invalid) {
-        this.$emit('action-save', this.studyRequestBulk);
-        this.studyRequestBulk = makeStudyRequestBulk();
-        this.internalValue = false;
-      } else {
-        this.errorOnSubmit = true;
-      }
+      setTimeout(() => {
+        if (!this.$v.$invalid) {
+          this.$emit('action-save', this.studyRequestBulk);
+          this.studyRequestBulk = makeStudyRequestBulk();
+          this.internalValue = false;
+        } else {
+          this.errorOnSubmit = true;
+        }
+      });
     },
   },
 };

--- a/web/components/inputs/FcInputProjectSearch.vue
+++ b/web/components/inputs/FcInputProjectSearch.vue
@@ -4,6 +4,7 @@
       v-model="select"
       cache-items
       clearable
+      autofocus
       hide-no-data
       hide-details="auto"
       :items="studyRequestsBulk"
@@ -38,6 +39,9 @@ export default {
       select: null,
       studyRequestsBulk: [],
     };
+  },
+  props: {
+    errorOnSubmit: Boolean,
   },
   computed: {
     studyRequestBulkSelected() {

--- a/web/components/inputs/FcInputTextArray.vue
+++ b/web/components/inputs/FcInputTextArray.vue
@@ -1,6 +1,7 @@
 <template>
   <v-combobox
     v-model="internalValue"
+    ref="comboInput"
     append-icon="mdi-plus"
     hide-no-data
     multiple

--- a/web/components/requests/FcStudyRequestBulkDetails.vue
+++ b/web/components/requests/FcStudyRequestBulkDetails.vue
@@ -29,6 +29,7 @@
             <FcInputTextArray
               v-model="v.ccEmails.$model"
               :error-messages="errorOnSubmit ? errorMessagesCcEmails : []"
+              ref="inputTextArray"
               label="Staff Subscribed"
               placeholder="Enter a @toronto.ca email address"
               messages="Staff who should be notified when the data is ready"

--- a/web/components/requests/FcStudyRequestBulkDetails.vue
+++ b/web/components/requests/FcStudyRequestBulkDetails.vue
@@ -11,6 +11,7 @@
           <v-col cols="8">
             <v-text-field
               ref="autofocus"
+              autofocus
               dense
               v-model="v.name.$model"
               :error-messages="errorOnSubmit ? errorMessagesName : []"

--- a/web/components/requests/FcStudyRequestBulkDetails.vue
+++ b/web/components/requests/FcStudyRequestBulkDetails.vue
@@ -13,9 +13,9 @@
               ref="autofocus"
               dense
               v-model="v.name.$model"
-              :error-messages="errorMessagesName"
-              label="Set Name for Project"
-              :messages="['Required']"
+              :error-messages="errorOnSubmit ? errorMessagesName : []"
+              label="Project Name (required)"
+              :messages="['The name of the project']"
               outlined>
             </v-text-field>
           </v-col>
@@ -27,7 +27,7 @@
           <v-col cols="8">
             <FcInputTextArray
               v-model="v.ccEmails.$model"
-              :error-messages="errorMessagesCcEmails"
+              :error-messages="errorOnSubmit ? errorMessagesCcEmails : []"
               label="Staff Subscribed"
               placeholder="Enter a @toronto.ca email address"
               messages="Staff who should be notified when the data is ready"
@@ -70,6 +70,7 @@ export default {
   props: {
     isCreate: Boolean,
     v: Object,
+    errorOnSubmit: Boolean,
   },
   data() {
     return {


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-1230.

# Description
Forms related to study request projects now validate on submit, improving user experience. Cursor now automatically lands on first input on form load. Some inputs have new labels as well.

![image](https://github.com/CityofToronto/bdit_flashcrow/assets/64811136/d5b4911a-dc03-4ad6-ba39-0ca073c001b8)

Validation on submission implemented via sending a boolean prop from the parent form to the children input fields, signalling them to display errors if needed. Timeout function is called on submission to ensure that the emails field validates its input.

# Tests
Tested in MOVE local v1.12 in Firefox, by performing the following actions: Adding to existing project, adding to new project, editing a project.