### PR TITLE
MOVE-1189 - Make the dialog hang around for a bit.

### DIFF
--- a/web/components/dialogs/FcDialogAlertIncompatibleStudy.vue
+++ b/web/components/dialogs/FcDialogAlertIncompatibleStudy.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="internalValue" max-width="560" z-index="401">
+  <v-dialog v-model="internalValue" max-width="560" z-index="301">
     <v-card aria-labelledby="heading_dialog_alert" role="dialog">
       <v-card-title class="shading">
         <h2 class="display-1" id="heading_dialog_alert">{{ title }}</h2>

--- a/web/components/dialogs/FcDialogAlertIncompatibleStudy.vue
+++ b/web/components/dialogs/FcDialogAlertIncompatibleStudy.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="internalValue" max-width="560" z-index="301">
+  <v-dialog v-model="internalValue" max-width="560" z-index="401">
     <v-card aria-labelledby="heading_dialog_alert" role="dialog">
       <v-card-title class="shading">
         <h2 class="display-1" id="heading_dialog_alert">{{ title }}</h2>

--- a/web/components/geo/map/EditStudyLocationPopUp.vue
+++ b/web/components/geo/map/EditStudyLocationPopUp.vue
@@ -3,17 +3,6 @@
     <FcButton type="tertiary" @click="actionSelected">
       Set Location
     </FcButton>
-    <!-- <FcDialogAlertIncompatibleStudy
-      v-model="showIncompatableDialog"
-      textOk="OK" title="Cannot change location" okButtonType="primary">
-      <span class="body-1">
-        We cannot conduct a {{this.currentStudyTypeString}} at this location.
-        To learn more about studies and the limitations of where they can be
-        conducted, email Data Collection at TrafficData@toronto.ca. <br />
-        Alternatively, cancel this request and submit a new one. This will
-        not affect the turnaround time of your request.
-      </span>
-    </FcDialogAlertIncompatibleStudy> -->
   </div>
 
 </template>
@@ -21,8 +10,6 @@
 <script>
 import { mapActions, mapMutations, mapState } from 'vuex';
 import { getLocationByCentreline, getStudyRequest } from '@/lib/api/WebApi';
-// eslint-disable-next-line max-len
-// import FcDialogAlertIncompatibleStudy from '@/web/components/dialogs/FcDialogAlertIncompatibleStudy.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import { getLocationStudyTypes } from '@/lib/geo/CentrelineUtils';
 
