### PR TITLE
MOVE-1257: Speed Percentile Report PDF formatting issue (prod bug)

### DIFF
--- a/lib/reports/ReportSpeedPercentile.js
+++ b/lib/reports/ReportSpeedPercentile.js
@@ -504,7 +504,9 @@ class ReportSpeedPercentile extends ReportBaseFlow {
       const tableOptions = ReportSpeedPercentile.getTableOptions(reportBlock);
       layout.push({ type: ReportBlock.METADATA, options: countMetadataOptions });
       layout.push({ type: ReportBlock.TABLE, options: tableOptions });
+      layout.push({ type: ReportBlock.PAGE_BREAK, options: {} });
     });
+    layout.pop();
     return layout;
   }
 }


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-1257.

# Description
Added pagebreaks to ensure that each table and the corresponding metadata stays on one page.
![image](https://github.com/CityofToronto/bdit_flashcrow/assets/64811136/9fda297d-9dbc-49eb-8ab2-f8e583b3d895)


# Tests
Tested in MOVE local v1.13 in Firefox.
