### PR TITLE
Tmc fix

### DIFF
--- a/lib/geo/GeometryUtils.js
+++ b/lib/geo/GeometryUtils.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import ArrayUtils from '@/lib/ArrayUtils';
 import { CardinalDirection } from '@/lib/Constants';
 import { identity } from '@/lib/FunctionUtils';
@@ -9,7 +8,6 @@ import { identity } from '@/lib/FunctionUtils';
  */
 
 /**
- *
  * @typedef {Array<GeoJsonPoint>} GeoJsonLineString
  * @see https://tools.ietf.org/html/rfc7946#section-3.1.4
  */
@@ -207,7 +205,6 @@ function getHackyDirectionCandidatesFrom(lineStrings, point) {
   if (bearings.length === 0) {
     return bestCandidates;
   }
-  console.log(bearings);
   const northBearingDiff = bearings
     .map(([bearing]) => Math.abs(getBearingDifference(bearing, CardinalDirection.NORTH.bearing)));
   const bestBearingIndex = ArrayUtils.getMinIndexBy(northBearingDiff, identity);
@@ -215,7 +212,6 @@ function getHackyDirectionCandidatesFrom(lineStrings, point) {
   if (northBearingDiff[bestBearingIndex] <= 45) {
     bestCandidates.set(CardinalDirection.NORTH, bestCandidateIndex);
   }
-  console.log('***********', bestCandidates);
   return bestCandidates;
 }
 

--- a/lib/geo/GeometryUtils.js
+++ b/lib/geo/GeometryUtils.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import ArrayUtils from '@/lib/ArrayUtils';
 import { CardinalDirection } from '@/lib/Constants';
 import { identity } from '@/lib/FunctionUtils';
@@ -198,6 +199,26 @@ function getDirectionCandidatesFrom(lineStrings, point) {
   return bestCandidates;
 }
 
+function getHackyDirectionCandidatesFrom(lineStrings, point) {
+  const bestCandidates = new Map();
+  const bearings = lineStrings
+    .map((lineString, i) => [getLineStringBearingFrom(lineString, point), i])
+    .filter(([bearing]) => bearing !== null);
+  if (bearings.length === 0) {
+    return bestCandidates;
+  }
+  console.log(bearings);
+  const northBearingDiff = bearings
+    .map(([bearing]) => Math.abs(getBearingDifference(bearing, CardinalDirection.NORTH.bearing)));
+  const bestBearingIndex = ArrayUtils.getMinIndexBy(northBearingDiff, identity);
+  const bestCandidateIndex = bearings[bestBearingIndex][1];
+  if (northBearingDiff[bestBearingIndex] <= 45) {
+    bestCandidates.set(CardinalDirection.NORTH, bestCandidateIndex);
+  }
+  console.log('***********', bestCandidates);
+  return bestCandidates;
+}
+
 /**
  * `GeometryUtils` contains helper methods for handling GeoJSON geometries, such as `LineString`
  * and `Point`.
@@ -212,6 +233,7 @@ const GeometryUtils = {
   getGreatCircleBearing,
   getLineStringBearingFrom,
   getLineStringMidpoint,
+  getHackyDirectionCandidatesFrom,
   RAD_TO_DEG,
 };
 
@@ -224,5 +246,6 @@ export {
   getGreatCircleBearing,
   getLineStringBearingFrom,
   getLineStringMidpoint,
+  getHackyDirectionCandidatesFrom,
   RAD_TO_DEG,
 };

--- a/lib/reports/ReportBaseFlowDirectional.js
+++ b/lib/reports/ReportBaseFlowDirectional.js
@@ -305,7 +305,6 @@ class ReportBaseFlowDirectional extends ReportBaseFlow {
   static getRoadDirections(intersection, segments) {
     const specialCaseCentrelineIds = [13453619];
 
-    // eslint-disable-next-line no-console
     if (intersection === null || segments.length === 0) {
       /*
        * If the underlying centreline locations cannot be found (e.g. because this study refers

--- a/lib/reports/ReportBaseFlowDirectional.js
+++ b/lib/reports/ReportBaseFlowDirectional.js
@@ -9,7 +9,7 @@ import {
 } from '@/lib/Constants';
 import { identity } from '@/lib/FunctionUtils';
 import CentrelineDAO from '@/lib/db/CentrelineDAO';
-import { getDirectionCandidatesFrom } from '@/lib/geo/GeometryUtils';
+import { getDirectionCandidatesFrom, getHackyDirectionCandidatesFrom } from '@/lib/geo/GeometryUtils';
 import ArrayStats from '@/lib/math/ArrayStats';
 import ReportBaseFlow from '@/lib/reports/ReportBaseFlow';
 
@@ -292,7 +292,6 @@ class ReportBaseFlowDirectional extends ReportBaseFlow {
         road.push(dir);
       }
     });
-
     return roadDirections;
   }
 
@@ -302,7 +301,11 @@ class ReportBaseFlowDirectional extends ReportBaseFlow {
    * @returns {Array<Array<CardinalDirection>>} array of roads, each containing
    * an array of "X-bound" directions from `intersection` for that road
    */
+
   static getRoadDirections(intersection, segments) {
+    const specialCaseCentrelineIds = [13453619];
+
+    // eslint-disable-next-line no-console
     if (intersection === null || segments.length === 0) {
       /*
        * If the underlying centreline locations cannot be found (e.g. because this study refers
@@ -322,9 +325,18 @@ class ReportBaseFlowDirectional extends ReportBaseFlow {
      */
     const segmentLineStrings = segments.map(({ geom: { coordinates } }) => coordinates);
     const intersectionPoint = intersection.geom.coordinates;
+
     const directionCandidates = getDirectionCandidatesFrom(segmentLineStrings, intersectionPoint);
 
     const roads = ReportBaseFlowDirectional.getRoads(segments);
+
+    if (specialCaseCentrelineIds.includes(intersection.centrelineId)) {
+      const hackyDirectionCandidates = getHackyDirectionCandidatesFrom(
+        segmentLineStrings,
+        intersectionPoint,
+      );
+      return ReportBaseFlowDirectional.inferRoadDirections(roads, hackyDirectionCandidates);
+    }
     return ReportBaseFlowDirectional.inferRoadDirections(roads, directionCandidates);
   }
 


### PR DESCRIPTION
# Issue Addressed
Bug fix -> https://move-toronto.atlassian.net/browse/MOVE-1498

# Description
A specific TMC was buggy due to intersection bearings not being correctly normalized. This issue has exposed an edgecase that is not correctly handled by our gemetry utils. However, fixing the problem may introduce other edge cases and issues, so the solution for this bug at the moment is to add the affected centrelineids to an array and deal with them as special cases.