### PR TITLE
MOVE-1254: Add Centreline ID to View Data summary (in dev only)

### DIFF
--- a/web/components/location/FcHeaderSingleLocation.vue
+++ b/web/components/location/FcHeaderSingleLocation.vue
@@ -9,15 +9,21 @@
       <div class="label mt-2">
         {{textLocationFeatureType}} &#x2022; {{textMostRecentStudy}}
       </div>
+      <div v-if="frontendEnv() === FrontendEnv.LOCAL || frontendEnv() === FrontendEnv.DEV"
+        class="label mt-0">
+        Centreline ID: {{ this.location.centrelineId }}
+      </div>
     </template>
   </div>
 </template>
 
 <script>
+import { mapState } from 'vuex';
 import { getStudiesByCentrelineSummary } from '@/lib/api/WebApi';
 import { getLocationFeatureType } from '@/lib/geo/CentrelineUtils';
 import DateTime from '@/lib/time/DateTime';
 import TimeFormatters from '@/lib/time/TimeFormatters';
+import FrontendEnv from '@/web/config/FrontendEnv';
 
 export default {
   name: 'FcHeaderSingleLocation',
@@ -29,6 +35,7 @@ export default {
     return {
       loading: false,
       studySummary: [],
+      FrontendEnv,
     };
   },
   computed: {
@@ -73,6 +80,7 @@ export default {
       this.studySummary = studySummary;
       this.loading = false;
     },
+    ...mapState(['frontendEnv']),
   },
 };
 </script>


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-1254.

# Description
Centreline ID is now displayed in the View Data drawer, to help with debugging. Only in local and dev environments.
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/64811136/570b0fca-9aad-4fc7-9c6f-4d21c871a9ba)

# Tests
Tested in MOVE local v1.13 using Firefox