### PR TITLE
MOVE-209: Use ST_AsMVT directly in DynamicTileDAO

### DIFF
--- a/lib/controller/DynamicTileController.js
+++ b/lib/controller/DynamicTileController.js
@@ -2,7 +2,7 @@ import vtpbf from 'vt-pbf';
 import Joi from '@/lib/model/Joi';
 
 import DynamicTileDAO from '@/lib/db/DynamicTileDAO';
-import VectorTile from '@/lib/geo/VectorTile';
+// import VectorTile from '@/lib/geo/VectorTile';
 
 /**
  * Routes for dynamic tile generation.
@@ -60,14 +60,22 @@ DynamicTileController.push({
       y,
     } = request.params;
     const features = await DynamicTileDAO.getTileFeatures(layerName, z, x, y);
-    const tile = new VectorTile(layerName, features);
-    const tileData = vtpbf(tile);
+    if (layerName === 'collisionsLevel1') {
+      // eslint-disable-next-line no-console
+      console.log('features', features);
+    }
+    // const tile = new VectorTile(layerName, features);
+    const tileData = vtpbf(features);
     const tileBuffer = Buffer.from(tileData);
+    // eslint-disable-next-line no-console
+    console.log('tileBuffer:', tileBuffer);
     /*
      * See https://github.com/mapbox/vector-tile-spec/tree/master/2.1#22-multipurpose-internet-mail-extensions-mime
      * for preferred MIME type here.
      */
-    return h.response(tileBuffer)
+    // eslint-disable-next-line no-console
+    console.log('Hello there:', features[0].st_asmvt);
+    return h.response(features[0].st_asmvt)
       .encoding('binary')
       .type('application/vnd.mapbox-vector-tile');
   },

--- a/lib/controller/DynamicTileController.js
+++ b/lib/controller/DynamicTileController.js
@@ -1,8 +1,6 @@
-// import vtpbf from 'vt-pbf';
 import Joi from '@/lib/model/Joi';
 
 import DynamicTileDAO from '@/lib/db/DynamicTileDAO';
-// import VectorTile from '@/lib/geo/VectorTile';
 
 /**
  * Routes for dynamic tile generation.
@@ -60,14 +58,10 @@ DynamicTileController.push({
       y,
     } = request.params;
     const features = await DynamicTileDAO.getTileFeatures(layerName, z, x, y);
-    // eslint-disable-next-line no-console
-    console.log('features', features);
     /*
      * See https://github.com/mapbox/vector-tile-spec/tree/master/2.1#22-multipurpose-internet-mail-extensions-mime
      * for preferred MIME type here.
      */
-    // eslint-disable-next-line no-console
-    console.log('Hello there:', features[0].tile);
     return h.response(features[0].tile)
       .encoding('binary')
       .type('application/vnd.mapbox-vector-tile');

--- a/lib/controller/DynamicTileController.js
+++ b/lib/controller/DynamicTileController.js
@@ -1,4 +1,4 @@
-import vtpbf from 'vt-pbf';
+// import vtpbf from 'vt-pbf';
 import Joi from '@/lib/model/Joi';
 
 import DynamicTileDAO from '@/lib/db/DynamicTileDAO';
@@ -60,22 +60,15 @@ DynamicTileController.push({
       y,
     } = request.params;
     const features = await DynamicTileDAO.getTileFeatures(layerName, z, x, y);
-    if (layerName === 'collisionsLevel1') {
-      // eslint-disable-next-line no-console
-      console.log('features', features);
-    }
-    // const tile = new VectorTile(layerName, features);
-    const tileData = vtpbf(features);
-    const tileBuffer = Buffer.from(tileData);
     // eslint-disable-next-line no-console
-    console.log('tileBuffer:', tileBuffer);
+    console.log('features', features);
     /*
      * See https://github.com/mapbox/vector-tile-spec/tree/master/2.1#22-multipurpose-internet-mail-extensions-mime
      * for preferred MIME type here.
      */
     // eslint-disable-next-line no-console
-    console.log('Hello there:', features[0].st_asmvt);
-    return h.response(features[0].st_asmvt)
+    console.log('Hello there:', features[0].tile);
+    return h.response(features[0].tile)
       .encoding('binary')
       .type('application/vnd.mapbox-vector-tile');
   },

