### PR TITLE
MOVE-1293: Add reply-to to automated emails (again)

### DIFF
--- a/lib/email/EmailBase.js
+++ b/lib/email/EmailBase.js
@@ -197,6 +197,6 @@ class EmailBase {
  * Reply-to address, so that email clients will direct people at our team's
  * incoming email address.
  */
-EmailBase.REPLY_TO = config.ENV === 'production' ? 'TrafficData@toronto.ca' : 'move-ops@toronto.ca';
+EmailBase.REPLY_TO = domain === 'move.intra.prod-toronto.ca' ? 'TrafficData@toronto.ca' : 'move-ops@toronto.ca';
 
 export default EmailBase;


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-1293.

# Description
Reply-to address in automated emails sent from MOVE QA was being set to `TrafficData@toronto.ca` when it should have been `move-ops@toronto.ca`.

# Tests
Tested in Firefox