### PR TITLE
Move 1803 fix

### DIFF
--- a/lib/reports/ReportSpeedPercentile.js
+++ b/lib/reports/ReportSpeedPercentile.js
@@ -504,13 +504,9 @@ class ReportSpeedPercentile extends ReportBaseFlow {
       const tableOptions = ReportSpeedPercentile.getTableOptions(reportBlock);
       layout.push({ type: ReportBlock.METADATA, options: countMetadataOptions });
       layout.push({ type: ReportBlock.TABLE, options: tableOptions });
-      layout.push({ type: ReportBlock.PAGE_BREAK, options: {} });
     });
     layout.pop();
-    if (study.startDate.equals(study.endDate)) {
-      layout.pop();
-      layout.pop();
-    }
+
     return layout;
   }
 }

--- a/lib/reports/ReportSpeedPercentile.js
+++ b/lib/reports/ReportSpeedPercentile.js
@@ -220,7 +220,7 @@ class ReportSpeedPercentile extends ReportBaseFlow {
         reportData.push({ date, direction: reportDirections, stats });
       }
     }
-    if (counts.length > 1) {
+    if (counts.length > 2) {
       const groupCountData = Array.prototype.concat.apply(
         [],
         countTuples.map(({ countData }) => countData),
@@ -504,6 +504,7 @@ class ReportSpeedPercentile extends ReportBaseFlow {
       const tableOptions = ReportSpeedPercentile.getTableOptions(reportBlock);
       layout.push({ type: ReportBlock.METADATA, options: countMetadataOptions });
       layout.push({ type: ReportBlock.TABLE, options: tableOptions });
+      layout.push({ type: ReportBlock.PAGE_BREAK, options: {} });
     });
     layout.pop();
 


### PR DESCRIPTION
# Issue Addressed
This is addressing MOVE-1813

# Description
We are receiving an empty response because of the broken report here. The report is broken because of the resolution of the ticket below (MOVE-1319).

An extra summary table was being added to multi-day, multi-direction speed percentile reports. The solution at the time was to just check if the report starts and ends on the same day and if so, to remove the extra summary. However, this leads to cases where nothing loads (presumably because these are situations that are similar but in which an extra summary has not been added).

Essentially we were unaware that the fix in 1319 was ignoring some edge cases. This solution should take care of that.

