### PR TITLE
MOVE-1205 - Map location hover tooltip not appearing in study request form

### DIFF
--- a/web/components/geo/map/FcMap.vue
+++ b/web/components/geo/map/FcMap.vue
@@ -412,6 +412,7 @@ export default {
         this.map.on('move', this.onMapMove.bind(this));
         this.map.on('click', this.onMapClick.bind(this));
         this.map.on('mousemove', this.onMapMousemove.bind(this));
+        this.zoomLevel = this.map.getZoom();
       });
       this.zoomLevel = this.map.getZoom();
     });


### PR DESCRIPTION
# Issue Addressed
This PR closes[MOVE-1205](https://move-toronto.atlassian.net/browse/MOVE-1205)

# Description
We weren't setting the zoomLevel when the map loaded, so I added this. The tooltip / toast now appears in local - I am assuming this will fix the issue in Dev also.

# Tests
All tests are passing.