### PR TITLE
MOVE-1230: Add to Existing Project broke 😅 

### DIFF
--- a/web/components/dialogs/FcDialogProjectMode.vue
+++ b/web/components/dialogs/FcDialogProjectMode.vue
@@ -114,6 +114,7 @@ export default {
           this.$emit('action-save', this.studyRequestBulk);
           this.studyRequestBulk = makeStudyRequestBulk();
           this.internalValue = false;
+          this.$v.$reset();
         } else {
           this.errorOnSubmit = true;
         }

--- a/web/components/dialogs/FcDialogProjectMode.vue
+++ b/web/components/dialogs/FcDialogProjectMode.vue
@@ -106,7 +106,9 @@ export default {
       this.errorOnSubmit = false;
     },
     actionSave() {
-      this.$refs.projectDetails.$refs.inputTextArray.$refs.comboInput.blur();
+      if (this.projectMode === ProjectMode.CREATE_NEW) {
+        this.$refs.projectDetails.$refs.inputTextArray.$refs.comboInput.blur();
+      }
       this.$nextTick(() => {
         if (!this.$v.$invalid) {
           this.$emit('action-save', this.studyRequestBulk);


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-1230.

# Description
Flawed logic was causing the project mode dialog save button to fail when attempting to add study requests to existing projects. Corrected code logic to only blur the email input field if it is present in the dialog / form.

# Tests
Tested in MOVE local v1.12 in Firefox.