### PR TITLE
MOVE-1251: Add data source to collision filters

### DIFF
--- a/web/components/filters/FcCollisionFilters.vue
+++ b/web/components/filters/FcCollisionFilters.vue
@@ -51,7 +51,7 @@
       </template>
     </FcRadioGroup>
 
-    <fieldset class="mt-4">
+    <fieldset class="mt-6">
       <div class="align-center d-flex">
         <legend class="headline">Data Source</legend>
         <v-spacer></v-spacer>
@@ -72,7 +72,7 @@
         class="align-center d-flex">
         <v-checkbox
           v-model="internalValue.sources"
-          class="mt-0"
+          class="mt-2"
           hide-details
           :label="source.text"
           :value="source"></v-checkbox>


### PR DESCRIPTION
# Issue Addressed
This PR closes MOVE-1251.

# Description
Edited the margin around data source components in the filter drawer to be consistent with the layout of the other components in the filter drawer.

![image](https://github.com/user-attachments/assets/6e0cc90d-dfd2-4909-8855-778d56d31f73)


# Tests
Tested on MOVE local 1.14 in Firefox.
