### PR TITLE
MOVE-1322: Random tiny boxes on TMC Detailed Report

### DIFF
--- a/lib/reports/ReportCountSummaryTurningMovementDetailed.js
+++ b/lib/reports/ReportCountSummaryTurningMovementDetailed.js
@@ -216,7 +216,7 @@ class ReportCountSummaryTurningMovementDetailed extends ReportBaseFlow {
         { value: null },
       ],
       [
-        { value: null, colspan: 19 },
+        { value: null, colspan: 20 },
       ],
     ];
   }


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-1322.

# Description
Increased the `colspan` attribute from 19 to 20. This appears to squash the tiny phantom boxes from the plane of existence.

![image](https://github.com/user-attachments/assets/0f8133e7-0e7a-4d46-8f03-84b13400decb)


# Tests
Tested in MOVE local 1.14 on Firefox