@@ -30,7 +17,6 @@ export default {
   name: 'EditStudyLocationPopUp',
   components: {
     FcButton,
-    // FcDialogAlertIncompatibleStudy,
   },
   data() {
     return {
@@ -69,10 +55,6 @@ export default {
         this.$emit('showDialog', msgStudyType);
       }
     },
-    // log() {
-    //   // eslint-disable-next-line no-console
-    //   console.log('showIncompatableDialog', this.showIncompatableDialog);
-    // },
     ...mapMutations(['setToastInfo']),
     ...mapMutations('editRequests', ['setIndicesSelected']),
     ...mapActions('editRequests', [

--- a/web/components/geo/map/EditStudyLocationPopUp.vue
+++ b/web/components/geo/map/EditStudyLocationPopUp.vue
@@ -3,7 +3,7 @@
     <FcButton type="tertiary" @click="actionSelected">
       Set Location
     </FcButton>
-    <FcDialogAlertIncompatibleStudy
+    <!-- <FcDialogAlertIncompatibleStudy
       v-model="showIncompatableDialog"
       textOk="OK" title="Cannot change location" okButtonType="primary">
       <span class="body-1">
@@ -13,7 +13,7 @@
         Alternatively, cancel this request and submit a new one. This will
         not affect the turnaround time of your request.
       </span>
-    </FcDialogAlertIncompatibleStudy>
+    </FcDialogAlertIncompatibleStudy> -->
   </div>
 
 </template>
@@ -21,7 +21,8 @@
 <script>
 import { mapActions, mapMutations, mapState } from 'vuex';
 import { getLocationByCentreline, getStudyRequest } from '@/lib/api/WebApi';
-import FcDialogAlertIncompatibleStudy from '@/web/components/dialogs/FcDialogAlertIncompatibleStudy.vue';
+// eslint-disable-next-line max-len
+// import FcDialogAlertIncompatibleStudy from '@/web/components/dialogs/FcDialogAlertIncompatibleStudy.vue';
 import FcButton from '@/web/components/inputs/FcButton.vue';
 import { getLocationStudyTypes } from '@/lib/geo/CentrelineUtils';
 
@@ -29,7 +30,7 @@ export default {
   name: 'EditStudyLocationPopUp',
   components: {
     FcButton,
-    FcDialogAlertIncompatibleStudy,
+    // FcDialogAlertIncompatibleStudy,
   },
   data() {
     return {
@@ -64,9 +65,14 @@ export default {
       if (await this.isCompatibleLocationChange(location)) {
         await this.actionSetStudyLocation(location);
       } else {
-        this.showIncompatableDialog = true;
+        const msgStudyType = this.currentStudyTypeString;
+        this.$emit('showDialog', msgStudyType);
       }
     },
+    // log() {
+    //   // eslint-disable-next-line no-console
+    //   console.log('showIncompatableDialog', this.showIncompatableDialog);
+    // },
     ...mapMutations(['setToastInfo']),
     ...mapMutations('editRequests', ['setIndicesSelected']),
     ...mapActions('editRequests', [

--- a/web/views/FcLayoutRequestEditor.vue
+++ b/web/views/FcLayoutRequestEditor.vue
@@ -1,10 +1,21 @@
 <template>
-  <div class="fc-layout-request-editor fill-height">
+    <div class="fc-layout-request-editor fill-height">
     <div class="fc-pane-wrapper d-flex fill-height">
       <div class="fc-drawer flex-shrink-0">
         <router-view
           @action-focus-map="actionFocusMap"></router-view>
       </div>
+        <FcDialogAlertIncompatibleStudy
+          v-model="showIncompatibleDialog"
+          textOk="OK" title="Cannot change location" okButtonType="primary">
+          <span class="body-1">
+            We cannot conduct a {{this.currentStudyTypeString}} at this location.
+            To learn more about studies and the limitations of where they can be
+            conducted, email Data Collection at TrafficData@toronto.ca. <br />
+            Alternatively, cancel this request and submit a new one. This will
+            not affect the turnaround time of your request.
+          </span>
+        </FcDialogAlertIncompatibleStudy>
       <div class="flex-shrink-0 map">
         <FcMap
           class="fill-height"
@@ -36,12 +47,12 @@
 
             <v-card-actions class="shading">
               <FcMapPopupActionRequestEditor v-if="isNewRequest" :feature="feature" />
-              <EditStudyLocationPopUpVue v-else :feature="feature" />
+              <EditStudyLocationPopUpVue v-else :feature="feature" @showDialog="showDialog" />
             </v-card-actions>
           </template>
         </FcMap>
-      </div>
     </div>
+  </div>
   </div>
 </template>
 
@@ -55,6 +66,8 @@ import FcMapPopupActionRequestEditor
   from '@/web/components/geo/map/FcMapPopupActionRequestEditor.vue';
 import FcInputLocationSearch from '@/web/components/inputs/FcInputLocationSearch.vue';
 import { focusInput } from '@/web/ui/FormUtils';
+// eslint-disable-next-line max-len
+import FcDialogAlertIncompatibleStudy from '@/web/components/dialogs/FcDialogAlertIncompatibleStudy.vue';
 
 export default {
   name: 'FcLayoutRequestEditor',
@@ -63,11 +76,14 @@ export default {
     FcMap,
     FcMapPopupActionRequestEditor,
     EditStudyLocationPopUpVue,
+    FcDialogAlertIncompatibleStudy,
   },
   data() {
     return {
       locationToAdd: null,
       mapEaseMode: 'all',
+      currentStudyTypeString: null,
+      showIncompatibleDialog: false,
       searchLocationMarkerOpts: {
         multi: true,
         locationIndex: false,
@@ -132,6 +148,12 @@ export default {
     },
     clearSearch() {
       this.locationToAdd = null;
+    },
+    showDialog(msgStudyType) {
+      // eslint-disable-next-line no-console
+      console.log('msgStudyType', msgStudyType);
+      this.currentStudyTypeString = msgStudyType;
+      this.showIncompatibleDialog = true;
     },
   },
   watch: {

--- a/web/views/FcLayoutRequestEditor.vue
+++ b/web/views/FcLayoutRequestEditor.vue
@@ -5,17 +5,17 @@
         <router-view
           @action-focus-map="actionFocusMap"></router-view>
       </div>
-        <FcDialogAlertIncompatibleStudy
-          v-model="showIncompatibleDialog"
-          textOk="OK" title="Cannot change location" okButtonType="primary">
-          <span class="body-1">
-            We cannot conduct a {{this.currentStudyTypeString}} at this location.
-            To learn more about studies and the limitations of where they can be
-            conducted, email Data Collection at TrafficData@toronto.ca. <br />
-            Alternatively, cancel this request and submit a new one. This will
-            not affect the turnaround time of your request.
-          </span>
-        </FcDialogAlertIncompatibleStudy>
+      <FcDialogAlertIncompatibleStudy
+        v-model="showIncompatibleDialog"
+        textOk="OK" title="Cannot change location" okButtonType="primary">
+        <span class="body-1">
+          We cannot conduct a {{this.currentStudyTypeString}} at this location.
+          To learn more about studies and the limitations of where they can be
+          conducted, email Data Collection at TrafficData@toronto.ca. <br />
+          Alternatively, cancel this request and submit a new one. This will
+          not affect the turnaround time of your request.
+        </span>
+      </FcDialogAlertIncompatibleStudy>
       <div class="flex-shrink-0 map">
         <FcMap
           class="fill-height"
@@ -66,8 +66,8 @@ import FcMapPopupActionRequestEditor
   from '@/web/components/geo/map/FcMapPopupActionRequestEditor.vue';
 import FcInputLocationSearch from '@/web/components/inputs/FcInputLocationSearch.vue';
 import { focusInput } from '@/web/ui/FormUtils';
-// eslint-disable-next-line max-len
-import FcDialogAlertIncompatibleStudy from '@/web/components/dialogs/FcDialogAlertIncompatibleStudy.vue';
+import FcDialogAlertIncompatibleStudy
+  from '@/web/components/dialogs/FcDialogAlertIncompatibleStudy.vue';
 
 export default {
   name: 'FcLayoutRequestEditor',
@@ -150,8 +150,6 @@ export default {
       this.locationToAdd = null;
     },
     showDialog(msgStudyType) {
-      // eslint-disable-next-line no-console
-      console.log('msgStudyType', msgStudyType);
       this.currentStudyTypeString = msgStudyType;
       this.showIncompatibleDialog = true;
     },


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-1189](https://move-toronto.atlassian.net/browse/MOVE-1189)

# Description
Had to move the dialog up so that it didn't dismiss when a new location was hovered over (which was on pretty much any mouse movement.)

# Tests
All tests are passing.