--- a/lib/db/DynamicTileDAO.js
+++ b/lib/db/DynamicTileDAO.js
@@ -87,44 +87,40 @@ collisions AS (
   FROM event_involved ei
   JOIN collisions.events e ON ei.collision_id = e.collision_id
   JOIN collisions.events_centreline ec ON ei.collision_id = ec.collision_id
+),
+collisions_mvt AS (
+  SELECT ST_AsMVTGeom(
+    ST_Transform(geom, 3857),
+    ST_MakeEnvelope($(xmin), $(ymin), $(xmax), $(ymax), 3857)
+  ) AS geom,
+  id,
+  accdate,
+  aggressive,
+  centreline_id AS "centrelineId",
+  centreline_type AS "centrelineType",
+  changed,
+  city_damage,
+  collision_id,
+  cyclist,
+  "dayOfWeek",
+  drivact,
+  drivcond,
+  "hourOfDay",
+  impactype,
+  initdir,
+  injury,
+  manoeuver,
+  motorcyclist,
+  mvaimg,
+  older_adult,
+  pedestrian,
+  rdsfcond,
+  red_light,
+  school_child,
+  vehtype
+  FROM collisions
 )
-SELECT ST_AsGeoJSON(
-  ST_SnapToGrid(
-    ST_Affine(
-      ST_Transform(geom, 3857),
-      $(fx), 0,
-      0, $(fy),
-      $(xoff), $(yoff)
-    ),
-    0, 0, 1, 1
-  )
-)::json AS geom,
-id,
-accdate,
-aggressive,
-centreline_id AS "centrelineId",
-centreline_type AS "centrelineType",
-changed,
-city_damage,
-collision_id,
-cyclist,
-"dayOfWeek",
-drivact,
-drivcond,
-"hourOfDay",
-impactype,
-initdir,
-injury,
-manoeuver,
-motorcyclist,
-mvaimg,
-older_adult,
-pedestrian,
-rdsfcond,
-red_light,
-school_child,
-vehtype
-FROM collisions`;
+SELECT ST_AsMVT(collisions_mvt.*) FROM collisions_mvt`;
     return db.manyOrNone(sql, {
       ...tileInfo,
       datesFromYear,

--- a/lib/db/DynamicTileDAO.js
+++ b/lib/db/DynamicTileDAO.js
@@ -88,7 +88,7 @@ collisions AS (
   JOIN collisions.events e ON ei.collision_id = e.collision_id
   JOIN collisions.events_centreline ec ON ei.collision_id = ec.collision_id
 ),
-collisions_mvt AS (
+mvtgeom AS (
   SELECT ST_AsMVTGeom(
     ST_Transform(geom, 3857),
     ST_MakeEnvelope($(xmin), $(ymin), $(xmax), $(ymax), 3857)
@@ -119,8 +119,9 @@ collisions_mvt AS (
   school_child,
   vehtype
   FROM collisions
+  WHERE accdate >= now() - interval $(datesFromYear)
 )
-SELECT ST_AsMVT(collisions_mvt.*) FROM collisions_mvt`;
+SELECT ST_AsMVT(mvtgeom.*, 'collisions') AS tile FROM mvtgeom`;
     return db.manyOrNone(sql, {
       ...tileInfo,
       datesFromYear,
@@ -136,22 +137,18 @@ WITH hospitals AS (
     ST_Transform(geom, 3857),
     ST_MakeEnvelope($(xmin), $(ymin), $(xmax), $(ymax), 3857)
   )
+),
+mvtgeom AS (
+  SELECT ST_AsMVTGeom(
+    ST_Transform(geom, 3857),
+    ST_MakeEnvelope($(xmin), $(ymin), $(xmax), $(ymax), 3857)
+  ) AS geom,
+  objectid AS id,
+  stn_name AS "name",
+  general_use_code AS "hospitalType"
+  FROM hospitals
 )
-SELECT ST_AsGeoJSON(
-  ST_SnapToGrid(
-    ST_Affine(
-      ST_Transform(geom, 3857),
-      $(fx), 0,
-      0, $(fy),
-      $(xoff), $(yoff)
-    ),
-    0, 0, 1, 1
-  )
-)::json AS geom,
-objectid AS id,
-stn_name AS "name",
-general_use_code AS "hospitalType"
-FROM hospitals`;
+SELECT ST_AsMVT(mvtgeom.*, 'hospitals') AS tile FROM mvtgeom`;
     return db.manyOrNone(sql, tileInfo);
   }
 

--- a/lib/db/DynamicTileDAO.js
+++ b/lib/db/DynamicTileDAO.js
@@ -119,9 +119,8 @@ mvtgeom AS (
   school_child,
   vehtype
   FROM collisions
-  WHERE accdate >= now() - interval $(datesFromYear)
 )
-SELECT ST_AsMVT(mvtgeom.*, 'collisions') AS tile FROM mvtgeom`;
+SELECT ST_AsMVT(mvtgeom.*, 'collisionsLevel1') AS tile FROM mvtgeom`;
     return db.manyOrNone(sql, {
       ...tileInfo,
       datesFromYear,
@@ -148,7 +147,7 @@ mvtgeom AS (
   general_use_code AS "hospitalType"
   FROM hospitals
 )
-SELECT ST_AsMVT(mvtgeom.*, 'hospitals') AS tile FROM mvtgeom`;
+SELECT ST_AsMVT(mvtgeom.*, 'hospitalsLevel1') AS tile FROM mvtgeom`;
     return db.manyOrNone(sql, tileInfo);
   }
 
@@ -161,22 +160,18 @@ WITH schools AS (
     ST_Transform(geom, 3857),
     ST_MakeEnvelope($(xmin), $(ymin), $(xmax), $(ymax), 3857)
   )
+),
+mvtgeom AS (
+  SELECT ST_AsMVTGeom(
+    ST_Transform(geom, 3857),
+    ST_MakeEnvelope($(xmin), $(ymin), $(xmax), $(ymax), 3857)
+  ) AS geom,
+  objectid AS id,
+  name,
+  school_type AS "schoolType"
+  FROM schools
 )
-SELECT ST_AsGeoJSON(
-  ST_SnapToGrid(
-    ST_Affine(
-      ST_Transform(geom, 3857),
-      $(fx), 0,
-      0, $(fy),
-      $(xoff), $(yoff)
-    ),
-    0, 0, 1, 1
-  )
-)::json AS geom,
-objectid AS id,
-name,
-school_type AS "schoolType"
-FROM schools`;
+SELECT ST_AsMVT(mvtgeom.*, 'schoolsLevel1') AS tile from mvtgeom`;
     return db.manyOrNone(sql, tileInfo);
   }
 
@@ -199,26 +194,22 @@ WITH studies AS (
   )
   AND "centrelineId" IS NOT NULL AND "centrelineType" IS NOT NULL
   AND "studyType" NOT IN (${excludeFilter})
+),
+mvtgeom AS (
+  SELECT ST_AsMVTGeom(
+    ST_Transform(geom, 3857),
+    ST_MakeEnvelope($(xmin), $(ymin), $(xmax), $(ymax), 3857)
+  ) AS geom,
+  "centrelineType" * 1000000000 + "centrelineId" AS id,
+  "centrelineId",
+  "centrelineType",
+  "daysOfWeek",
+  "hours",
+  "startDate",
+  "studyType"
+  FROM studies
 )
-SELECT ST_AsGeoJSON(
-  ST_SnapToGrid(
-    ST_Affine(
-      ST_Transform(geom, 3857),
-      $(fx), 0,
-      0, $(fy),
-      $(xoff), $(yoff)
-    ),
-    0, 0, 1, 1
-  )
-)::json AS geom,
-"centrelineType" * 1000000000 + "centrelineId" AS id,
-"centrelineId",
-"centrelineType",
-"daysOfWeek",
-"hours",
-"startDate",
-"studyType"
-FROM studies`;
+SELECT ST_AsMVT(mvtgeom.*, 'studies') AS tile from mvtgeom`;
     return db.manyOrNone(sql, tileInfo);
   }
 


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-209.

# Description
Edited queries in `DynamicTileDAO.js` to take advantage of the `ST_AsMVT` function in Postgis. This allows the database to serve vector tiles to the app, easing the load on the backend.

# Tests
Tested in MOVE local v1.13 using Firefox