### PR TITLE
Move 1319 - Multi-day, multi-direction Speed Percentile Reports have an extra table for 1-day counts

### DIFF
--- a/lib/reports/ReportSpeedPercentile.js
+++ b/lib/reports/ReportSpeedPercentile.js
@@ -359,11 +359,7 @@ class ReportSpeedPercentile extends ReportBaseFlow {
       fullDateStr = `${dateStr} (${dayOfWeekStr})`;
     } else {
       const dateStrStart = TimeFormatters.formatDefault(study.startDate);
-      // const dayOfWeekStrStart = TimeFormatters.formatDayOfWeek(study.startDate);
       const dateStrEnd = TimeFormatters.formatDefault(study.endDate);
-      // const dayOfWeekStrEnd = TimeFormatters.formatDayOfWeek(study.endDate);
-      // fullDateStr =
-      // `${dateStrStart} (${dayOfWeekStrStart}) - ${dateStrEnd} (${dayOfWeekStrEnd})`;
       fullDateStr = `${dateStrStart} to ${dateStrEnd}`;
     }
 
@@ -378,7 +374,6 @@ class ReportSpeedPercentile extends ReportBaseFlow {
         { cols: 3, name: '50th Percentile', value: `${totalStats.pct50} KPH` },
         { cols: 3, name: '85th Percentile', value: `${totalStats.pct85} KPH` },
         { cols: 3, name: '95th Percentile', value: `${totalStats.pct95} KPH` },
-        // { cols: 6, name: 'Notes', value: notes },
       ],
     };
   }

--- a/lib/reports/ReportSpeedPercentile.js
+++ b/lib/reports/ReportSpeedPercentile.js
@@ -357,6 +357,10 @@ class ReportSpeedPercentile extends ReportBaseFlow {
       const dateStr = TimeFormatters.formatDefault(date);
       const dayOfWeekStr = TimeFormatters.formatDayOfWeek(date);
       fullDateStr = `${dateStr} (${dayOfWeekStr})`;
+    } else if (study.startDate.equals(study.endDate)) {
+      const dateStr = TimeFormatters.formatDefault(study.startDate);
+      const dayOfWeekStr = TimeFormatters.formatDayOfWeek(study.startDate);
+      fullDateStr = `${dateStr} (${dayOfWeekStr})`;
     } else {
       const dateStrStart = TimeFormatters.formatDefault(study.startDate);
       const dateStrEnd = TimeFormatters.formatDefault(study.endDate);
@@ -503,6 +507,10 @@ class ReportSpeedPercentile extends ReportBaseFlow {
       layout.push({ type: ReportBlock.PAGE_BREAK, options: {} });
     });
     layout.pop();
+    if (study.startDate.equals(study.endDate)) {
+      layout.pop();
+      layout.pop();
+    }
     return layout;
   }
 }


### PR DESCRIPTION
# Issue Addressed
This PR closes [MOVE-1319](https://move-toronto.atlassian.net/browse/MOVE-1319)

# Description
Fixed the duplicate report appearing at the bottom of the Speed Percentile Report when the study is only 1 day. 

# Tests
All tests are passing, and I have visually checked a [1 day study](https://localhost:8080/view/location/s1:A7zMCB/POINTS/reports/ATR_SPEED_VOLUME), and a[ multiday study](https://localhost:8080/view/location/s1:AVfk3A/POINTS/reports/ATR_SPEED_VOLUME).
