### PR TITLE
MOVE-1239: Marker highlighting bug on track request project page

### DIFF
--- a/web/components/geo/map/FcMap.vue
+++ b/web/components/geo/map/FcMap.vue
@@ -366,13 +366,14 @@ export default {
       }
       return !this.drawerOpen || !featureMatchesRoute;
     },
-    locationMarkersByCentreline() {
-      const markersById = {};
-      this.locationsMarkersGeoJson.features.forEach(
-        // eslint-disable-next-line no-return-assign
-        feature => markersById[feature.properties.centrelineId] = feature,
-      );
-      return markersById;
+    centrelineByRequestId() {
+      const centrelineById = {};
+      this.locationsMarkersGeoJson.features.forEach((feature) => {
+        feature.properties.studyRequests.forEach((studyRequest) => {
+          centrelineById[studyRequest.requestId] = feature.properties.centrelineId;
+        });
+      });
+      return centrelineById;
     },
     locationMarkersByRequestId() {
       const markersById = {};
@@ -494,13 +495,20 @@ export default {
       );
     },
     hoveredStudyRequest(newValue, oldValue) {
-      if (newValue !== null) {
+      let newCentrelineId = -1;
+      let oldCentrelineId = -1;
+
+      if (typeof newValue === 'number' && !Number.isNaN(newValue)) {
+        newCentrelineId = this.centrelineByRequestId[newValue];
         const feature = this.locationMarkersByRequestId[newValue];
         feature.properties.selected = true;
       }
-      if (oldValue !== null) {
-        const feature = this.locationMarkersByRequestId[oldValue];
-        feature.properties.selected = false;
+      if (typeof oldValue === 'number' && !Number.isNaN(oldValue)) {
+        oldCentrelineId = this.centrelineByRequestId[oldValue];
+        if (newCentrelineId !== oldCentrelineId) {
+          const feature = this.locationMarkersByRequestId[oldValue];
+          feature.properties.selected = false;
+        }
       }
       this.updateLocationsMarkersSource();
     },


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-1239.

# Description
"Bad" variable types being passed into functions caused unexpected behaviour. Added logic to check for variable types, and ensure they are "good". 

Added new computed property to help identify different study requests that share the same location marker. When hovering between two study requests that share the same location marker, the location marker will remain selected.

# Tests
Tested in MOVE local v1.13 using Firefox
